### PR TITLE
fix: address pi-devtools CI PR mode and complexity issues

### DIFF
--- a/packages/pi-devtools/__tests__/tools.test.ts
+++ b/packages/pi-devtools/__tests__/tools.test.ts
@@ -327,14 +327,16 @@ describe("pi-devtools", () => {
 	});
 
 	describe("checkCiTool", () => {
-		it("checks CI by PR number", () => {
+		it("checks CI by PR number using gh pr checks", () => {
 			vi.mocked(execGh).mockReturnValue(
-				JSON.stringify([{ workflowName: "Build", status: "completed", conclusion: "success", url: "https://ci" }]),
+				JSON.stringify([{ name: "Build", state: "SUCCESS", link: "https://ci", workflow: "CI" }]),
 			);
 
 			const result = checkCiTool(123);
 
+			expect(vi.mocked(execGh)).toHaveBeenCalledWith("gh pr checks 123 --json name,state,link,workflow");
 			expect(result.content[0].text).toContain("CI Status");
+			expect(result.content[0].text).toContain("Build: SUCCESS");
 			expect(result.details.checks).toBeDefined();
 		});
 

--- a/packages/pi-devtools/extensions/index.ts
+++ b/packages/pi-devtools/extensions/index.ts
@@ -245,6 +245,62 @@ function createPrTool(title: string, body?: string, base?: string, draft = false
 	}
 }
 
+type PullRequestInfo = {
+	title?: string;
+	url?: string;
+	state?: string;
+};
+
+function detectCurrentPrNumber(): number | undefined {
+	const branch = execGit("git branch --show-current");
+	const prs = execGh(`gh pr list --head ${shellQuote(branch)} --state open --json number,title`);
+	if (!prs) {
+		return undefined;
+	}
+
+	const parsed = JSON.parse(prs) as Array<{ number?: number }>;
+	const prNumber = parsed[0]?.number;
+	return typeof prNumber === "number" ? prNumber : undefined;
+}
+
+function getPullRequestInfo(prNumber: number): PullRequestInfo {
+	return JSON.parse(execGh(`gh pr view ${prNumber} --json title,url,state`)) as PullRequestInfo;
+}
+
+function buildMergeCommand(
+	prNumber: number,
+	squash: boolean,
+	deleteBranch: boolean,
+	commitTitle?: string,
+	commitMessage?: string,
+): string {
+	const commandParts = [`gh pr merge ${prNumber}`, squash ? "--squash" : "--merge"];
+
+	if (squash && commitTitle) {
+		commandParts.push(`--title ${shellQuote(commitTitle)}`);
+	}
+	if (squash && commitMessage) {
+		commandParts.push(`--body ${shellQuote(commitMessage)}`);
+	}
+	if (deleteBranch) {
+		commandParts.push("--delete-branch");
+	}
+
+	return commandParts.join(" ");
+}
+
+function formatMergeResult(prNumber: number, squash: boolean, deleteBranch: boolean, prData: PullRequestInfo): ToolResult {
+	const mergeType = squash ? "squash-merged" : "merged";
+	const mergeLabel = `${mergeType.charAt(0).toUpperCase() + mergeType.slice(1)} PR #${prNumber}`;
+	const titleSuffix = prData.title ? `: ${prData.title}` : "";
+	const urlSuffix = prData.url ? `\n${prData.url}` : "";
+
+	return {
+		content: [{ type: "text", text: `${mergeLabel}${titleSuffix}${urlSuffix}` }],
+		details: { prNumber, mergeType, deletedBranch: deleteBranch },
+	};
+}
+
 function mergePrTool(
 	prNumber?: number,
 	squash = false,
@@ -253,18 +309,7 @@ function mergePrTool(
 	commitMessage?: string,
 ): ToolResult {
 	try {
-		let num = prNumber;
-		if (!num) {
-			const branch = execGit("git branch --show-current");
-			const prs = execGh(`gh pr list --head ${shellQuote(branch)} --state open --json number,title`);
-			if (prs) {
-				const parsed = JSON.parse(prs) as Array<{ number?: number }>;
-				if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0].number === "number") {
-					num = parsed[0].number;
-				}
-			}
-		}
-
+		const num = prNumber ?? detectCurrentPrNumber();
 		if (!num) {
 			return {
 				content: [{ type: "text", text: "No PR number provided and could not detect current PR." }],
@@ -273,10 +318,7 @@ function mergePrTool(
 			};
 		}
 
-		// Get PR info before merging
-		const prInfo = execGh(`gh pr view ${num} --json title,url,state`);
-		const prData = JSON.parse(prInfo);
-
+		const prData = getPullRequestInfo(num);
 		if (prData.state !== "OPEN") {
 			return {
 				content: [{ type: "text", text: `PR #${num} is not open (state: ${prData.state})` }],
@@ -285,36 +327,8 @@ function mergePrTool(
 			};
 		}
 
-		// Build merge command
-		let command = `gh pr merge ${num}`;
-		if (squash) {
-			command += " --squash";
-			if (commitTitle) {
-				command += ` --title ${shellQuote(commitTitle)}`;
-			}
-			if (commitMessage) {
-				command += ` --body ${shellQuote(commitMessage)}`;
-			}
-		} else {
-			command += " --merge";
-		}
-
-		if (deleteBranch) {
-			command += " --delete-branch";
-		}
-
-		execGh(command);
-
-		const mergeType = squash ? "squash-merged" : "merged";
-		return {
-			content: [
-				{
-					type: "text",
-					text: `${mergeType.charAt(0).toUpperCase() + mergeType.slice(1)} PR #${num}: ${prData.title}\n${prData.url}`,
-				},
-			],
-			details: { prNumber: num, mergeType, deletedBranch: deleteBranch },
-		};
+		execGh(buildMergeCommand(num, squash, deleteBranch, commitTitle, commitMessage));
+		return formatMergeResult(num, squash, deleteBranch, prData);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return {
@@ -385,6 +399,47 @@ function checkCiTool(prNumber?: number, branch?: string): ToolResult {
 	}
 }
 
+type RepoStatus = {
+	staged: string[];
+	modified: string[];
+	untracked: string[];
+};
+
+function parseRepoStatus(statusOutput: string): RepoStatus {
+	return statusOutput
+		.split("\n")
+		.filter(Boolean)
+		.reduce<RepoStatus>(
+			(status, line) => {
+				const indexStatus = line[0];
+				const workTreeStatus = line[1];
+				const file = line.slice(3);
+
+				if (indexStatus === "?" && workTreeStatus === "?") {
+					status.untracked.push(file);
+					return status;
+				}
+
+				if (indexStatus !== " " && indexStatus !== "?") {
+					status.staged.push(file);
+				}
+				if (workTreeStatus !== " " && workTreeStatus !== "?") {
+					status.modified.push(file);
+				}
+				return status;
+			},
+			{ staged: [], modified: [], untracked: [] },
+		);
+}
+
+function hasRepoChanges(status: RepoStatus): boolean {
+	return status.staged.length > 0 || status.modified.length > 0 || status.untracked.length > 0;
+}
+
+function formatRepoInfo(branch: string, defaultBranch: string, status: RepoStatus): string {
+	return `Repository Info:\n- Current branch: ${branch}\n- Default branch: ${defaultBranch}\n- Has changes: ${hasRepoChanges(status)}\n- Staged: ${status.staged.length}\n- Modified: ${status.modified.length}\n- Untracked: ${status.untracked.length}`;
+}
+
 function repoInfoTool(): ToolResult {
 	try {
 		const branch = execGit("git branch --show-current");
@@ -397,42 +452,16 @@ function repoInfoTool(): ToolResult {
 		}
 
 		const defaultBranch = getDefaultBranch();
-		const statusOutput = execGit("git status --porcelain");
-		const lines = statusOutput.split("\n").filter(Boolean);
-
-		const staged: string[] = [];
-		const modified: string[] = [];
-		const untracked: string[] = [];
-
-		for (const line of lines) {
-			const indexStatus = line[0];
-			const workTreeStatus = line[1];
-			const file = line.slice(3);
-
-			if (indexStatus === "?" && workTreeStatus === "?") {
-				untracked.push(file);
-			} else if (indexStatus !== " " && indexStatus !== "?") {
-				staged.push(file);
-			}
-			if (workTreeStatus !== " " && workTreeStatus !== "?") {
-				modified.push(file);
-			}
-		}
-
+		const status = parseRepoStatus(execGit("git status --porcelain"));
 		return {
-			content: [
-				{
-					type: "text",
-					text: `Repository Info:\n- Current branch: ${branch}\n- Default branch: ${defaultBranch}\n- Has changes: ${staged.length > 0 || modified.length > 0 || untracked.length > 0}\n- Staged: ${staged.length}\n- Modified: ${modified.length}\n- Untracked: ${untracked.length}`,
-				},
-			],
+			content: [{ type: "text", text: formatRepoInfo(branch, defaultBranch, status) }],
 			details: {
 				branch,
 				defaultBranch,
-				hasChanges: staged.length > 0 || modified.length > 0 || untracked.length > 0,
-				staged,
-				modified,
-				untracked,
+				hasChanges: hasRepoChanges(status),
+				staged: status.staged,
+				modified: status.modified,
+				untracked: status.untracked,
 			},
 		};
 	} catch (error) {

--- a/packages/pi-devtools/extensions/index.ts
+++ b/packages/pi-devtools/extensions/index.ts
@@ -325,54 +325,55 @@ function mergePrTool(
 	}
 }
 
+type CiCheck = {
+	name?: string;
+	state?: string;
+	link?: string;
+	workflow?: string;
+	workflowName?: string;
+	status?: string;
+	conclusion?: string;
+	url?: string;
+};
+
+function getCiCheckCommand(prNumber?: number, branch?: string): string {
+	if (prNumber) {
+		return `gh pr checks ${prNumber} --json name,state,link,workflow`;
+	}
+
+	const targetBranch = branch ?? execGit("git branch --show-current");
+	return `gh run list --branch ${shellQuote(targetBranch)} --limit 5 --json workflowName,status,conclusion,url`;
+}
+
+function formatCiCheck(check: CiCheck): string {
+	const status = check.conclusion ?? check.state ?? check.status ?? "unknown";
+	const name = check.name ?? check.workflowName ?? check.workflow ?? "Unknown workflow";
+	const link = check.link ?? check.url;
+	return `- ${name}: ${status}${link ? ` (${link})` : ""}`;
+}
+
 function checkCiTool(prNumber?: number, branch?: string): ToolResult {
 	try {
-		let checkCommand: string;
-
-		if (prNumber) {
-			checkCommand = `gh run list --pr ${prNumber} --limit 5 --json workflowName,status,conclusion,url`;
-		} else if (branch) {
-			checkCommand = `gh run list --branch ${shellQuote(branch)} --limit 5 --json workflowName,status,conclusion,url`;
-		} else {
-			const currentBranch = execGit("git branch --show-current");
-			checkCommand = `gh run list --branch ${shellQuote(currentBranch)} --limit 5 --json workflowName,status,conclusion,url`;
-		}
-
-		const runs = execGh(checkCommand);
-
-		if (!runs) {
+		const checks = execGh(getCiCheckCommand(prNumber, branch));
+		if (!checks) {
 			return {
 				content: [{ type: "text", text: "No CI runs found for this PR/branch." }],
 				details: { checks: [] },
 			};
 		}
 
-		const parsedRuns = JSON.parse(runs) as Array<{
-			workflowName?: string;
-			status?: string;
-			conclusion?: string;
-			url?: string;
-		}>;
-
-		if (!Array.isArray(parsedRuns) || parsedRuns.length === 0) {
+		const parsedChecks = JSON.parse(checks) as CiCheck[];
+		if (!Array.isArray(parsedChecks) || parsedChecks.length === 0) {
 			return {
 				content: [{ type: "text", text: "No CI runs found for this PR/branch." }],
 				details: { checks: [] },
 			};
 		}
 
-		const checkSummary = parsedRuns
-			.map((run) => {
-				const status = run.conclusion ?? run.status ?? "unknown";
-				const name = run.workflowName ?? "Unknown workflow";
-				const link = run.url ? ` (${run.url})` : "";
-				return `- ${name}: ${status}${link}`;
-			})
-			.join("\n");
-
+		const checkSummary = parsedChecks.map(formatCiCheck).join("\n");
 		return {
 			content: [{ type: "text", text: `CI Status:\n${checkSummary}` }],
-			details: { checks: parsedRuns },
+			details: { checks: parsedChecks },
 		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- fix `devtools_check_ci` PR mode to use `gh pr checks` instead of unsupported `gh run list --pr`
- add a regression test covering the PR-number CI path
- refactor `mergePrTool` and `repoInfoTool` to reduce cognitive complexity

## Affected package
- `packages/pi-devtools`

## Tests run
- `npm run test -- packages/pi-devtools/__tests__/tools.test.ts`
- `npm run test -- packages/pi-devtools/__tests__/tools.test.ts packages/pi-devtools/__tests__/helpers.test.ts packages/pi-devtools/__tests__/index.test.ts`
- `npm run test -- packages/pi-devtools/__tests__/git.integration.test.ts`
- `npx biome lint packages/pi-devtools/extensions/index.ts --only=lint/complexity/noExcessiveCognitiveComplexity --max-diagnostics=20`

## Related
Closes #18
Closes #10