### PR TITLE
feat: add pi-statusline extension with two-line terminal footer

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,11 @@
 		"lineWidth": 120
 	},
 	"files": {
-		"includes": ["packages/*/extensions/**/*.ts", "packages/*/__tests__/**/*.ts", "vitest.config.ts"]
+		"includes": [
+			"packages/*/extensions/**/*.ts",
+			"packages/*/__tests__/**/*.ts",
+			"packages/*/src/**/*.ts",
+			"vitest.config.ts"
+		]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,6 +1065,10 @@
       "resolved": "packages/pi-specdocs",
       "link": true
     },
+    "node_modules/@feniix/pi-statusline": {
+      "resolved": "packages/pi-statusline",
+      "link": true
+    },
     "node_modules/@google/genai": {
       "version": "1.48.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.48.0.tgz",
@@ -2943,9 +2947,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4215,9 +4219,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5306,9 +5310,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6509,6 +6513,408 @@
       "peerDependencies": {
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*"
+      }
+    },
+    "packages/pi-statusline": {
+      "name": "@feniix/pi-statusline",
+      "version": "0.1.0",
+      "dependencies": {
+        "chalk": "^5.5.1"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.9.2",
+        "vitest": "^4.1.4"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": "*"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "packages/pi-statusline/node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pi-statusline/node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pi-statusline/node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pi-statusline/node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pi-statusline/node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pi-statusline/node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pi-statusline/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/pi-statusline/node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "packages/pi-statusline/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     }
   }

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -1,0 +1,71 @@
+# pi-statusline
+
+A pi extension that renders a two-line status line with model info, thinking effort, context %, git branch/worktree, dirty changes, token consumption, and skill info.
+
+## Output Format
+
+```
+Model: Opus 4.6 (1M context) | Thinking: medium | Ctx: 11.0% | ⎇ main | dirty: +0 | Tokens: ↑10.5k/↓3.2k
+evie-platform | cwd: ~/src/spantree/evie-platform | 𖠰 main | Skill: none
+```
+
+## Features
+
+- **Model**: Display name from Claude settings (`Opus 4.6 (1M context)`)
+- **Thinking Effort**: Current thinking effort level from transcript metadata (`low`, `medium`, `high`, `max`)
+- **Context %**: Context window usage percentage from Claude settings
+- **Git Branch**: Current branch name with `⎇` prefix
+- **Dirty Changes**: Count of uncommitted files with `+N` format
+- **Token Consumption**: Input/output token counts with `↑` / `↓` arrows
+- **Project Name**: Git repo root directory name
+- **CWD**: Current working directory with `~` abbreviation for home
+- **Worktree**: Git worktree name with `𖠰` prefix
+- **Skill**: Last skill invoked (from transcript parsing)
+
+## Installation
+
+Copy the extension file to your pi extensions directory:
+
+```bash
+# Create extensions directory if it doesn't exist
+mkdir -p ~/.pi/agent/extensions
+
+# Symlink or copy the extension
+ln -s /path/to/pi-statusline/extensions/index.ts ~/.pi/agent/extensions/pi-statusline.ts
+```
+
+Or add it to your project's `.pi/extensions/` directory.
+
+## Configuration
+
+v1 has no configuration — the widget layout is hardcoded. The extension reads:
+
+- Claude settings from `~/.claude/settings.json` or `$CLAUDE_CONFIG_DIR`
+- Transcript files from standard Claude locations
+- Git state from the current working directory
+
+## Development
+
+```bash
+cd packages/pi-statusline
+npm install
+npm run check   # lint + typecheck
+npm run test    # run tests
+```
+
+## Architecture
+
+```
+src/
+├── index.ts          # Main orchestrator, widget formatters, render functions
+├── types.ts          # Shared TypeScript interfaces
+├── format.ts         # ANSI colors, token formatting helpers
+└── data/
+    ├── git.ts        # Git branch, worktree, dirty count
+    ├── session.ts    # CWD, repo root, transcript path discovery
+    ├── settings.ts   # Claude settings.json reader
+    └── transcript.ts # JSONL parser for tokens, thinking effort, skills
+
+extensions/
+└── index.ts          # pi extension entry — registers session_start hook
+```

--- a/packages/pi-statusline/__tests__/data/git.test.ts
+++ b/packages/pi-statusline/__tests__/data/git.test.ts
@@ -1,0 +1,74 @@
+import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { clearGitCache, getGitData } from "../../src/data/git.js";
+
+describe("git data", () => {
+	let repoDir: string;
+
+	beforeEach(() => {
+		clearGitCache();
+		repoDir = join(tmpdir(), `pi-statusline-test-${randomUUID()}`);
+		mkdirSync(repoDir, { recursive: true });
+
+		// Initialize a git repo
+		execSync("git init", { cwd: repoDir });
+		execSync("git config user.email test@test.com", { cwd: repoDir });
+		execSync("git config user.name Test", { cwd: repoDir });
+
+		// Create initial commit (git branch requires at least one commit)
+		writeFileSync(join(repoDir, "README.md"), "# test\n");
+		execSync("git add .", { cwd: repoDir });
+		execSync("git commit -m initial", { cwd: repoDir });
+	});
+
+	afterEach(() => {
+		clearGitCache();
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	it("returns the current branch", async () => {
+		const data = await getGitData(repoDir);
+		expect(data.branch).toBe("main");
+	});
+
+	it("returns 'main' as worktree for main repo", async () => {
+		const data = await getGitData(repoDir);
+		expect(data.worktree).toBe("main");
+	});
+
+	it("returns 0 dirty files for clean repo", async () => {
+		const data = await getGitData(repoDir);
+		expect(data.dirty).toBe(0);
+	});
+
+	it("increments dirty count when files are modified", async () => {
+		writeFileSync(join(repoDir, "test.txt"), "hello");
+		const data = await getGitData(repoDir);
+		expect(data.dirty).toBe(1);
+	});
+
+	it("increments dirty count when files are added", async () => {
+		writeFileSync(join(repoDir, "new.txt"), "content");
+		execSync("git add new.txt", { cwd: repoDir });
+		const data = await getGitData(repoDir);
+		expect(data.dirty).toBe(1);
+	});
+
+	it("returns null branch in non-git directory", async () => {
+		const nonGitDir = join(tmpdir(), `non-git-${randomUUID()}`);
+		mkdirSync(nonGitDir, { recursive: true });
+		try {
+			const data = await getGitData(nonGitDir);
+			expect(data.branch).toBeNull();
+			expect(data.worktree).toBeNull();
+			expect(data.dirty).toBe(0);
+		} finally {
+			rmSync(nonGitDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/pi-statusline/__tests__/data/session.test.ts
+++ b/packages/pi-statusline/__tests__/data/session.test.ts
@@ -1,0 +1,78 @@
+import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { findTranscriptPath, getRepoName, getRepoRoot } from "../../src/data/session.js";
+
+describe("session data", () => {
+	let repoDir: string;
+
+	beforeEach(() => {
+		repoDir = join(tmpdir(), `pi-statusline-session-${randomUUID()}`);
+		mkdirSync(repoDir, { recursive: true });
+		execSync("git init", { cwd: repoDir });
+		execSync("git config user.email test@test.com", { cwd: repoDir });
+		execSync("git config user.name Test", { cwd: repoDir });
+		writeFileSync(join(repoDir, "README.md"), "# test\n");
+		execSync("git add .", { cwd: repoDir });
+		execSync("git commit -m initial", { cwd: repoDir });
+	});
+
+	afterEach(() => {
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	describe("getRepoRoot", () => {
+		it("returns the repo root for a git directory", () => {
+			const root = getRepoRoot(repoDir);
+			expect(root).not.toBeNull();
+			const repoName = repoDir.split("/").pop();
+			expect(root?.endsWith(repoName ?? "")).toBe(true);
+		});
+
+		it("returns null for non-git directory", () => {
+			const nonGitDir = join(tmpdir(), `non-git-${randomUUID()}`);
+			mkdirSync(nonGitDir, { recursive: true });
+			try {
+				const root = getRepoRoot(nonGitDir);
+				expect(root).toBeNull();
+			} finally {
+				rmSync(nonGitDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe("getRepoName", () => {
+		it("returns the last path segment", () => {
+			const name = getRepoName(repoDir);
+			expect(name).toBe(repoDir.split("/").pop());
+		});
+
+		it("returns null for null input", () => {
+			expect(getRepoName(null)).toBeNull();
+		});
+	});
+
+	describe("findTranscriptPath", () => {
+		it("returns null when no transcript exists", () => {
+			const path = findTranscriptPath(repoDir, repoDir);
+			expect(path).toBeNull();
+		});
+
+		it("finds transcript in .claude/project/transcripts", () => {
+			const transcriptDir = join(repoDir, ".claude", "project", "transcripts");
+			mkdirSync(transcriptDir, { recursive: true });
+			writeFileSync(join(transcriptDir, "conversation.jsonl"), '{"type":"user"}\n');
+			const path = findTranscriptPath(repoDir, repoDir);
+			expect(path).toContain("conversation.jsonl");
+		});
+
+		it("returns null when repoRoot is null", () => {
+			const path = findTranscriptPath(null, repoDir);
+			expect(path).toBeNull();
+		});
+	});
+});

--- a/packages/pi-statusline/__tests__/data/transcript.test.ts
+++ b/packages/pi-statusline/__tests__/data/transcript.test.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseTranscript } from "../../src/data/transcript.js";
+
+describe("transcript parsing", () => {
+	let tmpPath: string;
+
+	beforeEach(() => {
+		tmpPath = join(tmpdir(), `transcript-${randomUUID()}.jsonl`);
+	});
+
+	afterEach(() => {
+		rmSync(tmpPath, { force: true });
+	});
+
+	it("parses Claude Code format (input_tokens/output_tokens)", async () => {
+		const content = [
+			JSON.stringify({
+				type: "user",
+				message: { role: "user", usage: { input_tokens: 1000, output_tokens: 0 } },
+			}),
+			JSON.stringify({
+				type: "assistant",
+				message: { role: "assistant", usage: { input_tokens: 1000, output_tokens: 500 } },
+			}),
+		].join("\n");
+		writeFileSync(tmpPath, content);
+
+		const metrics = await parseTranscript(tmpPath);
+		expect(metrics.tokens.inputTokens).toBe(2000);
+		expect(metrics.tokens.outputTokens).toBe(500);
+	});
+
+	it("parses pi session format (input/output)", async () => {
+		const content = [
+			JSON.stringify({
+				type: "message",
+				message: { role: "assistant", usage: { input: 484, output: 49 } },
+			}),
+			JSON.stringify({
+				type: "message",
+				message: { role: "assistant", usage: { input: 96, output: 66 } },
+			}),
+		].join("\n");
+		writeFileSync(tmpPath, content);
+
+		const metrics = await parseTranscript(tmpPath);
+		expect(metrics.tokens.inputTokens).toBe(580);
+		expect(metrics.tokens.outputTokens).toBe(115);
+	});
+
+	it("extracts skill name from slash command", async () => {
+		const content = [
+			JSON.stringify({
+				type: "user",
+				message: { role: "user", content: "/code-search find something" },
+			}),
+		].join("\n");
+		writeFileSync(tmpPath, content);
+
+		const metrics = await parseTranscript(tmpPath);
+		expect(metrics.lastSkill).toBe("code-search");
+	});
+
+	it("extracts thinking effort from metadata", async () => {
+		const content = [
+			JSON.stringify({
+				type: "assistant",
+				metadata: { effort: "high" },
+				message: { role: "assistant", content: [{ type: "text", text: "test" }] },
+			}),
+		].join("\n");
+		writeFileSync(tmpPath, content);
+
+		const metrics = await parseTranscript(tmpPath);
+		expect(metrics.thinkingEffort).toBe("high");
+	});
+
+	it("returns zeros for empty transcript", async () => {
+		writeFileSync(tmpPath, "");
+		const metrics = await parseTranscript(tmpPath);
+		expect(metrics.tokens.inputTokens).toBe(0);
+		expect(metrics.tokens.outputTokens).toBe(0);
+	});
+
+	it("ignores invalid JSON lines", async () => {
+		const content = [
+			"not valid json",
+			JSON.stringify({
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "ok" }],
+					usage: { input_tokens: 50, output_tokens: 10 },
+				},
+			}),
+		].join("\n");
+		writeFileSync(tmpPath, content);
+
+		const metrics = await parseTranscript(tmpPath);
+		expect(metrics.tokens.inputTokens).toBe(50);
+		expect(metrics.tokens.outputTokens).toBe(10);
+	});
+});

--- a/packages/pi-statusline/__tests__/format.test.ts
+++ b/packages/pi-statusline/__tests__/format.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { C, formatContextPct, formatTokenCount, formatTokenPair, joinWidgets } from "../src/format.js";
+
+describe("formatTokenCount", () => {
+	it("formats numbers below 1k as-is", () => {
+		expect(formatTokenCount(0)).toBe("0");
+		expect(formatTokenCount(999)).toBe("999");
+	});
+
+	it("formats thousands as k", () => {
+		expect(formatTokenCount(1000)).toBe("1.0k");
+		expect(formatTokenCount(10500)).toBe("10.5k");
+		expect(formatTokenCount(100_000)).toBe("100k");
+		expect(formatTokenCount(999_500)).toBe("1000k");
+	});
+
+	it("formats millions as M", () => {
+		expect(formatTokenCount(1_000_000)).toBe("1.0M");
+		expect(formatTokenCount(1_500_000)).toBe("1.5M");
+		expect(formatTokenCount(10_000_000)).toBe("10.0M");
+	});
+});
+
+describe("formatTokenPair", () => {
+	it("formats input/output with arrows and slash", () => {
+		expect(formatTokenPair(10_500, 3200)).toBe("↑10.5k/↓3.2k");
+		expect(formatTokenPair(1_000, 500)).toBe("↑1.0k/↓500");
+		expect(formatTokenPair(0, 0)).toBe("↑0/↓0");
+	});
+});
+
+describe("formatContextPct", () => {
+	it("returns '?' for null", () => {
+		expect(formatContextPct(null)).toBe("?");
+	});
+
+	it("formats to one decimal place", () => {
+		expect(formatContextPct(11.023)).toBe("11.0");
+		expect(formatContextPct(9.5)).toBe("9.5");
+		expect(formatContextPct(100)).toBe("100.0");
+	});
+});
+
+describe("joinWidgets", () => {
+	it("returns empty string for no segments", () => {
+		expect(joinWidgets()).toBe("");
+	});
+
+	it("joins single segment", () => {
+		const result = joinWidgets("foo");
+		expect(result.endsWith("foo")).toBe(true);
+	});
+
+	it("joins multiple segments with pipe separator", () => {
+		const result = joinWidgets("a", "b", "c");
+		expect(result).toContain(" | ");
+		expect(result).toContain("a");
+		expect(result).toContain("b");
+		expect(result).toContain("c");
+	});
+});
+
+describe("C colors", () => {
+	it("all color functions return non-empty strings", () => {
+		const tests: Array<[string, (t: string) => string]> = [
+			["cyan", C.cyan],
+			["magenta", C.magenta],
+			["blue", C.blue],
+			["yellow", C.yellow],
+			["brightBlack", C.brightBlack],
+			["green", C.green],
+		];
+		for (const [_name, fn] of tests) {
+			const result = fn("test");
+			expect(result.length).toBeGreaterThan(0);
+			expect(result).toContain("test");
+		}
+	});
+
+	it("bold wraps text with ANSI bold and reset", () => {
+		const result = C.bold("test");
+		expect(result).toContain("test");
+		expect(result).toContain("\x1b[1m");
+		expect(result).toContain("\x1b[0m");
+	});
+});

--- a/packages/pi-statusline/__tests__/render.test.ts
+++ b/packages/pi-statusline/__tests__/render.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { renderStatusLine } from "../src/index.js";
+
+function makeStatusLineInput(
+	overrides: {
+		cwd?: string;
+		repoName?: string | null;
+		model?: string | null;
+		contextPct?: number | null;
+		thinkingLevel?: "low" | "medium" | "high" | "max" | null;
+		branch?: string | null;
+		worktree?: string | null;
+		dirty?: number;
+		inputTokens?: number;
+		outputTokens?: number;
+		lastSkill?: string | null;
+	} = {},
+) {
+	const {
+		cwd = "/Users/test/src/my-project",
+		repoName = "my-project",
+		model = "Claude Opus 4",
+		contextPct = 11.0,
+		thinkingLevel = "medium",
+		branch = "main",
+		worktree = "main",
+		dirty = 3,
+		inputTokens = 10_500,
+		outputTokens = 3200,
+		lastSkill = "code-search",
+	} = overrides;
+
+	return {
+		gathered: {
+			repoRoot: cwd,
+			git: { branch, worktree, dirty },
+			transcriptTokens: inputTokens !== undefined || outputTokens !== undefined ? { inputTokens, outputTokens } : null,
+		},
+		params: {
+			cwd,
+			repoName,
+			model,
+			contextPct,
+			thinkingLevel: thinkingLevel as "low" | "medium" | "high" | "max" | null,
+		},
+		lastSkill: lastSkill ?? null,
+	};
+}
+
+function renderBoth(params: ReturnType<typeof makeStatusLineInput>) {
+	const full = renderStatusLine(params.gathered, params.params, params.lastSkill);
+	const lines = full.split("\n");
+	return { line1: lines[0], line2: lines[1] };
+}
+
+describe("renderStatusLine", () => {
+	it("renders line1 with all widgets", () => {
+		const p = makeStatusLineInput();
+		const { line1 } = renderBoth(p);
+
+		expect(line1).toContain("Model:");
+		expect(line1).toContain("Claude Opus 4");
+		expect(line1).toContain("Thinking:");
+		expect(line1).toContain("medium");
+		expect(line1).toContain("Ctx:");
+		expect(line1).toContain("11.0%");
+		expect(line1).toContain("⎇");
+		expect(line1).toContain("main");
+		expect(line1).toContain("dirty:");
+		expect(line1).toContain("+3");
+		expect(line1).toContain("Tokens:");
+		expect(line1).toContain("↑10.5k");
+		expect(line1).toContain("↓3.2k");
+	});
+
+	it("renders line1 with null transcript tokens", () => {
+		const p = makeStatusLineInput();
+		p.gathered.transcriptTokens = null;
+		const { line1 } = renderBoth(p);
+
+		expect(line1).toContain("Tokens:");
+		expect(line1).toContain("↑0/↓0");
+	});
+
+	it("renders line1 with no git branch", () => {
+		const p = makeStatusLineInput({ branch: null, worktree: null, dirty: 0 });
+		const { line1 } = renderBoth(p);
+
+		expect(line1).toContain("no git");
+		expect(line1).toContain("dirty:");
+		expect(line1).toContain("+0");
+	});
+
+	it("renders line1 with null model", () => {
+		const p = makeStatusLineInput({ model: null });
+		const { line1 } = renderBoth(p);
+
+		expect(line1).toContain("Model:");
+		expect(line1).toContain("?");
+	});
+
+	it("renders line2 with all widgets", () => {
+		const p = makeStatusLineInput();
+		const { line2 } = renderBoth(p);
+
+		expect(line2).toContain("my-project");
+		expect(line2).toContain("cwd:");
+		expect(line2).toContain("/Users/test/src/my-project");
+		expect(line2).toContain("𖠰");
+		expect(line2).toContain("main");
+		expect(line2).toContain("Skill:");
+		expect(line2).toContain("code-search");
+	});
+
+	it("renders line2 with null worktree", () => {
+		const p = makeStatusLineInput({ branch: null, worktree: null });
+		const { line2 } = renderBoth(p);
+
+		expect(line2).toContain("𖠰");
+		expect(line2).toContain("no git");
+	});
+
+	it("renders line2 with no skill", () => {
+		const p = makeStatusLineInput({ lastSkill: null });
+		const { line2 } = renderBoth(p);
+
+		expect(line2).toContain("Skill:");
+		expect(line2).toContain("none");
+	});
+});

--- a/packages/pi-statusline/extensions/index.ts
+++ b/packages/pi-statusline/extensions/index.ts
@@ -1,0 +1,189 @@
+/**
+ * pi-statusline extension entry point.
+ *
+ * Renders a two-line status bar in the terminal footer (interactive mode)
+ * or via console.log (RPC/print mode).
+ *
+ * Widgets: Model | Thinking | Ctx% | GitBranch | dirty | Tokens
+ *          ProjectName | cwd | worktree | Skill
+ *
+ * Data sources:
+ * - Model, context %, thinking level: from ExtensionContext (ctx API)
+ * - Git data: git commands
+ * - Tokens: tracked via agent_end events (accumulated during session)
+ * - Skills: tracked via tool_execution_start events
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import { gatherStatusData, renderStatusLine } from "../src/index.js";
+import type { ThinkingEffort } from "../src/types.js";
+
+// =============================================================================
+// Shared mutable state — accumulated during the session
+// =============================================================================
+
+interface SessionState {
+	lastSkill: string | null;
+	inputTokens: number;
+	outputTokens: number;
+}
+
+const session: SessionState = {
+	lastSkill: null,
+	inputTokens: 0,
+	outputTokens: 0,
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Normalize thinking level string to our format. */
+function normalizeThinkingLevel(level: string): ThinkingEffort | null {
+	if (level === "off") return null;
+	if (level === "low" || level === "medium" || level === "high" || level === "max") {
+		return level as ThinkingEffort;
+	}
+	return null;
+}
+
+/** Get the current thinking level from the session's branch entries. */
+function getCurrentThinkingLevel(ctx: ExtensionContext): ThinkingEffort | null {
+	const branch = ctx.sessionManager.getBranch();
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i];
+		if (entry.type === "thinking_level_change") {
+			return normalizeThinkingLevel(entry.thinkingLevel);
+		}
+	}
+	return null;
+}
+
+/**
+ * Build and render the status line as a string.
+ */
+async function buildStatusLine(ctx: ExtensionContext): Promise<string> {
+	const modelDisplay = ctx.model?.name ?? ctx.model?.id ?? null;
+	const contextUsage = ctx.getContextUsage();
+	const contextPct = contextUsage?.percent ?? null;
+	const thinkingLevel = getCurrentThinkingLevel(ctx);
+
+	const gathered = await gatherStatusData(ctx.cwd, true);
+	const repoName = gathered.repoRoot ? (gathered.repoRoot.split("/").pop() ?? null) : null;
+
+	const transcriptTokens =
+		session.inputTokens > 0 || session.outputTokens > 0
+			? { inputTokens: session.inputTokens, outputTokens: session.outputTokens }
+			: gathered.transcriptTokens;
+
+	return renderStatusLine(
+		{ ...gathered, transcriptTokens },
+		{
+			cwd: ctx.cwd,
+			repoName,
+			model: modelDisplay,
+			contextPct,
+			thinkingLevel,
+		},
+		session.lastSkill,
+	);
+}
+
+// =============================================================================
+// Extension
+// =============================================================================
+
+export default function statuslineExtension(pi: ExtensionAPI) {
+	// Track Skill tool invocations
+	pi.on("tool_execution_start", (event) => {
+		if (event.toolName === "Skill" || event.toolName === "skill") {
+			const args = event.args as Record<string, unknown> | undefined;
+			if (args?.skill && typeof args.skill === "string") {
+				session.lastSkill = args.skill;
+			}
+		}
+	});
+
+	// Accumulate token usage from completed turns and update footer
+	pi.on("agent_end", async (event, ctx: ExtensionContext) => {
+		for (const message of event.messages) {
+			if (message.role === "assistant") {
+				const msg = message as { usage?: { input: number; output: number } };
+				if (msg.usage) {
+					session.inputTokens += msg.usage.input;
+					session.outputTokens += msg.usage.output;
+				}
+			}
+		}
+
+		// Update footer with new token counts
+		try {
+			const statusLine = await buildStatusLine(ctx);
+			const lines = statusLine.split("\n");
+			if (ctx.hasUI) {
+				ctx.ui.setFooter(() => ({
+					render(_width: number): string[] {
+						return lines;
+					},
+					invalidate() {},
+				}));
+			} else {
+				for (const line of lines) {
+					console.log(line);
+				}
+			}
+		} catch {
+			// Ignore footer update errors
+		}
+	});
+
+	// Register /statusline tool
+	pi.registerTool({
+		name: "statusline",
+		label: "Statusline",
+		description: "Print the current status line with model, thinking effort, context %, git info, and token counts",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, ctx: ExtensionContext) {
+			try {
+				const statusLine = await buildStatusLine(ctx);
+				return {
+					content: [{ type: "text", text: statusLine }],
+					details: {},
+				};
+			} catch (error) {
+				return {
+					content: [{ type: "text", text: String(error) }],
+					isError: true,
+					details: {},
+				};
+			}
+		},
+	});
+
+	// Render footer on session start
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		try {
+			const statusLine = await buildStatusLine(ctx);
+			const lines = statusLine.split("\n");
+
+			if (ctx.hasUI) {
+				// Interactive mode: set footer component
+				ctx.ui.setFooter(() => ({
+					render(_width: number): string[] {
+						return lines;
+					},
+					invalidate() {},
+				}));
+			} else {
+				// RPC/print mode: fall back to console output
+				for (const line of lines) {
+					console.log(line);
+				}
+			}
+		} catch (error) {
+			console.error("[pi-statusline] Failed to render status line:", error);
+		}
+	});
+}

--- a/packages/pi-statusline/package.json
+++ b/packages/pi-statusline/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@feniix/pi-statusline",
+	"version": "0.1.0",
+	"description": "pi extension that renders a two-line status line with model, thinking effort, context %, git info, token consumption, and skill info",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts",
+		"./extension": "./extensions/index.ts"
+	},
+	"files": [
+		"extensions/",
+		"src/"
+	],
+	"scripts": {
+		"lint": "cd ../.. && biome check packages/pi-statusline/src packages/pi-statusline/extensions packages/pi-statusline/__tests__",
+		"lint:fix": "biome check --write .",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run",
+		"check": "npm run lint && npm run typecheck"
+	},
+	"dependencies": {
+		"chalk": "^5.5.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.0",
+		"@types/node": "^22.0.0",
+		"typescript": "^5.9.2",
+		"vitest": "^4.1.4"
+	},
+	"peerDependencies": {
+		"@mariozechner/pi-coding-agent": "*"
+	}
+}

--- a/packages/pi-statusline/src/data/git.ts
+++ b/packages/pi-statusline/src/data/git.ts
@@ -1,0 +1,88 @@
+/**
+ * Git data: branch, worktree name, dirty file count.
+ */
+
+import { execSync } from "node:child_process";
+
+import type { GitData } from "../types.js";
+
+/** Git command cache: key is "command|cwd" */
+const cache = new Map<string, string | null>();
+
+function runGit(command: string, cwd: string): string | null {
+	const key = `${command}|${cwd}`;
+	if (cache.has(key)) return cache.get(key) ?? null;
+
+	try {
+		const output = execSync(`git ${command}`, {
+			encoding: "utf8",
+			cwd,
+			timeout: 3000,
+		}).trim();
+		const result = output.length > 0 ? output : null;
+		cache.set(key, result);
+		return result;
+	} catch {
+		cache.set(key, null);
+		return null;
+	}
+}
+
+/** Parse the worktree name from `git rev-parse --git-dir` output. */
+function parseWorktreeName(gitDir: string): string | null {
+	// Normalize backslashes for consistent parsing
+	const normalized = gitDir.replace(/\\/g, "/");
+
+	// Main worktree: .git or /path/to/.git
+	if (normalized.endsWith("/.git") || normalized === ".git") {
+		return "main";
+	}
+
+	// Linked worktree: .../.git/worktrees/<name>
+	const worktreesMarker = "/.git/worktrees/";
+	const worktreesIdx = normalized.lastIndexOf(worktreesMarker);
+	if (worktreesIdx !== -1) {
+		const name = normalized.slice(worktreesIdx + worktreesMarker.length);
+		return name.length > 0 ? name : null;
+	}
+
+	// Bare repo worktree: .../worktrees/<name>
+	const bareMarker = "/worktrees/";
+	const bareIdx = normalized.lastIndexOf(bareMarker);
+	if (bareIdx === -1) return null;
+	const name = normalized.slice(bareIdx + bareMarker.length);
+	return name.length > 0 ? name : null;
+}
+
+/** Count dirty (uncommitted) files using `git status --porcelain`. */
+function getDirtyCount(cwd: string): number {
+	const output = runGit("status --porcelain", cwd);
+	if (!output) return 0;
+	return output.split("\n").filter((line) => line.length >= 2).length;
+}
+
+/** Collect all git data for a given working directory. */
+export async function getGitData(cwd: string): Promise<GitData> {
+	// Check if inside a work tree
+	const insideWorktree = runGit("rev-parse --is-inside-work-tree", cwd);
+	if (insideWorktree !== "true") {
+		return { branch: null, worktree: null, dirty: 0 };
+	}
+
+	const [branch, gitDir, dirty] = await Promise.all([
+		Promise.resolve(runGit("branch --show-current", cwd)),
+		Promise.resolve(runGit("rev-parse --git-dir", cwd)),
+		Promise.resolve(getDirtyCount(cwd)),
+	]);
+
+	return {
+		branch: branch || null,
+		worktree: gitDir ? parseWorktreeName(gitDir) : null,
+		dirty,
+	};
+}
+
+/** Clear the git command cache (useful for testing). */
+export function clearGitCache(): void {
+	cache.clear();
+}

--- a/packages/pi-statusline/src/data/session.ts
+++ b/packages/pi-statusline/src/data/session.ts
@@ -1,0 +1,84 @@
+/**
+ * Session data: cwd, repo root, transcript path.
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Find the most recently modified .jsonl file under a directory. */
+function findJsonlInDir(dir: string): string | null {
+	if (!existsSync(dir)) return null;
+	try {
+		const result = execSync(`ls -t "${dir}"/*.jsonl 2>/dev/null | head -1`, {
+			encoding: "utf8",
+			timeout: 2000,
+		})
+			.trim()
+			.split("\n")[0];
+		return result || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Encode a cwd into the pi session directory name format.
+ * e.g. /Users/feniix/src/spantree/pi-extensions
+ *   → --Users-feniix-src-spantree-pi-extensions--
+ */
+function encodeCwdForPi(cwd: string): string {
+	// Strip leading slash, replace remaining slashes with dashes, wrap in --
+	const stripped = cwd.startsWith("/") ? cwd.slice(1) : cwd;
+	return `--${stripped.replace(/\//g, "-")}--`;
+}
+
+/** Find the transcript path for the current session. */
+export function findTranscriptPath(repoRoot: string | null, cwd: string): string | null {
+	const candidates: string[] = [];
+
+	// pi session directory for the current cwd
+	const piSessionsDir = join(homedir(), ".pi", "agent", "sessions");
+	const encodedCwd = encodeCwdForPi(cwd);
+	candidates.push(join(piSessionsDir, encodedCwd));
+
+	// Also check .claude locations for Claude Code sessions (if they exist)
+	if (repoRoot) {
+		candidates.push(`${repoRoot}/.claude/project/transcripts`);
+	}
+	candidates.push(join(homedir(), ".claude", "projects", "transcripts"));
+
+	const telemetry = process.env.CLAUDE_TELEMETRY;
+	if (telemetry) {
+		candidates.push(join(telemetry, "transcripts"));
+	}
+
+	for (const dir of candidates) {
+		const found = findJsonlInDir(dir);
+		if (found) return found;
+	}
+
+	return null;
+}
+
+/** Get git repo root directory (null if not in a repo). */
+export function getRepoRoot(cwd: string): string | null {
+	try {
+		const output = execSync("git rev-parse --show-toplevel", {
+			encoding: "utf8",
+			cwd,
+			timeout: 2000,
+		}).trim();
+		return output.length > 0 ? output : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Get the repo name (last segment of repo root). */
+export function getRepoName(repoRoot: string | null): string | null {
+	if (!repoRoot) return null;
+	const parts = repoRoot.split("/");
+	return parts[parts.length - 1] || null;
+}

--- a/packages/pi-statusline/src/data/transcript.ts
+++ b/packages/pi-statusline/src/data/transcript.ts
@@ -1,0 +1,141 @@
+/**
+ * Transcript (.jsonl) parser for token counts, thinking effort, and skills.
+ *
+ * Supports both Claude Code and pi session file formats.
+ */
+
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+
+import type { ThinkingEffort, TranscriptMetrics } from "../types.js";
+
+/** Parse a single JSONL line into an object, or null on failure. */
+function parseLine(line: string): Record<string, unknown> | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return null;
+	}
+}
+
+/** Normalize a thinking effort string to a known level. */
+function normalizeThinkingEffort(value: unknown): ThinkingEffort | null {
+	if (typeof value !== "string") return null;
+	const lower = value.toLowerCase();
+	if (lower === "low" || lower === "medium" || lower === "high" || lower === "max") {
+		return lower as ThinkingEffort;
+	}
+	return null;
+}
+
+/** Look for a skill name at the start of a prompt string. */
+function extractSkillFromPrompt(prompt: unknown): string | null {
+	if (typeof prompt !== "string") return null;
+	const match = /^\/([a-zA-Z0-9_-]+)/.exec(prompt);
+	return match?.[1] ?? null;
+}
+
+/** Look for a skill name from a Skill tool invocation. */
+function extractSkillFromToolInput(input: unknown): string | null {
+	if (typeof input !== "object" || input === null) return null;
+	const obj = input as Record<string, unknown>;
+	if (typeof obj.skill === "string" && obj.skill.length > 0) {
+		return obj.skill;
+	}
+	return null;
+}
+
+/**
+ * Accumulate token counts from a usage object.
+ * Handles both Claude Code format (input_tokens / output_tokens) and
+ * pi session format (input / output).
+ */
+function accumulateUsage(
+	usage: Record<string, unknown> | undefined,
+	inputAcc: { value: number },
+	outputAcc: { value: number },
+): void {
+	if (!usage) return;
+	// Claude Code: input_tokens / output_tokens
+	// pi session: input / output
+	const input = (usage.input_tokens ?? usage.input) as number | undefined;
+	const output = (usage.output_tokens ?? usage.output) as number | undefined;
+	if (typeof input === "number") inputAcc.value += input;
+	if (typeof output === "number") outputAcc.value += output;
+}
+
+/**
+ * Parse a transcript .jsonl file and return token metrics, thinking effort,
+ * and the last skill invoked.
+ *
+ * Supports both Claude Code and pi session file formats.
+ */
+export async function parseTranscript(path: string): Promise<TranscriptMetrics> {
+	const inputAcc = { value: 0 };
+	const outputAcc = { value: 0 };
+	let thinkingEffort: ThinkingEffort | null = null;
+	let lastSkill: string | null = null;
+
+	const rl = createInterface({
+		input: createReadStream(path),
+		crlfDelay: Number.POSITIVE_INFINITY,
+	});
+
+	for await (const line of rl) {
+		const data = parseLine(line);
+		if (!data) continue;
+
+		const type = typeof data.type === "string" ? data.type : null;
+		const message = data.message as Record<string, unknown> | undefined;
+
+		// Determine role: pi uses message.role, Claude Code uses type
+		const role = typeof message?.role === "string" ? message.role : null;
+
+		// Accumulate token usage from assistant/user messages
+		if (type === "assistant" || type === "assistant_turn" || role === "assistant") {
+			accumulateUsage(message?.usage as Record<string, unknown> | undefined, inputAcc, outputAcc);
+		}
+
+		if (type === "user" || type === "user_turn" || role === "user") {
+			accumulateUsage(message?.usage as Record<string, unknown> | undefined, inputAcc, outputAcc);
+		}
+
+		// Extract thinking effort from metadata
+		if (thinkingEffort === null) {
+			const meta = data.metadata as Record<string, unknown> | undefined;
+			if (meta) {
+				thinkingEffort = normalizeThinkingEffort(meta.effort ?? meta.thinking_effort);
+			}
+			if (thinkingEffort === null) {
+				thinkingEffort = normalizeThinkingEffort(data.effort ?? data.thinking_effort);
+			}
+		}
+
+		// Extract skill from user prompts (slash commands)
+		if (type === "user" || type === "user_turn") {
+			const prompt = (data.message as Record<string, unknown>)?.content ?? data.content;
+			const skill = extractSkillFromPrompt(prompt);
+			if (skill) lastSkill = skill;
+		}
+
+		// Extract skill from Skill tool calls
+		if (data.tool_name === "Skill" || data.tool_name === "skill") {
+			const skill = extractSkillFromToolInput(data.tool_input);
+			if (skill) lastSkill = skill;
+		}
+	}
+
+	rl.close();
+
+	return {
+		tokens: {
+			inputTokens: inputAcc.value,
+			outputTokens: outputAcc.value,
+			totalTokens: inputAcc.value + outputAcc.value,
+		},
+		thinkingEffort,
+		lastSkill,
+	};
+}

--- a/packages/pi-statusline/src/format.ts
+++ b/packages/pi-statusline/src/format.ts
@@ -1,0 +1,57 @@
+/** ANSI escape to reset all styles */
+export const RESET = "\x1b[0m";
+
+/** Wrap text in a color using ANSI codes (no trailing reset) */
+function color(code: number, text: string): string {
+	return `\x1b[38;5;${code}m${text}`;
+}
+
+/** Color aliases matching ccstatusline's named colors */
+export const C = {
+	cyan: (text: string) => color(14, text),
+	magenta: (text: string) => color(13, text),
+	blue: (text: string) => color(12, text),
+	yellow: (text: string) => color(11, text),
+	brightBlack: (text: string) => color(8, text),
+	green: (text: string) => color(10, text),
+	bold: (text: string) => `\x1b[1m${text}${RESET}`,
+};
+
+const SEPARATOR = " | ";
+
+/** Join widget segments with the standard separator, resetting color between each */
+export function joinWidgets(...segments: string[]): string {
+	if (segments.length === 0) return "";
+	return segments.join(`${RESET}${SEPARATOR}`);
+}
+
+/**
+ * Format a token count into a compact human-readable string.
+ * e.g. 1200 → "1.2k", 1_500_000 → "1.5M"
+ */
+export function formatTokenCount(n: number): string {
+	if (n < 1000) return n.toString();
+	if (n < 1_000_000) {
+		const k = n / 1000;
+		return k >= 100 ? `${Math.round(k)}k` : `${k.toFixed(1)}k`;
+	}
+	const m = n / 1_000_000;
+	return `${m.toFixed(1)}M`;
+}
+
+/**
+ * Format input/output token pair with arrows.
+ * e.g. { input: 10500, output: 3200 } → "↑10.5k/↓3.2k"
+ */
+export function formatTokenPair(input: number, output: number): string {
+	return `↑${formatTokenCount(input)}/↓${formatTokenCount(output)}`;
+}
+
+/**
+ * Format context percentage to one decimal place.
+ * e.g. 11.023 → "11.0", 9.5 → "9.5"
+ */
+export function formatContextPct(pct: number | null): string {
+	if (pct === null) return "?";
+	return `${pct.toFixed(1)}`;
+}

--- a/packages/pi-statusline/src/index.ts
+++ b/packages/pi-statusline/src/index.ts
@@ -1,0 +1,165 @@
+/**
+ * pi-statusline: Gather session data and render the two-line status line.
+ *
+ * Model, context %, and thinking level come from the extension's ExtensionContext (ctx API).
+ * Git data and transcript parsing are done from the filesystem.
+ */
+
+import { homedir } from "node:os";
+import { getGitData } from "./data/git.js";
+import { findTranscriptPath, getRepoRoot } from "./data/session.js";
+import { parseTranscript } from "./data/transcript.js";
+import { C, formatContextPct, formatTokenPair, joinWidgets } from "./format.js";
+import type { GitData, StatusLineData, ThinkingEffort } from "./types.js";
+
+/** Separator between the two rendered lines */
+const LINE_BREAK = "\n";
+
+// ============================================================================
+// Data gathering
+// ============================================================================
+
+export interface GatheredData {
+	repoRoot: string | null;
+	git: GitData;
+	transcriptTokens: { inputTokens: number; outputTokens: number } | null;
+}
+
+/**
+ * Gather git and transcript data from the filesystem.
+ * Model, context %, and thinking level come from the extension's ExtensionContext.
+ */
+export async function gatherStatusData(cwd?: string, skipTranscript = false): Promise<GatheredData> {
+	const workingDir = cwd ?? process.cwd();
+
+	const [repoRoot, git] = await Promise.all([Promise.resolve(getRepoRoot(workingDir)), getGitData(workingDir)]);
+
+	let transcriptTokens: { inputTokens: number; outputTokens: number } | null = null;
+
+	if (!skipTranscript) {
+		const transcriptPath = findTranscriptPath(repoRoot, workingDir);
+		if (transcriptPath) {
+			try {
+				const metrics = await parseTranscript(transcriptPath);
+				transcriptTokens = {
+					inputTokens: metrics.tokens.inputTokens,
+					outputTokens: metrics.tokens.outputTokens,
+				};
+			} catch {
+				// Transcript parse failed — continue with null
+			}
+		}
+	}
+
+	return { repoRoot, git, transcriptTokens };
+}
+
+// ============================================================================
+// Widget formatters
+// ============================================================================
+
+function widgetModel(data: StatusLineData): string {
+	const model = data.model ?? "?";
+	return `${C.cyan("Model:")} ${C.cyan(model)}`;
+}
+
+function widgetThinking(data: StatusLineData): string {
+	const effort: ThinkingEffort = data.thinkingLevel ?? "medium";
+	return `${C.magenta("Thinking:")} ${C.magenta(effort)}`;
+}
+
+function widgetContext(data: StatusLineData): string {
+	const pct = formatContextPct(data.contextPct);
+	return `${C.blue("Ctx:")} ${C.blue(`${pct}%`)}`;
+}
+
+function widgetBranch(data: StatusLineData): string {
+	const branch = data.git.branch ?? "no git";
+	return `${C.magenta("⎇")} ${C.magenta(branch)}`;
+}
+
+function widgetDirty(data: StatusLineData): string {
+	const dirty = data.git.dirty;
+	return `${C.yellow("dirty:")} ${C.yellow(`+${dirty}`)}`;
+}
+
+function widgetTokens(data: StatusLineData): string {
+	if (!data.transcriptTokens) {
+		return `${C.cyan("Tokens:")} ${C.brightBlack("↑0/↓0")}`;
+	}
+	const { inputTokens, outputTokens } = data.transcriptTokens;
+	return `${C.cyan("Tokens:")} ${C.cyan(formatTokenPair(inputTokens, outputTokens))}`;
+}
+
+function widgetProjectName(data: StatusLineData): string {
+	return C.blue(data.repoName ?? "?");
+}
+
+function widgetCwd(data: StatusLineData): string {
+	const home = homedir();
+	const display = data.cwd.startsWith(home) ? `~${data.cwd.slice(home.length)}` : data.cwd;
+	return `${C.blue("cwd:")} ${C.blue(display)}`;
+}
+
+function widgetWorktree(data: StatusLineData): string {
+	const worktree = data.git.worktree ?? "no git";
+	return `${C.blue("𖠰")} ${C.blue(worktree)}`;
+}
+
+function widgetSkill(lastSkill: string | null): string {
+	const skill = lastSkill ?? "none";
+	return `${C.brightBlack("Skill:")} ${C.brightBlack(skill)}`;
+}
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+/** Render line 1 of the status line. */
+function renderLine1(data: StatusLineData): string {
+	return joinWidgets(
+		widgetModel(data),
+		widgetThinking(data),
+		widgetContext(data),
+		widgetBranch(data),
+		widgetDirty(data),
+		widgetTokens(data),
+	);
+}
+
+/** Render line 2 of the status line. */
+function renderLine2(data: StatusLineData, lastSkill: string | null): string {
+	return joinWidgets(widgetProjectName(data), widgetCwd(data), widgetWorktree(data), widgetSkill(lastSkill));
+}
+
+/**
+ * Render the full two-line status line.
+ *
+ * @param gathered - Git and transcript data from gatherStatusData()
+ * @param params  - Context-derived values (model, contextPct, thinkingLevel, cwd, repoName)
+ * @param lastSkill - Last skill invoked (tracked by the extension via tool_execution_end)
+ */
+export function renderStatusLine(
+	gathered: GatheredData,
+	params: {
+		cwd: string;
+		repoName: string | null;
+		model: string | null;
+		contextPct: number | null;
+		thinkingLevel: ThinkingEffort | null;
+	},
+	lastSkill: string | null,
+): string {
+	const data: StatusLineData = {
+		cwd: params.cwd,
+		repoRoot: gathered.repoRoot,
+		repoName: params.repoName,
+		git: gathered.git,
+		transcriptTokens: gathered.transcriptTokens,
+		model: params.model,
+		contextPct: params.contextPct,
+		thinkingLevel: params.thinkingLevel,
+	};
+
+	return [renderLine1(data), renderLine2(data, lastSkill)].join(LINE_BREAK);
+}

--- a/packages/pi-statusline/src/types.ts
+++ b/packages/pi-statusline/src/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for pi-statusline
+ */
+
+export interface TokenData {
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+}
+
+export interface TranscriptMetrics {
+	tokens: TokenData;
+	thinkingEffort: ThinkingEffort | null;
+	lastSkill: string | null;
+}
+
+export interface GitData {
+	branch: string | null;
+	worktree: string | null;
+	dirty: number;
+}
+
+export type ThinkingEffort = "low" | "medium" | "high" | "max";
+
+export interface StatusLineData {
+	/** Current working directory */
+	cwd: string;
+	/** Git repo root directory */
+	repoRoot: string | null;
+	/** Name of the git repo (last path segment of repoRoot) */
+	repoName: string | null;
+	git: GitData;
+	/** Input/output token pair from transcript parsing */
+	transcriptTokens: { inputTokens: number; outputTokens: number } | null;
+	/** Model display name, e.g. "Opus 4.6 (1M context)" */
+	model: string | null;
+	/** Context window usage percentage (0-100), e.g. 11.0 */
+	contextPct: number | null;
+	/** Current thinking level */
+	thinkingLevel: ThinkingEffort | null;
+}

--- a/packages/pi-statusline/tsconfig.json
+++ b/packages/pi-statusline/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "."
+	},
+	"include": ["extensions/**/*", "src/**/*"]
+}


### PR DESCRIPTION
## Summary
- New `pi-statusline` extension renders a two-line status bar in the terminal footer
- Line 1: Model | Thinking effort | Context % | Git branch | dirty files | Token counts
- Line 2: Project name | cwd | worktree | active Skill
- Token tracking via `agent_end` events, Skills tracking via `tool_execution_start`
- Falls back to `console.log` in RPC/non-interactive mode

## Type of change
- [x] Feature

## Test plan
- 37 unit tests passing (`npm run test` in `packages/pi-statusline/`)
- Lint clean (`npm run check`)
- Live-tested in both interactive and RPC modes