### PR TITLE
feat: add pi-conductor MVP worker orchestration

### DIFF
--- a/.claude/tracker.md
+++ b/.claude/tracker.md
@@ -1,0 +1,1 @@
+tracker: github

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -19,13 +19,17 @@ MVP implementation for the `pi-extensions` workspace, based on:
 - one worker record per named workstream
 - worker git worktree creation and recovery
 - real persisted Pi session linkage
+- explicit worker resume against persisted worktree/session metadata
 - task updates and session-derived summaries
+- lifecycle controls for `idle`, `running`, `blocked`, `ready_for_pr`, and `done`
+- health-aware status output distinguishing healthy, stale, and broken workers
 - broken-state detection and targeted recovery
 - targeted worker cleanup
 - minimal PR preparation flow:
   - commit
   - push
   - create PR
+  - explicit preflight checks for remote and `gh`
   - persist partial success/failure state
 
 ## Command surface
@@ -36,6 +40,8 @@ Primary operator UX is the `/conductor` command group:
 /conductor status
 /conductor start <worker-name>
 /conductor task <worker-name> <task>
+/conductor resume <worker-name>
+/conductor state <worker-name> <lifecycle>
 /conductor summarize <worker-name>
 /conductor recover <worker-name>
 /conductor cleanup <worker-name>
@@ -55,6 +61,8 @@ Registered tools:
 - `conductor_recover`
 - `conductor_summary_refresh`
 - `conductor_cleanup`
+- `conductor_resume`
+- `conductor_lifecycle_update`
 - `conductor_commit`
 - `conductor_push`
 - `conductor_pr_create`

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -1,10 +1,10 @@
 # @feniix/pi-conductor
 
-Long-lived multi-session worker orchestration for pi.
+Long-lived multi-session worker orchestration for Pi.
 
 ## Status
 
-Early scaffold based on:
+MVP implementation for the `pi-extensions` workspace, based on:
 - `docs/prd/PRD-001-pi-conductor-mvp.md`
 - `docs/adr/ADR-0001-sdk-first-worker-runtime.md`
 - `docs/adr/ADR-0002-conductor-project-scoped-storage.md`
@@ -13,21 +13,51 @@ Early scaffold based on:
 
 ## Current capabilities
 
-This initial implementation scaffold currently provides:
-- conductor project-key derivation
-- conductor storage root resolution
-- worker/run state types
-- a minimal `/conductor-status` command
-- a `conductor_status` tool for inspecting the current conductor project namespace
+`pi-conductor` currently provides:
+- deterministic project-key derivation
+- conductor-managed project storage
+- one worker record per named workstream
+- worker git worktree creation and recovery
+- real persisted Pi session linkage
+- task updates and session-derived summaries
+- broken-state detection and targeted recovery
+- targeted worker cleanup
+- minimal PR preparation flow:
+  - commit
+  - push
+  - create PR
+  - persist partial success/failure state
 
-## Planned next steps
+## Command surface
 
-- worker creation and persistence
-- worktree management
-- real Pi session linkage
-- task updates
-- recovery flows
-- PR preparation
+Primary operator UX is the `/conductor` command group:
+
+```text
+/conductor status
+/conductor start <worker-name>
+/conductor task <worker-name> <task>
+/conductor summarize <worker-name>
+/conductor recover <worker-name>
+/conductor cleanup <worker-name>
+/conductor commit <worker-name> <message>
+/conductor push <worker-name>
+/conductor pr <worker-name> <title>
+```
+
+There is also a convenience `/conductor-status` command.
+
+## Tool surface
+
+Registered tools:
+- `conductor_status`
+- `conductor_start`
+- `conductor_task_update`
+- `conductor_recover`
+- `conductor_summary_refresh`
+- `conductor_cleanup`
+- `conductor_commit`
+- `conductor_push`
+- `conductor_pr_create`
 
 ## Development
 

--- a/packages/pi-conductor/__tests__/cleanup.test.ts
+++ b/packages/pi-conductor/__tests__/cleanup.test.ts
@@ -46,4 +46,14 @@ describe("cleanup flows", () => {
 		removeWorkerForRepo(repoDir, "backend");
 		expect(existsSync(worker.sessionFile!)).toBe(false);
 	});
+
+	it("removes the worker branch so the same worker name can be recreated", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
+		expect(execSync(`git branch --list ${worker.branch}`, { cwd: repoDir, encoding: "utf-8" }).trim()).toContain(worker.branch!);
+		removeWorkerForRepo(repoDir, "backend");
+		expect(execSync(`git branch --list ${worker.branch}`, { cwd: repoDir, encoding: "utf-8" }).trim()).toBe("");
+
+		const recreated = await createWorkerForRepo(repoDir, "backend");
+		expect(recreated.branch).toBe(worker.branch);
+	});
 });

--- a/packages/pi-conductor/__tests__/cleanup.test.ts
+++ b/packages/pi-conductor/__tests__/cleanup.test.ts
@@ -1,0 +1,49 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorkerForRepo, getOrCreateRunForRepo, removeWorkerForRepo } from "../extensions/conductor.js";
+
+describe("cleanup flows", () => {
+	let repoDir: string;
+	let conductorHome: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+		process.env.PI_CONDUCTOR_HOME = conductorHome;
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		delete process.env.PI_CONDUCTOR_HOME;
+		if (existsSync(repoDir)) {
+			rmSync(repoDir, { recursive: true, force: true });
+		}
+		if (existsSync(conductorHome)) {
+			rmSync(conductorHome, { recursive: true, force: true });
+		}
+	});
+
+	it("removes a worker record and its worktree", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
+		expect(existsSync(worker.worktreePath!)).toBe(true);
+		const removed = removeWorkerForRepo(repoDir, "backend");
+		expect(removed.workerId).toBe(worker.workerId);
+		expect(existsSync(worker.worktreePath!)).toBe(false);
+		expect(getOrCreateRunForRepo(repoDir).workers).toHaveLength(0);
+	});
+
+	it("removes the persisted session file when cleaning up a worker", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
+		expect(existsSync(worker.sessionFile!)).toBe(true);
+		removeWorkerForRepo(repoDir, "backend");
+		expect(existsSync(worker.sessionFile!)).toBe(false);
+	});
+});

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -65,6 +65,21 @@ describe("runConductorCommand", () => {
 		expect(status).toContain("summary=fresh:");
 	});
 
+	it("resumes a healthy worker through the resume subcommand", async () => {
+		await runConductorCommand(repoDir, "start backend");
+		const text = await runConductorCommand(repoDir, "resume backend");
+		expect(text).toContain("resumed worker backend");
+	});
+
+	it("updates a worker lifecycle through the state subcommand", async () => {
+		await runConductorCommand(repoDir, "start backend");
+		const text = await runConductorCommand(repoDir, "state backend ready_for_pr");
+		expect(text).toContain("updated worker backend state to ready_for_pr");
+
+		const status = await runConductorCommand(repoDir, "status");
+		expect(status).toContain("state=ready_for_pr");
+	});
+
 	it("cleans up a worker through the cleanup subcommand", async () => {
 		await runConductorCommand(repoDir, "start backend");
 		const text = await runConductorCommand(repoDir, "cleanup backend");

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -1,0 +1,63 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runConductorCommand } from "../extensions/commands.js";
+
+describe("runConductorCommand", () => {
+	let repoDir: string;
+	let conductorHome: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+		process.env.PI_CONDUCTOR_HOME = conductorHome;
+
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		delete process.env.PI_CONDUCTOR_HOME;
+		if (existsSync(repoDir)) {
+			rmSync(repoDir, { recursive: true, force: true });
+		}
+		if (existsSync(conductorHome)) {
+			rmSync(conductorHome, { recursive: true, force: true });
+		}
+	});
+
+	it("returns status for the current repo", () => {
+		const text = runConductorCommand(repoDir, "status");
+		expect(text).toContain("workers: 0");
+	});
+
+	it("creates a worker from the start subcommand", () => {
+		const text = runConductorCommand(repoDir, "start backend");
+		expect(text).toContain("created worker");
+		expect(text).toContain("backend");
+
+		const status = runConductorCommand(repoDir, "status");
+		expect(status).toContain("workers: 1");
+		expect(status).toContain("backend");
+	});
+
+	it("updates a worker task through the task subcommand", () => {
+		runConductorCommand(repoDir, "start backend");
+		const text = runConductorCommand(repoDir, "task backend implement status command");
+		expect(text).toContain("updated task for backend");
+
+		const status = runConductorCommand(repoDir, "status");
+		expect(status).toContain("task=implement status command");
+	});
+
+	it("shows help for unknown subcommands", () => {
+		const text = runConductorCommand(repoDir, "wat");
+		expect(text).toContain("usage:");
+	});
+});

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -56,6 +56,15 @@ describe("runConductorCommand", () => {
 		expect(status).toContain("task=implement status command");
 	});
 
+	it("refreshes a worker summary from its session", async () => {
+		await runConductorCommand(repoDir, "start backend");
+		const text = await runConductorCommand(repoDir, "summarize backend");
+		expect(text).toContain("refreshed summary for backend");
+
+		const status = await runConductorCommand(repoDir, "status");
+		expect(status).toContain("summary=fresh:");
+	});
+
 	it("shows help for unknown subcommands", async () => {
 		const text = await runConductorCommand(repoDir, "wat");
 		expect(text).toContain("usage:");

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -32,32 +32,32 @@ describe("runConductorCommand", () => {
 		}
 	});
 
-	it("returns status for the current repo", () => {
-		const text = runConductorCommand(repoDir, "status");
+	it("returns status for the current repo", async () => {
+		const text = await runConductorCommand(repoDir, "status");
 		expect(text).toContain("workers: 0");
 	});
 
-	it("creates a worker from the start subcommand", () => {
-		const text = runConductorCommand(repoDir, "start backend");
+	it("creates a worker from the start subcommand", async () => {
+		const text = await runConductorCommand(repoDir, "start backend");
 		expect(text).toContain("created worker");
 		expect(text).toContain("backend");
 
-		const status = runConductorCommand(repoDir, "status");
+		const status = await runConductorCommand(repoDir, "status");
 		expect(status).toContain("workers: 1");
 		expect(status).toContain("backend");
 	});
 
-	it("updates a worker task through the task subcommand", () => {
-		runConductorCommand(repoDir, "start backend");
-		const text = runConductorCommand(repoDir, "task backend implement status command");
+	it("updates a worker task through the task subcommand", async () => {
+		await runConductorCommand(repoDir, "start backend");
+		const text = await runConductorCommand(repoDir, "task backend implement status command");
 		expect(text).toContain("updated task for backend");
 
-		const status = runConductorCommand(repoDir, "status");
+		const status = await runConductorCommand(repoDir, "status");
 		expect(status).toContain("task=implement status command");
 	});
 
-	it("shows help for unknown subcommands", () => {
-		const text = runConductorCommand(repoDir, "wat");
+	it("shows help for unknown subcommands", async () => {
+		const text = await runConductorCommand(repoDir, "wat");
 		expect(text).toContain("usage:");
 	});
 });

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -65,6 +65,15 @@ describe("runConductorCommand", () => {
 		expect(status).toContain("summary=fresh:");
 	});
 
+	it("cleans up a worker through the cleanup subcommand", async () => {
+		await runConductorCommand(repoDir, "start backend");
+		const text = await runConductorCommand(repoDir, "cleanup backend");
+		expect(text).toContain("removed worker backend");
+
+		const status = await runConductorCommand(repoDir, "status");
+		expect(status).toContain("workers: 0");
+	});
+
 	it("shows help for unknown subcommands", async () => {
 		const text = await runConductorCommand(repoDir, "wat");
 		expect(text).toContain("usage:");

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -39,15 +39,18 @@ describe("conductor service", () => {
 		expect(readFileSync(join(run.storageDir, "run.json"), "utf-8")).toContain("projectKey");
 	});
 
-	it("creates a worker, worktree, and persisted worker record", () => {
-		const worker = createWorkerForRepo(repoDir, "backend");
+	it("creates a worker, worktree, and persisted worker record", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
 		expect(worker.name).toBe("backend");
 		expect(worker.branch).toBe("conductor/backend");
 		expect(worker.worktreePath).toBeTruthy();
 		expect(existsSync(worker.worktreePath!)).toBe(true);
+		expect(worker.sessionFile).toBeTruthy();
+		expect(existsSync(worker.sessionFile!)).toBe(true);
 
 		const run = getOrCreateRunForRepo(repoDir);
 		expect(run.workers).toHaveLength(1);
 		expect(run.workers[0]?.name).toBe("backend");
+		expect(run.workers[0]?.sessionFile).toBeTruthy();
 	});
 });

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -1,0 +1,53 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorkerForRepo, getOrCreateRunForRepo } from "../extensions/conductor.js";
+
+describe("conductor service", () => {
+	let repoDir: string;
+	let conductorHome: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+		process.env.PI_CONDUCTOR_HOME = conductorHome;
+
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		delete process.env.PI_CONDUCTOR_HOME;
+		if (existsSync(repoDir)) {
+			rmSync(repoDir, { recursive: true, force: true });
+		}
+		if (existsSync(conductorHome)) {
+			rmSync(conductorHome, { recursive: true, force: true });
+		}
+	});
+
+	it("creates and persists an empty run for a repo", () => {
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.repoRoot).toBe(repoDir);
+		expect(run.workers).toEqual([]);
+		expect(readFileSync(join(run.storageDir, "run.json"), "utf-8")).toContain("projectKey");
+	});
+
+	it("creates a worker, worktree, and persisted worker record", () => {
+		const worker = createWorkerForRepo(repoDir, "backend");
+		expect(worker.name).toBe("backend");
+		expect(worker.branch).toBe("conductor/backend");
+		expect(worker.worktreePath).toBeTruthy();
+		expect(existsSync(worker.worktreePath!)).toBe(true);
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers).toHaveLength(1);
+		expect(run.workers[0]?.name).toBe("backend");
+	});
+});

--- a/packages/pi-conductor/__tests__/git-pr.test.ts
+++ b/packages/pi-conductor/__tests__/git-pr.test.ts
@@ -1,0 +1,47 @@
+import { execSync } from "node:child_process";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getPreferredBaseBranch } from "../extensions/git-pr.js";
+
+describe("git-pr helpers", () => {
+	let repoDir: string;
+	let remoteDir: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		remoteDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello\n");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git init --bare", { cwd: remoteDir, stdio: "pipe" });
+		execSync(`git remote add origin ${remoteDir}`, { cwd: repoDir, stdio: "pipe" });
+		execSync("git push -u origin main", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		for (const dir of [repoDir, remoteDir]) {
+			if (dir && existsSync(dir)) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("uses the current branch when it exists on origin", () => {
+		execSync("git checkout -b feature/test-base", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "feature.txt"), "feature\n");
+		execSync("git add feature.txt", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'feature commit'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git push -u origin feature/test-base", { cwd: repoDir, stdio: "pipe" });
+
+		expect(getPreferredBaseBranch(repoDir)).toBe("feature/test-base");
+	});
+
+	it("falls back to the remote default branch when the current branch is only local", () => {
+		execSync("git checkout -b feature/local-only", { cwd: repoDir, stdio: "pipe" });
+		expect(getPreferredBaseBranch(repoDir)).toBe("main");
+	});
+});

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("pi-conductor extension", () => {
+	it("registers the main conductor command group", () => {
+		const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+		expect(extension).toContain('registerCommand("conductor"');
+	});
+
+	it("registers conductor tools", () => {
+		const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+		expect(extension).toContain('name: "conductor_status"');
+		expect(extension).toContain('name: "conductor_start"');
+		expect(extension).toContain('name: "conductor_task_update"');
+	});
+});

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -13,5 +13,7 @@ describe("pi-conductor extension", () => {
 		expect(extension).toContain('name: "conductor_status"');
 		expect(extension).toContain('name: "conductor_start"');
 		expect(extension).toContain('name: "conductor_task_update"');
+		expect(extension).toContain('name: "conductor_recover"');
+		expect(extension).toContain('name: "conductor_summary_refresh"');
 	});
 });

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -16,6 +16,8 @@ describe("pi-conductor extension", () => {
 		expect(extension).toContain('name: "conductor_recover"');
 		expect(extension).toContain('name: "conductor_summary_refresh"');
 		expect(extension).toContain('name: "conductor_cleanup"');
+		expect(extension).toContain('name: "conductor_resume"');
+		expect(extension).toContain('name: "conductor_lifecycle_update"');
 		expect(extension).toContain('name: "conductor_commit"');
 		expect(extension).toContain('name: "conductor_push"');
 		expect(extension).toContain('name: "conductor_pr_create"');

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -16,5 +16,8 @@ describe("pi-conductor extension", () => {
 		expect(extension).toContain('name: "conductor_recover"');
 		expect(extension).toContain('name: "conductor_summary_refresh"');
 		expect(extension).toContain('name: "conductor_cleanup"');
+		expect(extension).toContain('name: "conductor_commit"');
+		expect(extension).toContain('name: "conductor_push"');
+		expect(extension).toContain('name: "conductor_pr_create"');
 	});
 });

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -15,5 +15,6 @@ describe("pi-conductor extension", () => {
 		expect(extension).toContain('name: "conductor_task_update"');
 		expect(extension).toContain('name: "conductor_recover"');
 		expect(extension).toContain('name: "conductor_summary_refresh"');
+		expect(extension).toContain('name: "conductor_cleanup"');
 	});
 });

--- a/packages/pi-conductor/__tests__/lifecycle.test.ts
+++ b/packages/pi-conductor/__tests__/lifecycle.test.ts
@@ -1,0 +1,48 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorkerForRepo, getOrCreateRunForRepo, resumeWorkerForRepo, updateWorkerLifecycleForRepo } from "../extensions/conductor.js";
+
+describe("worker lifecycle flows", () => {
+	let repoDir: string;
+	let conductorHome: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+		process.env.PI_CONDUCTOR_HOME = conductorHome;
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello\n");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		delete process.env.PI_CONDUCTOR_HOME;
+		for (const dir of [repoDir, conductorHome]) {
+			if (dir && existsSync(dir)) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("resumes a healthy worker using its persisted worktree and session linkage", async () => {
+		const created = await createWorkerForRepo(repoDir, "backend");
+		const resumed = resumeWorkerForRepo(repoDir, "backend");
+		expect(resumed.workerId).toBe(created.workerId);
+		expect(resumed.worktreePath).toBe(created.worktreePath);
+		expect(resumed.sessionFile).toBe(created.sessionFile);
+	});
+
+	it("updates a worker lifecycle to blocked, ready_for_pr, and done", async () => {
+		await createWorkerForRepo(repoDir, "backend");
+		expect(updateWorkerLifecycleForRepo(repoDir, "backend", "blocked").lifecycle).toBe("blocked");
+		expect(updateWorkerLifecycleForRepo(repoDir, "backend", "ready_for_pr").lifecycle).toBe("ready_for_pr");
+		expect(updateWorkerLifecycleForRepo(repoDir, "backend", "done").lifecycle).toBe("done");
+		expect(getOrCreateRunForRepo(repoDir).workers[0]?.lifecycle).toBe("done");
+	});
+});

--- a/packages/pi-conductor/__tests__/pr-flow.test.ts
+++ b/packages/pi-conductor/__tests__/pr-flow.test.ts
@@ -1,0 +1,116 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runConductorCommand } from "../extensions/commands.js";
+import { getOrCreateRunForRepo } from "../extensions/conductor.js";
+
+describe("PR preparation flow", () => {
+	let repoDir: string;
+	let bareRemoteDir: string;
+	let conductorHome: string;
+	let fakeBinDir: string;
+	let originalPath: string | undefined;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		bareRemoteDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+		fakeBinDir = mkdtempSync(join(tmpdir(), "pi-conductor-bin-"));
+		originalPath = process.env.PATH;
+		process.env.PI_CONDUCTOR_HOME = conductorHome;
+		process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+
+		execSync("git init --bare", { cwd: bareRemoteDir, stdio: "pipe" });
+		execSync(`git remote add origin ${bareRemoteDir}`, { cwd: repoDir, stdio: "pipe" });
+		execSync("git push -u origin main", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		delete process.env.PI_CONDUCTOR_HOME;
+		process.env.PATH = originalPath;
+		for (const dir of [repoDir, bareRemoteDir, conductorHome, fakeBinDir]) {
+			if (dir && existsSync(dir)) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	function writeFakeGhScript(content: string): void {
+		const path = join(fakeBinDir, "gh");
+		writeFileSync(path, `#!/bin/sh\n${content}\n`, { encoding: "utf-8", mode: 0o755 });
+	}
+
+	async function createChangedWorker(): Promise<string> {
+		await runConductorCommand(repoDir, "start backend");
+		const worker = getOrCreateRunForRepo(repoDir).workers[0];
+		if (!worker?.worktreePath) {
+			throw new Error("worker worktree missing in test setup");
+		}
+		writeFileSync(join(worker.worktreePath, "backend.txt"), "backend changes\n", "utf-8");
+		return worker.worktreePath;
+	}
+
+	it("commits worker changes and persists commit state", async () => {
+		const worktreePath = await createChangedWorker();
+		const text = await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+		expect(text).toContain("committed worker backend");
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.pushSucceeded).toBe(false);
+
+		const log = execSync("git log -1 --pretty=%s", { cwd: worktreePath, encoding: "utf-8" }).trim();
+		expect(log).toBe("feat: add backend worker");
+	});
+
+	it("pushes a worker branch and persists push state", async () => {
+		await createChangedWorker();
+		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+		const text = await runConductorCommand(repoDir, "push backend");
+		expect(text).toContain("pushed worker backend");
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+		const remoteHead = execSync("git ls-remote --heads origin conductor/backend", { cwd: repoDir, encoding: "utf-8" }).trim();
+		expect(remoteHead).toContain("refs/heads/conductor/backend");
+	});
+
+	it("creates a pull request and persists PR metadata", async () => {
+		writeFakeGhScript("echo 'https://github.com/example/repo/pull/123'");
+		await createChangedWorker();
+		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+		await runConductorCommand(repoDir, "push backend");
+		const text = await runConductorCommand(repoDir, "pr backend Backend worker PR");
+		expect(text).toContain("created PR for backend");
+		expect(text).toContain("pull/123");
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
+		expect(run.workers[0]?.pr.number).toBe(123);
+		expect(run.workers[0]?.pr.url).toContain("pull/123");
+	});
+
+	it("persists partial PR state when gh pr create fails", async () => {
+		writeFakeGhScript("echo 'gh pr create failed' >&2\nexit 1");
+		await createChangedWorker();
+		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+		await runConductorCommand(repoDir, "push backend");
+
+		await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow();
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
+		expect(run.workers[0]?.pr.url).toBeNull();
+	});
+});

--- a/packages/pi-conductor/__tests__/pr-flow.test.ts
+++ b/packages/pi-conductor/__tests__/pr-flow.test.ts
@@ -85,7 +85,7 @@ describe("PR preparation flow", () => {
 	});
 
 	it("creates a pull request and persists PR metadata", async () => {
-		writeFakeGhScript("echo 'https://github.com/example/repo/pull/123'");
+		writeFakeGhScript("if [ \"$1\" = \"--version\" ]; then echo 'gh version test'; exit 0; fi\nif [ \"$1 $2\" = \"auth status\" ]; then exit 0; fi\necho 'https://github.com/example/repo/pull/123'");
 		await createChangedWorker();
 		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
 		await runConductorCommand(repoDir, "push backend");
@@ -100,7 +100,7 @@ describe("PR preparation flow", () => {
 	});
 
 	it("persists partial PR state when gh pr create fails", async () => {
-		writeFakeGhScript("echo 'gh pr create failed' >&2\nexit 1");
+		writeFakeGhScript("if [ \"$1\" = \"--version\" ]; then echo 'gh version test'; exit 0; fi\nif [ \"$1 $2\" = \"auth status\" ]; then exit 0; fi\necho 'gh pr create failed' >&2\nexit 1");
 		await createChangedWorker();
 		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
 		await runConductorCommand(repoDir, "push backend");
@@ -112,5 +112,34 @@ describe("PR preparation flow", () => {
 		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
 		expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
 		expect(run.workers[0]?.pr.url).toBeNull();
+	});
+
+	it("reports a preflight error when gh is not installed", async () => {
+		writeFakeGhScript("exit 127");
+		process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+		await createChangedWorker();
+		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+		await runConductorCommand(repoDir, "push backend");
+
+		await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow(/GitHub CLI/i);
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.prCreationAttempted).toBe(false);
+	});
+
+	it("reports a preflight error when gh is not authenticated", async () => {
+		writeFakeGhScript("if [ \"$1\" = \"--version\" ]; then echo 'gh version test'; exit 0; fi\nif [ \"$1 $2\" = \"auth status\" ]; then echo 'not authenticated' >&2; exit 1; fi\necho 'unexpected call' >&2\nexit 1");
+		await createChangedWorker();
+		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+		await runConductorCommand(repoDir, "push backend");
+
+		await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow(/authenticated/i);
+
+		const run = getOrCreateRunForRepo(repoDir);
+		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+		expect(run.workers[0]?.pr.prCreationAttempted).toBe(false);
 	});
 });

--- a/packages/pi-conductor/__tests__/recovery.test.ts
+++ b/packages/pi-conductor/__tests__/recovery.test.ts
@@ -48,4 +48,15 @@ describe("recovery flows", () => {
 		expect(recovered.lifecycle).toBe("idle");
 		expect(recovered.recoverable).toBe(false);
 	});
+
+	it("recreates a missing worktree during recovery", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
+		rmSync(worker.worktreePath!, { recursive: true, force: true });
+		const recovered = await recoverWorkerForRepo(repoDir, "backend");
+		expect(recovered.worktreePath).toBeTruthy();
+		expect(existsSync(recovered.worktreePath!)).toBe(true);
+		expect(recovered.sessionFile).toBeTruthy();
+		expect(existsSync(recovered.sessionFile!)).toBe(true);
+		expect(recovered.lifecycle).toBe("idle");
+	});
 });

--- a/packages/pi-conductor/__tests__/recovery.test.ts
+++ b/packages/pi-conductor/__tests__/recovery.test.ts
@@ -1,0 +1,51 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorkerForRepo, getOrCreateRunForRepo, reconcileWorkerHealth, recoverWorkerForRepo } from "../extensions/conductor.js";
+
+describe("recovery flows", () => {
+	let repoDir: string;
+	let conductorHome: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+		process.env.PI_CONDUCTOR_HOME = conductorHome;
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		delete process.env.PI_CONDUCTOR_HOME;
+		if (existsSync(repoDir)) {
+			rmSync(repoDir, { recursive: true, force: true });
+		}
+		if (existsSync(conductorHome)) {
+			rmSync(conductorHome, { recursive: true, force: true });
+		}
+	});
+
+	it("marks a worker broken and recoverable when its session file is missing", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
+		rmSync(worker.sessionFile!, { force: true });
+		const updated = reconcileWorkerHealth(getOrCreateRunForRepo(repoDir));
+		expect(updated.workers[0]?.lifecycle).toBe("broken");
+		expect(updated.workers[0]?.recoverable).toBe(true);
+	});
+
+	it("recreates a missing session file during recovery", async () => {
+		const worker = await createWorkerForRepo(repoDir, "backend");
+		rmSync(worker.sessionFile!, { force: true });
+		const recovered = await recoverWorkerForRepo(repoDir, "backend");
+		expect(recovered.sessionFile).toBeTruthy();
+		expect(existsSync(recovered.sessionFile!)).toBe(true);
+		expect(recovered.lifecycle).toBe("idle");
+		expect(recovered.recoverable).toBe(false);
+	});
+});

--- a/packages/pi-conductor/__tests__/sessions.test.ts
+++ b/packages/pi-conductor/__tests__/sessions.test.ts
@@ -1,0 +1,31 @@
+import { execSync } from "node:child_process";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorkerSessionLink } from "../extensions/sessions.js";
+
+describe("session linkage", () => {
+	let repoDir: string;
+
+	beforeEach(() => {
+		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+		writeFileSync(join(repoDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		if (repoDir && existsSync(repoDir)) {
+			rmSync(repoDir, { recursive: true, force: true });
+		}
+	});
+
+	it("creates a persisted pi session file for a worker worktree", async () => {
+		const sessionFile = await createWorkerSessionLink(repoDir);
+		expect(sessionFile).toBeTruthy();
+		expect(existsSync(sessionFile!)).toBe(true);
+	});
+});

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatRunStatus } from "../extensions/status.js";
+import { createEmptyRun, createWorkerRecord } from "../extensions/storage.js";
+
+describe("formatRunStatus", () => {
+	it("formats an empty run", () => {
+		const run = createEmptyRun("abc", "/tmp/repo");
+		const text = formatRunStatus(run);
+		expect(text).toContain("projectKey: abc");
+		expect(text).toContain("workers: 0");
+	});
+
+	it("includes task, session, pr, and summary staleness details", () => {
+		const run = createEmptyRun("abc", "/tmp/repo");
+		const worker = createWorkerRecord({
+			workerId: "worker-1",
+			name: "backend",
+			branch: "conductor/backend",
+			worktreePath: "/tmp/repo/.worktrees/backend",
+			sessionFile: "/tmp/session.jsonl",
+		});
+		worker.currentTask = "implement status command";
+		worker.summary.text = "Half done";
+		worker.summary.stale = true;
+		worker.pr.url = "https://github.com/example/repo/pull/123";
+
+		const text = formatRunStatus({ ...run, workers: [worker] });
+		expect(text).toContain("task=implement status command");
+		expect(text).toContain("session=/tmp/session.jsonl");
+		expect(text).toContain("pr=https://github.com/example/repo/pull/123");
+		expect(text).toContain("summary=stale: Half done");
+	});
+});

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -24,10 +24,17 @@ describe("formatRunStatus", () => {
 		worker.summary.stale = true;
 		worker.pr.url = "https://github.com/example/repo/pull/123";
 
+		worker.pr.commitSucceeded = true;
+		worker.pr.pushSucceeded = true;
+		worker.pr.prCreationAttempted = true;
+
 		const text = formatRunStatus({ ...run, workers: [worker] });
 		expect(text).toContain("task=implement status command");
 		expect(text).toContain("session=/tmp/session.jsonl");
 		expect(text).toContain("pr=https://github.com/example/repo/pull/123");
+		expect(text).toContain("commit=true");
+		expect(text).toContain("push=true");
+		expect(text).toContain("prAttempted=true");
 		expect(text).toContain("recoverable=false");
 		expect(text).toContain("summary=stale: Half done");
 	});

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -29,6 +29,7 @@ describe("formatRunStatus", () => {
 		worker.pr.prCreationAttempted = true;
 
 		const text = formatRunStatus({ ...run, workers: [worker] });
+		expect(text).toContain("health=stale");
 		expect(text).toContain("task=implement status command");
 		expect(text).toContain("session=/tmp/session.jsonl");
 		expect(text).toContain("pr=https://github.com/example/repo/pull/123");

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -28,6 +28,7 @@ describe("formatRunStatus", () => {
 		expect(text).toContain("task=implement status command");
 		expect(text).toContain("session=/tmp/session.jsonl");
 		expect(text).toContain("pr=https://github.com/example/repo/pull/123");
+		expect(text).toContain("recoverable=false");
 		expect(text).toContain("summary=stale: Half done");
 	});
 });

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createEmptyRun, getConductorProjectDir } from "../extensions/storage.js";
+import { addWorker, createEmptyRun, createWorkerRecord, getConductorProjectDir } from "../extensions/storage.js";
 
 describe("storage helpers", () => {
 	it("creates an empty run", () => {
@@ -12,5 +12,64 @@ describe("storage helpers", () => {
 	it("builds a conductor project dir", () => {
 		const dir = getConductorProjectDir("abc");
 		expect(dir).toContain(".pi/agent/conductor/projects/abc");
+	});
+
+	it("creates a worker record with default lifecycle metadata", () => {
+		const worker = createWorkerRecord({
+			workerId: "worker-1",
+			name: "backend",
+			branch: "conductor/backend",
+			worktreePath: "/tmp/repo/.worktrees/backend",
+			sessionFile: null,
+		});
+
+		expect(worker.workerId).toBe("worker-1");
+		expect(worker.name).toBe("backend");
+		expect(worker.lifecycle).toBe("idle");
+		expect(worker.currentTask).toBeNull();
+		expect(worker.recoverable).toBe(false);
+		expect(worker.summary.stale).toBe(false);
+		expect(worker.pr.prCreationAttempted).toBe(false);
+	});
+
+	it("adds a worker and updates the run timestamp", () => {
+		const run = createEmptyRun("abc", "/tmp/repo");
+		const worker = createWorkerRecord({
+			workerId: "worker-1",
+			name: "backend",
+			branch: "conductor/backend",
+			worktreePath: "/tmp/repo/.worktrees/backend",
+			sessionFile: null,
+		});
+
+		const updated = addWorker(run, worker);
+		expect(updated.workers).toHaveLength(1);
+		expect(updated.workers[0]?.name).toBe("backend");
+		expect(updated.updatedAt >= run.updatedAt).toBe(true);
+	});
+
+	it("rejects duplicate worker names within a project", () => {
+		const run = createEmptyRun("abc", "/tmp/repo");
+		const worker = createWorkerRecord({
+			workerId: "worker-1",
+			name: "backend",
+			branch: "conductor/backend",
+			worktreePath: "/tmp/repo/.worktrees/backend",
+			sessionFile: null,
+		});
+
+		const updated = addWorker(run, worker);
+		expect(() =>
+			addWorker(
+				updated,
+				createWorkerRecord({
+					workerId: "worker-2",
+					name: "backend",
+					branch: "conductor/backend-2",
+					worktreePath: "/tmp/repo/.worktrees/backend-2",
+					sessionFile: null,
+				}),
+			),
+		).toThrow(/already exists/i);
 	});
 });

--- a/packages/pi-conductor/__tests__/summaries.test.ts
+++ b/packages/pi-conductor/__tests__/summaries.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { generateWorkerSummaryFromSession } from "../extensions/summaries.js";
+
+describe("generateWorkerSummaryFromSession", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("extracts text from a persisted pi session file", () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-conductor-summary-"));
+		tempDirs.push(dir);
+		const sessionFile = join(dir, "worker.jsonl");
+		writeFileSync(
+			sessionFile,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "session-1", timestamp: "2026-01-01T00:00:00.000Z", cwd: "/tmp/repo" }),
+				JSON.stringify({ type: "message", id: "u1", parentId: null, timestamp: "2026-01-01T00:00:01.000Z", message: { role: "user", content: "Implement status output" } }),
+				JSON.stringify({ type: "message", id: "a1", parentId: "u1", timestamp: "2026-01-01T00:00:02.000Z", message: { role: "assistant", content: [{ type: "text", text: "Added status output and worker recovery handling." }] } }),
+			].join("\n") + "\n",
+			"utf-8",
+		);
+
+		expect(generateWorkerSummaryFromSession(sessionFile)).toBe("Implement status output | Added status output and worker recovery handling.");
+	});
+});

--- a/packages/pi-conductor/__tests__/workers.test.ts
+++ b/packages/pi-conductor/__tests__/workers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildBranchName, createWorkerId, normalizeWorkerSlug } from "../extensions/workers.js";
+import { createEmptyRun, createWorkerRecord, setWorkerTask } from "../extensions/storage.js";
+
+describe("worker helpers", () => {
+	it("normalizes worker names into branch-safe slugs", () => {
+		expect(normalizeWorkerSlug("Fix Auth")).toBe("fix-auth");
+		expect(normalizeWorkerSlug("frontend/api")).toBe("frontend-api");
+		expect(normalizeWorkerSlug("***")).toBeNull();
+	});
+
+	it("builds a branch name from a normalized worker slug", () => {
+		expect(buildBranchName("worker-1", "Fix Auth")).toBe("conductor/fix-auth");
+		expect(buildBranchName("worker-1", "***")).toBe("conductor/worker-1");
+	});
+
+	it("creates stable-enough worker ids with conductor prefix", () => {
+		const id = createWorkerId();
+		expect(id.startsWith("worker-")).toBe(true);
+		expect(id.length).toBeGreaterThan(10);
+	});
+
+	it("updating a task marks an existing summary as stale", () => {
+		const run = createEmptyRun("abc", "/tmp/repo");
+		const worker = createWorkerRecord({
+			workerId: "worker-1",
+			name: "backend",
+			branch: "conductor/backend",
+			worktreePath: "/tmp/repo/.worktrees/backend",
+			sessionFile: "/tmp/session.jsonl",
+		});
+		worker.summary.text = "Current progress";
+		worker.summary.updatedAt = new Date().toISOString();
+
+		const updated = setWorkerTask({ ...run, workers: [worker] }, "worker-1", "implement status command");
+		expect(updated.workers[0]?.currentTask).toBe("implement status command");
+		expect(updated.workers[0]?.summary.stale).toBe(true);
+	});
+});

--- a/packages/pi-conductor/__tests__/worktrees.test.ts
+++ b/packages/pi-conductor/__tests__/worktrees.test.ts
@@ -1,0 +1,56 @@
+import { execSync } from "node:child_process";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createManagedWorktree, getCurrentBranch, planWorktreePath } from "../extensions/worktrees.js";
+
+describe("worktree helpers", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+		execSync("git init -b main", { cwd: tempDir, stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", { cwd: tempDir, stdio: "pipe" });
+		execSync("git config user.name 'Test User'", { cwd: tempDir, stdio: "pipe" });
+		writeFileSync(join(tempDir, "README.md"), "hello");
+		execSync("git add README.md", { cwd: tempDir, stdio: "pipe" });
+		execSync("git commit -m 'initial commit'", { cwd: tempDir, stdio: "pipe" });
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+		const siblingRoot = join(tempDir, "..", ".pi-conductor-worktrees", basename(tempDir));
+		if (existsSync(siblingRoot)) {
+			rmSync(siblingRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("gets the current branch from a repo root", () => {
+		expect(getCurrentBranch(tempDir)).toBe("main");
+	});
+
+	it("plans a worktree path outside the repo root", () => {
+		const path = planWorktreePath(tempDir, "backend");
+		expect(path).toContain(`.pi-conductor-worktrees/${basename(tempDir)}`);
+		expect(path).toContain("backend");
+		expect(path.startsWith(tempDir)).toBe(false);
+	});
+
+	it("creates a managed worktree on a conductor branch", () => {
+		const result = createManagedWorktree(tempDir, {
+			workerId: "worker-1",
+			workerName: "backend",
+		});
+
+		expect(result.branch).toBe("conductor/backend");
+		expect(existsSync(result.worktreePath)).toBe(true);
+
+		const branch = execSync("git branch --show-current", {
+			cwd: result.worktreePath,
+			encoding: "utf-8",
+		}).trim();
+		expect(branch).toBe("conductor/backend");
+	});
+});

--- a/packages/pi-conductor/__tests__/worktrees.test.ts
+++ b/packages/pi-conductor/__tests__/worktrees.test.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createManagedWorktree, getCurrentBranch, planWorktreePath } from "../extensions/worktrees.js";
+import { createManagedWorktree, getCurrentBranch, planWorktreePath, recreateManagedWorktree } from "../extensions/worktrees.js";
 
 describe("worktree helpers", () => {
 	let tempDir: string;
@@ -52,5 +52,21 @@ describe("worktree helpers", () => {
 			encoding: "utf-8",
 		}).trim();
 		expect(branch).toBe("conductor/backend");
+	});
+
+	it("recreates a pruned managed worktree on an existing branch", () => {
+		const created = createManagedWorktree(tempDir, {
+			workerId: "worker-1",
+			workerName: "backend",
+		});
+		rmSync(created.worktreePath, { recursive: true, force: true });
+
+		const recreated = recreateManagedWorktree(tempDir, {
+			workerName: "backend",
+			branch: created.branch,
+		});
+
+		expect(recreated.branch).toBe(created.branch);
+		expect(existsSync(recreated.worktreePath)).toBe(true);
 	});
 });

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -1,6 +1,9 @@
 import {
+	commitWorkerForRepo,
 	createWorkerForRepo,
+	createWorkerPrForRepo,
 	getOrCreateRunForRepo,
+	pushWorkerForRepo,
 	removeWorkerForRepo,
 	reconcileWorkerHealth,
 	recoverWorkerForRepo,
@@ -18,6 +21,9 @@ function getUsage(): string {
 		"  /conductor recover <worker-name>",
 		"  /conductor summarize <worker-name>",
 		"  /conductor cleanup <worker-name>",
+		"  /conductor commit <worker-name> <message>",
+		"  /conductor push <worker-name>",
+		"  /conductor pr <worker-name> <title>",
 	].join("\n");
 }
 
@@ -71,6 +77,32 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
 		}
 		const worker = removeWorkerForRepo(cwd, workerName);
 		return `removed worker ${worker.name} [${worker.workerId}]`;
+	}
+	if (subcommand === "commit") {
+		const [workerName, ...messageParts] = rest;
+		const message = messageParts.join(" ").trim();
+		if (!workerName || !message) {
+			return `${getUsage()}\n\nerror: missing worker name or commit message`;
+		}
+		const worker = commitWorkerForRepo(cwd, workerName, message);
+		return `committed worker ${worker.name}: ${message}`;
+	}
+	if (subcommand === "push") {
+		const workerName = rest.join(" ").trim();
+		if (!workerName) {
+			return `${getUsage()}\n\nerror: missing worker name`;
+		}
+		const worker = pushWorkerForRepo(cwd, workerName);
+		return `pushed worker ${worker.name} on branch ${worker.branch}`;
+	}
+	if (subcommand === "pr") {
+		const [workerName, ...titleParts] = rest;
+		const title = titleParts.join(" ").trim();
+		if (!workerName || !title) {
+			return `${getUsage()}\n\nerror: missing worker name or PR title`;
+		}
+		const worker = createWorkerPrForRepo(cwd, workerName, title);
+		return `created PR for ${worker.name}: ${worker.pr.url}`;
 	}
 
 	return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -8,6 +8,8 @@ import {
 	reconcileWorkerHealth,
 	recoverWorkerForRepo,
 	refreshWorkerSummaryForRepo,
+	resumeWorkerForRepo,
+	updateWorkerLifecycleForRepo,
 	updateWorkerTaskForRepo,
 } from "./conductor.js";
 import { formatRunStatus } from "./status.js";
@@ -18,6 +20,8 @@ function getUsage(): string {
 		"  /conductor status",
 		"  /conductor start <worker-name>",
 		"  /conductor task <worker-name> <task>",
+		"  /conductor resume <worker-name>",
+		"  /conductor state <worker-name> <lifecycle>",
 		"  /conductor recover <worker-name>",
 		"  /conductor summarize <worker-name>",
 		"  /conductor cleanup <worker-name>",
@@ -53,6 +57,22 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
 		}
 		const worker = updateWorkerTaskForRepo(cwd, workerName, task);
 		return `updated task for ${worker.name}: ${worker.currentTask}`;
+	}
+	if (subcommand === "resume") {
+		const workerName = rest.join(" ").trim();
+		if (!workerName) {
+			return `${getUsage()}\n\nerror: missing worker name`;
+		}
+		const worker = resumeWorkerForRepo(cwd, workerName);
+		return `resumed worker ${worker.name}: session=${worker.sessionFile}`;
+	}
+	if (subcommand === "state") {
+		const [workerName, lifecycle] = rest;
+		if (!workerName || !lifecycle) {
+			return `${getUsage()}\n\nerror: missing worker name or lifecycle state`;
+		}
+		const worker = updateWorkerLifecycleForRepo(cwd, workerName, lifecycle as never);
+		return `updated worker ${worker.name} state to ${worker.lifecycle}`;
 	}
 	if (subcommand === "recover") {
 		const workerName = rest.join(" ").trim();

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -1,0 +1,42 @@
+import { createWorkerForRepo, getOrCreateRunForRepo, updateWorkerTaskForRepo } from "./conductor.js";
+import { formatRunStatus } from "./status.js";
+
+function getUsage(): string {
+	return [
+		"usage:",
+		"  /conductor status",
+		"  /conductor start <worker-name>",
+		"  /conductor task <worker-name> <task>",
+	].join("\n");
+}
+
+export function runConductorCommand(cwd: string, args: string): string {
+	const trimmed = args.trim();
+	if (!trimmed || trimmed === "help") {
+		return getUsage();
+	}
+
+	const [subcommand, ...rest] = trimmed.split(/\s+/);
+	if (subcommand === "status") {
+		return formatRunStatus(getOrCreateRunForRepo(cwd));
+	}
+	if (subcommand === "start") {
+		const workerName = rest.join(" ").trim();
+		if (!workerName) {
+			return `${getUsage()}\n\nerror: missing worker name`;
+		}
+		const worker = createWorkerForRepo(cwd, workerName);
+		return `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}`;
+	}
+	if (subcommand === "task") {
+		const [workerName, ...taskParts] = rest;
+		const task = taskParts.join(" ").trim();
+		if (!workerName || !task) {
+			return `${getUsage()}\n\nerror: missing worker name or task`;
+		}
+		const worker = updateWorkerTaskForRepo(cwd, workerName, task);
+		return `updated task for ${worker.name}: ${worker.currentTask}`;
+	}
+
+	return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;
+}

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -1,4 +1,10 @@
-import { createWorkerForRepo, getOrCreateRunForRepo, updateWorkerTaskForRepo } from "./conductor.js";
+import {
+	createWorkerForRepo,
+	getOrCreateRunForRepo,
+	reconcileWorkerHealth,
+	recoverWorkerForRepo,
+	updateWorkerTaskForRepo,
+} from "./conductor.js";
 import { formatRunStatus } from "./status.js";
 
 function getUsage(): string {
@@ -7,6 +13,7 @@ function getUsage(): string {
 		"  /conductor status",
 		"  /conductor start <worker-name>",
 		"  /conductor task <worker-name> <task>",
+		"  /conductor recover <worker-name>",
 	].join("\n");
 }
 
@@ -18,7 +25,7 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
 
 	const [subcommand, ...rest] = trimmed.split(/\s+/);
 	if (subcommand === "status") {
-		return formatRunStatus(getOrCreateRunForRepo(cwd));
+		return formatRunStatus(reconcileWorkerHealth(getOrCreateRunForRepo(cwd)));
 	}
 	if (subcommand === "start") {
 		const workerName = rest.join(" ").trim();
@@ -36,6 +43,14 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
 		}
 		const worker = updateWorkerTaskForRepo(cwd, workerName, task);
 		return `updated task for ${worker.name}: ${worker.currentTask}`;
+	}
+	if (subcommand === "recover") {
+		const workerName = rest.join(" ").trim();
+		if (!workerName) {
+			return `${getUsage()}\n\nerror: missing worker name`;
+		}
+		const worker = await recoverWorkerForRepo(cwd, workerName);
+		return `recovered worker ${worker.name}: session=${worker.sessionFile}`;
 	}
 
 	return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -10,7 +10,7 @@ function getUsage(): string {
 	].join("\n");
 }
 
-export function runConductorCommand(cwd: string, args: string): string {
+export async function runConductorCommand(cwd: string, args: string): Promise<string> {
 	const trimmed = args.trim();
 	if (!trimmed || trimmed === "help") {
 		return getUsage();
@@ -25,7 +25,7 @@ export function runConductorCommand(cwd: string, args: string): string {
 		if (!workerName) {
 			return `${getUsage()}\n\nerror: missing worker name`;
 		}
-		const worker = createWorkerForRepo(cwd, workerName);
+		const worker = await createWorkerForRepo(cwd, workerName);
 		return `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}`;
 	}
 	if (subcommand === "task") {

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -3,6 +3,7 @@ import {
 	getOrCreateRunForRepo,
 	reconcileWorkerHealth,
 	recoverWorkerForRepo,
+	refreshWorkerSummaryForRepo,
 	updateWorkerTaskForRepo,
 } from "./conductor.js";
 import { formatRunStatus } from "./status.js";
@@ -14,6 +15,7 @@ function getUsage(): string {
 		"  /conductor start <worker-name>",
 		"  /conductor task <worker-name> <task>",
 		"  /conductor recover <worker-name>",
+		"  /conductor summarize <worker-name>",
 	].join("\n");
 }
 
@@ -51,6 +53,14 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
 		}
 		const worker = await recoverWorkerForRepo(cwd, workerName);
 		return `recovered worker ${worker.name}: session=${worker.sessionFile}`;
+	}
+	if (subcommand === "summarize") {
+		const workerName = rest.join(" ").trim();
+		if (!workerName) {
+			return `${getUsage()}\n\nerror: missing worker name`;
+		}
+		const worker = refreshWorkerSummaryForRepo(cwd, workerName);
+		return `refreshed summary for ${worker.name}: ${worker.summary.text}`;
 	}
 
 	return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -1,6 +1,7 @@
 import {
 	createWorkerForRepo,
 	getOrCreateRunForRepo,
+	removeWorkerForRepo,
 	reconcileWorkerHealth,
 	recoverWorkerForRepo,
 	refreshWorkerSummaryForRepo,
@@ -16,6 +17,7 @@ function getUsage(): string {
 		"  /conductor task <worker-name> <task>",
 		"  /conductor recover <worker-name>",
 		"  /conductor summarize <worker-name>",
+		"  /conductor cleanup <worker-name>",
 	].join("\n");
 }
 
@@ -61,6 +63,14 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
 		}
 		const worker = refreshWorkerSummaryForRepo(cwd, workerName);
 		return `refreshed summary for ${worker.name}: ${worker.summary.text}`;
+	}
+	if (subcommand === "cleanup") {
+		const workerName = rest.join(" ").trim();
+		if (!workerName) {
+			return `${getUsage()}\n\nerror: missing worker name`;
+		}
+		const worker = removeWorkerForRepo(cwd, workerName);
+		return `removed worker ${worker.name} [${worker.workerId}]`;
 	}
 
 	return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
 import { addWorker, createEmptyRun, createWorkerRecord, readRun, setWorkerTask, writeRun } from "./storage.js";
@@ -49,6 +50,66 @@ export function updateWorkerTaskForRepo(repoRoot: string, workerName: string, ta
 	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
 	if (!updatedWorker) {
 		throw new Error(`Worker named ${workerName} disappeared during task update`);
+	}
+	return updatedWorker;
+}
+
+export function reconcileWorkerHealth(run: RunRecord): RunRecord {
+	const workers = run.workers.map((worker) => {
+		const worktreeMissing = !worker.worktreePath || !existsSync(worker.worktreePath);
+		const sessionMissing = !worker.sessionFile || !existsSync(worker.sessionFile);
+		if (!worktreeMissing && !sessionMissing) {
+			return worker;
+		}
+		return {
+			...worker,
+			lifecycle: "broken" as const,
+			recoverable: true,
+			updatedAt: new Date().toISOString(),
+		};
+	});
+	return {
+		...run,
+		workers,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export async function recoverWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+
+	let sessionFile = worker.sessionFile;
+	if (!sessionFile || !existsSync(sessionFile)) {
+		if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
+			throw new Error(`Worker named ${workerName} cannot be recovered without a valid worktree`);
+		}
+		sessionFile = await createWorkerSessionLink(worker.worktreePath);
+	}
+
+	const workers = run.workers.map((entry) =>
+		entry.workerId === worker.workerId
+			? {
+				...entry,
+				sessionFile,
+				lifecycle: "idle" as const,
+				recoverable: false,
+				updatedAt: new Date().toISOString(),
+			}
+			: entry,
+	);
+	const updatedRun = {
+		...run,
+		workers,
+		updatedAt: new Date().toISOString(),
+	};
+	writeRun(updatedRun);
+	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+	if (!updatedWorker) {
+		throw new Error(`Worker named ${workerName} disappeared during recovery`);
 	}
 	return updatedWorker;
 }

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -14,7 +14,7 @@ import {
 	writeRun,
 } from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
-import { createManagedWorktree, recreateManagedWorktree, removeManagedWorktree } from "./worktrees.js";
+import { createManagedWorktree, recreateManagedWorktree, removeManagedBranch, removeManagedWorktree } from "./worktrees.js";
 import { createWorkerSessionLink } from "./sessions.js";
 import { generateWorkerSummaryFromSession } from "./summaries.js";
 import { createWorkerId } from "./workers.js";
@@ -117,6 +117,9 @@ export function removeWorkerForRepo(repoRoot: string, workerName: string): Worke
 	}
 	if (worker.sessionFile && existsSync(worker.sessionFile)) {
 		rmSync(worker.sessionFile, { force: true });
+	}
+	if (worker.branch) {
+		removeManagedBranch(run.repoRoot, worker.branch);
 	}
 	const updatedRun = removeWorker(run, worker.workerId);
 	writeRun(updatedRun);

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,7 +1,18 @@
 import { existsSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
-import { addWorker, createEmptyRun, createWorkerRecord, readRun, removeWorker, setWorkerSummary, setWorkerTask, writeRun } from "./storage.js";
+import { createPullRequest, commitAllChanges, pushBranchToOrigin } from "./git-pr.js";
+import {
+	addWorker,
+	createEmptyRun,
+	createWorkerRecord,
+	readRun,
+	removeWorker,
+	setWorkerPrState,
+	setWorkerSummary,
+	setWorkerTask,
+	writeRun,
+} from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
 import { createManagedWorktree, recreateManagedWorktree, removeManagedWorktree } from "./worktrees.js";
 import { createWorkerSessionLink } from "./sessions.js";
@@ -110,6 +121,80 @@ export function removeWorkerForRepo(repoRoot: string, workerName: string): Worke
 	const updatedRun = removeWorker(run, worker.workerId);
 	writeRun(updatedRun);
 	return worker;
+}
+
+export function commitWorkerForRepo(repoRoot: string, workerName: string, message: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
+		throw new Error(`Worker named ${workerName} does not have a valid worktree`);
+	}
+	commitAllChanges(worker.worktreePath, message);
+	const updatedRun = setWorkerPrState(run, worker.workerId, {
+		commitSucceeded: true,
+		pushSucceeded: false,
+		prCreationAttempted: false,
+		url: null,
+		number: null,
+	});
+	writeRun(updatedRun);
+	return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+}
+
+export function pushWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
+		throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
+	}
+	pushBranchToOrigin(worker.worktreePath, worker.branch);
+	const updatedRun = setWorkerPrState(run, worker.workerId, {
+		pushSucceeded: true,
+	});
+	writeRun(updatedRun);
+	return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+}
+
+export function createWorkerPrForRepo(repoRoot: string, workerName: string, title: string, body?: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
+		throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
+	}
+	const prBody = body?.trim() || worker.summary.text || worker.currentTask || `PR for ${worker.name}`;
+	try {
+		const pr = createPullRequest({
+			repoRoot: run.repoRoot,
+			worktreePath: worker.worktreePath,
+			branch: worker.branch,
+			title,
+			body: prBody,
+		});
+		const updatedRun = setWorkerPrState(run, worker.workerId, {
+			prCreationAttempted: true,
+			url: pr.url,
+			number: pr.number,
+		});
+		writeRun(updatedRun);
+		return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+	} catch (error) {
+		const updatedRun = setWorkerPrState(run, worker.workerId, {
+			prCreationAttempted: true,
+			url: null,
+			number: null,
+		});
+		writeRun(updatedRun);
+		throw error;
+	}
 }
 
 export async function recoverWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,9 +1,9 @@
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
-import { addWorker, createEmptyRun, createWorkerRecord, readRun, setWorkerSummary, setWorkerTask, writeRun } from "./storage.js";
+import { addWorker, createEmptyRun, createWorkerRecord, readRun, removeWorker, setWorkerSummary, setWorkerTask, writeRun } from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
-import { createManagedWorktree, recreateManagedWorktree } from "./worktrees.js";
+import { createManagedWorktree, recreateManagedWorktree, removeManagedWorktree } from "./worktrees.js";
 import { createWorkerSessionLink } from "./sessions.js";
 import { generateWorkerSummaryFromSession } from "./summaries.js";
 import { createWorkerId } from "./workers.js";
@@ -93,6 +93,23 @@ export function refreshWorkerSummaryForRepo(repoRoot: string, workerName: string
 		throw new Error(`Worker named ${workerName} disappeared during summary refresh`);
 	}
 	return updatedWorker;
+}
+
+export function removeWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	if (worker.worktreePath && existsSync(worker.worktreePath)) {
+		removeManagedWorktree(run.repoRoot, worker.worktreePath);
+	}
+	if (worker.sessionFile && existsSync(worker.sessionFile)) {
+		rmSync(worker.sessionFile, { force: true });
+	}
+	const updatedRun = removeWorker(run, worker.workerId);
+	writeRun(updatedRun);
+	return worker;
 }
 
 export async function recoverWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -3,6 +3,7 @@ import { deriveProjectKey } from "./project-key.js";
 import { addWorker, createEmptyRun, createWorkerRecord, readRun, setWorkerTask, writeRun } from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
 import { createManagedWorktree } from "./worktrees.js";
+import { createWorkerSessionLink } from "./sessions.js";
 import { createWorkerId } from "./workers.js";
 
 export function getOrCreateRunForRepo(repoRoot: string): RunRecord {
@@ -17,19 +18,20 @@ export function getOrCreateRunForRepo(repoRoot: string): RunRecord {
 	return run;
 }
 
-export function createWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
+export async function createWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {
 	const run = getOrCreateRunForRepo(repoRoot);
 	const workerId = createWorkerId();
 	const worktree = createManagedWorktree(run.repoRoot, {
 		workerId,
 		workerName,
 	});
+	const sessionFile = await createWorkerSessionLink(worktree.worktreePath);
 	const worker = createWorkerRecord({
 		workerId,
 		name: workerName,
 		branch: worktree.branch,
 		worktreePath: worktree.worktreePath,
-		sessionFile: null,
+		sessionFile,
 	});
 	const updatedRun = addWorker(run, worker);
 	writeRun(updatedRun);

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -8,12 +8,13 @@ import {
 	createWorkerRecord,
 	readRun,
 	removeWorker,
+	setWorkerLifecycle,
 	setWorkerPrState,
 	setWorkerSummary,
 	setWorkerTask,
 	writeRun,
 } from "./storage.js";
-import type { RunRecord, WorkerRecord } from "./types.js";
+import type { RunRecord, WorkerLifecycleState, WorkerRecord } from "./types.js";
 import { createManagedWorktree, recreateManagedWorktree, removeManagedBranch, removeManagedWorktree } from "./worktrees.js";
 import { createWorkerSessionLink } from "./sessions.js";
 import { generateWorkerSummaryFromSession } from "./summaries.js";
@@ -57,11 +58,45 @@ export function updateWorkerTaskForRepo(repoRoot: string, workerName: string, ta
 	if (!worker) {
 		throw new Error(`Worker named ${workerName} not found`);
 	}
-	const updatedRun = setWorkerTask(run, worker.workerId, task);
+	const updatedRun = setWorkerLifecycle(setWorkerTask(run, worker.workerId, task), worker.workerId, "idle");
 	writeRun(updatedRun);
 	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
 	if (!updatedWorker) {
 		throw new Error(`Worker named ${workerName} disappeared during task update`);
+	}
+	return updatedWorker;
+}
+
+export function resumeWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
+	const run = reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot));
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	if (worker.lifecycle === "broken") {
+		throw new Error(`Worker named ${workerName} is broken and must be recovered before resume`);
+	}
+	return worker;
+}
+
+export function updateWorkerLifecycleForRepo(
+	repoRoot: string,
+	workerName: string,
+	lifecycle: WorkerLifecycleState,
+): WorkerRecord {
+	if (lifecycle === "broken") {
+		throw new Error("Broken lifecycle is reserved for detected health failures");
+	}
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	const updatedRun = setWorkerLifecycle(run, worker.workerId, lifecycle);
+	writeRun(updatedRun);
+	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+	if (!updatedWorker) {
+		throw new Error(`Worker named ${workerName} disappeared during lifecycle update`);
 	}
 	return updatedWorker;
 }

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,10 +1,11 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
-import { addWorker, createEmptyRun, createWorkerRecord, readRun, setWorkerTask, writeRun } from "./storage.js";
+import { addWorker, createEmptyRun, createWorkerRecord, readRun, setWorkerSummary, setWorkerTask, writeRun } from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
-import { createManagedWorktree } from "./worktrees.js";
+import { createManagedWorktree, recreateManagedWorktree } from "./worktrees.js";
 import { createWorkerSessionLink } from "./sessions.js";
+import { generateWorkerSummaryFromSession } from "./summaries.js";
 import { createWorkerId } from "./workers.js";
 
 export function getOrCreateRunForRepo(repoRoot: string): RunRecord {
@@ -75,6 +76,25 @@ export function reconcileWorkerHealth(run: RunRecord): RunRecord {
 	};
 }
 
+export function refreshWorkerSummaryForRepo(repoRoot: string, workerName: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	if (!worker.sessionFile || !existsSync(worker.sessionFile)) {
+		throw new Error(`Worker named ${workerName} does not have a valid session file`);
+	}
+	const summaryText = generateWorkerSummaryFromSession(worker.sessionFile);
+	const updatedRun = setWorkerSummary(run, worker.workerId, summaryText);
+	writeRun(updatedRun);
+	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+	if (!updatedWorker) {
+		throw new Error(`Worker named ${workerName} disappeared during summary refresh`);
+	}
+	return updatedWorker;
+}
+
 export async function recoverWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {
 	const run = getOrCreateRunForRepo(repoRoot);
 	const worker = run.workers.find((entry) => entry.name === workerName);
@@ -82,18 +102,27 @@ export async function recoverWorkerForRepo(repoRoot: string, workerName: string)
 		throw new Error(`Worker named ${workerName} not found`);
 	}
 
+	let worktreePath = worker.worktreePath;
+	if (!worktreePath || !existsSync(worktreePath)) {
+		if (!worker.branch) {
+			throw new Error(`Worker named ${workerName} cannot be recovered without a valid branch`);
+		}
+		worktreePath = recreateManagedWorktree(run.repoRoot, {
+			workerName: worker.name,
+			branch: worker.branch,
+		}).worktreePath;
+	}
+
 	let sessionFile = worker.sessionFile;
 	if (!sessionFile || !existsSync(sessionFile)) {
-		if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
-			throw new Error(`Worker named ${workerName} cannot be recovered without a valid worktree`);
-		}
-		sessionFile = await createWorkerSessionLink(worker.worktreePath);
+		sessionFile = await createWorkerSessionLink(worktreePath);
 	}
 
 	const workers = run.workers.map((entry) =>
 		entry.workerId === worker.workerId
 			? {
 				...entry,
+				worktreePath,
 				sessionFile,
 				lifecycle: "idle" as const,
 				recoverable: false,

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,7 +1,13 @@
 import { existsSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
-import { createPullRequest, commitAllChanges, pushBranchToOrigin } from "./git-pr.js";
+import {
+	createPullRequest,
+	commitAllChanges,
+	pushBranchToOrigin,
+	validatePrPreconditions,
+	validatePushPreconditions,
+} from "./git-pr.js";
 import {
 	addWorker,
 	createEmptyRun,
@@ -191,6 +197,7 @@ export function pushWorkerForRepo(repoRoot: string, workerName: string): WorkerR
 	if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
 		throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
 	}
+	validatePushPreconditions(run.repoRoot);
 	pushBranchToOrigin(worker.worktreePath, worker.branch);
 	const updatedRun = setWorkerPrState(run, worker.workerId, {
 		pushSucceeded: true,
@@ -208,6 +215,7 @@ export function createWorkerPrForRepo(repoRoot: string, workerName: string, titl
 	if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
 		throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
 	}
+	validatePrPreconditions(run.repoRoot);
 	const prBody = body?.trim() || worker.summary.text || worker.currentTask || `PR for ${worker.name}`;
 	try {
 		const pr = createPullRequest({

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,0 +1,52 @@
+import { resolve } from "node:path";
+import { deriveProjectKey } from "./project-key.js";
+import { addWorker, createEmptyRun, createWorkerRecord, readRun, setWorkerTask, writeRun } from "./storage.js";
+import type { RunRecord, WorkerRecord } from "./types.js";
+import { createManagedWorktree } from "./worktrees.js";
+import { createWorkerId } from "./workers.js";
+
+export function getOrCreateRunForRepo(repoRoot: string): RunRecord {
+	const normalizedRoot = resolve(repoRoot);
+	const projectKey = deriveProjectKey(normalizedRoot);
+	const existing = readRun(projectKey);
+	if (existing) {
+		return existing;
+	}
+	const run = createEmptyRun(projectKey, normalizedRoot);
+	writeRun(run);
+	return run;
+}
+
+export function createWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const workerId = createWorkerId();
+	const worktree = createManagedWorktree(run.repoRoot, {
+		workerId,
+		workerName,
+	});
+	const worker = createWorkerRecord({
+		workerId,
+		name: workerName,
+		branch: worktree.branch,
+		worktreePath: worktree.worktreePath,
+		sessionFile: null,
+	});
+	const updatedRun = addWorker(run, worker);
+	writeRun(updatedRun);
+	return worker;
+}
+
+export function updateWorkerTaskForRepo(repoRoot: string, workerName: string, task: string): WorkerRecord {
+	const run = getOrCreateRunForRepo(repoRoot);
+	const worker = run.workers.find((entry) => entry.name === workerName);
+	if (!worker) {
+		throw new Error(`Worker named ${workerName} not found`);
+	}
+	const updatedRun = setWorkerTask(run, worker.workerId, task);
+	writeRun(updatedRun);
+	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+	if (!updatedWorker) {
+		throw new Error(`Worker named ${workerName} disappeared during task update`);
+	}
+	return updatedWorker;
+}

--- a/packages/pi-conductor/extensions/git-pr.ts
+++ b/packages/pi-conductor/extensions/git-pr.ts
@@ -1,0 +1,68 @@
+import { execSync } from "node:child_process";
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function execInCwd(cwd: string, command: string, label: string): string {
+	try {
+		return execSync(command, {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+		}).trim();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`${label} error: ${message}`);
+	}
+}
+
+export function getPreferredBaseBranch(repoRoot: string): string {
+	const currentBranch = execInCwd(repoRoot, "git branch --show-current", "git");
+	if (currentBranch && !currentBranch.startsWith("conductor/")) {
+		return currentBranch;
+	}
+	try {
+		const originHead = execInCwd(
+			repoRoot,
+			"git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'",
+			"git",
+		);
+		if (originHead) {
+			return originHead;
+		}
+	} catch {
+		// fall through
+	}
+	return "main";
+}
+
+export function commitAllChanges(worktreePath: string, message: string): void {
+	execInCwd(worktreePath, "git add -A", "git");
+	execInCwd(worktreePath, `git commit -m ${shellQuote(message)}`, "git");
+}
+
+export function pushBranchToOrigin(worktreePath: string, branch: string): void {
+	execInCwd(worktreePath, `git push -u origin ${shellQuote(branch)}`, "git");
+}
+
+export function createPullRequest(input: {
+	repoRoot: string;
+	worktreePath: string;
+	branch: string;
+	title: string;
+	body: string;
+}): { url: string | null; number: number | null } {
+	const base = getPreferredBaseBranch(input.repoRoot);
+	const output = execInCwd(
+		input.worktreePath,
+		`gh pr create --base ${shellQuote(base)} --head ${shellQuote(input.branch)} --title ${shellQuote(input.title)} --body ${shellQuote(input.body)}`,
+		"gh",
+	);
+	const url = output.split("\n").map((line) => line.trim()).find((line) => line.startsWith("http")) ?? null;
+	const match = url?.match(/\/pull\/(\d+)/);
+	return {
+		url,
+		number: match ? Number.parseInt(match[1] ?? "", 10) : null,
+	};
+}

--- a/packages/pi-conductor/extensions/git-pr.ts
+++ b/packages/pi-conductor/extensions/git-pr.ts
@@ -17,6 +17,41 @@ function execInCwd(cwd: string, command: string, label: string): string {
 	}
 }
 
+function execOrNull(cwd: string, command: string): string | null {
+	try {
+		return execInCwd(cwd, command, "git");
+	} catch {
+		return null;
+	}
+}
+
+export function validatePushPreconditions(repoRoot: string): void {
+	const remoteUrl = execOrNull(repoRoot, "git remote get-url origin");
+	if (!remoteUrl) {
+		throw new Error("Git remote 'origin' is not configured for this repository");
+	}
+}
+
+export function validatePrPreconditions(repoRoot: string): void {
+	validatePushPreconditions(repoRoot);
+	try {
+		execSync("command -v gh", {
+			cwd: repoRoot,
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+			shell: "/bin/bash",
+		});
+		execInCwd(repoRoot, "gh --version", "gh");
+	} catch {
+		throw new Error("GitHub CLI (gh) is not installed or not available on PATH");
+	}
+	try {
+		execInCwd(repoRoot, "gh auth status", "gh");
+	} catch {
+		throw new Error("GitHub CLI (gh) is not authenticated");
+	}
+}
+
 export function getPreferredBaseBranch(repoRoot: string): string {
 	const currentBranch = execInCwd(repoRoot, "git branch --show-current", "git");
 	if (currentBranch && !currentBranch.startsWith("conductor/")) {

--- a/packages/pi-conductor/extensions/git-pr.ts
+++ b/packages/pi-conductor/extensions/git-pr.ts
@@ -20,7 +20,18 @@ function execInCwd(cwd: string, command: string, label: string): string {
 export function getPreferredBaseBranch(repoRoot: string): string {
 	const currentBranch = execInCwd(repoRoot, "git branch --show-current", "git");
 	if (currentBranch && !currentBranch.startsWith("conductor/")) {
-		return currentBranch;
+		try {
+			const remoteMatch = execInCwd(
+				repoRoot,
+				`git ls-remote --heads origin ${shellQuote(currentBranch)}`,
+				"git",
+			);
+			if (remoteMatch.includes(`refs/heads/${currentBranch}`)) {
+				return currentBranch;
+			}
+		} catch {
+			// fall through
+		}
 	}
 	try {
 		const originHead = execInCwd(

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -3,7 +3,13 @@ import { execSync } from "node:child_process";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { runConductorCommand } from "./commands.js";
-import { createWorkerForRepo, recoverWorkerForRepo, refreshWorkerSummaryForRepo, updateWorkerTaskForRepo } from "./conductor.js";
+import {
+	createWorkerForRepo,
+	removeWorkerForRepo,
+	recoverWorkerForRepo,
+	refreshWorkerSummaryForRepo,
+	updateWorkerTaskForRepo,
+} from "./conductor.js";
 import { deriveProjectKey } from "./project-key.js";
 import { createEmptyRun, readRun, writeRun } from "./storage.js";
 import { formatRunStatus } from "./status.js";
@@ -137,6 +143,22 @@ export default function conductorExtension(pi: ExtensionAPI) {
 			return {
 				content: [{ type: "text", text: `refreshed summary for ${worker.name}: ${worker.summary.text}` }],
 				details: { workerId: worker.workerId, summary: worker.summary },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_cleanup",
+		label: "Conductor Cleanup",
+		description: "Remove a named pi-conductor worker and clean up its worktree and session link",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = removeWorkerForRepo(ctx.cwd, params.name);
+			return {
+				content: [{ type: "text", text: `removed worker ${worker.name} [${worker.workerId}]` }],
+				details: { workerId: worker.workerId },
 			};
 		},
 	});

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -4,8 +4,13 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { runConductorCommand } from "./commands.js";
 import {
+	commitWorkerForRepo,
 	createWorkerForRepo,
+	createWorkerPrForRepo,
+	getOrCreateRunForRepo,
+	pushWorkerForRepo,
 	removeWorkerForRepo,
+	reconcileWorkerHealth,
 	recoverWorkerForRepo,
 	refreshWorkerSummaryForRepo,
 	updateWorkerTaskForRepo,
@@ -38,7 +43,7 @@ function getStatusText(cwd: string): string {
 		writeRun(run);
 	}
 
-	return formatRunStatus(run);
+	return formatRunStatus(reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot)));
 }
 
 export default function conductorExtension(pi: ExtensionAPI) {
@@ -55,7 +60,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("conductor", {
-		description: "Manage pi-conductor workers (status, start)",
+		description: "Manage pi-conductor workers and PR preparation",
 		handler: async (args, ctx) => {
 			const text = await runConductorCommand(ctx.cwd, args);
 			if (ctx.hasUI) {
@@ -159,6 +164,57 @@ export default function conductorExtension(pi: ExtensionAPI) {
 			return {
 				content: [{ type: "text", text: `removed worker ${worker.name} [${worker.workerId}]` }],
 				details: { workerId: worker.workerId },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_commit",
+		label: "Conductor Commit",
+		description: "Commit all current worker worktree changes with a supplied commit message",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+			message: Type.String({ description: "Commit message" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = commitWorkerForRepo(ctx.cwd, params.name, params.message);
+			return {
+				content: [{ type: "text", text: `committed worker ${worker.name}: ${params.message}` }],
+				details: { workerId: worker.workerId, commitSucceeded: worker.pr.commitSucceeded },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_push",
+		label: "Conductor Push",
+		description: "Push a worker branch to origin",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = pushWorkerForRepo(ctx.cwd, params.name);
+			return {
+				content: [{ type: "text", text: `pushed worker ${worker.name} on branch ${worker.branch}` }],
+				details: { workerId: worker.workerId, pushSucceeded: worker.pr.pushSucceeded },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_pr_create",
+		label: "Conductor PR Create",
+		description: "Create a GitHub pull request for a worker branch",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+			title: Type.String({ description: "PR title" }),
+			body: Type.Optional(Type.String({ description: "Optional PR body" })),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = createWorkerPrForRepo(ctx.cwd, params.name, params.title, params.body);
+			return {
+				content: [{ type: "text", text: `created PR for ${worker.name}: ${worker.pr.url}` }],
+				details: { workerId: worker.workerId, pr: worker.pr },
 			};
 		},
 	});

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -13,6 +13,8 @@ import {
 	reconcileWorkerHealth,
 	recoverWorkerForRepo,
 	refreshWorkerSummaryForRepo,
+	resumeWorkerForRepo,
+	updateWorkerLifecycleForRepo,
 	updateWorkerTaskForRepo,
 } from "./conductor.js";
 import { deriveProjectKey } from "./project-key.js";
@@ -164,6 +166,45 @@ export default function conductorExtension(pi: ExtensionAPI) {
 			return {
 				content: [{ type: "text", text: `removed worker ${worker.name} [${worker.workerId}]` }],
 				details: { workerId: worker.workerId },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_resume",
+		label: "Conductor Resume",
+		description: "Resume a healthy pi-conductor worker using its persisted worktree and session linkage",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = resumeWorkerForRepo(ctx.cwd, params.name);
+			return {
+				content: [{ type: "text", text: `resumed worker ${worker.name}: session=${worker.sessionFile}` }],
+				details: { workerId: worker.workerId, sessionFile: worker.sessionFile, worktreePath: worker.worktreePath },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_lifecycle_update",
+		label: "Conductor Lifecycle Update",
+		description: "Update a named pi-conductor worker lifecycle state",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+			lifecycle: Type.Union([
+				Type.Literal("idle"),
+				Type.Literal("running"),
+				Type.Literal("blocked"),
+				Type.Literal("ready_for_pr"),
+				Type.Literal("done"),
+			]),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = updateWorkerLifecycleForRepo(ctx.cwd, params.name, params.lifecycle);
+			return {
+				content: [{ type: "text", text: `updated worker ${worker.name} state to ${worker.lifecycle}` }],
+				details: { workerId: worker.workerId, lifecycle: worker.lifecycle },
 			};
 		},
 	});

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -51,7 +51,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
 	pi.registerCommand("conductor", {
 		description: "Manage pi-conductor workers (status, start)",
 		handler: async (args, ctx) => {
-			const text = runConductorCommand(ctx.cwd, args);
+			const text = await runConductorCommand(ctx.cwd, args);
 			if (ctx.hasUI) {
 				ctx.ui.notify(text, "info");
 			} else {
@@ -82,7 +82,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
 			name: Type.String({ description: "Worker name" }),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = createWorkerForRepo(ctx.cwd, params.name);
+			const worker = await createWorkerForRepo(ctx.cwd, params.name);
 			return {
 				content: [
 					{ type: "text", text: `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}` },

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -3,7 +3,7 @@ import { execSync } from "node:child_process";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { runConductorCommand } from "./commands.js";
-import { createWorkerForRepo, updateWorkerTaskForRepo } from "./conductor.js";
+import { createWorkerForRepo, recoverWorkerForRepo, refreshWorkerSummaryForRepo, updateWorkerTaskForRepo } from "./conductor.js";
 import { deriveProjectKey } from "./project-key.js";
 import { createEmptyRun, readRun, writeRun } from "./storage.js";
 import { formatRunStatus } from "./status.js";
@@ -105,6 +105,38 @@ export default function conductorExtension(pi: ExtensionAPI) {
 			return {
 				content: [{ type: "text", text: `updated task for ${worker.name}: ${worker.currentTask}` }],
 				details: { workerId: worker.workerId, task: worker.currentTask },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_recover",
+		label: "Conductor Recover",
+		description: "Recover a broken pi-conductor worker with a missing session link",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = await recoverWorkerForRepo(ctx.cwd, params.name);
+			return {
+				content: [{ type: "text", text: `recovered worker ${worker.name}: session=${worker.sessionFile}` }],
+				details: { workerId: worker.workerId, sessionFile: worker.sessionFile },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_summary_refresh",
+		label: "Conductor Summary Refresh",
+		description: "Refresh a named pi-conductor worker summary from its persisted session",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = refreshWorkerSummaryForRepo(ctx.cwd, params.name);
+			return {
+				content: [{ type: "text", text: `refreshed summary for ${worker.name}: ${worker.summary.text}` }],
+				details: { workerId: worker.workerId, summary: worker.summary },
 			};
 		},
 	});

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -2,8 +2,11 @@ import { existsSync } from "node:fs";
 import { execSync } from "node:child_process";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import { runConductorCommand } from "./commands.js";
+import { createWorkerForRepo, updateWorkerTaskForRepo } from "./conductor.js";
 import { deriveProjectKey } from "./project-key.js";
-import { createEmptyRun, getConductorProjectDir, readRun, writeRun } from "./storage.js";
+import { createEmptyRun, readRun, writeRun } from "./storage.js";
+import { formatRunStatus } from "./status.js";
 
 function findRepoRoot(cwd: string): string | null {
 	try {
@@ -29,22 +32,7 @@ function getStatusText(cwd: string): string {
 		writeRun(run);
 	}
 
-	const lines = [
-		`projectKey: ${run.projectKey}`,
-		`repoRoot: ${run.repoRoot}`,
-		`storageDir: ${getConductorProjectDir(projectKey)}`,
-		`workers: ${run.workers.length}`,
-	];
-
-	for (const worker of run.workers) {
-		lines.push(
-			`- ${worker.name} [${worker.workerId}] ` +
-				`state=${worker.lifecycle} task=${worker.currentTask ?? "none"} ` +
-				`branch=${worker.branch ?? "none"}`,
-		);
-	}
-
-	return lines.join("\n");
+	return formatRunStatus(run);
 }
 
 export default function conductorExtension(pi: ExtensionAPI) {
@@ -52,6 +40,18 @@ export default function conductorExtension(pi: ExtensionAPI) {
 		description: "Show the current pi-conductor project status",
 		handler: async (_args, ctx) => {
 			const text = getStatusText(ctx.cwd);
+			if (ctx.hasUI) {
+				ctx.ui.notify(text, "info");
+			} else {
+				console.log(text);
+			}
+		},
+	});
+
+	pi.registerCommand("conductor", {
+		description: "Manage pi-conductor workers (status, start)",
+		handler: async (args, ctx) => {
+			const text = runConductorCommand(ctx.cwd, args);
 			if (ctx.hasUI) {
 				ctx.ui.notify(text, "info");
 			} else {
@@ -70,6 +70,41 @@ export default function conductorExtension(pi: ExtensionAPI) {
 			return {
 				content: [{ type: "text", text }],
 				details: {},
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_start",
+		label: "Conductor Start",
+		description: "Create a new pi-conductor worker for the current repository",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = createWorkerForRepo(ctx.cwd, params.name);
+			return {
+				content: [
+					{ type: "text", text: `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}` },
+				],
+				details: { workerId: worker.workerId, branch: worker.branch, worktreePath: worker.worktreePath },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "conductor_task_update",
+		label: "Conductor Task Update",
+		description: "Update the current task for a named pi-conductor worker",
+		parameters: Type.Object({
+			name: Type.String({ description: "Worker name" }),
+			task: Type.String({ description: "Task text" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const worker = updateWorkerTaskForRepo(ctx.cwd, params.name, params.task);
+			return {
+				content: [{ type: "text", text: `updated task for ${worker.name}: ${worker.currentTask}` }],
+				details: { workerId: worker.workerId, task: worker.currentTask },
 			};
 		},
 	});

--- a/packages/pi-conductor/extensions/sessions.ts
+++ b/packages/pi-conductor/extensions/sessions.ts
@@ -1,0 +1,25 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+
+function ensurePersistedSessionFile(sessionManager: SessionManager, sessionFile: string): void {
+	if (existsSync(sessionFile)) {
+		return;
+	}
+	const header = sessionManager.getHeader();
+	const entries = sessionManager.getEntries();
+	mkdirSync(dirname(sessionFile), { recursive: true });
+	const lines = [header, ...entries].map((entry) => JSON.stringify(entry));
+	writeFileSync(sessionFile, `${lines.join("\n")}\n`, "utf-8");
+}
+
+export async function createWorkerSessionLink(worktreePath: string): Promise<string | null> {
+	const sessionManager = SessionManager.create(worktreePath);
+	await sessionManager.appendSessionInfo("pi-conductor worker");
+	const sessionFile = sessionManager.getSessionFile() ?? null;
+	if (!sessionFile) {
+		return null;
+	}
+	ensurePersistedSessionFile(sessionManager, sessionFile);
+	return sessionFile;
+}

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -1,5 +1,15 @@
 import { getConductorProjectDir } from "./storage.js";
-import type { RunRecord } from "./types.js";
+import type { RunRecord, WorkerRecord } from "./types.js";
+
+function getWorkerHealth(worker: WorkerRecord): "healthy" | "stale" | "broken" {
+	if (worker.lifecycle === "broken") {
+		return "broken";
+	}
+	if (worker.summary.stale || worker.lifecycle === "done") {
+		return "stale";
+	}
+	return "healthy";
+}
 
 export function formatRunStatus(run: RunRecord): string {
 	const lines = [
@@ -15,6 +25,7 @@ export function formatRunStatus(run: RunRecord): string {
 			: "none";
 		lines.push(
 			`- ${worker.name} [${worker.workerId}] ` +
+				`health=${getWorkerHealth(worker)} ` +
 				`state=${worker.lifecycle} ` +
 				`recoverable=${worker.recoverable} ` +
 				`task=${worker.currentTask ?? "none"} ` +

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -1,0 +1,28 @@
+import { getConductorProjectDir } from "./storage.js";
+import type { RunRecord } from "./types.js";
+
+export function formatRunStatus(run: RunRecord): string {
+	const lines = [
+		`projectKey: ${run.projectKey}`,
+		`repoRoot: ${run.repoRoot}`,
+		`storageDir: ${getConductorProjectDir(run.projectKey)}`,
+		`workers: ${run.workers.length}`,
+	];
+
+	for (const worker of run.workers) {
+		const summary = worker.summary.text
+			? `${worker.summary.stale ? "stale" : "fresh"}: ${worker.summary.text}`
+			: "none";
+		lines.push(
+			`- ${worker.name} [${worker.workerId}] ` +
+				`state=${worker.lifecycle} ` +
+				`task=${worker.currentTask ?? "none"} ` +
+				`branch=${worker.branch ?? "none"} ` +
+				`session=${worker.sessionFile ?? "none"} ` +
+				`pr=${worker.pr.url ?? "none"} ` +
+				`summary=${summary}`,
+		);
+	}
+
+	return lines.join("\n");
+}

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -21,6 +21,9 @@ export function formatRunStatus(run: RunRecord): string {
 				`branch=${worker.branch ?? "none"} ` +
 				`session=${worker.sessionFile ?? "none"} ` +
 				`pr=${worker.pr.url ?? "none"} ` +
+				`commit=${worker.pr.commitSucceeded} ` +
+				`push=${worker.pr.pushSucceeded} ` +
+				`prAttempted=${worker.pr.prCreationAttempted} ` +
 				`summary=${summary}`,
 		);
 	}

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -16,6 +16,7 @@ export function formatRunStatus(run: RunRecord): string {
 		lines.push(
 			`- ${worker.name} [${worker.workerId}] ` +
 				`state=${worker.lifecycle} ` +
+				`recoverable=${worker.recoverable} ` +
 				`task=${worker.currentTask ?? "none"} ` +
 				`branch=${worker.branch ?? "none"} ` +
 				`session=${worker.sessionFile ?? "none"} ` +

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { RunRecord, WorkerRecord } from "./types.js";
+import type { RunRecord, WorkerPrState, WorkerRecord } from "./types.js";
 
 function getConductorRoot(): string {
 	const override = process.env.PI_CONDUCTOR_HOME?.trim();
@@ -163,5 +163,32 @@ export function removeWorker(run: RunRecord, workerId: string): RunRecord {
 		...run,
 		workers,
 		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function setWorkerPrState(run: RunRecord, workerId: string, pr: Partial<WorkerPrState>): RunRecord {
+	let found = false;
+	const now = new Date().toISOString();
+	const workers = run.workers.map((worker) => {
+		if (worker.workerId !== workerId) {
+			return worker;
+		}
+		found = true;
+		return {
+			...worker,
+			pr: {
+				...worker.pr,
+				...pr,
+			},
+			updatedAt: now,
+		};
+	});
+	if (!found) {
+		throw new Error(`Worker ${workerId} not found`);
+	}
+	return {
+		...run,
+		workers,
+		updatedAt: now,
 	};
 }

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -1,12 +1,18 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { RunRecord } from "./types.js";
+import type { RunRecord, WorkerRecord } from "./types.js";
 
-const CONDUCTOR_ROOT = join(homedir(), ".pi", "agent", "conductor", "projects");
+function getConductorRoot(): string {
+	const override = process.env.PI_CONDUCTOR_HOME?.trim();
+	if (override) {
+		return join(resolve(override), "projects");
+	}
+	return join(homedir(), ".pi", "agent", "conductor", "projects");
+}
 
 export function getConductorProjectDir(projectKey: string): string {
-	return join(CONDUCTOR_ROOT, projectKey);
+	return join(getConductorRoot(), projectKey);
 }
 
 export function getRunFile(projectKey: string): string {
@@ -40,5 +46,80 @@ export function createEmptyRun(projectKey: string, repoRoot: string): RunRecord 
 		workers: [],
 		createdAt: now,
 		updatedAt: now,
+	};
+}
+
+export function createWorkerRecord(input: {
+	workerId: string;
+	name: string;
+	branch: string | null;
+	worktreePath: string | null;
+	sessionFile: string | null;
+}): WorkerRecord {
+	const now = new Date().toISOString();
+	return {
+		workerId: input.workerId,
+		name: input.name,
+		branch: input.branch,
+		worktreePath: input.worktreePath,
+		sessionFile: input.sessionFile,
+		currentTask: null,
+		lifecycle: "idle",
+		recoverable: false,
+		summary: {
+			text: null,
+			updatedAt: null,
+			stale: false,
+		},
+		pr: {
+			url: null,
+			number: null,
+			commitSucceeded: false,
+			pushSucceeded: false,
+			prCreationAttempted: false,
+		},
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export function addWorker(run: RunRecord, worker: WorkerRecord): RunRecord {
+	if (run.workers.some((existing) => existing.name === worker.name)) {
+		throw new Error(`Worker named ${worker.name} already exists`);
+	}
+
+	return {
+		...run,
+		workers: [...run.workers, worker],
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function setWorkerTask(run: RunRecord, workerId: string, task: string): RunRecord {
+	let found = false;
+	const workers = run.workers.map((worker) => {
+		if (worker.workerId !== workerId) {
+			return worker;
+		}
+		found = true;
+		return {
+			...worker,
+			currentTask: task,
+			summary: {
+				...worker.summary,
+				stale: worker.summary.text !== null ? true : worker.summary.stale,
+			},
+			updatedAt: new Date().toISOString(),
+		};
+	});
+
+	if (!found) {
+		throw new Error(`Worker ${workerId} not found`);
+	}
+
+	return {
+		...run,
+		workers,
+		updatedAt: new Date().toISOString(),
 	};
 }

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { RunRecord, WorkerPrState, WorkerRecord } from "./types.js";
+import type { RunRecord, WorkerLifecycleState, WorkerPrState, WorkerRecord } from "./types.js";
 
 function getConductorRoot(): string {
 	const override = process.env.PI_CONDUCTOR_HOME?.trim();
@@ -180,6 +180,34 @@ export function setWorkerPrState(run: RunRecord, workerId: string, pr: Partial<W
 				...worker.pr,
 				...pr,
 			},
+			updatedAt: now,
+		};
+	});
+	if (!found) {
+		throw new Error(`Worker ${workerId} not found`);
+	}
+	return {
+		...run,
+		workers,
+		updatedAt: now,
+	};
+}
+
+export function setWorkerLifecycle(
+	run: RunRecord,
+	workerId: string,
+	lifecycle: WorkerLifecycleState,
+): RunRecord {
+	let found = false;
+	const now = new Date().toISOString();
+	const workers = run.workers.map((worker) => {
+		if (worker.workerId !== workerId) {
+			return worker;
+		}
+		found = true;
+		return {
+			...worker,
+			lifecycle,
 			updatedAt: now,
 		};
 	});

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -153,3 +153,15 @@ export function setWorkerSummary(run: RunRecord, workerId: string, summaryText: 
 		updatedAt: now,
 	};
 }
+
+export function removeWorker(run: RunRecord, workerId: string): RunRecord {
+	const workers = run.workers.filter((worker) => worker.workerId !== workerId);
+	if (workers.length === run.workers.length) {
+		throw new Error(`Worker ${workerId} not found`);
+	}
+	return {
+		...run,
+		workers,
+		updatedAt: new Date().toISOString(),
+	};
+}

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -123,3 +123,33 @@ export function setWorkerTask(run: RunRecord, workerId: string, task: string): R
 		updatedAt: new Date().toISOString(),
 	};
 }
+
+export function setWorkerSummary(run: RunRecord, workerId: string, summaryText: string): RunRecord {
+	let found = false;
+	const now = new Date().toISOString();
+	const workers = run.workers.map((worker) => {
+		if (worker.workerId !== workerId) {
+			return worker;
+		}
+		found = true;
+		return {
+			...worker,
+			summary: {
+				text: summaryText,
+				updatedAt: now,
+				stale: false,
+			},
+			updatedAt: now,
+		};
+	});
+
+	if (!found) {
+		throw new Error(`Worker ${workerId} not found`);
+	}
+
+	return {
+		...run,
+		workers,
+		updatedAt: now,
+	};
+}

--- a/packages/pi-conductor/extensions/summaries.ts
+++ b/packages/pi-conductor/extensions/summaries.ts
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from "node:fs";
+
+type TextPart = { type?: string; text?: string };
+
+type SessionLine = {
+	type?: string;
+	message?: {
+		role?: string;
+		content?: string | TextPart[];
+	};
+	content?: string | TextPart[];
+};
+
+function extractTextContent(content: string | TextPart[] | undefined): string[] {
+	if (typeof content === "string") {
+		return [content.trim()].filter(Boolean);
+	}
+	if (!Array.isArray(content)) {
+		return [];
+	}
+	return content
+		.filter((item) => item?.type === "text" && typeof item.text === "string")
+		.map((item) => item.text!.trim())
+		.filter(Boolean);
+}
+
+export function generateWorkerSummaryFromSession(sessionFile: string): string {
+	if (!existsSync(sessionFile)) {
+		throw new Error(`Session file not found: ${sessionFile}`);
+	}
+
+	const snippets = readFileSync(sessionFile, "utf-8")
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as SessionLine)
+		.flatMap((entry) => {
+			if (entry.type === "message") {
+				return extractTextContent(entry.message?.content);
+			}
+			if (entry.type === "custom_message") {
+				return extractTextContent(entry.content);
+			}
+			return [];
+		});
+
+	if (snippets.length === 0) {
+		return "Session exists but has no summarizable text yet.";
+	}
+
+	return snippets.slice(-3).join(" | ");
+}

--- a/packages/pi-conductor/extensions/workers.ts
+++ b/packages/pi-conductor/extensions/workers.ts
@@ -1,0 +1,23 @@
+function collapseDashes(value: string): string {
+	return value.replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+export function normalizeWorkerSlug(name: string): string | null {
+	const normalized = collapseDashes(
+		name
+			.toLowerCase()
+			.replace(/\s+/g, "-")
+			.replace(/[^a-z0-9._-]+/g, "-"),
+	);
+	return normalized.length > 0 ? normalized : null;
+}
+
+export function buildBranchName(workerId: string, name: string): string {
+	const slug = normalizeWorkerSlug(name);
+	return `conductor/${slug ?? workerId}`;
+}
+
+export function createWorkerId(): string {
+	const random = Math.random().toString(36).slice(2, 10);
+	return `worker-${Date.now().toString(36)}-${random}`;
+}

--- a/packages/pi-conductor/extensions/worktrees.ts
+++ b/packages/pi-conductor/extensions/worktrees.ts
@@ -58,6 +58,14 @@ export function removeManagedWorktree(repoRoot: string, worktreePath: string): v
 	}
 }
 
+export function removeManagedBranch(repoRoot: string, branch: string): void {
+	try {
+		execGit(repoRoot, `git branch -D ${shellQuote(branch)}`);
+	} catch {
+		// Ignore missing or already-removed branches during cleanup.
+	}
+}
+
 function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/pi-conductor/extensions/worktrees.ts
+++ b/packages/pi-conductor/extensions/worktrees.ts
@@ -49,6 +49,15 @@ export function recreateManagedWorktree(
 	return { branch: input.branch, worktreePath };
 }
 
+export function removeManagedWorktree(repoRoot: string, worktreePath: string): void {
+	execGit(repoRoot, "git worktree prune");
+	try {
+		execGit(repoRoot, `git worktree remove --force ${shellQuote(worktreePath)}`);
+	} catch {
+		execGit(repoRoot, "git worktree prune");
+	}
+}
+
 function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/pi-conductor/extensions/worktrees.ts
+++ b/packages/pi-conductor/extensions/worktrees.ts
@@ -38,6 +38,17 @@ export function createManagedWorktree(
 	return { branch, baseBranch, worktreePath };
 }
 
+export function recreateManagedWorktree(
+	repoRoot: string,
+	input: { workerName: string; branch: string },
+): { branch: string; worktreePath: string } {
+	const worktreePath = planWorktreePath(repoRoot, input.workerName);
+	ensureDir(dirname(worktreePath));
+	execGit(repoRoot, "git worktree prune");
+	execGit(repoRoot, `git worktree add ${shellQuote(worktreePath)} ${shellQuote(input.branch)}`);
+	return { branch: input.branch, worktreePath };
+}
+
 function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/pi-conductor/extensions/worktrees.ts
+++ b/packages/pi-conductor/extensions/worktrees.ts
@@ -1,0 +1,43 @@
+import { execSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { buildBranchName, normalizeWorkerSlug } from "./workers.js";
+import { ensureDir } from "./storage.js";
+
+function execGit(cwd: string, command: string): string {
+	return execSync(command, {
+		cwd,
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+	}).trim();
+}
+
+export function getCurrentBranch(repoRoot: string): string {
+	const branch = execGit(repoRoot, "git branch --show-current");
+	if (!branch) {
+		throw new Error("Unable to determine current branch");
+	}
+	return branch;
+}
+
+export function planWorktreePath(repoRoot: string, workerName: string): string {
+	const repoParent = dirname(repoRoot);
+	const repoBase = repoRoot.split("/").filter(Boolean).at(-1) ?? "repo";
+	const slug = normalizeWorkerSlug(workerName) ?? "worker";
+	return join(repoParent, ".pi-conductor-worktrees", repoBase, slug);
+}
+
+export function createManagedWorktree(
+	repoRoot: string,
+	input: { workerId: string; workerName: string },
+): { branch: string; baseBranch: string; worktreePath: string } {
+	const baseBranch = getCurrentBranch(repoRoot);
+	const branch = buildBranchName(input.workerId, input.workerName);
+	const worktreePath = planWorktreePath(repoRoot, input.workerName);
+	ensureDir(dirname(worktreePath));
+	execGit(repoRoot, `git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(baseBranch)}`);
+	return { branch, baseBranch, worktreePath };
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}


### PR DESCRIPTION
## Summary
- add `@feniix/pi-conductor` MVP foundations for project-scoped worker orchestration, managed worktrees, and persisted Pi session linkage
- add task/status/summary/recovery/cleanup flows with text-first `/conductor` commands and matching tool surface
- add minimal worker-aware PR preparation with commit, push, PR creation, and persisted partial-failure state

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- run `npm run typecheck`
- run the `pi-conductor` Vitest suite from the repo root
- manually validate `/conductor start|task|summarize|recover|cleanup|commit|push|pr`
- verify live GitHub PR creation through the conductor flow
