### PR TITLE
refactor: reduce pi-specdocs validation complexity

### DIFF
--- a/packages/pi-specdocs/extensions/index.ts
+++ b/packages/pi-specdocs/extensions/index.ts
@@ -68,63 +68,97 @@ function isAdr(path: string): boolean {
 	return path.includes("docs/adr/ADR-");
 }
 
-function validateFrontmatter(filepath: string): string[] {
-	const warnings: string[] = [];
-	const filename = basename(filepath);
+interface DocValidationConfig {
+	docType: "PRD" | "ADR";
+	requiredFields: readonly string[];
+	validStatuses: readonly string[];
+	numberPattern: RegExp;
+	numberField: "prd" | "adr";
+	expectedNumberFormat: string;
+}
 
-	let docType: string;
-	let requiredFields: readonly string[];
-	let validStatuses: readonly string[];
-	let numberPattern: RegExp;
-	let numberField: string;
-
+function getDocValidationConfig(filepath: string): DocValidationConfig | null {
 	if (isPrd(filepath)) {
-		docType = "PRD";
-		requiredFields = PRD_REQUIRED_FIELDS;
-		validStatuses = PRD_VALID_STATUSES;
-		numberPattern = /^PRD-\d{3}$/;
-		numberField = "prd";
-	} else if (isAdr(filepath)) {
-		docType = "ADR";
-		requiredFields = ADR_REQUIRED_FIELDS;
-		validStatuses = ADR_VALID_STATUSES;
-		numberPattern = /^ADR-\d{4}$/;
-		numberField = "adr";
-	} else {
-		return warnings;
+		return {
+			docType: "PRD",
+			requiredFields: PRD_REQUIRED_FIELDS,
+			validStatuses: PRD_VALID_STATUSES,
+			numberPattern: /^PRD-\d{3}$/,
+			numberField: "prd",
+			expectedNumberFormat: "PRD-NNN (3-digit zero-padded)",
+		};
+	}
+
+	if (isAdr(filepath)) {
+		return {
+			docType: "ADR",
+			requiredFields: ADR_REQUIRED_FIELDS,
+			validStatuses: ADR_VALID_STATUSES,
+			numberPattern: /^ADR-\d{4}$/,
+			numberField: "adr",
+			expectedNumberFormat: "ADR-NNNN (4-digit zero-padded)",
+		};
+	}
+
+	return null;
+}
+
+function collectMissingFieldWarnings(
+	fields: Record<string, string>,
+	config: DocValidationConfig,
+	warnings: string[],
+): void {
+	for (const field of config.requiredFields) {
+		if (!fields[field]) {
+			warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
+		}
+	}
+}
+
+function collectNumberWarnings(
+	fields: Record<string, string>,
+	config: DocValidationConfig,
+	filename: string,
+	warnings: string[],
+): void {
+	const numberValue = fields[config.numberField] ?? "";
+	if (!numberValue) {
+		return;
+	}
+
+	if (!config.numberPattern.test(numberValue)) {
+		warnings.push(
+			`⚠ ${config.docType}: Number '${numberValue}' doesn't match expected format ${config.expectedNumberFormat}.`,
+		);
+	}
+
+	if (!filename.startsWith(numberValue)) {
+		warnings.push(`⚠ ${config.docType}: Frontmatter says '${numberValue}' but filename is '${filename}'.`);
+	}
+}
+
+function collectStatusWarnings(fields: Record<string, string>, config: DocValidationConfig, warnings: string[]): void {
+	const status = fields.status ?? "";
+	if (status && !config.validStatuses.includes(status)) {
+		warnings.push(`⚠ ${config.docType}: Unknown status '${status}'. Expected: ${config.validStatuses.join(", ")}.`);
+	}
+}
+
+function validateFrontmatter(filepath: string): string[] {
+	const config = getDocValidationConfig(filepath);
+	if (!config) {
+		return [];
 	}
 
 	const fields = parseFrontmatter(filepath);
 	if (fields === null) {
-		warnings.push(`⚠ ${docType}: No YAML frontmatter found.`);
-		return warnings;
+		return [`⚠ ${config.docType}: No YAML frontmatter found.`];
 	}
 
-	// Check required fields
-	for (const field of requiredFields) {
-		if (!fields[field]) {
-			warnings.push(`⚠ ${docType}: Missing required frontmatter field: ${field}`);
-		}
-	}
-
-	// Check number format
-	const numberValue = fields[numberField] ?? "";
-	if (numberValue && !numberPattern.test(numberValue)) {
-		const expected = docType === "PRD" ? "PRD-NNN (3-digit zero-padded)" : "ADR-NNNN (4-digit zero-padded)";
-		warnings.push(`⚠ ${docType}: Number '${numberValue}' doesn't match expected format ${expected}.`);
-	}
-
-	// Check filename/number match
-	if (numberValue && !filename.startsWith(numberValue)) {
-		warnings.push(`⚠ ${docType}: Frontmatter says '${numberValue}' but filename is '${filename}'.`);
-	}
-
-	// Check status
-	const status = fields.status ?? "";
-	if (status && !validStatuses.includes(status)) {
-		warnings.push(`⚠ ${docType}: Unknown status '${status}'. Expected: ${validStatuses.join(", ")}.`);
-	}
-
+	const warnings: string[] = [];
+	collectMissingFieldWarnings(fields, config, warnings);
+	collectNumberWarnings(fields, config, basename(filepath), warnings);
+	collectStatusWarnings(fields, config, warnings);
 	return warnings;
 }
 
@@ -183,44 +217,69 @@ function readConfig(cwd: string): TrackerConfig {
 	}
 }
 
-function formatConfig(config: TrackerConfig): string {
-	const lines: string[] = [];
-
-	let tracker = config.tracker || "github";
-	if (tracker !== "github" && tracker !== "linear") {
-		lines.push(`[specdocs] WARNING: unknown tracker '${tracker}' in ${CONFIG_PATH} — defaulting to github`);
-		tracker = "github";
+function resolveTracker(config: TrackerConfig): { tracker: "github" | "linear"; warning?: string } {
+	const tracker = config.tracker || "github";
+	if (tracker === "github" || tracker === "linear") {
+		return { tracker };
 	}
 
-	let trackerInfo = `Tracker: ${tracker}`;
+	return {
+		tracker: "github",
+		warning: `[specdocs] WARNING: unknown tracker '${tracker}' in ${CONFIG_PATH} — defaulting to github`,
+	};
+}
+
+function formatTrackerInfo(tracker: "github" | "linear", config: TrackerConfig): { info: string; warnings: string[] } {
+	const warnings: string[] = [];
+	let info = `Tracker: ${tracker}`;
+
 	if (tracker === "linear") {
 		const team = config["linear-team"] || "";
 		if (team) {
-			trackerInfo += ` (team: ${team})`;
+			info += ` (team: ${team})`;
 		} else {
-			lines.push(`[specdocs] WARNING: tracker=linear but linear-team is not set in ${CONFIG_PATH}`);
+			warnings.push(`[specdocs] WARNING: tracker=linear but linear-team is not set in ${CONFIG_PATH}`);
 		}
-	} else if (tracker === "github" && Object.keys(config).length === 0) {
-		trackerInfo += " (default)";
+	} else if (Object.keys(config).length === 0) {
+		info += " (default)";
 	}
 
+	return { info, warnings };
+}
+
+function getNotionConfigInfo(config: TrackerConfig): { info: string; warnings: string[] } {
 	const notionSync = (config["notion-sync"] || "false").toLowerCase() === "true";
-	const notionInfo = notionSync ? "Notion sync: enabled" : "Notion sync: disabled";
+	const warnings: string[] = [];
 
-	if (notionSync) {
-		if (!config["notion-prd-database"]) {
-			lines.push(`[specdocs] WARNING: notion-sync=true but notion-prd-database is not set in ${CONFIG_PATH}`);
-		}
-		if (!config["notion-adr-database"]) {
-			lines.push(`[specdocs] WARNING: notion-sync=true but notion-adr-database is not set in ${CONFIG_PATH}`);
-		}
+	if (notionSync && !config["notion-prd-database"]) {
+		warnings.push(`[specdocs] WARNING: notion-sync=true but notion-prd-database is not set in ${CONFIG_PATH}`);
 	}
 
-	if (Object.keys(config).length === 0) {
-		lines.push(`[specdocs] ${trackerInfo} | ${notionInfo}`);
+	if (notionSync && !config["notion-adr-database"]) {
+		warnings.push(`[specdocs] WARNING: notion-sync=true but notion-adr-database is not set in ${CONFIG_PATH}`);
+	}
+
+	return {
+		info: notionSync ? "Notion sync: enabled" : "Notion sync: disabled",
+		warnings,
+	};
+}
+
+function formatConfig(config: TrackerConfig): string {
+	const lines: string[] = [];
+	const hasConfig = Object.keys(config).length > 0;
+	const { tracker, warning: trackerWarning } = resolveTracker(config);
+	const trackerInfo = formatTrackerInfo(tracker, config);
+	const notionInfo = getNotionConfigInfo(config);
+
+	if (trackerWarning) {
+		lines.push(trackerWarning);
+	}
+	lines.push(...trackerInfo.warnings, ...notionInfo.warnings);
+	lines.push(`[specdocs] ${trackerInfo.info} | ${notionInfo.info}`);
+
+	if (!hasConfig) {
 		lines.push("[specdocs] No config found. Any tracker-aware skill or command will prompt for setup on first use.");
-	} else {
-		lines.push(`[specdocs] ${trackerInfo} | ${notionInfo}`);
 	}
 
 	return lines.join("\n");
@@ -373,107 +432,137 @@ interface ValidationIssue {
 	message: string;
 }
 
-async function runValidation(ctx: { cwd: string } & ExtensionContext) {
+interface ValidationFiles {
+	prdDir: string;
+	adrDir: string;
+	prdFiles: string[];
+	adrFiles: string[];
+}
+
+function getValidationFiles(cwd: string): ValidationFiles {
+	const prdDir = join(cwd, PRD_DIR);
+	const adrDir = join(cwd, ADR_DIR);
+	const planDir = join(cwd, PLAN_DIR);
+	void listMatchingFiles(planDir, SCAN_PLAN_PATTERN);
+
+	return {
+		prdDir,
+		adrDir,
+		prdFiles: listMatchingFiles(prdDir, PRD_FILENAME_PATTERN),
+		adrFiles: listMatchingFiles(adrDir, ADR_FILENAME_PATTERN),
+	};
+}
+
+function toWarningIssues(messages: string[]): ValidationIssue[] {
+	return messages.map((message) => ({ type: "warning", message }));
+}
+
+function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
 	const issues: ValidationIssue[] = [];
 
-	const prdDir = join(ctx.cwd, PRD_DIR);
-	const adrDir = join(ctx.cwd, ADR_DIR);
-	const planDir = join(ctx.cwd, PLAN_DIR);
-
-	const prdFiles = listMatchingFiles(prdDir, PRD_FILENAME_PATTERN);
-	const adrFiles = listMatchingFiles(adrDir, ADR_FILENAME_PATTERN);
-	listMatchingFiles(planDir, SCAN_PLAN_PATTERN);
-
-	// Validate frontmatter
-	for (const filename of prdFiles) {
-		const filepath = join(prdDir, filename);
-		for (const warning of validateFrontmatter(filepath)) {
-			issues.push({ type: "warning", message: warning });
-		}
+	for (const filename of files.prdFiles) {
+		issues.push(...toWarningIssues(validateFrontmatter(join(files.prdDir, filename))));
 	}
 
-	for (const filename of adrFiles) {
-		const filepath = join(adrDir, filename);
-		for (const warning of validateFrontmatter(filepath)) {
-			issues.push({ type: "warning", message: warning });
-		}
+	for (const filename of files.adrFiles) {
+		issues.push(...toWarningIssues(validateFrontmatter(join(files.adrDir, filename))));
 	}
 
-	// Check filename conventions
-	const { readdirSync: readDir } = await import("node:fs");
-	if (existsSync(prdDir)) {
-		for (const f of readDir(prdDir)) {
-			if (f.endsWith(".md") && !PRD_FILENAME_PATTERN.test(f)) {
-				issues.push({ type: "error", message: `✗ ${PRD_DIR}/${f}: filename doesn't match PRD-NNN-*.md pattern` });
-			}
-		}
+	return issues;
+}
+
+function listMarkdownFiles(directory: string): string[] {
+	if (!existsSync(directory)) {
+		return [];
 	}
 
-	if (existsSync(adrDir)) {
-		for (const f of readDir(adrDir)) {
-			if (f.endsWith(".md") && !ADR_FILENAME_PATTERN.test(f)) {
-				issues.push({ type: "error", message: `✗ ${ADR_DIR}/${f}: filename doesn't match ADR-NNNN-*.md pattern` });
-			}
-		}
+	try {
+		return readdirSync(directory).filter((filename) => filename.endsWith(".md"));
+	} catch {
+		return [];
 	}
+}
 
-	// Check numbering gaps
-	const prdNumbers = prdFiles
-		.map((f) => {
-			const m = f.match(/^PRD-(\d{3})-.*\.md$/);
-			return m ? parseInt(m[1], 10) : null;
+function collectFilenameIssues(
+	directory: string,
+	displayDir: string,
+	pattern: RegExp,
+	expected: string,
+): ValidationIssue[] {
+	return listMarkdownFiles(directory)
+		.filter((filename) => !pattern.test(filename))
+		.map((filename) => ({
+			type: "error" as const,
+			message: `✗ ${displayDir}/${filename}: filename doesn't match ${expected} pattern`,
+		}));
+}
+
+function extractDocumentNumbers(files: string[], pattern: RegExp): number[] {
+	return files
+		.map((filename) => {
+			const match = filename.match(pattern);
+			return match ? parseInt(match[1], 10) : null;
 		})
-		.filter((n): n is number => n !== null)
+		.filter((value): value is number => value !== null)
 		.sort((a, b) => a - b);
+}
 
-	for (let i = 0; i < prdNumbers.length - 1; i++) {
-		if (prdNumbers[i + 1] - prdNumbers[i] > 1) {
-			for (let gap = prdNumbers[i] + 1; gap < prdNumbers[i + 1]; gap++) {
-				const padded = String(gap).padStart(3, "0");
-				issues.push({ type: "warning", message: `⚠ Numbering gap: PRD-${padded} is missing` });
-			}
+function collectNumberingGapIssues(files: string[], pattern: RegExp, prefix: string, width: number): ValidationIssue[] {
+	const issues: ValidationIssue[] = [];
+	const numbers = extractDocumentNumbers(files, pattern);
+
+	for (let i = 0; i < numbers.length - 1; i++) {
+		for (let gap = numbers[i] + 1; gap < numbers[i + 1]; gap++) {
+			issues.push({
+				type: "warning",
+				message: `⚠ Numbering gap: ${prefix}-${String(gap).padStart(width, "0")} is missing`,
+			});
 		}
 	}
 
-	const adrNumbers = adrFiles
-		.map((f) => {
-			const m = f.match(/^ADR-(\d{4})-.*\.md$/);
-			return m ? parseInt(m[1], 10) : null;
-		})
-		.filter((n): n is number => n !== null)
-		.sort((a, b) => a - b);
+	return issues;
+}
 
-	for (let i = 0; i < adrNumbers.length - 1; i++) {
-		if (adrNumbers[i + 1] - adrNumbers[i] > 1) {
-			for (let gap = adrNumbers[i] + 1; gap < adrNumbers[i + 1]; gap++) {
-				const padded = String(gap).padStart(4, "0");
-				issues.push({ type: "warning", message: `⚠ Numbering gap: ADR-${padded} is missing` });
-			}
-		}
-	}
-
-	// Report results
-	const errors = issues.filter((i) => i.type === "error");
-	const warnings = issues.filter((i) => i.type === "warning");
-
+function formatValidationIssues(issues: ValidationIssue[]): { message: string; level: "error" | "warning" | "info" } {
 	if (issues.length === 0) {
-		ctx.ui.notify("[specdocs] Validation passed: no issues found.", "info");
-	} else {
-		const lines: string[] = [];
-		if (errors.length > 0) {
-			lines.push(`Errors (${errors.length}):`);
-			for (const e of errors) {
-				lines.push(`  ${e.message}`);
-			}
-		}
-		if (warnings.length > 0) {
-			lines.push(`Warnings (${warnings.length}):`);
-			for (const w of warnings) {
-				lines.push(`  ${w.message}`);
-			}
-		}
-		ctx.ui.notify(`[specdocs] Validation:\n${lines.join("\n")}`, errors.length > 0 ? "error" : "warning");
+		return { message: "[specdocs] Validation passed: no issues found.", level: "info" };
 	}
+
+	const errors = issues.filter((issue) => issue.type === "error");
+	const warnings = issues.filter((issue) => issue.type === "warning");
+	const lines: string[] = [];
+
+	if (errors.length > 0) {
+		lines.push(`Errors (${errors.length}):`);
+		for (const error of errors) {
+			lines.push(`  ${error.message}`);
+		}
+	}
+
+	if (warnings.length > 0) {
+		lines.push(`Warnings (${warnings.length}):`);
+		for (const warning of warnings) {
+			lines.push(`  ${warning.message}`);
+		}
+	}
+
+	return {
+		message: `[specdocs] Validation:\n${lines.join("\n")}`,
+		level: errors.length > 0 ? "error" : "warning",
+	};
+}
+
+async function runValidation(ctx: { cwd: string } & ExtensionContext) {
+	const files = getValidationFiles(ctx.cwd);
+	const issues = [
+		...collectFrontmatterIssues(files),
+		...collectFilenameIssues(files.prdDir, PRD_DIR, PRD_FILENAME_PATTERN, "PRD-NNN-*.md"),
+		...collectFilenameIssues(files.adrDir, ADR_DIR, ADR_FILENAME_PATTERN, "ADR-NNNN-*.md"),
+		...collectNumberingGapIssues(files.prdFiles, /^PRD-(\d{3})-.*\.md$/, "PRD", 3),
+		...collectNumberingGapIssues(files.adrFiles, /^ADR-(\d{4})-.*\.md$/, "ADR", 4),
+	];
+	const result = formatValidationIssues(issues);
+	ctx.ui.notify(result.message, result.level);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- split `pi-specdocs` frontmatter validation into smaller helper functions
- extract tracker and Notion config formatting helpers to reduce branching in startup output
- break workspace validation into file discovery, issue collection, numbering-gap detection, and result formatting

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [x] Refactor

## Test plan
- Run `npx biome lint packages/pi-specdocs/extensions/index.ts --only=lint/complexity/noExcessiveCognitiveComplexity --max-diagnostics=15`
- Run `npx biome check packages/pi-specdocs/extensions/index.ts`
- Run `npm test -- packages/pi-specdocs`
- Run `npm run typecheck`

Closes #15