### PR TITLE
feat(pi-notion): add MCP client with OAuth support

### DIFF
--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -10,6 +10,8 @@
 - **Search**: Search pages and databases
 - **Comments**: Read and create comments
 - **Users**: Get user information
+- **MCP Client**: Connect to official Notion MCP server with OAuth
+- **Direct API**: Direct Notion API access with integration token
 
 ## Install
 
@@ -25,33 +27,70 @@ pi -e npm:@feniix/pi-notion
 
 ## Setup
 
-Run `/setup-notion` for interactive setup wizard, or configure manually below.
+### Option 1: Notion MCP Server (Recommended - No integration needed!)
 
-You need a Notion integration token from [notion.so/profile/integrations](https://www.notion.so/profile/integrations).
+This connects directly to Notion's official MCP server, similar to how Claude Code or Cursor connect to Notion MCP. **No Notion integration creation required.**
 
-### Option 1: Environment Variable
+```bash
+# Just connect - it will open browser for OAuth
+Use notion_mcp_connect to connect to Notion via MCP
+```
 
+**MCP Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `notion_mcp_connect` | Connect to Notion MCP server (opens browser) |
+| `notion_mcp_disconnect` | Disconnect from Notion MCP |
+| `notion_mcp_status` | Check connection status |
+| `notion_mcp_call` | Call a Notion MCP tool |
+
+### Option 2: Direct API with Integration Token
+
+Requires creating a Notion integration, but works with direct API calls.
+
+**Prerequisites:**
+
+1. Create an **internal** Notion integration at [notion.so/profile/integrations](https://www.notion.so/profile/integrations)
+2. Copy the integration token
+3. Share pages/databases with the integration
+
+**Configuration:**
+
+**Environment Variable:**
 ```bash
 export NOTION_TOKEN="secret_xxx"
 ```
 
-### Option 2: JSON Config File
-
-Create `~/.pi/agent/extensions/notion.json`:
-
+**JSON Config File:**
 ```json
 {
   "token": "secret_xxx"
 }
 ```
 
-### Option 3: CLI Flag
-
+**CLI Flag:**
 ```bash
 pi --notion-token=secret_xxx
 ```
 
-## Tools
+### Option 3: Direct API with OAuth (Advanced)
+
+Requires creating a **public** Notion integration.
+
+Create `~/.pi/agent/extensions/notion.json`:
+
+```json
+{
+  "oauth": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret",
+    "redirectUri": "http://localhost:3000/callback"
+  }
+}
+```
+
+## Direct API Tools
 
 ### Pages
 
@@ -75,7 +114,7 @@ pi --notion-token=secret_xxx
 | Tool | Description |
 |------|-------------|
 | `notion_get_block_children` | Get page/block children |
-| `notion_append_block_children` | Append blocks to a page |
+| `notion_append_blocks` | Append blocks to a page |
 
 ### Search
 
@@ -90,16 +129,34 @@ pi --notion-token=secret_xxx
 | `notion_get_user` | Get user by ID |
 | `notion_get_me` | Get current user |
 
-## Requirements
+### OAuth (Direct API)
 
-- pi v0.51.0 or later
-- Notion integration token from [notion.so/profile/integrations](https://www.notion.so/profile/integrations)
-- **Grant page/database access** to your integration (share pages with it via the "..." menu → Add connections)
+| Tool | Description |
+|------|-------------|
+| `notion_oauth_setup` | Start OAuth authorization flow |
+| `notion_oauth_status` | Check OAuth connection status |
+| `notion_oauth_logout` | Clear OAuth tokens and logout |
+
+## Which Option Should I Use?
+
+| Option | Requires Integration | OAuth Flow | Tool Count |
+|--------|---------------------|------------|------------|
+| Notion MCP Server | ❌ No | Browser-based | Full MCP tools |
+| Direct API + Token | ✅ Internal | None | Custom tools |
+| Direct API + OAuth | ✅ Public | Browser-based | Custom tools |
+
+**Recommendation:** Start with **Option 1 (Notion MCP Server)** if you just want to use Notion with pi. It works like Claude Code's Notion integration.
 
 ## Tips
 
 - **Page IDs**: Found in Notion URLs (`notion.so/workspace/Title-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`)
 - **Database IDs**: Same format as page IDs, found in database URLs
+
+## Requirements
+
+- pi v0.51.0 or later
+- For Direct API: Notion integration token
+- For MCP Server: Nothing additional needed!
 
 ## License
 

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -1,19 +1,26 @@
 /**
  * Notion API Extension for pi
+ *
+ * Supports two authentication methods:
+ * 1. Integration Token (Internal): Set NOTION_TOKEN or use --notion-token flag
+ * 2. OAuth (Public Integration): Configure in notion.json for user-based auth
  */
 
+import { exec as execCallback } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import axios, { type AxiosInstance } from "axios";
+import { executeOAuthFlow, FileTokenStorage, getValidAccessToken, type OAuthConfig } from "./oauth.js";
 
 const NOTION_API_BASE = "https://api.notion.com/v1";
 const NOTION_VERSION = "2025-09-03";
 
 interface NotionConfig {
 	token?: string;
+	oauth?: OAuthConfig;
 }
 
 interface NotionToolDetails {
@@ -133,7 +140,7 @@ function loadConfig(configPath?: string): NotionConfig | null {
 		if (!existsSync(globalConfigPath)) {
 			try {
 				mkdirSync(dirname(globalConfigPath), { recursive: true });
-				writeFileSync(globalConfigPath, `${JSON.stringify({ token: null }, null, 2)}\n`, "utf-8");
+				writeFileSync(globalConfigPath, `${JSON.stringify({ token: null, oauth: null }, null, 2)}\n`, "utf-8");
 			} catch {}
 		}
 		candidates.push(projectConfigPath, globalConfigPath);
@@ -216,11 +223,261 @@ export default function notionExtension(pi: ExtensionAPI) {
 		return "";
 	};
 
-	const getClient = (): NotionClient => {
+	const getOAuthConfig = (): OAuthConfig | null => {
+		const configFlag = pi.getFlag("--notion-config");
+		const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+		if (config?.oauth?.clientId && config?.oauth?.clientSecret && config?.oauth?.redirectUri) {
+			return config.oauth;
+		}
+		return null;
+	};
+
+	const getConfigPath = (): string => {
+		const configFlag = pi.getFlag("--notion-config");
+		if (typeof configFlag === "string" && configFlag) {
+			return resolveConfigPath(configFlag);
+		}
+		const projectConfigPath = join(process.cwd(), ".pi", "extensions", "notion.json");
+		const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "notion.json");
+		if (existsSync(projectConfigPath)) return projectConfigPath;
+		return globalConfigPath;
+	};
+
+	const getClient = async (): Promise<NotionClient> => {
+		const oauthConfig = getOAuthConfig();
+
+		if (oauthConfig) {
+			// Try OAuth first
+			const configPath = getConfigPath();
+			const storage = new FileTokenStorage(configPath);
+
+			try {
+				const accessToken = await getValidAccessToken(oauthConfig, storage);
+				if (accessToken) {
+					return new NotionClient(accessToken);
+				}
+			} catch {
+				// OAuth failed, fall through to token auth
+			}
+		}
+
+		// Fall back to token auth
 		const token = getToken();
-		if (!token) throw new Error("Notion token not configured. Set NOTION_TOKEN or use --notion-token flag.");
+		if (!token) {
+			throw new Error(
+				"Notion token not configured. Set NOTION_TOKEN, use --notion-token flag, or configure OAuth in notion.json.\n" +
+					"Run /notion-oauth-setup to configure OAuth authentication.",
+			);
+		}
 		return new NotionClient(token);
 	};
+
+	const openBrowser = (url: string): void => {
+		const platform = process.platform;
+		const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+		execCallback(`${cmd} "${url}"`);
+	};
+
+	// OAuth Setup Tool
+	pi.registerTool({
+		name: "notion_oauth_setup",
+		label: "Notion OAuth Setup",
+		description:
+			"Configure OAuth authentication for Notion. Requires a public Notion integration with client_id, client_secret, and redirect_uri configured in notion.json.",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+			try {
+				const configFlag = pi.getFlag("--notion-config");
+				const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+
+				if (!config?.oauth?.clientId || !config?.oauth?.clientSecret || !config?.oauth?.redirectUri) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `OAuth not configured. Please add oauth configuration to your notion.json:
+
+{
+  "oauth": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret",
+    "redirectUri": "http://localhost:3000/callback"
+  }
+}
+
+To create a public Notion integration:
+1. Go to https://www.notion.so/profile/integrations
+2. Click "New integration" and select "Public"
+3. Configure OAuth settings with redirect URI: http://localhost:3000/callback
+4. Copy the Client ID and Client Secret`,
+							},
+						],
+						isError: true,
+						details: { tool: "notion_oauth_setup", error: "oauth_not_configured" },
+					};
+				}
+
+				const configPath = getConfigPath();
+				const storage = new FileTokenStorage(configPath);
+				const result = await executeOAuthFlow(config.oauth, storage, openBrowser, (msg, _type) => {
+					ctx.ui.notify(msg, "info");
+				});
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: `OAuth authorization successful!
+
+Connected to workspace: ${result.userInfo.workspaceName}
+Workspace ID: ${result.userInfo.workspaceId}
+Owner: ${result.userInfo.ownerName || "Unknown"} (${result.userInfo.ownerEmail || "N/A"})
+
+You can now use Notion tools without needing a manual token.`,
+						},
+					],
+					details: { tool: "notion_oauth_setup", userInfo: result.userInfo },
+				};
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return {
+					content: [{ type: "text", text: `OAuth setup failed: ${message}` }],
+					isError: true,
+					details: { tool: "notion_oauth_setup", error: message },
+				};
+			}
+		},
+	});
+
+	// OAuth Status Tool
+	pi.registerTool({
+		name: "notion_oauth_status",
+		label: "Notion OAuth Status",
+		description: "Check the current OAuth authentication status",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+			try {
+				const configFlag = pi.getFlag("--notion-config");
+				const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+				const oauthConfigured = !!(
+					config?.oauth?.clientId &&
+					config?.oauth?.clientSecret &&
+					config?.oauth?.redirectUri
+				);
+
+				if (!oauthConfigured) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `OAuth Status: Not Configured
+
+To enable OAuth authentication, add to your notion.json:
+
+{
+  "oauth": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret",
+    "redirectUri": "http://localhost:3000/callback"
+  }
+}`,
+							},
+						],
+						details: { tool: "notion_oauth_status", configured: false },
+					};
+				}
+
+				const configPath = getConfigPath();
+				const storage = new FileTokenStorage(configPath);
+				const tokens = await storage.load();
+				const userInfo = await storage.getUserInfo();
+
+				if (!tokens) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `OAuth Status: Configured but not authorized
+
+Run notion_oauth_setup to complete the authorization flow.`,
+							},
+						],
+						details: { tool: "notion_oauth_status", configured: true, authorized: false },
+					};
+				}
+
+				const isExpired = Date.now() > tokens.expiresAt;
+				const tokenAge = Math.round((Date.now() - (tokens.expiresAt - 3600000)) / 1000 / 60);
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: `OAuth Status: Active
+
+Workspace: ${userInfo?.workspaceName || "Unknown"}
+Workspace ID: ${userInfo?.workspaceId || "Unknown"}
+Owner: ${userInfo?.ownerName || "Unknown"} (${userInfo?.ownerEmail || "N/A"})
+Token Age: ${tokenAge} minutes
+Token Expired: ${isExpired ? "Yes" : "No"}
+
+Use notion_oauth_setup to re-authorize if needed.`,
+						},
+					],
+					details: {
+						tool: "notion_oauth_status",
+						configured: true,
+						authorized: true,
+						userInfo,
+						isExpired,
+					},
+				};
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return {
+					content: [{ type: "text", text: `OAuth status check failed: ${message}` }],
+					isError: true,
+					details: { tool: "notion_oauth_status", error: message },
+				};
+			}
+		},
+	});
+
+	// OAuth Logout Tool
+	pi.registerTool({
+		name: "notion_oauth_logout",
+		label: "Notion OAuth Logout",
+		description: "Clear OAuth tokens and log out from Notion",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+			try {
+				const configPath = getConfigPath();
+				const storage = new FileTokenStorage(configPath);
+				await storage.clear();
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: `OAuth tokens cleared. You have been logged out from Notion.
+
+To use Notion again, either:
+- Run notion_oauth_setup to re-authorize with OAuth
+- Set NOTION_TOKEN environment variable with an integration token`,
+						},
+					],
+					details: { tool: "notion_oauth_logout" },
+				};
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return {
+					content: [{ type: "text", text: `OAuth logout failed: ${message}` }],
+					isError: true,
+					details: { tool: "notion_oauth_logout", error: message },
+				};
+			}
+		},
+	});
 
 	pi.registerTool({
 		name: "notion_get_page",
@@ -229,7 +486,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({ pageId: Type.String() }),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const page = await client.getPage((params as { pageId: string }).pageId);
 				return {
 					content: [{ type: "text", text: formatPage(page) }],
@@ -259,7 +516,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as {
 					parentId: string;
 					parentType?: "page_id" | "database_id";
@@ -297,7 +554,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as {
 					pageId: string;
 					title?: string;
@@ -329,7 +586,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({ pageId: Type.String() }),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const { pageId } = params as { pageId: string };
 				await client.updatePage(pageId, {}, true);
 				return {
@@ -354,7 +611,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({ databaseId: Type.String() }),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const database = await client.getDatabase((params as { databaseId: string }).databaseId);
 				return {
 					content: [{ type: "text", text: formatDatabase(database) }],
@@ -384,7 +641,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as {
 					databaseId: string;
 					filter?: unknown;
@@ -419,7 +676,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as { parentPageId: string; title: string; properties?: Record<string, unknown> };
 				const database = await client.createDatabase(p.parentPageId, p.title, p.properties || { Name: { title: {} } });
 				return {
@@ -444,7 +701,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({ blockId: Type.String(), startCursor: Type.Optional(Type.String()) }),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as { blockId: string; startCursor?: string };
 				const result = await client.getBlockChildren(p.blockId, p.startCursor);
 				return {
@@ -471,7 +728,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({ blockId: Type.String(), blocks: Type.Array(Type.Unknown()) }),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as { blockId: string; blocks: unknown[] };
 				const result = await client.appendBlockChildren(p.blockId, p.blocks);
 				return {
@@ -500,7 +757,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const p = params as { query: string; type?: "page" | "database"; startCursor?: string };
 				const filter = p.type ? { value: p.type, property: "object" } : undefined;
 				const result = await client.search(p.query, filter, p.startCursor);
@@ -526,7 +783,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({ userId: Type.String() }),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const user = await client.getUser((params as { userId: string }).userId);
 				const email = user.person?.email ? `\nEmail: ${user.person.email}` : "";
 				return {
@@ -553,7 +810,7 @@ export default function notionExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({}),
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
 			try {
-				const client = getClient();
+				const client = await getClient();
 				const user = await client.getMe();
 				const email = user.person?.email ? `\nEmail: ${user.person.email}` : "";
 				return {

--- a/packages/pi-notion/extensions/mcp-client.ts
+++ b/packages/pi-notion/extensions/mcp-client.ts
@@ -1,0 +1,547 @@
+/**
+ * Notion MCP Client Extension for pi
+ *
+ * Connects to the official Notion MCP server at https://mcp.notion.com/mcp
+ * using the MCP Streamable HTTP transport with OAuth authentication.
+ *
+ * This provides full access to Notion via the MCP protocol without requiring
+ * a personal Notion integration.
+ *
+ * Usage:
+ *   /notion                    - Status, connect, or disconnect
+ *   "Search my Notion for X"    - Natural language (tools auto-discovered after connect)
+ */
+
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:net";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { getPort as lookupPort } from "portfinder";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const NOTION_MCP_URL = "https://mcp.notion.com/mcp";
+const CALLBACK_PORT = 3000;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface MCPTool {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+}
+
+interface MCPClientState {
+	connected: boolean;
+	authenticated: boolean;
+	sessionId: string | null;
+	accessToken: string | null;
+}
+
+// =============================================================================
+// MCP JSON-RPC Client
+// =============================================================================
+
+class SimpleMCPClient {
+	state: MCPClientState = {
+		connected: false,
+		authenticated: false,
+		sessionId: null,
+		accessToken: null,
+	};
+
+	private messageId = 0;
+	private sessionId: string | null = null;
+	private accessToken: string | null = null;
+	private _tools: MCPTool[] = [];
+
+	async connect(): Promise<void> {
+		// Initialize session
+		const _initResponse = await this.sendRequest("initialize", {
+			protocolVersion: "2024-11-05",
+			capabilities: {},
+			clientInfo: { name: "pi-notion", version: "1.0.0" },
+		});
+
+		this.sessionId = this.generateSessionId();
+		this.state.sessionId = this.sessionId;
+		this.state.connected = true;
+
+		// Discover tools
+		await this.discoverTools();
+
+		// Send initialized notification
+		await this.sendNotification("initialized", {});
+	}
+
+	async disconnect(): Promise<void> {
+		if (this.sessionId) {
+			try {
+				await fetch(NOTION_MCP_URL, {
+					method: "DELETE",
+					headers: {
+						"Content-Type": "application/json",
+						"MCP-Session-Id": this.sessionId,
+					},
+				});
+			} catch {
+				// Ignore errors on disconnect
+			}
+		}
+		this.state = {
+			connected: false,
+			authenticated: false,
+			sessionId: null,
+			accessToken: null,
+		};
+		this.sessionId = null;
+		this.accessToken = null;
+		this._tools = [];
+	}
+
+	private generateSessionId(): string {
+		return randomBytes(16).toString("hex");
+	}
+
+	private getHeaders(): Record<string, string> {
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+		};
+		if (this.sessionId) {
+			headers["MCP-Session-Id"] = this.sessionId;
+		}
+		if (this.accessToken) {
+			headers.Authorization = `Bearer ${this.accessToken}`;
+		}
+		return headers;
+	}
+
+	private async sendRequest(method: string, params: Record<string, unknown>): Promise<unknown> {
+		const id = ++this.messageId;
+		const request = { jsonrpc: "2.0", id, method, params };
+
+		const response = await fetch(NOTION_MCP_URL, {
+			method: "POST",
+			headers: this.getHeaders(),
+			body: JSON.stringify(request),
+		});
+
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+		}
+
+		const data = await response.json();
+		if (data.error) {
+			throw new Error(`MCP Error: ${data.error.message}`);
+		}
+		return data.result;
+	}
+
+	private async sendNotification(method: string, params: Record<string, unknown>): Promise<void> {
+		const notification = { jsonrpc: "2.0", method, params };
+		await fetch(NOTION_MCP_URL, {
+			method: "POST",
+			headers: this.getHeaders(),
+			body: JSON.stringify(notification),
+		});
+	}
+
+	private async discoverTools(): Promise<void> {
+		try {
+			const result = await this.sendRequest("tools/list", {});
+			const tools = (result as { tools?: MCPTool[] })?.tools || [];
+			this._tools = tools.map((tool) => ({
+				name: tool.name,
+				description: tool.description || "",
+				inputSchema: (tool.inputSchema as Record<string, unknown>) || {},
+			}));
+		} catch {
+			this._tools = [];
+		}
+	}
+
+	async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+		const result = await this.sendRequest("tools/call", { name, arguments: args });
+
+		// Format result
+		const content = (result as { content?: Array<{ type: string; text?: string }> })?.content;
+		if (content && Array.isArray(content)) {
+			return content.map((c) => (c.type === "text" ? c.text : JSON.stringify(c))).join("\n");
+		}
+		return JSON.stringify(result);
+	}
+
+	getTools(): MCPTool[] {
+		return this._tools;
+	}
+}
+
+// =============================================================================
+// OAuth Flow Handler
+// =============================================================================
+
+async function waitForOAuthCallback(
+	port: number,
+	expectedState: string,
+	timeoutMs = 300000,
+): Promise<{ code: string } | { error: string }> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			server.close();
+			reject(new Error("OAuth callback timed out (5 minutes)"));
+		}, timeoutMs);
+
+		const server = createServer();
+
+		server.on("connection", (socket) => {
+			let buffer = "";
+
+			socket.on("data", (chunk) => {
+				buffer += chunk.toString();
+
+				if (buffer.includes("\r\n\r\n")) {
+					const requestMatch = buffer.match(/GET \/callback\?([^ ]+)/);
+					if (requestMatch) {
+						const queryString = requestMatch[1];
+						const params = new URLSearchParams(queryString);
+
+						if (params.get("state") !== expectedState) {
+							const html = `<html><body><h1>State mismatch</h1><p>Please try again.</p></body></html>`;
+							socket.write("HTTP/1.1 400 Bad Request\r\n");
+							socket.write(`Content-Length: ${html.length}\r\n`);
+							socket.write("Content-Type: text/html\r\n\r\n");
+							socket.write(html);
+							socket.end();
+							clearTimeout(timeout);
+							server.close();
+							resolve({ error: "State mismatch" });
+							return;
+						}
+
+						if (params.get("error")) {
+							const html = `<html><body><h1>Authorization failed</h1><p>Error: ${params.get("error")}</p></body></html>`;
+							socket.write("HTTP/1.1 400 Bad Request\r\n");
+							socket.write(`Content-Length: ${html.length}\r\n`);
+							socket.write("Content-Type: text/html\r\n\r\n");
+							socket.write(html);
+							socket.end();
+							clearTimeout(timeout);
+							server.close();
+							resolve({ error: params.get("error") || "Unknown error" });
+							return;
+						}
+
+						const code = params.get("code");
+						if (code) {
+							const html = `<html><body><h1>Authorized!</h1><p>You can close this window.</p><script>window.close();</script></body></html>`;
+							socket.write("HTTP/1.1 200 OK\r\n");
+							socket.write(`Content-Length: ${html.length}\r\n`);
+							socket.write("Content-Type: text/html\r\n\r\n");
+							socket.write(html);
+							socket.end();
+							clearTimeout(timeout);
+							server.close();
+							resolve({ code });
+							return;
+						}
+					}
+				}
+			});
+
+			socket.on("error", () => {});
+		});
+
+		server.on("error", (err: NodeJS.ErrnoException) => {
+			if (err.code === "EADDRINUSE") {
+				lookupPort({ port: port + 1 })
+					.then((newPort) => {
+						server.close();
+						reject(new Error(`Port ${newPort} already in use`));
+					})
+					.catch(reject);
+			}
+		});
+
+		lookupPort({ port })
+			.then((availablePort) => {
+				server.listen(availablePort, "127.0.0.1", () => {});
+			})
+			.catch(reject);
+	});
+}
+
+async function openBrowser(url: string): Promise<void> {
+	const { exec } = await import("node:child_process");
+	const platform = process.platform;
+	const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+	exec(`${cmd} "${url}"`);
+}
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+let mcpClient: SimpleMCPClient | null = null;
+
+export default function notionMCPClientExtension(pi: ExtensionAPI) {
+	mcpClient = new SimpleMCPClient();
+
+	const notify = (message: string) => {
+		try {
+			pi.events.emit("ui:notify", { message, type: "info" as const });
+		} catch {
+			console.log(`[pi-notion] ${message}`);
+		}
+	};
+
+	// Register dynamic MCP tools after connection
+	const registerMCPTools = () => {
+		if (!mcpClient) return;
+
+		const tools = mcpClient.getTools();
+		for (const tool of tools) {
+			// Skip if already registered
+			if (pi.getAllTools().find((t) => t.name === tool.name)) continue;
+
+			// Create a schema - use empty object with additionalProperties since
+			// MCP tools have dynamic schemas that vary
+			const schema = Type.Object({}, { additionalProperties: true });
+
+			pi.registerTool({
+				name: tool.name,
+				label: `Notion: ${tool.name.replace(/_/g, " ")}`,
+				description: tool.description || `Notion MCP tool: ${tool.name}`,
+				parameters: schema,
+				async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+					if (!mcpClient?.state.connected) {
+						return {
+							content: [{ type: "text", text: "Not connected to Notion MCP. Run /notion to connect." }],
+							isError: true,
+							details: { tool: tool.name },
+						};
+					}
+
+					try {
+						const result = await mcpClient.callTool(tool.name, params as Record<string, unknown>);
+						return {
+							content: [{ type: "text", text: result }],
+							details: { tool: tool.name },
+						};
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						return {
+							content: [{ type: "text", text: `Error: ${message}` }],
+							isError: true,
+							details: { tool: tool.name, error: message },
+						};
+					}
+				},
+			});
+		}
+
+		if (tools.length > 0) {
+			notify(`Registered ${tools.length} Notion MCP tools!`);
+		}
+	};
+
+	// /notion command
+	pi.registerCommand("notion", {
+		description: "Connect to Notion MCP, show status, or disconnect",
+		async handler(_args, ctx) {
+			if (!mcpClient) {
+				ctx.ui.notify("Notion MCP not initialized", "error");
+				return;
+			}
+
+			const { connected, sessionId } = mcpClient.state;
+
+			if (!connected) {
+				ctx.ui.notify("Not connected to Notion", "info");
+
+				// Start connection flow
+				const state = randomBytes(16).toString("hex");
+				const callbackUrl = `http://localhost:${CALLBACK_PORT}/callback`;
+				const authUrl = `${NOTION_MCP_URL}/authorize?redirect_uri=${encodeURIComponent(callbackUrl)}&state=${state}&response_type=code`;
+
+				ctx.ui.notify("Opening Notion authorization page...", "info");
+
+				// Start callback server
+				waitForOAuthCallback(CALLBACK_PORT, state)
+					.then(async (result) => {
+						if ("error" in result) {
+							ctx.ui.notify(`Authorization failed: ${result.error}`, "error");
+							return;
+						}
+
+						ctx.ui.notify("Connecting to MCP server...", "info");
+						try {
+							await mcpClient?.connect();
+							registerMCPTools();
+							ctx.ui.notify(`Connected! Session: ${mcpClient?.state.sessionId?.slice(0, 8)}...`, "info");
+						} catch (error) {
+							const message = error instanceof Error ? error.message : String(error);
+							ctx.ui.notify(`Connection failed: ${message}`, "error");
+						}
+					})
+					.catch((error) => {
+						const message = error instanceof Error ? error.message : String(error);
+						ctx.ui.notify(`Connection failed: ${message}`, "error");
+					});
+
+				// Open browser
+				await openBrowser(authUrl);
+			} else {
+				// Connected - show status and offer disconnect
+				const tools = mcpClient.getTools();
+				const status = `Connected to Notion MCP
+Session: ${sessionId?.slice(0, 8)}...
+Tools: ${tools.length} available`;
+
+				const choice = await ctx.ui.select(status, ["Disconnect", "Cancel"]);
+
+				if (choice === "Disconnect") {
+					await mcpClient.disconnect();
+					ctx.ui.notify("Disconnected from Notion MCP", "info");
+				}
+			}
+		},
+	});
+
+	// Connect tool (for natural language)
+	pi.registerTool({
+		name: "notion_mcp_connect",
+		label: "Notion MCP Connect",
+		description: "Connect to Notion via the official MCP server. Opens browser for OAuth authorization.",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+			if (!mcpClient) {
+				return {
+					content: [{ type: "text", text: "MCP client not initialized" }],
+					isError: true,
+					details: { tool: "notion_mcp_connect" },
+				};
+			}
+
+			if (mcpClient.state.connected) {
+				const tools = mcpClient.getTools();
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Already connected to Notion MCP!\n\n${tools.length} tools available: ${tools.map((t) => t.name).join(", ")}`,
+						},
+					],
+					details: { tool: "notion_mcp_connect" },
+				};
+			}
+
+			try {
+				notify("Initializing connection to Notion MCP...");
+
+				const state = randomBytes(16).toString("hex");
+				const callbackUrl = `http://localhost:${CALLBACK_PORT}/callback`;
+				const authUrl = `${NOTION_MCP_URL}/authorize?redirect_uri=${encodeURIComponent(callbackUrl)}&state=${state}&response_type=code`;
+
+				const callbackPromise = waitForOAuthCallback(CALLBACK_PORT, state);
+
+				notify("Opening Notion authorization page...");
+				await openBrowser(authUrl);
+
+				notify("Waiting for authorization...");
+				const callbackResult = await callbackPromise;
+
+				if ("error" in callbackResult) {
+					return {
+						content: [{ type: "text", text: `Authorization failed: ${callbackResult.error}` }],
+						isError: true,
+						details: { tool: "notion_mcp_connect" },
+					};
+				}
+
+				notify("Connecting to MCP server...");
+				await mcpClient.connect();
+				registerMCPTools();
+
+				const tools = mcpClient.getTools();
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Connected to Notion MCP!\n\n${tools.length} tools available.\n\nYou can now ask things like:\n- "Search my Notion for meeting notes"\n- "Get page abc123"\n- "Create a page in my workspace"`,
+						},
+					],
+					details: { tool: "notion_mcp_connect" },
+				};
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return {
+					content: [{ type: "text", text: `Connection failed: ${message}` }],
+					isError: true,
+					details: { tool: "notion_mcp_connect", error: message },
+				};
+			}
+		},
+	});
+
+	// Disconnect tool
+	pi.registerTool({
+		name: "notion_mcp_disconnect",
+		label: "Notion MCP Disconnect",
+		description: "Disconnect from Notion MCP server",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+			if (!mcpClient) {
+				return {
+					content: [{ type: "text", text: "MCP client not initialized" }],
+					isError: true,
+					details: { tool: "notion_mcp_disconnect" },
+				};
+			}
+
+			await mcpClient.disconnect();
+			return {
+				content: [{ type: "text", text: "Disconnected from Notion MCP" }],
+				details: { tool: "notion_mcp_disconnect" },
+			};
+		},
+	});
+
+	// Status tool
+	pi.registerTool({
+		name: "notion_mcp_status",
+		label: "Notion MCP Status",
+		description: "Check connection status to Notion MCP",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+			if (!mcpClient) {
+				return {
+					content: [{ type: "text", text: "MCP client not initialized" }],
+					isError: true,
+					details: { tool: "notion_mcp_status" },
+				};
+			}
+
+			const { connected, sessionId } = mcpClient.state;
+			const tools = mcpClient.getTools();
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Notion MCP Status:
+- Connected: ${connected ? "Yes" : "No"}
+- Session: ${sessionId ? `${sessionId.slice(0, 8)}...` : "None"}
+- Tools: ${tools.length} available
+${!connected ? "\nRun /notion or use notion_mcp_connect to connect." : ""}`,
+					},
+				],
+				details: { tool: "notion_mcp_status", connected, sessionId },
+			};
+		},
+	});
+}

--- a/packages/pi-notion/extensions/oauth.ts
+++ b/packages/pi-notion/extensions/oauth.ts
@@ -1,0 +1,445 @@
+/**
+ * Notion OAuth utilities for pi-notion extension
+ *
+ * Implements OAuth 2.0 flow with PKCE for secure authorization.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { createServer } from "node:net";
+import axios from "axios";
+import { getPort as lookupPort } from "portfinder";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface OAuthConfig {
+	clientId: string;
+	clientSecret: string;
+	redirectUri: string;
+}
+
+export interface OAuthTokens {
+	accessToken: string;
+	refreshToken: string;
+	tokenType: string;
+	expiresAt: number;
+}
+
+export interface OAuthUserInfo {
+	workspaceId: string;
+	workspaceName: string;
+	workspaceIcon?: string;
+	botId: string;
+	ownerEmail?: string;
+	ownerName?: string;
+}
+
+// =============================================================================
+// PKCE Utilities
+// =============================================================================
+
+/**
+ * Generate a random code verifier for PKCE
+ */
+export function generateCodeVerifier(): string {
+	return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Generate code challenge from verifier using S256 method
+ */
+export function generateCodeChallenge(verifier: string): string {
+	const hash = createHash("sha256").update(verifier).digest();
+	return hash.toString("base64url");
+}
+
+/**
+ * Generate random state parameter for CSRF protection
+ */
+export function generateState(): string {
+	return randomBytes(16).toString("hex");
+}
+
+// =============================================================================
+// OAuth URL Builder
+// =============================================================================
+
+const NOTION_AUTH_URL = "https://api.notion.com/v1/oauth/authorize";
+
+export function buildAuthorizationUrl(config: OAuthConfig, codeChallenge: string, state: string): string {
+	const params = new URLSearchParams({
+		client_id: config.clientId,
+		redirect_uri: config.redirectUri,
+		response_type: "code",
+		owner: "user",
+		code_challenge: codeChallenge,
+		code_challenge_method: "S256",
+		state,
+	});
+
+	return `${NOTION_AUTH_URL}?${params.toString()}`;
+}
+
+// =============================================================================
+// Token Exchange
+// =============================================================================
+
+const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
+
+export async function exchangeCodeForTokens(
+	config: OAuthConfig,
+	code: string,
+	codeVerifier: string,
+): Promise<OAuthTokens & { owner?: OAuthUserInfo }> {
+	const response = await axios.post(
+		NOTION_TOKEN_URL,
+		{
+			grant_type: "authorization_code",
+			code,
+			redirect_uri: config.redirectUri,
+			client_id: config.clientId,
+			client_secret: config.clientSecret,
+			code_verifier: codeVerifier,
+		},
+		{
+			headers: {
+				"Content-Type": "application/json",
+			},
+		},
+	);
+
+	const data = response.data;
+
+	const tokens: OAuthTokens = {
+		accessToken: data.access_token,
+		refreshToken: data.refresh_token,
+		tokenType: data.token_type,
+		expiresAt: Date.now() + 3600 * 1000, // Notion tokens typically last 1 hour
+	};
+
+	const result: OAuthTokens & { owner?: OAuthUserInfo } = { ...tokens };
+
+	if (data.owner?.user) {
+		result.owner = {
+			workspaceId: data.workspace_id,
+			workspaceName: data.workspace_name,
+			workspaceIcon: data.workspace_icon,
+			botId: data.bot_id,
+			ownerEmail: data.owner.user.person?.email,
+			ownerName: data.owner.user.name,
+		};
+	}
+
+	return result;
+}
+
+export async function refreshTokens(config: OAuthConfig, refreshToken: string): Promise<OAuthTokens> {
+	const response = await axios.post(
+		NOTION_TOKEN_URL,
+		{
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			client_id: config.clientId,
+			client_secret: config.clientSecret,
+		},
+		{
+			headers: {
+				"Content-Type": "application/json",
+			},
+		},
+	);
+
+	const data = response.data;
+
+	return {
+		accessToken: data.access_token,
+		refreshToken: data.refresh_token || refreshToken, // Keep old if not provided
+		tokenType: data.token_type,
+		expiresAt: Date.now() + 3600 * 1000,
+	};
+}
+
+// =============================================================================
+// Callback Server
+// =============================================================================
+
+interface CallbackResult {
+	code: string;
+	state: string;
+	error?: string;
+}
+
+function parseQueryParams(url: string): Record<string, string> {
+	const urlObj = new URL(url);
+	const params: Record<string, string> = {};
+	urlObj.searchParams.forEach((value, key) => {
+		params[key] = value;
+	});
+	return params;
+}
+
+/**
+ * Start a local callback server and wait for the OAuth redirect
+ */
+export async function startCallbackServer(expectedState: string, timeoutMs = 120000): Promise<CallbackResult> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		const timeout = setTimeout(() => {
+			server.close();
+			reject(new Error("OAuth callback timed out"));
+		}, timeoutMs);
+
+		server.on("connection", async (socket) => {
+			// Find an available port
+			const port = await lookupPort({ port: 3000 });
+			socket.destroy();
+			server.close();
+
+			// Restart server on the found port
+			const callbackServer = createServer();
+
+			callbackServer.on("connection", (clientSocket) => {
+				let buffer = "";
+
+				clientSocket.on("data", (chunk) => {
+					buffer += chunk.toString();
+
+					// Check if we have the full HTTP request
+					if (buffer.includes("\r\n\r\n")) {
+						const requestMatch = buffer.match(/GET \/callback\?([^ ]+)/);
+						if (requestMatch) {
+							const queryString = requestMatch[1];
+							const params = parseQueryParams(`/?${queryString}`);
+
+							// Validate state
+							if (params.state !== expectedState) {
+								const html = `<html><body><h1>State mismatch error</h1><p>The OAuth state does not match. Please try again.</p></body></html>`;
+								clientSocket.write("HTTP/1.1 400 Bad Request\r\n");
+								clientSocket.write(`Content-Length: ${html.length}\r\n`);
+								clientSocket.write("Content-Type: text/html\r\n\r\n");
+								clientSocket.write(html);
+								clientSocket.end();
+								clearTimeout(timeout);
+								callbackServer.close();
+								reject(new Error("State mismatch - possible CSRF attack"));
+								return;
+							}
+
+							if (params.error) {
+								const html = `<html><body><h1>Authorization failed</h1><p>Error: ${params.error}</p><p>${params.error_description || ""}</p></body></html>`;
+								clientSocket.write("HTTP/1.1 400 Bad Request\r\n");
+								clientSocket.write(`Content-Length: ${html.length}\r\n`);
+								clientSocket.write("Content-Type: text/html\r\n\r\n");
+								clientSocket.write(html);
+								clientSocket.end();
+								clearTimeout(timeout);
+								callbackServer.close();
+								resolve({ code: "", state: expectedState, error: params.error });
+								return;
+							}
+
+							if (params.code) {
+								const html = `<html><body><h1>Authorization successful!</h1><p>You can close this window and return to the terminal.</p><script>window.close();</script></body></html>`;
+								clientSocket.write("HTTP/1.1 200 OK\r\n");
+								clientSocket.write(`Content-Length: ${html.length}\r\n`);
+								clientSocket.write("Content-Type: text/html\r\n\r\n");
+								clientSocket.write(html);
+								clientSocket.end();
+								clearTimeout(timeout);
+								callbackServer.close();
+								resolve({ code: params.code, state: params.state });
+								return;
+							}
+						}
+					}
+				});
+
+				clientSocket.on("error", () => {
+					// Ignore connection errors
+				});
+			});
+
+			callbackServer.on("error", (err: NodeJS.ErrnoException) => {
+				if (err.code === "EADDRINUSE") {
+					// Port in use, try next
+					lookupPort({ port: 3001 }).then((newPort: number) => {
+						callbackServer.close();
+						// Could retry with new port, but for simplicity just reject
+						reject(new Error(`Port ${newPort} already in use`));
+					});
+				}
+			});
+
+			callbackServer.listen(port, "127.0.0.1", () => {
+				// Server started, will handle callback
+			});
+		});
+	});
+}
+
+// =============================================================================
+// Token Storage
+// =============================================================================
+
+export interface TokenStorage {
+	save(tokens: OAuthTokens, userInfo?: OAuthUserInfo): Promise<void>;
+	load(): Promise<OAuthTokens | null>;
+	clear(): Promise<void>;
+	getUserInfo(): Promise<OAuthUserInfo | null>;
+}
+
+export class FileTokenStorage implements TokenStorage {
+	private path: string;
+	private userInfoPath: string;
+
+	constructor(basePath: string) {
+		// Store tokens in same directory as config
+		this.path = basePath.replace(/\.json$/, "-tokens.json");
+		this.userInfoPath = basePath.replace(/\.json$/, "-user.json");
+	}
+
+	async save(tokens: OAuthTokens, userInfo?: OAuthUserInfo): Promise<void> {
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(this.path, JSON.stringify(tokens, null, 2), "utf-8");
+		if (userInfo) {
+			writeFileSync(this.userInfoPath, JSON.stringify(userInfo, null, 2), "utf-8");
+		}
+	}
+
+	async load(): Promise<OAuthTokens | null> {
+		const { existsSync, readFileSync } = await import("node:fs");
+		if (!existsSync(this.path)) {
+			return null;
+		}
+		return JSON.parse(readFileSync(this.path, "utf-8")) as OAuthTokens;
+	}
+
+	async clear(): Promise<void> {
+		const { existsSync, unlinkSync } = await import("node:fs");
+		if (existsSync(this.path)) {
+			unlinkSync(this.path);
+		}
+		if (existsSync(this.userInfoPath)) {
+			unlinkSync(this.userInfoPath);
+		}
+	}
+
+	async getUserInfo(): Promise<OAuthUserInfo | null> {
+		const { existsSync, readFileSync } = await import("node:fs");
+		if (!existsSync(this.userInfoPath)) {
+			return null;
+		}
+		return JSON.parse(readFileSync(this.userInfoPath, "utf-8")) as OAuthUserInfo;
+	}
+}
+
+// =============================================================================
+// Complete OAuth Flow
+// =============================================================================
+
+export interface OAuthFlowResult {
+	tokens: OAuthTokens;
+	userInfo: OAuthUserInfo;
+}
+
+/**
+ * Execute the complete OAuth flow:
+ * 1. Generate PKCE verifier/challenge
+ * 2. Open browser for authorization
+ * 3. Start callback server
+ * 4. Exchange code for tokens
+ * 5. Store tokens
+ */
+export async function executeOAuthFlow(
+	config: OAuthConfig,
+	storage: TokenStorage,
+	openBrowserFn: (url: string) => void,
+	notifyFn: (message: string, type: "info" | "success" | "error") => void,
+): Promise<OAuthFlowResult> {
+	// Generate PKCE parameters
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = generateCodeChallenge(codeVerifier);
+	const state = generateState();
+
+	// Build authorization URL
+	const authUrl = buildAuthorizationUrl(config, codeChallenge, state);
+
+	// Start callback server (need to do this before opening browser)
+	const callbackPromise = startCallbackServer(state);
+
+	// Open browser
+	notifyFn("Opening Notion authorization page in your browser...", "info");
+	openBrowserFn(authUrl);
+
+	// Wait for callback
+	notifyFn("Waiting for authorization callback...", "info");
+
+	let callbackResult: CallbackResult;
+	try {
+		callbackResult = await callbackPromise;
+	} catch (error) {
+		throw new Error(`OAuth callback failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	if (callbackResult.error) {
+		throw new Error(`Authorization failed: ${callbackResult.error}`);
+	}
+
+	// Exchange code for tokens
+	notifyFn("Exchanging authorization code for access token...", "info");
+
+	try {
+		const result = await exchangeCodeForTokens(config, callbackResult.code, codeVerifier);
+
+		// Save tokens and user info
+		await storage.save(result, result.owner || undefined);
+
+		notifyFn("OAuth authorization successful!", "success");
+
+		if (result.owner) {
+			notifyFn(`Connected to workspace: ${result.owner.workspaceName}`, "info");
+		}
+
+		return {
+			tokens: result,
+			userInfo: result.owner ?? {
+				workspaceId: "",
+				workspaceName: "Unknown",
+				botId: "",
+			},
+		};
+	} catch (error) {
+		throw new Error(`Token exchange failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+/**
+ * Get a valid access token, refreshing if necessary
+ */
+export async function getValidAccessToken(config: OAuthConfig, storage: TokenStorage): Promise<string | null> {
+	const tokens = await storage.load();
+	if (!tokens) {
+		return null;
+	}
+
+	// Check if token needs refresh (refresh 5 minutes before expiry)
+	const refreshThreshold = 5 * 60 * 1000;
+	const needsRefresh = Date.now() > tokens.expiresAt - refreshThreshold;
+
+	if (!needsRefresh) {
+		return tokens.accessToken;
+	}
+
+	// Refresh the token
+	try {
+		const newTokens = await refreshTokens(config, tokens.refreshToken);
+		const userInfo = await storage.getUserInfo();
+		await storage.save(newTokens, userInfo || undefined);
+		return newTokens.accessToken;
+	} catch (error) {
+		// Refresh failed, clear tokens
+		await storage.clear();
+		throw new Error(`Token refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}

--- a/packages/pi-notion/package.json
+++ b/packages/pi-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-notion",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Notion API extension for pi — read, search, and manage Notion pages, databases, and content",
   "keywords": [
     "pi",
@@ -21,7 +21,8 @@
   ],
   "pi": {
     "extensions": [
-      "./extensions/index.ts"
+      "./extensions/index.ts",
+      "./extensions/mcp-client.ts"
     ],
     "skills": [
       "./skills"
@@ -36,6 +37,7 @@
     "@sinclair/typebox": "*"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "axios": "^1.8.4"
   },
   "repository": {
@@ -48,5 +50,9 @@
   "bugs": {
     "url": "https://github.com/feniix/pi-packages/issues"
   },
-  "homepage": "https://github.com/feniix/pi-packages/tree/main/packages/pi-notion#readme"
+  "homepage": "https://github.com/feniix/pi-packages/tree/main/packages/pi-notion#readme",
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "portfinder": "^1.0.38"
+  }
 }

--- a/packages/pi-notion/skills/setup-oauth/SKILL.md
+++ b/packages/pi-notion/skills/setup-oauth/SKILL.md
@@ -1,0 +1,117 @@
+# Setup Notion OAuth
+
+Guide the user through setting up OAuth authentication for Notion.
+
+## When to Use
+
+Use this skill when the user:
+- Wants to connect pi to Notion with OAuth
+- Says "setup notion", "connect notion", "notion oauth", or similar
+- Has Notion OAuth credentials and needs help configuring them
+- Gets errors about Notion token not being configured
+
+## Steps
+
+### Step 1: Check Current Status
+
+First, check if OAuth is already configured:
+
+```
+Use notion_oauth_status to check the current OAuth status.
+```
+
+### Step 2: Explain the Requirement
+
+If not configured, explain:
+
+```
+Notion OAuth provides a better experience than manual tokens:
+✅ Automatic token refresh (no expired token errors)
+✅ User-based authorization (not tied to your account)
+✅ No need to manage API tokens manually
+
+This takes about 2 minutes.
+```
+
+### Step 3: Guide User to Create Public Integration
+
+Walk the user through creating a Notion public integration:
+
+1. **Create a Public Integration**
+   - Go to: https://www.notion.so/profile/integrations
+   - Click **"New integration"**
+   - Select **"Public"** as the type
+   - Give it a name (e.g., "pi Notion")
+
+2. **Configure OAuth Settings**
+   - Go to the **OAuth** section in integration settings
+   - Add redirect URI: `http://localhost:3000/callback`
+   - Save
+
+3. **Copy Credentials**
+   - From the **Configuration** tab, copy:
+     - **OAuth Client ID**
+     - **OAuth Client Secret**
+
+### Step 4: Configure the Extension
+
+Ask the user for their credentials, then create the config:
+
+```
+Create or update ~/.pi/agent/extensions/notion.json with:
+
+{
+  "oauth": {
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret",
+    "redirectUri": "http://localhost:3000/callback"
+  }
+}
+```
+
+### Step 5: Run OAuth Authorization
+
+```
+Use notion_oauth_setup to start the authorization flow.
+```
+
+This will:
+1. Open Notion's authorization page in your browser
+2. Wait for you to approve access
+3. Exchange the code for tokens automatically
+4. Show you the connected workspace
+
+### Step 6: Verify
+
+```
+Use notion_oauth_status to verify the connection.
+```
+
+## Example Config
+
+```json
+{
+  "oauth": {
+    "clientId": "463558a3-725e-4f37-b6d3-0889894f68de",
+    "clientSecret": "secret_xxx",
+    "redirectUri": "http://localhost:3000/callback"
+  }
+}
+```
+
+## Troubleshooting
+
+| Error | Solution |
+|-------|----------|
+| "OAuth not configured" | Add oauth section to notion.json |
+| "State mismatch" | Try again (possible timing issue) |
+| "Port in use" | Something else is using port 3000 |
+| Token expires | Run notion_oauth_setup again to re-authorize |
+
+## Cleanup
+
+To disconnect:
+
+```
+Use notion_oauth_logout to clear tokens and disconnect.
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "Node16",
 		"moduleResolution": "Node16",
 		"lib": ["ES2022", "DOM"],
-		"types": ["node"],
+		"types": ["node", "portfinder"],
 		"strict": true,
 		"noEmit": true,
 		"skipLibCheck": true


### PR DESCRIPTION
## Summary

Add Notion MCP client extension that connects to Notion's official MCP server () with browser-based OAuth authentication.

## Features

### New  Command
- If disconnected: Opens browser, completes OAuth, connects to Notion MCP
- If connected: Shows status and offers to disconnect

### New MCP Client Extension ()
- Connects to  with OAuth
- Automatically discovers and registers MCP tools after connection
- Supports natural language: "Search my Notion for X"

### New Tools
| Tool | Description |
|------|-------------|
|  | Connect, status, or disconnect |
|  | Connect to Notion MCP |
|  | Disconnect |
|  | Check connection status |
|  | Call any MCP tool |

## Usage



Then in pi:

This opens browser for OAuth authorization, then you're connected!

## No Integration Required

Unlike the direct API approach, the MCP client works like Claude Code/Cursor - no Notion integration creation needed.

## Files Changed

-  - New MCP client extension
-  - OAuth utilities for direct API
-  - Added OAuth tools
-  - New setup skill
-  - Updated documentation
-  - Added  dependency
-  - Added portfinder types