### PR TITLE
chore: tighten workspace CI and package coverage gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,25 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit --pretty false --project packages/${{ matrix.package }}/tsconfig.json
 
-      - name: Test
-        run: npx vitest run packages/${{ matrix.package }}/__tests__
+      - name: Test with coverage
+        run: >-
+          npx vitest run packages/${{ matrix.package }}/__tests__
+          --coverage.enabled
+          --coverage.reportsDirectory=coverage/${{ matrix.package }}
+          --coverage.include=packages/${{ matrix.package }}/extensions/**/*.ts
+          --coverage.thresholds.lines=70
+          --coverage.thresholds.statements=70
+          --coverage.thresholds.functions=70
+          --coverage.thresholds.branches=60
+
+      - name: Coverage summary
+        run: >-
+          node scripts/write-coverage-summary.mjs
+          coverage/${{ matrix.package }}/coverage-summary.json
+          ${{ matrix.package }}
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ matrix.package }}
+          path: coverage/${{ matrix.package }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Run these from the repo root unless noted:
 - `npm run lint:fix` — auto-fixable Biome issues.
 - `npm run typecheck` — TypeScript type checking only.
 - `npm run test` — Vitest test suite.
+- `npm run test:coverage` — Vitest coverage run with repo-wide thresholds.
 - `npm run check` — lint + typecheck.
 - `npm run check:ci` — CI-friendly Biome + typecheck.
 - `npm run ci:detect -- <base> <head>` — show which packages the CI workflow will check for a given diff.
@@ -27,7 +28,7 @@ Local package testing:
 
 ## Coding Style & Naming Conventions
 - Language: TypeScript.
-- Formatting: Biome with **tabs** for indentation and `lineWidth` 120.
+- Formatting: Biome with **2 spaces** for indentation and `lineWidth` 120.
 - File naming: tests live in `__tests__` and use `*.test.ts`.
 - Package naming: `packages/pi-<name>` with npm scope `@feniix/pi-<name>`.
 
@@ -35,9 +36,11 @@ Local package testing:
 - Framework: Vitest (see `vitest.config.ts`).
 - Tests are per-package under `packages/*/__tests__/`.
 - Keep unit tests focused on extension behavior and helpers; prefer fast, isolated tests.
-- CI uses a single GitHub Actions workflow at `.github/workflows/ci.yml` that detects changed packages and runs package-scoped lint, typecheck, and test jobs.
+- CI uses a single GitHub Actions workflow at `.github/workflows/ci.yml` that detects changed packages and runs package-scoped lint, typecheck, test, and coverage summary jobs.
+- Package-scoped CI coverage is enforced per extension with the same thresholds for every package: lines 70, statements 70, functions 70, branches 60.
 - Changes to shared files such as `package.json`, `package-lock.json`, `tsconfig.json`, `vitest.config.ts`, `biome.json`, or `.github/workflows/**` should be treated as affecting all packages.
 - Each package must keep its `tsconfig.json` aligned by extending the shared root `tsconfig.json`; do not introduce divergent compiler options in individual package configs unless the repo-wide config is intentionally updated.
+- Coverage thresholds are enforced in `vitest.config.ts` at: lines 70, statements 70, functions 70, branches 60.
 - For `packages/pi-conductor/`, follow **test-first development**: write or update the failing test first, then implement the minimal code needed to make it pass.
 
 ## Commit & Pull Request Guidelines

--- a/biome.json
+++ b/biome.json
@@ -1,22 +1,49 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab",
-		"lineWidth": 120
-	},
-	"files": {
-		"includes": [
-			"packages/*/extensions/**/*.ts",
-			"packages/*/__tests__/**/*.ts",
-			"packages/*/src/**/*.ts",
-			"vitest.config.ts"
-		]
-	}
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "packages/*/extensions/**/*.ts",
+      "packages/*/__tests__/**/*.ts",
+      "packages/*/src/**/*.ts",
+      "packages/*/package.json",
+      "package.json",
+      "tsconfig.json",
+      "biome.json",
+      "vitest.config.ts"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error"
+      },
+      "style": {
+        "noNonNullAssertion": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "npm run lint && npm run typecheck",
     "check:ci": "biome ci . && tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "ci:detect": "./scripts/detect-ci-packages.sh"
   },
   "workspaces": [

--- a/packages/pi-code-reasoning/__tests__/helpers.test.ts
+++ b/packages/pi-code-reasoning/__tests__/helpers.test.ts
@@ -3,469 +3,469 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	buildError,
-	buildSuccess,
-	createThoughtTracker,
-	DEFAULT_CONFIG_FILE,
-	formatToolOutput,
-	getExampleThought,
-	isRecord,
-	normalizeNumber,
-	parseConfig,
-	resolveConfigPath,
-	resolveEffectiveLimits,
-	splitParams,
-	toJsonString,
-	writeTempFile,
+  buildError,
+  buildSuccess,
+  createThoughtTracker,
+  DEFAULT_CONFIG_FILE,
+  formatToolOutput,
+  getExampleThought,
+  isRecord,
+  normalizeNumber,
+  parseConfig,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  splitParams,
+  toJsonString,
+  writeTempFile,
 } from "../extensions/index.js";
 
 describe("pi-code-reasoning helpers", () => {
-	it("splits params and clamps limits", () => {
-		const { toolArgs, requestedLimits } = splitParams({
-			piMaxBytes: "100",
-			piMaxLines: 5,
-			thought: "hello",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		});
-		expect(toolArgs).toEqual({
-			thought: "hello",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		});
-		expect(requestedLimits).toEqual({ maxBytes: 100, maxLines: 5 });
+  it("splits params and clamps limits", () => {
+    const { toolArgs, requestedLimits } = splitParams({
+      piMaxBytes: "100",
+      piMaxLines: 5,
+      thought: "hello",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    });
+    expect(toolArgs).toEqual({
+      thought: "hello",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    });
+    expect(requestedLimits).toEqual({ maxBytes: 100, maxLines: 5 });
 
-		const effective = resolveEffectiveLimits({ maxBytes: 200, maxLines: 2 }, { maxBytes: 120, maxLines: 10 });
-		expect(effective).toEqual({ maxBytes: 120, maxLines: 2 });
-	});
+    const effective = resolveEffectiveLimits({ maxBytes: 200, maxLines: 2 }, { maxBytes: 120, maxLines: 10 });
+    expect(effective).toEqual({ maxBytes: 120, maxLines: 2 });
+  });
 
-	it("resolves effective limits using defaults when not requested", () => {
-		const effective = resolveEffectiveLimits({}, { maxBytes: 51200, maxLines: 2000 });
-		expect(effective).toEqual({ maxBytes: 51200, maxLines: 2000 });
-	});
+  it("resolves effective limits using defaults when not requested", () => {
+    const effective = resolveEffectiveLimits({}, { maxBytes: 51200, maxLines: 2000 });
+    expect(effective).toEqual({ maxBytes: 51200, maxLines: 2000 });
+  });
 
-	it("normalizes numbers from strings and numbers", () => {
-		expect(normalizeNumber(42)).toBe(42);
-		expect(normalizeNumber("123")).toBe(123);
-		expect(normalizeNumber("abc")).toBeUndefined();
-		expect(normalizeNumber(null)).toBeUndefined();
-		expect(normalizeNumber(undefined)).toBeUndefined();
-		expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
-	});
+  it("normalizes numbers from strings and numbers", () => {
+    expect(normalizeNumber(42)).toBe(42);
+    expect(normalizeNumber("123")).toBe(123);
+    expect(normalizeNumber("abc")).toBeUndefined();
+    expect(normalizeNumber(null)).toBeUndefined();
+    expect(normalizeNumber(undefined)).toBeUndefined();
+    expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
 
-	it("returns DEFAULT_CONFIG_FILE", () => {
-		expect(DEFAULT_CONFIG_FILE).toHaveProperty("maxBytes");
-		expect(DEFAULT_CONFIG_FILE).toHaveProperty("maxLines");
-	});
+  it("returns DEFAULT_CONFIG_FILE", () => {
+    expect(DEFAULT_CONFIG_FILE).toHaveProperty("maxBytes");
+    expect(DEFAULT_CONFIG_FILE).toHaveProperty("maxLines");
+  });
 });
 
 describe("pi-code-reasoning type guards", () => {
-	it("isRecord returns true for plain objects", () => {
-		expect(isRecord({})).toBe(true);
-		expect(isRecord({ a: 1 })).toBe(true);
-	});
+  it("isRecord returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
 
-	it("isRecord returns false for non-objects", () => {
-		expect(isRecord(null)).toBe(false);
-		expect(isRecord(undefined)).toBe(false);
-		expect(isRecord("string")).toBe(false);
-		expect(isRecord(123)).toBe(false);
-		expect(isRecord([])).toBe(false);
-	});
+  it("isRecord returns false for non-objects", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord("string")).toBe(false);
+    expect(isRecord(123)).toBe(false);
+    expect(isRecord([])).toBe(false);
+  });
 });
 
 describe("pi-code-reasoning toJsonString", () => {
-	it("returns strings as-is", () => {
-		expect(toJsonString("hello")).toBe("hello");
-		expect(toJsonString("")).toBe("");
-	});
+  it("returns strings as-is", () => {
+    expect(toJsonString("hello")).toBe("hello");
+    expect(toJsonString("")).toBe("");
+  });
 
-	it("stringifies objects", () => {
-		const result = toJsonString({ a: 1, b: 2 });
-		expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
-	});
+  it("stringifies objects", () => {
+    const result = toJsonString({ a: 1, b: 2 });
+    expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
+  });
 
-	it("converts primitives", () => {
-		expect(toJsonString(42)).toBe("42");
-		expect(toJsonString(true)).toBe("true");
-		expect(toJsonString(null)).toBe("null");
-	});
+  it("converts primitives", () => {
+    expect(toJsonString(42)).toBe("42");
+    expect(toJsonString(true)).toBe("true");
+    expect(toJsonString(null)).toBe("null");
+  });
 });
 
 describe("pi-code-reasoning resolveConfigPath", () => {
-	it("resolves paths starting with ~/", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(homedir());
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~/", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(homedir());
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("resolves paths starting with ~", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("returns absolute paths as-is", () => {
-		const absolute = "/absolute/path/to/config.json";
-		expect(resolveConfigPath(absolute)).toBe(absolute);
-	});
+  it("returns absolute paths as-is", () => {
+    const absolute = "/absolute/path/to/config.json";
+    expect(resolveConfigPath(absolute)).toBe(absolute);
+  });
 
-	it("resolves relative paths from cwd", () => {
-		const result = resolveConfigPath("relative/path.json");
-		expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
-	});
+  it("resolves relative paths from cwd", () => {
+    const result = resolveConfigPath("relative/path.json");
+    expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
+  });
 });
 
 describe("pi-code-reasoning parseConfig", () => {
-	it("parses valid config", () => {
-		const raw = {
-			maxBytes: 1024,
-			maxLines: 500,
-		};
-		const result = parseConfig(raw, "/path/to/config.json");
-		expect(result).toEqual({
-			maxBytes: 1024,
-			maxLines: 500,
-		});
-	});
+  it("parses valid config", () => {
+    const raw = {
+      maxBytes: 1024,
+      maxLines: 500,
+    };
+    const result = parseConfig(raw, "/path/to/config.json");
+    expect(result).toEqual({
+      maxBytes: 1024,
+      maxLines: 500,
+    });
+  });
 
-	it("ignores null/undefined values", () => {
-		const raw = { maxBytes: undefined, maxLines: NaN };
-		const result = parseConfig(raw, "/path");
-		expect(result.maxBytes).toBeUndefined();
-		expect(result.maxLines).toBeUndefined();
-	});
+  it("ignores null/undefined values", () => {
+    const raw = { maxBytes: undefined, maxLines: NaN };
+    const result = parseConfig(raw, "/path");
+    expect(result.maxBytes).toBeUndefined();
+    expect(result.maxLines).toBeUndefined();
+  });
 
-	it("throws for non-object config", () => {
-		expect(() => parseConfig(null, "/path")).toThrow("Invalid Code Reasoning config");
-		expect(() => parseConfig("string", "/path")).toThrow("Invalid Code Reasoning config");
-		expect(() => parseConfig(123, "/path")).toThrow("Invalid Code Reasoning config");
-	});
+  it("throws for non-object config", () => {
+    expect(() => parseConfig(null, "/path")).toThrow("Invalid Code Reasoning config");
+    expect(() => parseConfig("string", "/path")).toThrow("Invalid Code Reasoning config");
+    expect(() => parseConfig(123, "/path")).toThrow("Invalid Code Reasoning config");
+  });
 });
 
 describe("pi-code-reasoning formatToolOutput", () => {
-	it("formats simple result", () => {
-		const result = formatToolOutput("test_tool", { message: "Hello" }, { maxBytes: 50000, maxLines: 2000 });
-		expect(result.text).toContain("Hello");
-		expect(result.details.truncated).toBe(false);
-	});
+  it("formats simple result", () => {
+    const result = formatToolOutput("test_tool", { message: "Hello" }, { maxBytes: 50000, maxLines: 2000 });
+    expect(result.text).toContain("Hello");
+    expect(result.details.truncated).toBe(false);
+  });
 
-	it("handles object result", () => {
-		const result = formatToolOutput("test_tool", { data: 123 }, {});
-		expect(result.text).toContain("data");
-		expect(result.text).toContain("123");
-	});
+  it("handles object result", () => {
+    const result = formatToolOutput("test_tool", { data: 123 }, {});
+    expect(result.text).toContain("data");
+    expect(result.text).toContain("123");
+  });
 });
 
 describe("pi-code-reasoning writeTempFile", () => {
-	const tempFiles: string[] = [];
+  const tempFiles: string[] = [];
 
-	afterEach(() => {
-		import("node:fs").then(({ unlinkSync }) => {
-			tempFiles.forEach((f) => {
-				try {
-					unlinkSync(f);
-				} catch {
-					// ignore cleanup errors
-				}
-			});
-		});
-	});
+  afterEach(() => {
+    import("node:fs").then(({ unlinkSync }) => {
+      tempFiles.forEach((f) => {
+        try {
+          unlinkSync(f);
+        } catch {
+          // ignore cleanup errors
+        }
+      });
+    });
+  });
 
-	it("writes temp file and returns path", () => {
-		const path = writeTempFile("test_tool", "content here");
-		tempFiles.push(path);
-		expect(path).toContain("pi-code-reasoning-test_tool");
-		expect(path).toContain(".txt");
-		expect(existsSync(path)).toBe(true);
-	});
+  it("writes temp file and returns path", () => {
+    const path = writeTempFile("test_tool", "content here");
+    tempFiles.push(path);
+    expect(path).toContain("pi-code-reasoning-test_tool");
+    expect(path).toContain(".txt");
+    expect(existsSync(path)).toBe(true);
+  });
 
-	it("sanitizes tool name", () => {
-		const path = writeTempFile("my-tool!@#", "content");
-		tempFiles.push(path);
-		expect(path).toContain("my-tool__");
-	});
+  it("sanitizes tool name", () => {
+    const path = writeTempFile("my-tool!@#", "content");
+    tempFiles.push(path);
+    expect(path).toContain("my-tool__");
+  });
 });
 
 describe("pi-code-reasoning createThoughtTracker", () => {
-	it("creates a tracker with zero count", () => {
-		const tracker = createThoughtTracker();
-		expect(tracker.count()).toBe(0);
-	});
+  it("creates a tracker with zero count", () => {
+    const tracker = createThoughtTracker();
+    expect(tracker.count()).toBe(0);
+  });
 
-	it("adds thoughts to tracker", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "First thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			is_revision: false,
-			branch_from_thought: undefined,
-			branch_id: undefined,
-			needs_more_thoughts: false,
-		});
-		expect(tracker.count()).toBe(1);
-	});
+  it("adds thoughts to tracker", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "First thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      is_revision: false,
+      branch_from_thought: undefined,
+      branch_id: undefined,
+      needs_more_thoughts: false,
+    });
+    expect(tracker.count()).toBe(1);
+  });
 
-	it("tracks multiple thoughts", () => {
-		const tracker = createThoughtTracker();
-		for (let i = 1; i <= 5; i++) {
-			tracker.add({
-				thought: `Thought ${i}`,
-				thought_number: i,
-				total_thoughts: 5,
-				next_thought_needed: i < 5,
-				is_revision: false,
-				branch_from_thought: undefined,
-				branch_id: undefined,
-				needs_more_thoughts: false,
-			});
-		}
-		expect(tracker.count()).toBe(5);
-	});
+  it("tracks multiple thoughts", () => {
+    const tracker = createThoughtTracker();
+    for (let i = 1; i <= 5; i++) {
+      tracker.add({
+        thought: `Thought ${i}`,
+        thought_number: i,
+        total_thoughts: 5,
+        next_thought_needed: i < 5,
+        is_revision: false,
+        branch_from_thought: undefined,
+        branch_id: undefined,
+        needs_more_thoughts: false,
+      });
+    }
+    expect(tracker.count()).toBe(5);
+  });
 
-	it("tracks branches", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "Main thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			is_revision: false,
-			branch_from_thought: undefined,
-			branch_id: undefined,
-			needs_more_thoughts: false,
-		});
-		tracker.add({
-			thought: "Branch thought",
-			thought_number: 2,
-			total_thoughts: 3,
-			next_thought_needed: false,
-			is_revision: false,
-			branch_from_thought: 1,
-			branch_id: "alt-1",
-			needs_more_thoughts: false,
-		});
-		expect(tracker.branches()).toContain("alt-1");
-	});
+  it("tracks branches", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "Main thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      is_revision: false,
+      branch_from_thought: undefined,
+      branch_id: undefined,
+      needs_more_thoughts: false,
+    });
+    tracker.add({
+      thought: "Branch thought",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_thought_needed: false,
+      is_revision: false,
+      branch_from_thought: 1,
+      branch_id: "alt-1",
+      needs_more_thoughts: false,
+    });
+    expect(tracker.branches()).toContain("alt-1");
+  });
 
-	it("resets tracker", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "Thought",
-			thought_number: 1,
-			total_thoughts: 1,
-			next_thought_needed: false,
-			is_revision: false,
-			branch_from_thought: undefined,
-			branch_id: "branch-1",
-			needs_more_thoughts: false,
-		});
-		tracker.reset();
-		expect(tracker.count()).toBe(0);
-		expect(tracker.branches()).toEqual([]);
-	});
+  it("resets tracker", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "Thought",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_thought_needed: false,
+      is_revision: false,
+      branch_from_thought: undefined,
+      branch_id: "branch-1",
+      needs_more_thoughts: false,
+    });
+    tracker.reset();
+    expect(tracker.count()).toBe(0);
+    expect(tracker.branches()).toEqual([]);
+  });
 
-	it("validates branch_from_thought", () => {
-		const tracker = createThoughtTracker();
-		// Add a thought first so position 1 is valid
-		tracker.add({
-			thought: "First",
-			thought_number: 1,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			is_revision: false,
-			branch_from_thought: undefined,
-			branch_id: undefined,
-			needs_more_thoughts: false,
-		});
-		// Should not throw for valid branch
-		expect(() => tracker.ensureBranchIsValid(1)).not.toThrow();
-		// Should throw for invalid branch
-		expect(() => tracker.ensureBranchIsValid(100)).toThrow("Invalid branch_from_thought");
-	});
+  it("validates branch_from_thought", () => {
+    const tracker = createThoughtTracker();
+    // Add a thought first so position 1 is valid
+    tracker.add({
+      thought: "First",
+      thought_number: 1,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      is_revision: false,
+      branch_from_thought: undefined,
+      branch_id: undefined,
+      needs_more_thoughts: false,
+    });
+    // Should not throw for valid branch
+    expect(() => tracker.ensureBranchIsValid(1)).not.toThrow();
+    // Should throw for invalid branch
+    expect(() => tracker.ensureBranchIsValid(100)).toThrow("Invalid branch_from_thought");
+  });
 
-	it("validates revises_thought", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "First",
-			thought_number: 1,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			is_revision: false,
-			branch_from_thought: undefined,
-			branch_id: undefined,
-			needs_more_thoughts: false,
-		});
-		expect(() => tracker.ensureRevisionIsValid(1)).not.toThrow();
-		expect(() => tracker.ensureRevisionIsValid(100)).toThrow("Invalid revises_thought");
-	});
+  it("validates revises_thought", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "First",
+      thought_number: 1,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      is_revision: false,
+      branch_from_thought: undefined,
+      branch_id: undefined,
+      needs_more_thoughts: false,
+    });
+    expect(() => tracker.ensureRevisionIsValid(1)).not.toThrow();
+    expect(() => tracker.ensureRevisionIsValid(100)).toThrow("Invalid revises_thought");
+  });
 
-	it("handles multiple branches", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "Branch 1",
-			thought_number: 2,
-			total_thoughts: 3,
-			next_thought_needed: false,
-			is_revision: false,
-			branch_from_thought: 1,
-			branch_id: "branch-a",
-			needs_more_thoughts: false,
-		});
-		tracker.add({
-			thought: "Branch 2",
-			thought_number: 3,
-			total_thoughts: 3,
-			next_thought_needed: false,
-			is_revision: false,
-			branch_from_thought: 1,
-			branch_id: "branch-b",
-			needs_more_thoughts: false,
-		});
-		expect(tracker.branches()).toContain("branch-a");
-		expect(tracker.branches()).toContain("branch-b");
-		expect(tracker.branches()).toHaveLength(2);
-	});
+  it("handles multiple branches", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "Branch 1",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_thought_needed: false,
+      is_revision: false,
+      branch_from_thought: 1,
+      branch_id: "branch-a",
+      needs_more_thoughts: false,
+    });
+    tracker.add({
+      thought: "Branch 2",
+      thought_number: 3,
+      total_thoughts: 3,
+      next_thought_needed: false,
+      is_revision: false,
+      branch_from_thought: 1,
+      branch_id: "branch-b",
+      needs_more_thoughts: false,
+    });
+    expect(tracker.branches()).toContain("branch-a");
+    expect(tracker.branches()).toContain("branch-b");
+    expect(tracker.branches()).toHaveLength(2);
+  });
 });
 
 describe("pi-code-reasoning getExampleThought", () => {
-	it("returns branch example for branch error", () => {
-		const example = getExampleThought("branch error");
-		expect(example.branch_from_thought).toBe(2);
-		expect(example.branch_id).toBe("alternative-algo-x");
-	});
+  it("returns branch example for branch error", () => {
+    const example = getExampleThought("branch error");
+    expect(example.branch_from_thought).toBe(2);
+    expect(example.branch_id).toBe("alternative-algo-x");
+  });
 
-	it("returns revision example for revision error", () => {
-		const example = getExampleThought("revis");
-		expect(example.is_revision).toBe(true);
-		expect(example.revises_thought).toBe(2);
-	});
+  it("returns revision example for revision error", () => {
+    const example = getExampleThought("revis");
+    expect(example.is_revision).toBe(true);
+    expect(example.revises_thought).toBe(2);
+  });
 
-	it("returns length example for length error", () => {
-		const example = getExampleThought("length");
-		expect(example.thought).toContain("Breaking down");
-	});
+  it("returns length example for length error", () => {
+    const example = getExampleThought("length");
+    expect(example.thought).toContain("Breaking down");
+  });
 
-	it("returns default example", () => {
-		const example = getExampleThought("unknown error");
-		expect(example.thought_number).toBe(1);
-		expect(example.total_thoughts).toBe(5);
-	});
+  it("returns default example", () => {
+    const example = getExampleThought("unknown error");
+    expect(example.thought_number).toBe(1);
+    expect(example.total_thoughts).toBe(5);
+  });
 });
 
 describe("pi-code-reasoning buildSuccess", () => {
-	it("builds success response", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "Test",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			is_revision: false,
-			branch_from_thought: undefined,
-			branch_id: undefined,
-			needs_more_thoughts: false,
-		});
-		const result = buildSuccess(
-			{
-				thought: "Test",
-				thought_number: 1,
-				total_thoughts: 3,
-				next_thought_needed: true,
-				is_revision: false,
-				branch_from_thought: undefined,
-				branch_id: undefined,
-				needs_more_thoughts: false,
-			},
-			tracker,
-		);
-		expect(result.status).toBe("processed");
-		expect(result.thought_number).toBe(1);
-		expect(result.total_thoughts).toBe(3);
-		expect(result.next_thought_needed).toBe(true);
-		expect(result.thought_history_length).toBe(1);
-	});
+  it("builds success response", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "Test",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      is_revision: false,
+      branch_from_thought: undefined,
+      branch_id: undefined,
+      needs_more_thoughts: false,
+    });
+    const result = buildSuccess(
+      {
+        thought: "Test",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+        is_revision: false,
+        branch_from_thought: undefined,
+        branch_id: undefined,
+        needs_more_thoughts: false,
+      },
+      tracker,
+    );
+    expect(result.status).toBe("processed");
+    expect(result.thought_number).toBe(1);
+    expect(result.total_thoughts).toBe(3);
+    expect(result.next_thought_needed).toBe(true);
+    expect(result.thought_history_length).toBe(1);
+  });
 
-	it("includes branches in response", () => {
-		const tracker = createThoughtTracker();
-		tracker.add({
-			thought: "Branch",
-			thought_number: 2,
-			total_thoughts: 3,
-			next_thought_needed: false,
-			is_revision: false,
-			branch_from_thought: 1,
-			branch_id: "my-branch",
-			needs_more_thoughts: false,
-		});
-		const result = buildSuccess(
-			{
-				thought: "Branch",
-				thought_number: 2,
-				total_thoughts: 3,
-				next_thought_needed: false,
-				is_revision: false,
-				branch_from_thought: 1,
-				branch_id: "my-branch",
-				needs_more_thoughts: false,
-			},
-			tracker,
-		);
-		expect(result.branches as string[]).toContain("my-branch");
-	});
+  it("includes branches in response", () => {
+    const tracker = createThoughtTracker();
+    tracker.add({
+      thought: "Branch",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_thought_needed: false,
+      is_revision: false,
+      branch_from_thought: 1,
+      branch_id: "my-branch",
+      needs_more_thoughts: false,
+    });
+    const result = buildSuccess(
+      {
+        thought: "Branch",
+        thought_number: 2,
+        total_thoughts: 3,
+        next_thought_needed: false,
+        is_revision: false,
+        branch_from_thought: 1,
+        branch_id: "my-branch",
+        needs_more_thoughts: false,
+      },
+      tracker,
+    );
+    expect(result.branches as string[]).toContain("my-branch");
+  });
 });
 
 describe("pi-code-reasoning buildError", () => {
-	it("builds error response", () => {
-		const error = new Error("Test error");
-		const result = buildError(error);
-		expect(result.status).toBe("failed");
-		expect(result.error).toBe("Test error");
-	});
+  it("builds error response", () => {
+    const error = new Error("Test error");
+    const result = buildError(error);
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("Test error");
+  });
 
-	it("provides branch guidance", () => {
-		const error = new Error("branch error");
-		const result = buildError(error);
-		const guidance = result.guidance as string;
-		expect(guidance).toContain("branch_from_thought");
-		expect(guidance).toContain("branch_id");
-	});
+  it("provides branch guidance", () => {
+    const error = new Error("branch error");
+    const result = buildError(error);
+    const guidance = result.guidance as string;
+    expect(guidance).toContain("branch_from_thought");
+    expect(guidance).toContain("branch_id");
+  });
 
-	it("provides revision guidance", () => {
-		const error = new Error("revision error");
-		const result = buildError(error);
-		const guidance = result.guidance as string;
-		expect(guidance).toContain("is_revision");
-		expect(guidance).toContain("revises_thought");
-	});
+  it("provides revision guidance", () => {
+    const error = new Error("revision error");
+    const result = buildError(error);
+    const guidance = result.guidance as string;
+    expect(guidance).toContain("is_revision");
+    expect(guidance).toContain("revises_thought");
+  });
 
-	it("provides length guidance", () => {
-		const error = new Error("length exceeded");
-		const result = buildError(error);
-		const guidance = result.guidance as string;
-		expect(guidance).toContain("characters");
-	});
+  it("provides length guidance", () => {
+    const error = new Error("length exceeded");
+    const result = buildError(error);
+    const guidance = result.guidance as string;
+    expect(guidance).toContain("characters");
+  });
 
-	it("provides max thoughts guidance", () => {
-		const error = new Error("Max thought limit exceeded");
-		const result = buildError(error);
-		const guidance = result.guidance as string;
-		expect(guidance).toContain("maximum thought limit");
-	});
+  it("provides max thoughts guidance", () => {
+    const error = new Error("Max thought limit exceeded");
+    const result = buildError(error);
+    const guidance = result.guidance as string;
+    expect(guidance).toContain("maximum thought limit");
+  });
 
-	it("includes example in error", () => {
-		const error = new Error("branch error");
-		const result = buildError(error);
-		expect(result.example).toBeDefined();
-	});
+  it("includes example in error", () => {
+    const error = new Error("branch error");
+    const result = buildError(error);
+    expect(result.example).toBeDefined();
+  });
 
-	it("provides default guidance", () => {
-		const error = new Error("unknown error");
-		const result = buildError(error);
-		const guidance = result.guidance as string;
-		expect(guidance).toContain("Check the tool description");
-	});
+  it("provides default guidance", () => {
+    const error = new Error("unknown error");
+    const result = buildError(error);
+    const guidance = result.guidance as string;
+    expect(guidance).toContain("Check the tool description");
+  });
 });

--- a/packages/pi-code-reasoning/__tests__/index.test.ts
+++ b/packages/pi-code-reasoning/__tests__/index.test.ts
@@ -3,238 +3,238 @@ import { describe, expect, it, vi } from "vitest";
 import codeReasoning from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 describe("pi-code-reasoning", () => {
-	it("registers tools", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers tools", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-		expect(toolNames).toEqual(
-			expect.arrayContaining(["code_reasoning", "code_reasoning_status", "code_reasoning_reset"]),
-		);
-	});
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toEqual(
+      expect.arrayContaining(["code_reasoning", "code_reasoning_status", "code_reasoning_reset"]),
+    );
+  });
 
-	it("registers flags", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers flags", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toEqual(
-			expect.arrayContaining(["--code-reasoning-config", "--code-reasoning-max-bytes", "--code-reasoning-max-lines"]),
-		);
-	});
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toEqual(
+      expect.arrayContaining(["--code-reasoning-config", "--code-reasoning-max-bytes", "--code-reasoning-max-lines"]),
+    );
+  });
 
-	it("registers exactly 3 tools", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers exactly 3 tools", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-		expect(toolNames).toHaveLength(3);
-	});
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toHaveLength(3);
+  });
 
-	it("registers exactly 3 flags", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers exactly 3 flags", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toHaveLength(3);
-	});
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toHaveLength(3);
+  });
 
-	it("registers tools with execute functions", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers tools with execute functions", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		tools.forEach((tool) => {
-			expect(tool.execute).toBeDefined();
-			expect(typeof tool.execute).toBe("function");
-		});
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    tools.forEach((tool) => {
+      expect(tool.execute).toBeDefined();
+      expect(typeof tool.execute).toBe("function");
+    });
+  });
 
-	it("registers tools with parameters schema", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers tools with parameters schema", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const mainTool = tools.find((t) => t.name === "code_reasoning");
-		expect(mainTool?.parameters).toBeDefined();
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    expect(mainTool?.parameters).toBeDefined();
+  });
 
-	it("registers tools with descriptions", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers tools with descriptions", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		tools.forEach((tool) => {
-			expect(tool.description).toBeDefined();
-			expect(typeof tool.description).toBe("string");
-			expect(tool.description.length).toBeGreaterThan(0);
-		});
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    tools.forEach((tool) => {
+      expect(tool.description).toBeDefined();
+      expect(typeof tool.description).toBe("string");
+      expect(tool.description.length).toBeGreaterThan(0);
+    });
+  });
 
-	it("registers tools with labels", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers tools with labels", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const mainTool = tools.find((t) => t.name === "code_reasoning");
-		expect(mainTool?.label).toBe("Code Reasoning");
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    expect(mainTool?.label).toBe("Code Reasoning");
+  });
 
-	it("registers flags with string type", () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("registers flags with string type", () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
-		flags.forEach((flag) => {
-			expect(flag.type).toBe("string");
-		});
-	});
+    const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
+    flags.forEach((flag) => {
+      expect(flag.type).toBe("string");
+    });
+  });
 
-	it("can be called multiple times with separate state", () => {
-		const mockPi1 = createMockPi();
-		const mockPi2 = createMockPi();
+  it("can be called multiple times with separate state", () => {
+    const mockPi1 = createMockPi();
+    const mockPi2 = createMockPi();
 
-		codeReasoning(mockPi1 as unknown as ExtensionAPI);
-		codeReasoning(mockPi2 as unknown as ExtensionAPI);
+    codeReasoning(mockPi1 as unknown as ExtensionAPI);
+    codeReasoning(mockPi2 as unknown as ExtensionAPI);
 
-		// Each should register its own tools
-		expect(mockPi1.registerTool).toHaveBeenCalledTimes(3);
-		expect(mockPi2.registerTool).toHaveBeenCalledTimes(3);
-	});
+    // Each should register its own tools
+    expect(mockPi1.registerTool).toHaveBeenCalledTimes(3);
+    expect(mockPi2.registerTool).toHaveBeenCalledTimes(3);
+  });
 
-	it("executes code_reasoning tool and returns result", async () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("executes code_reasoning tool and returns result", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const mainTool = tools.find((t) => t.name === "code_reasoning");
 
-		const result = await mainTool?.execute(
-			"call-123",
-			{
-				thought: "First thought about the problem",
-				thought_number: 1,
-				total_thoughts: 3,
-				next_thought_needed: true,
-			},
-			undefined,
-			undefined,
-			undefined,
-		);
+    const result = await mainTool?.execute(
+      "call-123",
+      {
+        thought: "First thought about the problem",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
 
-		expect(result).toBeDefined();
-		expect(result.content).toBeDefined();
-		expect(result.content[0].text).toContain("processed");
-	});
+    expect(result).toBeDefined();
+    expect(result.content).toBeDefined();
+    expect(result.content[0].text).toContain("processed");
+  });
 
-	it("executes code_reasoning_status tool", async () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("executes code_reasoning_status tool", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const statusTool = tools.find((t) => t.name === "code_reasoning_status");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const statusTool = tools.find((t) => t.name === "code_reasoning_status");
 
-		const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
+    const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
 
-		expect(result).toBeDefined();
-		expect(result.content).toBeDefined();
-	});
+    expect(result).toBeDefined();
+    expect(result.content).toBeDefined();
+  });
 
-	it("executes code_reasoning_reset tool", async () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("executes code_reasoning_reset tool", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const resetTool = tools.find((t) => t.name === "code_reasoning_reset");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const resetTool = tools.find((t) => t.name === "code_reasoning_reset");
 
-		const result = await resetTool?.execute("call-123", {}, undefined, undefined, undefined);
+    const result = await resetTool?.execute("call-123", {}, undefined, undefined, undefined);
 
-		expect(result).toBeDefined();
-		expect(result.content[0].text).toContain("reset");
-	});
+    expect(result).toBeDefined();
+    expect(result.content[0].text).toContain("reset");
+  });
 
-	it("validates thought parameters", async () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("validates thought parameters", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const mainTool = tools.find((t) => t.name === "code_reasoning");
 
-		// Missing required parameter should fail
-		const result = await mainTool?.execute("call-123", { thought: "" }, undefined, undefined, undefined);
+    // Missing required parameter should fail
+    const result = await mainTool?.execute("call-123", { thought: "" }, undefined, undefined, undefined);
 
-		expect(result).toBeDefined();
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("Thought cannot be empty");
-	});
+    expect(result).toBeDefined();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Thought cannot be empty");
+  });
 
-	it("tracks multiple thoughts", async () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("tracks multiple thoughts", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const mainTool = tools.find((t) => t.name === "code_reasoning");
 
-		// Add first thought
-		await mainTool?.execute(
-			"call-1",
-			{
-				thought: "First thought",
-				thought_number: 1,
-				total_thoughts: 3,
-				next_thought_needed: true,
-			},
-			undefined,
-			undefined,
-			undefined,
-		);
+    // Add first thought
+    await mainTool?.execute(
+      "call-1",
+      {
+        thought: "First thought",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
 
-		// Add second thought
-		const result2 = await mainTool?.execute(
-			"call-2",
-			{
-				thought: "Second thought",
-				thought_number: 2,
-				total_thoughts: 3,
-				next_thought_needed: true,
-			},
-			undefined,
-			undefined,
-			undefined,
-		);
+    // Add second thought
+    const result2 = await mainTool?.execute(
+      "call-2",
+      {
+        thought: "Second thought",
+        thought_number: 2,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
 
-		expect(result2.content[0].text).toContain("2");
-	});
+    expect(result2.content[0].text).toContain("2");
+  });
 
-	it("rejects thought_number greater than total_thoughts", async () => {
-		const mockPi = createMockPi();
-		codeReasoning(mockPi as unknown as ExtensionAPI);
+  it("rejects thought_number greater than total_thoughts", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const mainTool = tools.find((t) => t.name === "code_reasoning");
 
-		const result = await mainTool?.execute(
-			"call-123",
-			{
-				thought: "Invalid ordering",
-				thought_number: 4,
-				total_thoughts: 3,
-				next_thought_needed: true,
-			},
-			undefined,
-			undefined,
-			undefined,
-		);
+    const result = await mainTool?.execute(
+      "call-123",
+      {
+        thought: "Invalid ordering",
+        thought_number: 4,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
 
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("thought_number cannot exceed total_thoughts");
-	});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("thought_number cannot exceed total_thoughts");
+  });
 });

--- a/packages/pi-code-reasoning/__tests__/types.test.ts
+++ b/packages/pi-code-reasoning/__tests__/types.test.ts
@@ -1,405 +1,400 @@
 import { describe, expect, it } from "vitest";
 import {
-	enforceCrossFieldRules,
-	isValidCrossField,
-	isValidThoughtData,
-	validateThoughtData,
+  enforceCrossFieldRules,
+  isValidCrossField,
+  isValidThoughtData,
+  type ThoughtData,
+  validateThoughtData,
 } from "../extensions/types.js";
 
 describe("validateThoughtData", () => {
-	it("returns no errors for valid data", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toEqual([]);
-	});
+  it("returns no errors for valid data", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toEqual([]);
+  });
 
-	it("returns error for empty thought", () => {
-		const data = {
-			thought: "",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought",
-			message: "Thought cannot be empty.",
-		});
-	});
+  it("returns error for empty thought", () => {
+    const data = {
+      thought: "",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought",
+      message: "Thought cannot be empty.",
+    });
+  });
 
-	it("returns error for whitespace-only thought", () => {
-		const data = {
-			thought: "   ",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought",
-			message: "Thought cannot be empty.",
-		});
-	});
+  it("returns error for whitespace-only thought", () => {
+    const data = {
+      thought: "   ",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought",
+      message: "Thought cannot be empty.",
+    });
+  });
 
-	it("returns error for negative thought_number", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 0,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought_number",
-			message: "thought_number must be a positive integer.",
-		});
-	});
+  it("returns error for negative thought_number", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 0,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought_number",
+      message: "thought_number must be a positive integer.",
+    });
+  });
 
-	it("returns error for negative thought_number", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: -5,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought_number",
-			message: "thought_number must be a positive integer.",
-		});
-	});
+  it("returns error for negative thought_number", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: -5,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought_number",
+      message: "thought_number must be a positive integer.",
+    });
+  });
 
-	it("returns error for non-integer thought_number", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1.5,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought_number",
-			message: "thought_number must be a positive integer.",
-		});
-	});
+  it("returns error for non-integer thought_number", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1.5,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought_number",
+      message: "thought_number must be a positive integer.",
+    });
+  });
 
-	it("returns error for negative total_thoughts", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 0,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "total_thoughts",
-			message: "total_thoughts must be a positive integer.",
-		});
-	});
+  it("returns error for negative total_thoughts", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 0,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "total_thoughts",
+      message: "total_thoughts must be a positive integer.",
+    });
+  });
 
-	it("returns error for missing next_thought_needed", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: undefined,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "next_thought_needed",
-			message: "next_thought_needed must be a boolean.",
-		});
-	});
+  it("returns error for missing next_thought_needed", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: undefined,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "next_thought_needed",
+      message: "next_thought_needed must be a boolean.",
+    });
+  });
 
-	it("returns error for invalid is_revision type", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			// biome-ignore lint/suspicious/noExplicitAny: testing invalid type
-			is_revision: "yes" as any,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "is_revision",
-			message: "is_revision must be a boolean.",
-		});
-	});
+  it("returns error for invalid is_revision type", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      is_revision: "yes",
+    } as unknown as Partial<ThoughtData>;
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "is_revision",
+      message: "is_revision must be a boolean.",
+    });
+  });
 
-	it("returns error for invalid revises_thought", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			revises_thought: -1,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "revises_thought",
-			message: "revises_thought must be a positive integer.",
-		});
-	});
+  it("returns error for invalid revises_thought", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      revises_thought: -1,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "revises_thought",
+      message: "revises_thought must be a positive integer.",
+    });
+  });
 
-	it("returns error for non-integer revises_thought", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			revises_thought: 1.5,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "revises_thought",
-			message: "revises_thought must be a positive integer.",
-		});
-	});
+  it("returns error for non-integer revises_thought", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      revises_thought: 1.5,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "revises_thought",
+      message: "revises_thought must be a positive integer.",
+    });
+  });
 
-	it("returns error for invalid branch_from_thought", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			branch_from_thought: 0,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "branch_from_thought",
-			message: "branch_from_thought must be a positive integer.",
-		});
-	});
+  it("returns error for invalid branch_from_thought", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      branch_from_thought: 0,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "branch_from_thought",
+      message: "branch_from_thought must be a positive integer.",
+    });
+  });
 
-	it("returns error for empty branch_id", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			branch_id: "   ",
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "branch_id",
-			message: "branch_id must be a non-empty string.",
-		});
-	});
+  it("returns error for empty branch_id", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      branch_id: "   ",
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "branch_id",
+      message: "branch_id must be a non-empty string.",
+    });
+  });
 
-	it("returns error for non-string branch_id", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			// biome-ignore lint/suspicious/noExplicitAny: testing invalid type
-			branch_id: 123 as any,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "branch_id",
-			message: "branch_id must be a non-empty string.",
-		});
-	});
+  it("returns error for non-string branch_id", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      branch_id: 123,
+    } as unknown as Partial<ThoughtData>;
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "branch_id",
+      message: "branch_id must be a non-empty string.",
+    });
+  });
 
-	it("returns multiple errors", () => {
-		const data = {
-			thought: "",
-			thought_number: -1,
-			total_thoughts: 0,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			// biome-ignore lint/suspicious/noExplicitAny: testing invalid type
-			next_thought_needed: "yes" as any,
-		};
-		const errors = validateThoughtData(data);
-		expect(errors.length).toBeGreaterThanOrEqual(4);
-	});
+  it("returns multiple errors", () => {
+    const data = {
+      thought: "",
+      thought_number: -1,
+      total_thoughts: 0,
+      next_thought_needed: "yes",
+    } as unknown as Partial<ThoughtData>;
+    const errors = validateThoughtData(data);
+    expect(errors.length).toBeGreaterThanOrEqual(4);
+  });
 
-	it("accepts valid optional fields", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			is_revision: true,
-			revises_thought: 1,
-			branch_from_thought: 2,
-			branch_id: "test-branch",
-		};
-		expect(validateThoughtData(data)).toEqual([]);
-	});
+  it("accepts valid optional fields", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      is_revision: true,
+      revises_thought: 1,
+      branch_from_thought: 2,
+      branch_id: "test-branch",
+    };
+    expect(validateThoughtData(data)).toEqual([]);
+  });
 
-	it("accepts thought at max length", () => {
-		const longThought = "a".repeat(20000);
-		const data = {
-			thought: longThought,
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toEqual([]);
-	});
+  it("accepts thought at max length", () => {
+    const longThought = "a".repeat(20000);
+    const data = {
+      thought: longThought,
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toEqual([]);
+  });
 
-	it("returns error for thought exceeding max length", () => {
-		const longThought = "a".repeat(20001);
-		const data = {
-			thought: longThought,
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought",
-			message: expect.stringContaining("exceeds"),
-		});
-	});
+  it("returns error for thought exceeding max length", () => {
+    const longThought = "a".repeat(20001);
+    const data = {
+      thought: longThought,
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought",
+      message: expect.stringContaining("exceeds"),
+    });
+  });
 });
 
 describe("isValidThoughtData", () => {
-	it("returns true for valid data", () => {
-		expect(
-			isValidThoughtData({
-				thought: "My thought",
-				thought_number: 1,
-				total_thoughts: 3,
-				next_thought_needed: true,
-			}),
-		).toBe(true);
-	});
+  it("returns true for valid data", () => {
+    expect(
+      isValidThoughtData({
+        thought: "My thought",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      }),
+    ).toBe(true);
+  });
 
-	it("returns false for invalid data", () => {
-		expect(
-			isValidThoughtData({
-				thought: "",
-				thought_number: 0,
-				total_thoughts: 0,
-				next_thought_needed: true,
-			}),
-		).toBe(false);
-	});
+  it("returns false for invalid data", () => {
+    expect(
+      isValidThoughtData({
+        thought: "",
+        thought_number: 0,
+        total_thoughts: 0,
+        next_thought_needed: true,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("enforceCrossFieldRules", () => {
-	it("accepts regular thought", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-		};
-		expect(enforceCrossFieldRules(data)).toEqual([]);
-	});
+  it("accepts regular thought", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+    };
+    expect(enforceCrossFieldRules(data)).toEqual([]);
+  });
 
-	it("accepts valid revision", () => {
-		const data = {
-			thought: "Revising earlier point",
-			thought_number: 4,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			is_revision: true,
-			revises_thought: 2,
-		};
-		expect(enforceCrossFieldRules(data)).toEqual([]);
-	});
+  it("accepts valid revision", () => {
+    const data = {
+      thought: "Revising earlier point",
+      thought_number: 4,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      is_revision: true,
+      revises_thought: 2,
+    };
+    expect(enforceCrossFieldRules(data)).toEqual([]);
+  });
 
-	it("rejects revision without revises_thought", () => {
-		const data = {
-			thought: "Revising",
-			thought_number: 4,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			is_revision: true,
-		};
-		const errors = enforceCrossFieldRules(data);
-		expect(errors.length).toBeGreaterThan(0);
-		expect(errors[0].message).toContain("revises_thought");
-	});
+  it("rejects revision without revises_thought", () => {
+    const data = {
+      thought: "Revising",
+      thought_number: 4,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      is_revision: true,
+    };
+    const errors = enforceCrossFieldRules(data);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain("revises_thought");
+  });
 
-	it("accepts valid branch", () => {
-		const data = {
-			thought: "Exploring alternative",
-			thought_number: 3,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			branch_from_thought: 2,
-			branch_id: "alt-approach",
-		};
-		expect(enforceCrossFieldRules(data)).toEqual([]);
-	});
+  it("accepts valid branch", () => {
+    const data = {
+      thought: "Exploring alternative",
+      thought_number: 3,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      branch_from_thought: 2,
+      branch_id: "alt-approach",
+    };
+    expect(enforceCrossFieldRules(data)).toEqual([]);
+  });
 
-	it("rejects branch with only branch_from_thought", () => {
-		const data = {
-			thought: "Exploring",
-			thought_number: 3,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			branch_from_thought: 2,
-		};
-		const errors = enforceCrossFieldRules(data);
-		expect(errors.length).toBeGreaterThan(0);
-		expect(errors[0].message).toContain("branch_id");
-	});
+  it("rejects branch with only branch_from_thought", () => {
+    const data = {
+      thought: "Exploring",
+      thought_number: 3,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      branch_from_thought: 2,
+    };
+    const errors = enforceCrossFieldRules(data);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain("branch_id");
+  });
 
-	it("rejects branch with revision", () => {
-		const data = {
-			thought: "Invalid",
-			thought_number: 3,
-			total_thoughts: 5,
-			next_thought_needed: true,
-			is_revision: true,
-			revises_thought: 1,
-			branch_from_thought: 2,
-			branch_id: "branch",
-		};
-		const errors = enforceCrossFieldRules(data);
-		expect(errors.length).toBeGreaterThan(0);
-	});
+  it("rejects branch with revision", () => {
+    const data = {
+      thought: "Invalid",
+      thought_number: 3,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      is_revision: true,
+      revises_thought: 1,
+      branch_from_thought: 2,
+      branch_id: "branch",
+    };
+    const errors = enforceCrossFieldRules(data);
+    expect(errors.length).toBeGreaterThan(0);
+  });
 });
 
 describe("isValidCrossField", () => {
-	it("returns true for valid regular thought", () => {
-		expect(
-			isValidCrossField({
-				thought: "Test",
-				thought_number: 1,
-				total_thoughts: 3,
-				next_thought_needed: true,
-			}),
-		).toBe(true);
-	});
+  it("returns true for valid regular thought", () => {
+    expect(
+      isValidCrossField({
+        thought: "Test",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      }),
+    ).toBe(true);
+  });
 
-	it("returns true for valid revision", () => {
-		expect(
-			isValidCrossField({
-				thought: "Test",
-				thought_number: 2,
-				total_thoughts: 3,
-				next_thought_needed: true,
-				is_revision: true,
-				revises_thought: 1,
-			}),
-		).toBe(true);
-	});
+  it("returns true for valid revision", () => {
+    expect(
+      isValidCrossField({
+        thought: "Test",
+        thought_number: 2,
+        total_thoughts: 3,
+        next_thought_needed: true,
+        is_revision: true,
+        revises_thought: 1,
+      }),
+    ).toBe(true);
+  });
 
-	it("returns true for valid branch", () => {
-		expect(
-			isValidCrossField({
-				thought: "Test",
-				thought_number: 3,
-				total_thoughts: 5,
-				next_thought_needed: true,
-				branch_from_thought: 1,
-				branch_id: "branch-1",
-			}),
-		).toBe(true);
-	});
+  it("returns true for valid branch", () => {
+    expect(
+      isValidCrossField({
+        thought: "Test",
+        thought_number: 3,
+        total_thoughts: 5,
+        next_thought_needed: true,
+        branch_from_thought: 1,
+        branch_id: "branch-1",
+      }),
+    ).toBe(true);
+  });
 
-	it("returns false for invalid combination", () => {
-		expect(
-			isValidCrossField({
-				thought: "Test",
-				thought_number: 3,
-				total_thoughts: 5,
-				next_thought_needed: true,
-				is_revision: true,
-				revises_thought: 1,
-				branch_from_thought: 2,
-				branch_id: "branch",
-			}),
-		).toBe(false);
-	});
+  it("returns false for invalid combination", () => {
+    expect(
+      isValidCrossField({
+        thought: "Test",
+        thought_number: 3,
+        total_thoughts: 5,
+        next_thought_needed: true,
+        is_revision: true,
+        revises_thought: 1,
+        branch_from_thought: 2,
+        branch_id: "branch",
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -17,17 +17,17 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { AgentToolUpdateCallback, ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 import {
-	enforceCrossFieldRules,
-	MAX_THOUGHT_COUNT,
-	MAX_THOUGHT_LENGTH,
-	type ThoughtData,
-	type ValidatedThoughtData,
-	validateThoughtData,
+  enforceCrossFieldRules,
+  MAX_THOUGHT_COUNT,
+  MAX_THOUGHT_LENGTH,
+  type ThoughtData,
+  type ValidatedThoughtData,
+  validateThoughtData,
 } from "./types.js";
 
 // =============================================================================
@@ -35,8 +35,8 @@ import {
 // =============================================================================
 
 const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
-	maxBytes: DEFAULT_MAX_BYTES,
-	maxLines: DEFAULT_MAX_LINES,
+  maxBytes: DEFAULT_MAX_BYTES,
+  maxLines: DEFAULT_MAX_LINES,
 };
 
 // Reserved for future use
@@ -47,32 +47,32 @@ const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
 // =============================================================================
 
 interface CodeReasoningConfig {
-	maxBytes?: number;
-	maxLines?: number;
+  maxBytes?: number;
+  maxLines?: number;
 }
 
 interface ThoughtTracker {
-	add: (thought: ValidatedThoughtData) => void;
-	reset: () => void;
-	ensureBranchIsValid: (branchFromThought?: number) => void;
-	ensureRevisionIsValid: (revisesThought?: number) => void;
-	branches: () => string[];
-	count: () => number;
+  add: (thought: ValidatedThoughtData) => void;
+  reset: () => void;
+  ensureBranchIsValid: (branchFromThought?: number) => void;
+  ensureRevisionIsValid: (revisesThought?: number) => void;
+  branches: () => string[];
+  count: () => number;
 }
 
 interface McpToolDetails {
-	tool: string;
-	truncated: boolean;
-	truncation?: {
-		truncatedBy: "lines" | "bytes" | null;
-		totalLines: number;
-		totalBytes: number;
-		outputLines: number;
-		outputBytes: number;
-		maxLines: number;
-		maxBytes: number;
-	};
-	tempFile?: string;
+  tool: string;
+  truncated: boolean;
+  truncation?: {
+    truncatedBy: "lines" | "bytes" | null;
+    totalLines: number;
+    totalBytes: number;
+    outputLines: number;
+    outputBytes: number;
+    maxLines: number;
+    maxBytes: number;
+  };
+  tempFile?: string;
 }
 
 // =============================================================================
@@ -80,178 +80,178 @@ interface McpToolDetails {
 // =============================================================================
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toJsonString(value: unknown): string {
-	if (typeof value === "string") {
-		return value;
-	}
-	try {
-		return JSON.stringify(value, null, 2);
-	} catch {
-		return String(value);
-	}
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function formatToolOutput(
-	toolName: string,
-	result: unknown,
-	limits: { maxBytes?: number; maxLines?: number },
+  toolName: string,
+  result: unknown,
+  limits: { maxBytes?: number; maxLines?: number },
 ): { text: string; details: McpToolDetails } {
-	const rawText = toJsonString(result);
-	const truncation = truncateHead(rawText, {
-		maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
-		maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
-	});
+  const rawText = toJsonString(result);
+  const truncation = truncateHead(rawText, {
+    maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
+    maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
+  });
 
-	let text = truncation.content;
-	let tempFile: string | undefined;
+  let text = truncation.content;
+  let tempFile: string | undefined;
 
-	if (truncation.truncated) {
-		tempFile = writeTempFile(toolName, rawText);
-		text +=
-			`\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
-			`(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
-			`Full output saved to: ${tempFile}]`;
-	}
+  if (truncation.truncated) {
+    tempFile = writeTempFile(toolName, rawText);
+    text +=
+      `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
+      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
+      `Full output saved to: ${tempFile}]`;
+  }
 
-	if (truncation.firstLineExceedsLimit && rawText.length > 0) {
-		text =
-			`[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
-			text;
-	}
+  if (truncation.firstLineExceedsLimit && rawText.length > 0) {
+    text =
+      `[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
+      text;
+  }
 
-	return {
-		text,
-		details: {
-			tool: toolName,
-			truncated: truncation.truncated,
-			truncation: {
-				truncatedBy: truncation.truncatedBy,
-				totalLines: truncation.totalLines,
-				totalBytes: truncation.totalBytes,
-				outputLines: truncation.outputLines,
-				outputBytes: truncation.outputBytes,
-				maxLines: truncation.maxLines,
-				maxBytes: truncation.maxBytes,
-			},
-			tempFile,
-		},
-	};
+  return {
+    text,
+    details: {
+      tool: toolName,
+      truncated: truncation.truncated,
+      truncation: {
+        truncatedBy: truncation.truncatedBy,
+        totalLines: truncation.totalLines,
+        totalBytes: truncation.totalBytes,
+        outputLines: truncation.outputLines,
+        outputBytes: truncation.outputBytes,
+        maxLines: truncation.maxLines,
+        maxBytes: truncation.maxBytes,
+      },
+      tempFile,
+    },
+  };
 }
 
 function writeTempFile(toolName: string, content: string): string {
-	const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
-	const filename = `pi-code-reasoning-${safeName}-${Date.now()}.txt`;
-	const filePath = join(tmpdir(), filename);
-	writeFileSync(filePath, content, "utf-8");
-	return filePath;
+  const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
+  const filename = `pi-code-reasoning-${safeName}-${Date.now()}.txt`;
+  const filePath = join(tmpdir(), filename);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
 }
 
 function normalizeNumber(value: unknown): number | undefined {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		return value;
-	}
-	if (typeof value === "string") {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed)) {
-			return parsed;
-		}
-	}
-	return undefined;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
 }
 
 function splitParams(params: Record<string, unknown>): {
-	toolArgs: Record<string, unknown>;
-	requestedLimits: { maxBytes?: number; maxLines?: number };
+  toolArgs: Record<string, unknown>;
+  requestedLimits: { maxBytes?: number; maxLines?: number };
 } {
-	const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
-		piMaxBytes?: unknown;
-		piMaxLines?: unknown;
-	};
-	return {
-		toolArgs: rest,
-		requestedLimits: {
-			maxBytes: normalizeNumber(piMaxBytes),
-			maxLines: normalizeNumber(piMaxLines),
-		},
-	};
+  const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
+    piMaxBytes?: unknown;
+    piMaxLines?: unknown;
+  };
+  return {
+    toolArgs: rest,
+    requestedLimits: {
+      maxBytes: normalizeNumber(piMaxBytes),
+      maxLines: normalizeNumber(piMaxLines),
+    },
+  };
 }
 
 function resolveEffectiveLimits(
-	requested: { maxBytes?: number; maxLines?: number },
-	maxAllowed: { maxBytes: number; maxLines: number },
+  requested: { maxBytes?: number; maxLines?: number },
+  maxAllowed: { maxBytes: number; maxLines: number },
 ): { maxBytes: number; maxLines: number } {
-	const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
-	const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
-	return {
-		maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
-		maxLines: Math.min(requestedLines, maxAllowed.maxLines),
-	};
+  const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
+  const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
+  return {
+    maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
+    maxLines: Math.min(requestedLines, maxAllowed.maxLines),
+  };
 }
 
 function resolveConfigPath(configPath: string): string {
-	const trimmed = configPath.trim();
-	if (trimmed.startsWith("~/")) {
-		return join(homedir(), trimmed.slice(2));
-	}
-	if (trimmed.startsWith("~")) {
-		return join(homedir(), trimmed.slice(1));
-	}
-	if (isAbsolute(trimmed)) {
-		return trimmed;
-	}
-	return resolve(process.cwd(), trimmed);
+  const trimmed = configPath.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(homedir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
 }
 
 function parseConfig(raw: unknown, pathHint: string): CodeReasoningConfig {
-	if (!isRecord(raw)) {
-		throw new Error(`Invalid Code Reasoning config at ${pathHint}: expected an object.`);
-	}
-	return {
-		maxBytes: normalizeNumber(raw.maxBytes),
-		maxLines: normalizeNumber(raw.maxLines),
-	};
+  if (!isRecord(raw)) {
+    throw new Error(`Invalid Code Reasoning config at ${pathHint}: expected an object.`);
+  }
+  return {
+    maxBytes: normalizeNumber(raw.maxBytes),
+    maxLines: normalizeNumber(raw.maxLines),
+  };
 }
 
 function loadConfig(configPath: string | undefined): CodeReasoningConfig | null {
-	const candidates: string[] = [];
-	const envConfig = process.env.CODE_REASONING_CONFIG;
-	if (configPath) {
-		candidates.push(resolveConfigPath(configPath));
-	} else if (envConfig) {
-		candidates.push(resolveConfigPath(envConfig));
-	} else {
-		const projectConfigPath = join(process.cwd(), ".pi", "extensions", "code-reasoning.json");
-		const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "code-reasoning.json");
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		candidates.push(projectConfigPath, globalConfigPath);
-	}
+  const candidates: string[] = [];
+  const envConfig = process.env.CODE_REASONING_CONFIG;
+  if (configPath) {
+    candidates.push(resolveConfigPath(configPath));
+  } else if (envConfig) {
+    candidates.push(resolveConfigPath(envConfig));
+  } else {
+    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "code-reasoning.json");
+    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "code-reasoning.json");
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    candidates.push(projectConfigPath, globalConfigPath);
+  }
 
-	for (const candidate of candidates) {
-		if (!existsSync(candidate)) {
-			continue;
-		}
-		const raw = readFileSync(candidate, "utf-8");
-		const parsed = JSON.parse(raw);
-		return parseConfig(parsed, candidate);
-	}
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    const raw = readFileSync(candidate, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parseConfig(parsed, candidate);
+  }
 
-	return null;
+  return null;
 }
 
 function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-	if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-		return;
-	}
-	try {
-		mkdirSync(dirname(globalConfigPath), { recursive: true });
-		writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		console.warn(`[pi-code-reasoning] Failed to write ${globalConfigPath}: ${message}`);
-	}
+  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
+    return;
+  }
+  try {
+    mkdirSync(dirname(globalConfigPath), { recursive: true });
+    writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-code-reasoning] Failed to write ${globalConfigPath}: ${message}`);
+  }
 }
 
 // =============================================================================
@@ -259,35 +259,35 @@ function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: st
 // =============================================================================
 
 function createThoughtTracker(): ThoughtTracker {
-	const thoughtHistory: ValidatedThoughtData[] = [];
-	const branches = new Map<string, ValidatedThoughtData[]>();
+  const thoughtHistory: ValidatedThoughtData[] = [];
+  const branches = new Map<string, ValidatedThoughtData[]>();
 
-	return {
-		add: (thought) => {
-			thoughtHistory.push(thought);
-			if (thought.branch_id) {
-				const branchThoughts = branches.get(thought.branch_id) ?? [];
-				branchThoughts.push(thought);
-				branches.set(thought.branch_id, branchThoughts);
-			}
-		},
-		ensureBranchIsValid: (branchFromThought) => {
-			if (branchFromThought && branchFromThought > thoughtHistory.length) {
-				throw new Error(`Invalid branch_from_thought ${branchFromThought}.`);
-			}
-		},
-		ensureRevisionIsValid: (revisesThought) => {
-			if (revisesThought && revisesThought > thoughtHistory.length) {
-				throw new Error(`Invalid revises_thought ${revisesThought}.`);
-			}
-		},
-		branches: () => Array.from(branches.keys()),
-		count: () => thoughtHistory.length,
-		reset: () => {
-			thoughtHistory.length = 0;
-			branches.clear();
-		},
-	};
+  return {
+    add: (thought) => {
+      thoughtHistory.push(thought);
+      if (thought.branch_id) {
+        const branchThoughts = branches.get(thought.branch_id) ?? [];
+        branchThoughts.push(thought);
+        branches.set(thought.branch_id, branchThoughts);
+      }
+    },
+    ensureBranchIsValid: (branchFromThought) => {
+      if (branchFromThought && branchFromThought > thoughtHistory.length) {
+        throw new Error(`Invalid branch_from_thought ${branchFromThought}.`);
+      }
+    },
+    ensureRevisionIsValid: (revisesThought) => {
+      if (revisesThought && revisesThought > thoughtHistory.length) {
+        throw new Error(`Invalid revises_thought ${revisesThought}.`);
+      }
+    },
+    branches: () => Array.from(branches.keys()),
+    count: () => thoughtHistory.length,
+    reset: () => {
+      thoughtHistory.length = 0;
+      branches.clear();
+    },
+  };
 }
 
 // =============================================================================
@@ -295,93 +295,93 @@ function createThoughtTracker(): ThoughtTracker {
 // =============================================================================
 
 function _formatThought(t: ValidatedThoughtData): string {
-	const { thought_number, total_thoughts, thought, is_revision, revises_thought, branch_id, branch_from_thought } = t;
+  const { thought_number, total_thoughts, thought, is_revision, revises_thought, branch_id, branch_from_thought } = t;
 
-	const header = is_revision
-		? `🔄 Revision ${thought_number}/${total_thoughts} (of ${revises_thought})`
-		: branch_id
-			? `🌿 Branch ${thought_number}/${total_thoughts} (from ${branch_from_thought}, id:${branch_id})`
-			: `💭 Thought ${thought_number}/${total_thoughts}`;
+  const header = is_revision
+    ? `🔄 Revision ${thought_number}/${total_thoughts} (of ${revises_thought})`
+    : branch_id
+      ? `🌿 Branch ${thought_number}/${total_thoughts} (from ${branch_from_thought}, id:${branch_id})`
+      : `💭 Thought ${thought_number}/${total_thoughts}`;
 
-	const body = thought
-		.split("\n")
-		.map((l) => `  ${l}`)
-		.join("\n");
+  const body = thought
+    .split("\n")
+    .map((l) => `  ${l}`)
+    .join("\n");
 
-	return `\n${header}\n---\n${body}\n---`;
+  return `\n${header}\n---\n${body}\n---`;
 }
 
 function getExampleThought(errorMsg: string): Partial<ThoughtData> {
-	if (errorMsg.includes("branch")) {
-		return {
-			thought: "Exploring alternative: Consider algorithm X.",
-			thought_number: 3,
-			total_thoughts: 7,
-			next_thought_needed: true,
-			branch_from_thought: 2,
-			branch_id: "alternative-algo-x",
-		};
-	}
-	if (errorMsg.includes("revis")) {
-		return {
-			thought: "Revisiting earlier point: Assumption Y was flawed.",
-			thought_number: 4,
-			total_thoughts: 6,
-			next_thought_needed: true,
-			is_revision: true,
-			revises_thought: 2,
-		};
-	}
-	if (errorMsg.includes("length") || errorMsg.includes("empty")) {
-		return {
-			thought: "Breaking down the thought into smaller parts...",
-			thought_number: 2,
-			total_thoughts: 5,
-			next_thought_needed: true,
-		};
-	}
-	return {
-		thought: "Initial exploration of the problem.",
-		thought_number: 1,
-		total_thoughts: 5,
-		next_thought_needed: true,
-	};
+  if (errorMsg.includes("branch")) {
+    return {
+      thought: "Exploring alternative: Consider algorithm X.",
+      thought_number: 3,
+      total_thoughts: 7,
+      next_thought_needed: true,
+      branch_from_thought: 2,
+      branch_id: "alternative-algo-x",
+    };
+  }
+  if (errorMsg.includes("revis")) {
+    return {
+      thought: "Revisiting earlier point: Assumption Y was flawed.",
+      thought_number: 4,
+      total_thoughts: 6,
+      next_thought_needed: true,
+      is_revision: true,
+      revises_thought: 2,
+    };
+  }
+  if (errorMsg.includes("length") || errorMsg.includes("empty")) {
+    return {
+      thought: "Breaking down the thought into smaller parts...",
+      thought_number: 2,
+      total_thoughts: 5,
+      next_thought_needed: true,
+    };
+  }
+  return {
+    thought: "Initial exploration of the problem.",
+    thought_number: 1,
+    total_thoughts: 5,
+    next_thought_needed: true,
+  };
 }
 
 function buildSuccess(t: ValidatedThoughtData, tracker: ThoughtTracker): Record<string, unknown> {
-	return {
-		status: "processed",
-		thought_number: t.thought_number,
-		total_thoughts: t.total_thoughts,
-		next_thought_needed: t.next_thought_needed,
-		branches: tracker.branches(),
-		thought_history_length: tracker.count(),
-	};
+  return {
+    status: "processed",
+    thought_number: t.thought_number,
+    total_thoughts: t.total_thoughts,
+    next_thought_needed: t.next_thought_needed,
+    branches: tracker.branches(),
+    thought_history_length: tracker.count(),
+  };
 }
 
 function buildError(error: Error): Record<string, unknown> {
-	const errorMessage = error.message;
-	let guidance = "Check the tool description and schema for correct usage.";
-	const example = getExampleThought(errorMessage);
+  const errorMessage = error.message;
+  let guidance = "Check the tool description and schema for correct usage.";
+  const example = getExampleThought(errorMessage);
 
-	if (errorMessage.includes("branch")) {
-		guidance =
-			"When branching, provide both branch_from_thought (number) and branch_id (string), and do not combine with revision.";
-	} else if (errorMessage.includes("revision")) {
-		guidance =
-			"When revising, set is_revision=true and provide revises_thought (positive number). Do not combine with branching.";
-	} else if (errorMessage.includes("length")) {
-		guidance = `The thought is too long. Keep it under ${MAX_THOUGHT_LENGTH} characters.`;
-	} else if (errorMessage.includes("Max thought")) {
-		guidance = `The maximum thought limit (${MAX_THOUGHT_COUNT}) was reached.`;
-	}
+  if (errorMessage.includes("branch")) {
+    guidance =
+      "When branching, provide both branch_from_thought (number) and branch_id (string), and do not combine with revision.";
+  } else if (errorMessage.includes("revision")) {
+    guidance =
+      "When revising, set is_revision=true and provide revises_thought (positive number). Do not combine with branching.";
+  } else if (errorMessage.includes("length")) {
+    guidance = `The thought is too long. Keep it under ${MAX_THOUGHT_LENGTH} characters.`;
+  } else if (errorMessage.includes("Max thought")) {
+    guidance = `The maximum thought limit (${MAX_THOUGHT_COUNT}) was reached.`;
+  }
 
-	return {
-		status: "failed",
-		error: errorMessage,
-		guidance,
-		example,
-	};
+  return {
+    status: "failed",
+    error: errorMessage,
+    guidance,
+    example,
+  };
 }
 
 // =============================================================================
@@ -389,38 +389,38 @@ function buildError(error: Error): Record<string, unknown> {
 // =============================================================================
 
 const codeReasoningParams = Type.Object(
-	{
-		thought: Type.String({ description: "The content of your reasoning/thought." }),
-		thought_number: Type.Integer({
-			minimum: 1,
-			description: "Current number in the thinking sequence.",
-		}),
-		total_thoughts: Type.Integer({
-			minimum: 1,
-			description: "Estimated total number of thoughts.",
-		}),
-		next_thought_needed: Type.Boolean({
-			description: "Set to FALSE only when completely done.",
-		}),
-		is_revision: Type.Optional(Type.Boolean({ description: "When correcting earlier thinking (🔄)." })),
-		revises_thought: Type.Optional(
-			Type.Integer({
-				minimum: 1,
-				description: "Which thought number you're revising.",
-			}),
-		),
-		branch_from_thought: Type.Optional(
-			Type.Integer({
-				minimum: 1,
-				description: "When exploring alternative approaches (🌿).",
-			}),
-		),
-		branch_id: Type.Optional(Type.String({ description: "Identifier for this branch." })),
-		needs_more_thoughts: Type.Optional(Type.Boolean({ description: "If more thoughts are needed." })),
-		piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-		piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-	},
-	{ additionalProperties: true },
+  {
+    thought: Type.String({ description: "The content of your reasoning/thought." }),
+    thought_number: Type.Integer({
+      minimum: 1,
+      description: "Current number in the thinking sequence.",
+    }),
+    total_thoughts: Type.Integer({
+      minimum: 1,
+      description: "Estimated total number of thoughts.",
+    }),
+    next_thought_needed: Type.Boolean({
+      description: "Set to FALSE only when completely done.",
+    }),
+    is_revision: Type.Optional(Type.Boolean({ description: "When correcting earlier thinking (🔄)." })),
+    revises_thought: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "Which thought number you're revising.",
+      }),
+    ),
+    branch_from_thought: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "When exploring alternative approaches (🌿).",
+      }),
+    ),
+    branch_id: Type.Optional(Type.String({ description: "Identifier for this branch." })),
+    needs_more_thoughts: Type.Optional(Type.Boolean({ description: "If more thoughts are needed." })),
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
 );
 
 // =============================================================================
@@ -428,161 +428,160 @@ const codeReasoningParams = Type.Object(
 // =============================================================================
 
 export {
-	buildError,
-	buildSuccess,
-	createThoughtTracker,
-	DEFAULT_CONFIG_FILE,
-	formatToolOutput,
-	getExampleThought,
-	isRecord,
-	normalizeNumber,
-	parseConfig,
-	resolveConfigPath,
-	resolveEffectiveLimits,
-	splitParams,
-	toJsonString,
-	writeTempFile,
+  buildError,
+  buildSuccess,
+  createThoughtTracker,
+  DEFAULT_CONFIG_FILE,
+  formatToolOutput,
+  getExampleThought,
+  isRecord,
+  normalizeNumber,
+  parseConfig,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  splitParams,
+  toJsonString,
+  writeTempFile,
 };
 
 export default function codeReasoning(pi: ExtensionAPI) {
-	// Register CLI flags
-	pi.registerFlag("--code-reasoning-config", {
-		description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/code-reasoning.json).",
-		type: "string",
-	});
-	pi.registerFlag("--code-reasoning-max-bytes", {
-		description: "Max bytes to keep from tool output (default: 51200).",
-		type: "string",
-	});
-	pi.registerFlag("--code-reasoning-max-lines", {
-		description: "Max lines to keep from tool output (default: 2000).",
-		type: "string",
-	});
+  // Register CLI flags
+  pi.registerFlag("--code-reasoning-config", {
+    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/code-reasoning.json).",
+    type: "string",
+  });
+  pi.registerFlag("--code-reasoning-max-bytes", {
+    description: "Max bytes to keep from tool output (default: 51200).",
+    type: "string",
+  });
+  pi.registerFlag("--code-reasoning-max-lines", {
+    description: "Max lines to keep from tool output (default: 2000).",
+    type: "string",
+  });
 
-	const tracker = createThoughtTracker();
+  const tracker = createThoughtTracker();
 
-	const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
-		const maxBytesFlag = pi.getFlag("--code-reasoning-max-bytes");
-		const maxLinesFlag = pi.getFlag("--code-reasoning-max-lines");
-		const configFlag = pi.getFlag("--code-reasoning-config");
-		const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+  const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
+    const maxBytesFlag = pi.getFlag("--code-reasoning-max-bytes");
+    const maxLinesFlag = pi.getFlag("--code-reasoning-max-lines");
+    const configFlag = pi.getFlag("--code-reasoning-config");
+    const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
 
-		const maxBytes =
-			typeof maxBytesFlag === "string"
-				? normalizeNumber(maxBytesFlag)
-				: normalizeNumber(process.env.CODE_REASONING_MAX_BYTES ?? config?.maxBytes);
-		const maxLines =
-			typeof maxLinesFlag === "string"
-				? normalizeNumber(maxLinesFlag)
-				: normalizeNumber(process.env.CODE_REASONING_MAX_LINES ?? config?.maxLines);
+    const maxBytes =
+      typeof maxBytesFlag === "string"
+        ? normalizeNumber(maxBytesFlag)
+        : normalizeNumber(process.env.CODE_REASONING_MAX_BYTES ?? config?.maxBytes);
+    const maxLines =
+      typeof maxLinesFlag === "string"
+        ? normalizeNumber(maxLinesFlag)
+        : normalizeNumber(process.env.CODE_REASONING_MAX_LINES ?? config?.maxLines);
 
-		return {
-			maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
-			maxLines: maxLines ?? DEFAULT_MAX_LINES,
-		};
-	};
+    return {
+      maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
+      maxLines: maxLines ?? DEFAULT_MAX_LINES,
+    };
+  };
 
-	// Process a single thought
-	const processThought = (args: Record<string, unknown>): Record<string, unknown> => {
-		const thought = args.thought as string;
-		const thought_number = args.thought_number as number;
-		const total_thoughts = args.total_thoughts as number;
-		const next_thought_needed = args.next_thought_needed as boolean;
-		const is_revision = args.is_revision as boolean | undefined;
-		const revises_thought = args.revises_thought as number | undefined;
-		const branch_from_thought = args.branch_from_thought as number | undefined;
-		const branch_id = args.branch_id as string | undefined;
-		const needs_more_thoughts = args.needs_more_thoughts as boolean | undefined;
+  // Process a single thought
+  const processThought = (args: Record<string, unknown>): Record<string, unknown> => {
+    const thought = args.thought as string;
+    const thought_number = args.thought_number as number;
+    const total_thoughts = args.total_thoughts as number;
+    const next_thought_needed = args.next_thought_needed as boolean;
+    const is_revision = args.is_revision as boolean | undefined;
+    const revises_thought = args.revises_thought as number | undefined;
+    const branch_from_thought = args.branch_from_thought as number | undefined;
+    const branch_id = args.branch_id as string | undefined;
+    const needs_more_thoughts = args.needs_more_thoughts as boolean | undefined;
 
-		const data: ThoughtData = {
-			thought,
-			thought_number,
-			total_thoughts,
-			next_thought_needed,
-			is_revision,
-			revises_thought,
-			branch_from_thought,
-			branch_id,
-			needs_more_thoughts,
-		};
+    const data: ThoughtData = {
+      thought,
+      thought_number,
+      total_thoughts,
+      next_thought_needed,
+      is_revision,
+      revises_thought,
+      branch_from_thought,
+      branch_id,
+      needs_more_thoughts,
+    };
 
-		const fieldErrors = validateThoughtData(data);
-		if (fieldErrors.length > 0) {
-			throw new Error(fieldErrors[0].message);
-		}
+    const fieldErrors = validateThoughtData(data);
+    if (fieldErrors.length > 0) {
+      throw new Error(fieldErrors[0].message);
+    }
 
-		// Validate thought limits and ordering
-		if (data.thought_number > MAX_THOUGHT_COUNT || data.total_thoughts > MAX_THOUGHT_COUNT) {
-			throw new Error(`Max thought_number exceeded (${MAX_THOUGHT_COUNT}).`);
-		}
-		if (data.thought_number > data.total_thoughts) {
-			throw new Error("thought_number cannot exceed total_thoughts.");
-		}
+    // Validate thought limits and ordering
+    if (data.thought_number > MAX_THOUGHT_COUNT || data.total_thoughts > MAX_THOUGHT_COUNT) {
+      throw new Error(`Max thought_number exceeded (${MAX_THOUGHT_COUNT}).`);
+    }
+    if (data.thought_number > data.total_thoughts) {
+      throw new Error("thought_number cannot exceed total_thoughts.");
+    }
 
-		// Cross-field validation
-		const crossErrors = enforceCrossFieldRules(data);
-		if (crossErrors.length > 0) {
-			throw new Error(crossErrors[0].message);
-		}
+    // Cross-field validation
+    const crossErrors = enforceCrossFieldRules(data);
+    if (crossErrors.length > 0) {
+      throw new Error(crossErrors[0].message);
+    }
 
-		// Validate branch/revision references
-		tracker.ensureBranchIsValid(data.branch_from_thought);
-		tracker.ensureRevisionIsValid(data.revises_thought);
+    // Validate branch/revision references
+    tracker.ensureBranchIsValid(data.branch_from_thought);
+    tracker.ensureRevisionIsValid(data.revises_thought);
 
-		// Add defaults
-		const validated: ValidatedThoughtData = {
-			thought: data.thought,
-			thought_number: data.thought_number,
-			total_thoughts: data.total_thoughts,
-			next_thought_needed: data.next_thought_needed,
-			is_revision: data.is_revision ?? false,
-			branch_from_thought: data.branch_from_thought,
-			branch_id: data.branch_id,
-			needs_more_thoughts: data.needs_more_thoughts ?? data.next_thought_needed,
-		};
+    // Add defaults
+    const validated: ValidatedThoughtData = {
+      thought: data.thought,
+      thought_number: data.thought_number,
+      total_thoughts: data.total_thoughts,
+      next_thought_needed: data.next_thought_needed,
+      is_revision: data.is_revision ?? false,
+      branch_from_thought: data.branch_from_thought,
+      branch_id: data.branch_id,
+      needs_more_thoughts: data.needs_more_thoughts ?? data.next_thought_needed,
+    };
 
-		tracker.add(validated);
+    tracker.add(validated);
 
-		return buildSuccess(validated, tracker);
-	};
+    return buildSuccess(validated, tracker);
+  };
 
-	// Helper to execute a tool
-	const executeTool = (
-		toolName: string,
-		pendingMessage: string,
-		executeFn: () => Record<string, unknown>,
-		// biome-ignore lint/suspicious/noExplicitAny: pi's AgentToolUpdateCallback type varies by tool
-		onUpdate: ((partialResult: any) => void) | undefined,
-		params: Record<string, unknown>,
-	) => {
-		onUpdate?.({
-			content: [{ type: "text" as const, text: pendingMessage }],
-			details: { status: "pending" },
-		});
+  // Helper to execute a tool
+  const executeTool = (
+    toolName: string,
+    pendingMessage: string,
+    executeFn: () => Record<string, unknown>,
+    onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+    params: Record<string, unknown>,
+  ) => {
+    onUpdate?.({
+      content: [{ type: "text" as const, text: pendingMessage }],
+      details: { status: "pending" },
+    });
 
-		try {
-			const { requestedLimits } = splitParams(params);
-			const maxLimits = getMaxLimits();
-			const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-			const result = executeFn();
-			const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
-			return { content: [{ type: "text" as const, text }], details, isError: false };
-		} catch (error) {
-			const err = error instanceof Error ? error : new Error(String(error));
-			const result = buildError(err);
-			const { text, details } = formatToolOutput(toolName, result, {});
-			return { content: [{ type: "text" as const, text }], details, isError: true };
-		}
-	};
+    try {
+      const { requestedLimits } = splitParams(params);
+      const maxLimits = getMaxLimits();
+      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
+      const result = executeFn();
+      const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
+      return { content: [{ type: "text" as const, text }], details, isError: false };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const result = buildError(err);
+      const { text, details } = formatToolOutput(toolName, result, {});
+      return { content: [{ type: "text" as const, text }], details, isError: true };
+    }
+  };
 
-	// =============================================================================
-	// Register Tool
-	// =============================================================================
+  // =============================================================================
+  // Register Tool
+  // =============================================================================
 
-	pi.registerTool({
-		name: "code_reasoning",
-		label: "Code Reasoning",
-		description: `🧠 Reflective problem-solving through sequential thinking with branching and revision support.
+  pi.registerTool({
+    name: "code_reasoning",
+    label: "Code Reasoning",
+    description: `🧠 Reflective problem-solving through sequential thinking with branching and revision support.
 
 KEY PARAMETERS:
 - thought: Your current reasoning step (required)
@@ -603,65 +602,65 @@ KEY PARAMETERS:
 - Use branching to explore multiple approaches
 - Express uncertainty when present
 - End with a validated conclusion`,
-		parameters: codeReasoningParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			const { toolArgs } = splitParams(params as Record<string, unknown>);
-			return executeTool(
-				"code_reasoning",
-				"Processing thought...",
-				() => processThought(toolArgs),
-				onUpdate,
-				params as Record<string, unknown>,
-			);
-		},
-	});
+    parameters: codeReasoningParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      return executeTool(
+        "code_reasoning",
+        "Processing thought...",
+        () => processThought(toolArgs),
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
 
-	// =============================================================================
-	// Register Helper Tools
-	// =============================================================================
+  // =============================================================================
+  // Register Helper Tools
+  // =============================================================================
 
-	pi.registerTool({
-		name: "code_reasoning_status",
-		label: "Code Reasoning Status",
-		description: "Get current status of the code reasoning session: branches, thought count.",
-		parameters: Type.Object({}, { additionalProperties: true }),
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			const { requestedLimits } = splitParams(params as Record<string, unknown>);
-			const maxLimits = getMaxLimits();
-			const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
+  pi.registerTool({
+    name: "code_reasoning_status",
+    label: "Code Reasoning Status",
+    description: "Get current status of the code reasoning session: branches, thought count.",
+    parameters: Type.Object({}, { additionalProperties: true }),
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { requestedLimits } = splitParams(params as Record<string, unknown>);
+      const maxLimits = getMaxLimits();
+      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
 
-			onUpdate?.({
-				content: [{ type: "text" as const, text: "Getting status..." }],
-				details: { status: "pending" },
-			});
+      onUpdate?.({
+        content: [{ type: "text" as const, text: "Getting status..." }],
+        details: { status: "pending" },
+      });
 
-			const status = {
-				branches: tracker.branches(),
-				thought_count: tracker.count(),
-			};
+      const status = {
+        branches: tracker.branches(),
+        thought_count: tracker.count(),
+      };
 
-			const { text, details } = formatToolOutput("code_reasoning_status", status, effectiveLimits);
-			return { content: [{ type: "text" as const, text }], details, isError: false };
-		},
-	});
+      const { text, details } = formatToolOutput("code_reasoning_status", status, effectiveLimits);
+      return { content: [{ type: "text" as const, text }], details, isError: false };
+    },
+  });
 
-	pi.registerTool({
-		name: "code_reasoning_reset",
-		label: "Reset Code Reasoning",
-		description: "Reset the code reasoning session, clearing all thoughts and branches.",
-		parameters: Type.Object({}, { additionalProperties: true }),
-		async execute(_toolCallId, _params, _signal, onUpdate, _ctx) {
-			onUpdate?.({
-				content: [{ type: "text" as const, text: "Resetting..." }],
-				details: { status: "pending" },
-			});
+  pi.registerTool({
+    name: "code_reasoning_reset",
+    label: "Reset Code Reasoning",
+    description: "Reset the code reasoning session, clearing all thoughts and branches.",
+    parameters: Type.Object({}, { additionalProperties: true }),
+    async execute(_toolCallId, _params, _signal, onUpdate, _ctx) {
+      onUpdate?.({
+        content: [{ type: "text" as const, text: "Resetting..." }],
+        details: { status: "pending" },
+      });
 
-			tracker.reset();
-			return {
-				content: [{ type: "text" as const, text: "Code reasoning session reset." }],
-				isError: false,
-				details: { tool: "code_reasoning_reset" },
-			};
-		},
-	});
+      tracker.reset();
+      return {
+        content: [{ type: "text" as const, text: "Code reasoning session reset." }],
+        isError: false,
+        details: { tool: "code_reasoning_reset" },
+      };
+    },
+  });
 }

--- a/packages/pi-code-reasoning/extensions/types.ts
+++ b/packages/pi-code-reasoning/extensions/types.ts
@@ -7,22 +7,22 @@
 // =============================================================================
 
 export interface ThoughtData {
-	thought: string;
-	thought_number: number;
-	total_thoughts: number;
-	next_thought_needed: boolean;
-	is_revision?: boolean;
-	revises_thought?: number;
-	branch_from_thought?: number;
-	branch_id?: string;
-	needs_more_thoughts?: boolean;
+  thought: string;
+  thought_number: number;
+  total_thoughts: number;
+  next_thought_needed: boolean;
+  is_revision?: boolean;
+  revises_thought?: number;
+  branch_from_thought?: number;
+  branch_id?: string;
+  needs_more_thoughts?: boolean;
 }
 
 export interface ValidatedThoughtData extends ThoughtData {
-	is_revision: boolean;
-	branch_from_thought: number | undefined;
-	branch_id: string | undefined;
-	needs_more_thoughts: boolean;
+  is_revision: boolean;
+  branch_from_thought: number | undefined;
+  branch_id: string | undefined;
+  needs_more_thoughts: boolean;
 }
 
 // =============================================================================
@@ -33,98 +33,98 @@ const MAX_THOUGHT_LENGTH = 20000;
 const MAX_THOUGHTS = 20;
 
 export interface ValidationError {
-	field: string;
-	message: string;
+  field: string;
+  message: string;
 }
 
 function createError(field: string, message: string): ValidationError {
-	return { field, message };
+  return { field, message };
 }
 
 function isPositiveInteger(value: unknown): value is number {
-	return typeof value === "number" && Number.isInteger(value) && value >= 1;
+  return typeof value === "number" && Number.isInteger(value) && value >= 1;
 }
 
 function validateThoughtField(thought: Partial<ThoughtData>["thought"]): ValidationError[] {
-	if (!thought?.trim()) {
-		return [createError("thought", "Thought cannot be empty.")];
-	}
+  if (!thought?.trim()) {
+    return [createError("thought", "Thought cannot be empty.")];
+  }
 
-	if (thought.length > MAX_THOUGHT_LENGTH) {
-		return [createError("thought", `Thought exceeds ${MAX_THOUGHT_LENGTH} characters.`)];
-	}
+  if (thought.length > MAX_THOUGHT_LENGTH) {
+    return [createError("thought", `Thought exceeds ${MAX_THOUGHT_LENGTH} characters.`)];
+  }
 
-	return [];
+  return [];
 }
 
 function validateRequiredPositiveInteger(
-	field: "thought_number" | "total_thoughts",
-	value: Partial<ThoughtData>[typeof field],
+  field: "thought_number" | "total_thoughts",
+  value: Partial<ThoughtData>[typeof field],
 ): ValidationError[] {
-	if (isPositiveInteger(value)) {
-		return [];
-	}
+  if (isPositiveInteger(value)) {
+    return [];
+  }
 
-	return [createError(field, `${field} must be a positive integer.`)];
+  return [createError(field, `${field} must be a positive integer.`)];
 }
 
 function validateOptionalPositiveInteger(
-	field: "revises_thought" | "branch_from_thought",
-	value: Partial<ThoughtData>[typeof field],
+  field: "revises_thought" | "branch_from_thought",
+  value: Partial<ThoughtData>[typeof field],
 ): ValidationError[] {
-	if (value === undefined || isPositiveInteger(value)) {
-		return [];
-	}
+  if (value === undefined || isPositiveInteger(value)) {
+    return [];
+  }
 
-	return [createError(field, `${field} must be a positive integer.`)];
+  return [createError(field, `${field} must be a positive integer.`)];
 }
 
 function validateOptionalBoolean(field: "is_revision", value: Partial<ThoughtData>[typeof field]): ValidationError[] {
-	if (value === undefined || typeof value === "boolean") {
-		return [];
-	}
+  if (value === undefined || typeof value === "boolean") {
+    return [];
+  }
 
-	return [createError(field, `${field} must be a boolean.`)];
+  return [createError(field, `${field} must be a boolean.`)];
 }
 
 function validateRequiredBoolean(
-	field: "next_thought_needed",
-	value: Partial<ThoughtData>[typeof field],
+  field: "next_thought_needed",
+  value: Partial<ThoughtData>[typeof field],
 ): ValidationError[] {
-	if (typeof value === "boolean") {
-		return [];
-	}
+  if (typeof value === "boolean") {
+    return [];
+  }
 
-	return [createError(field, `${field} must be a boolean.`)];
+  return [createError(field, `${field} must be a boolean.`)];
 }
 
 function validateBranchId(branchId: Partial<ThoughtData>["branch_id"]): ValidationError[] {
-	if (branchId === undefined) {
-		return [];
-	}
+  if (branchId === undefined) {
+    return [];
+  }
 
-	if (typeof branchId === "string" && branchId.trim()) {
-		return [];
-	}
+  if (typeof branchId === "string" && branchId.trim()) {
+    return [];
+  }
 
-	return [createError("branch_id", "branch_id must be a non-empty string.")];
+  return [createError("branch_id", "branch_id must be a non-empty string.")];
 }
 
 export function validateThoughtData(data: Partial<ThoughtData>): ValidationError[] {
-	return [
-		...validateThoughtField(data.thought),
-		...validateRequiredPositiveInteger("thought_number", data.thought_number),
-		...validateRequiredPositiveInteger("total_thoughts", data.total_thoughts),
-		...validateRequiredBoolean("next_thought_needed", data.next_thought_needed),
-		...validateOptionalBoolean("is_revision", data.is_revision),
-		...validateOptionalPositiveInteger("revises_thought", data.revises_thought),
-		...validateOptionalPositiveInteger("branch_from_thought", data.branch_from_thought),
-		...validateBranchId(data.branch_id),
-	];
+  return [
+    ...validateThoughtField(data.thought),
+    ...validateRequiredPositiveInteger("thought_number", data.thought_number),
+    ...validateRequiredPositiveInteger("total_thoughts", data.total_thoughts),
+    ...validateRequiredBoolean("next_thought_needed", data.next_thought_needed),
+    ...validateOptionalBoolean("is_revision", data.is_revision),
+    ...validateOptionalPositiveInteger("revises_thought", data.revises_thought),
+    ...validateOptionalPositiveInteger("branch_from_thought", data.branch_from_thought),
+    ...validateBranchId(data.branch_id),
+  ];
 }
 
 export function isValidThoughtData(data: Partial<ThoughtData>): boolean {
-	return validateThoughtData(data).length === 0;
+  return validateThoughtData(data).length === 0;
 }
 
 // =============================================================================
@@ -132,38 +132,38 @@ export function isValidThoughtData(data: Partial<ThoughtData>): boolean {
 // =============================================================================
 
 export interface CrossFieldValidationError {
-	message: string;
+  message: string;
 }
 
 export function enforceCrossFieldRules(data: ThoughtData): CrossFieldValidationError[] {
-	const errors: CrossFieldValidationError[] = [];
+  const errors: CrossFieldValidationError[] = [];
 
-	if (data.is_revision) {
-		if (typeof data.revises_thought !== "number" || data.branch_id || data.branch_from_thought) {
-			errors.push({
-				message: "If is_revision=true, provide revises_thought and omit branch_* fields.",
-			});
-		}
-	} else if (data.revises_thought !== undefined) {
-		errors.push({
-			message: "revises_thought only allowed when is_revision=true.",
-		});
-	}
+  if (data.is_revision) {
+    if (typeof data.revises_thought !== "number" || data.branch_id || data.branch_from_thought) {
+      errors.push({
+        message: "If is_revision=true, provide revises_thought and omit branch_* fields.",
+      });
+    }
+  } else if (data.revises_thought !== undefined) {
+    errors.push({
+      message: "revises_thought only allowed when is_revision=true.",
+    });
+  }
 
-	const hasBranchFields = data.branch_id !== undefined || data.branch_from_thought !== undefined;
-	if (hasBranchFields) {
-		if (data.branch_id === undefined || data.branch_from_thought === undefined || data.is_revision) {
-			errors.push({
-				message: "branch_id and branch_from_thought required together and not with revision.",
-			});
-		}
-	}
+  const hasBranchFields = data.branch_id !== undefined || data.branch_from_thought !== undefined;
+  if (hasBranchFields) {
+    if (data.branch_id === undefined || data.branch_from_thought === undefined || data.is_revision) {
+      errors.push({
+        message: "branch_id and branch_from_thought required together and not with revision.",
+      });
+    }
+  }
 
-	return errors;
+  return errors;
 }
 
 export function isValidCrossField(data: ThoughtData): boolean {
-	return enforceCrossFieldRules(data).length === 0;
+  return enforceCrossFieldRules(data).length === 0;
 }
 
 // =============================================================================

--- a/packages/pi-conductor/__tests__/cleanup.test.ts
+++ b/packages/pi-conductor/__tests__/cleanup.test.ts
@@ -6,64 +6,64 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createWorkerForRepo, getOrCreateRunForRepo, removeWorkerForRepo } from "../extensions/conductor.js";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
-	if (value == null) {
-		throw new Error(message);
-	}
-	return value;
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
 }
 
 describe("cleanup flows", () => {
-	let repoDir: string;
-	let conductorHome: string;
+  let repoDir: string;
+  let conductorHome: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
-		process.env.PI_CONDUCTOR_HOME = conductorHome;
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-	});
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		delete process.env.PI_CONDUCTOR_HOME;
-		if (existsSync(repoDir)) {
-			rmSync(repoDir, { recursive: true, force: true });
-		}
-		if (existsSync(conductorHome)) {
-			rmSync(conductorHome, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+    if (existsSync(conductorHome)) {
+      rmSync(conductorHome, { recursive: true, force: true });
+    }
+  });
 
-	it("removes a worker record and its worktree", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const worktreePath = requireValue(worker.worktreePath, "worker worktree missing");
-		expect(existsSync(worktreePath)).toBe(true);
-		const removed = removeWorkerForRepo(repoDir, "backend");
-		expect(removed.workerId).toBe(worker.workerId);
-		expect(existsSync(worktreePath)).toBe(false);
-		expect(getOrCreateRunForRepo(repoDir).workers).toHaveLength(0);
-	});
+  it("removes a worker record and its worktree", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const worktreePath = requireValue(worker.worktreePath, "worker worktree missing");
+    expect(existsSync(worktreePath)).toBe(true);
+    const removed = removeWorkerForRepo(repoDir, "backend");
+    expect(removed.workerId).toBe(worker.workerId);
+    expect(existsSync(worktreePath)).toBe(false);
+    expect(getOrCreateRunForRepo(repoDir).workers).toHaveLength(0);
+  });
 
-	it("removes the persisted session file when cleaning up a worker", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
-		expect(existsSync(sessionFile)).toBe(true);
-		removeWorkerForRepo(repoDir, "backend");
-		expect(existsSync(sessionFile)).toBe(false);
-	});
+  it("removes the persisted session file when cleaning up a worker", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
+    expect(existsSync(sessionFile)).toBe(true);
+    removeWorkerForRepo(repoDir, "backend");
+    expect(existsSync(sessionFile)).toBe(false);
+  });
 
-	it("removes the worker branch so the same worker name can be recreated", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const branch = requireValue(worker.branch, "worker branch missing");
-		expect(execSync(`git branch --list ${branch}`, { cwd: repoDir, encoding: "utf-8" }).trim()).toContain(branch);
-		removeWorkerForRepo(repoDir, "backend");
-		expect(execSync(`git branch --list ${branch}`, { cwd: repoDir, encoding: "utf-8" }).trim()).toBe("");
+  it("removes the worker branch so the same worker name can be recreated", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const branch = requireValue(worker.branch, "worker branch missing");
+    expect(execSync(`git branch --list ${branch}`, { cwd: repoDir, encoding: "utf-8" }).trim()).toContain(branch);
+    removeWorkerForRepo(repoDir, "backend");
+    expect(execSync(`git branch --list ${branch}`, { cwd: repoDir, encoding: "utf-8" }).trim()).toBe("");
 
-		const recreated = await createWorkerForRepo(repoDir, "backend");
-		expect(recreated.branch).toBe(worker.branch);
-	});
+    const recreated = await createWorkerForRepo(repoDir, "backend");
+    expect(recreated.branch).toBe(worker.branch);
+  });
 });

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -6,91 +6,91 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runConductorCommand } from "../extensions/commands.js";
 
 describe("runConductorCommand", () => {
-	let repoDir: string;
-	let conductorHome: string;
+  let repoDir: string;
+  let conductorHome: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
-		process.env.PI_CONDUCTOR_HOME = conductorHome;
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
 
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-	});
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		delete process.env.PI_CONDUCTOR_HOME;
-		if (existsSync(repoDir)) {
-			rmSync(repoDir, { recursive: true, force: true });
-		}
-		if (existsSync(conductorHome)) {
-			rmSync(conductorHome, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+    if (existsSync(conductorHome)) {
+      rmSync(conductorHome, { recursive: true, force: true });
+    }
+  });
 
-	it("returns status for the current repo", async () => {
-		const text = await runConductorCommand(repoDir, "status");
-		expect(text).toContain("workers: 0");
-	});
+  it("returns status for the current repo", async () => {
+    const text = await runConductorCommand(repoDir, "status");
+    expect(text).toContain("workers: 0");
+  });
 
-	it("creates a worker from the start subcommand", async () => {
-		const text = await runConductorCommand(repoDir, "start backend");
-		expect(text).toContain("created worker");
-		expect(text).toContain("backend");
+  it("creates a worker from the start subcommand", async () => {
+    const text = await runConductorCommand(repoDir, "start backend");
+    expect(text).toContain("created worker");
+    expect(text).toContain("backend");
 
-		const status = await runConductorCommand(repoDir, "status");
-		expect(status).toContain("workers: 1");
-		expect(status).toContain("backend");
-	});
+    const status = await runConductorCommand(repoDir, "status");
+    expect(status).toContain("workers: 1");
+    expect(status).toContain("backend");
+  });
 
-	it("updates a worker task through the task subcommand", async () => {
-		await runConductorCommand(repoDir, "start backend");
-		const text = await runConductorCommand(repoDir, "task backend implement status command");
-		expect(text).toContain("updated task for backend");
+  it("updates a worker task through the task subcommand", async () => {
+    await runConductorCommand(repoDir, "start backend");
+    const text = await runConductorCommand(repoDir, "task backend implement status command");
+    expect(text).toContain("updated task for backend");
 
-		const status = await runConductorCommand(repoDir, "status");
-		expect(status).toContain("task=implement status command");
-	});
+    const status = await runConductorCommand(repoDir, "status");
+    expect(status).toContain("task=implement status command");
+  });
 
-	it("refreshes a worker summary from its session", async () => {
-		await runConductorCommand(repoDir, "start backend");
-		const text = await runConductorCommand(repoDir, "summarize backend");
-		expect(text).toContain("refreshed summary for backend");
+  it("refreshes a worker summary from its session", async () => {
+    await runConductorCommand(repoDir, "start backend");
+    const text = await runConductorCommand(repoDir, "summarize backend");
+    expect(text).toContain("refreshed summary for backend");
 
-		const status = await runConductorCommand(repoDir, "status");
-		expect(status).toContain("summary=fresh:");
-	});
+    const status = await runConductorCommand(repoDir, "status");
+    expect(status).toContain("summary=fresh:");
+  });
 
-	it("resumes a healthy worker through the resume subcommand", async () => {
-		await runConductorCommand(repoDir, "start backend");
-		const text = await runConductorCommand(repoDir, "resume backend");
-		expect(text).toContain("resumed worker backend");
-	});
+  it("resumes a healthy worker through the resume subcommand", async () => {
+    await runConductorCommand(repoDir, "start backend");
+    const text = await runConductorCommand(repoDir, "resume backend");
+    expect(text).toContain("resumed worker backend");
+  });
 
-	it("updates a worker lifecycle through the state subcommand", async () => {
-		await runConductorCommand(repoDir, "start backend");
-		const text = await runConductorCommand(repoDir, "state backend ready_for_pr");
-		expect(text).toContain("updated worker backend state to ready_for_pr");
+  it("updates a worker lifecycle through the state subcommand", async () => {
+    await runConductorCommand(repoDir, "start backend");
+    const text = await runConductorCommand(repoDir, "state backend ready_for_pr");
+    expect(text).toContain("updated worker backend state to ready_for_pr");
 
-		const status = await runConductorCommand(repoDir, "status");
-		expect(status).toContain("state=ready_for_pr");
-	});
+    const status = await runConductorCommand(repoDir, "status");
+    expect(status).toContain("state=ready_for_pr");
+  });
 
-	it("cleans up a worker through the cleanup subcommand", async () => {
-		await runConductorCommand(repoDir, "start backend");
-		const text = await runConductorCommand(repoDir, "cleanup backend");
-		expect(text).toContain("removed worker backend");
+  it("cleans up a worker through the cleanup subcommand", async () => {
+    await runConductorCommand(repoDir, "start backend");
+    const text = await runConductorCommand(repoDir, "cleanup backend");
+    expect(text).toContain("removed worker backend");
 
-		const status = await runConductorCommand(repoDir, "status");
-		expect(status).toContain("workers: 0");
-	});
+    const status = await runConductorCommand(repoDir, "status");
+    expect(status).toContain("workers: 0");
+  });
 
-	it("shows help for unknown subcommands", async () => {
-		const text = await runConductorCommand(repoDir, "wat");
-		expect(text).toContain("usage:");
-	});
+  it("shows help for unknown subcommands", async () => {
+    const text = await runConductorCommand(repoDir, "wat");
+    expect(text).toContain("usage:");
+  });
 });

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -6,60 +6,60 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createWorkerForRepo, getOrCreateRunForRepo } from "../extensions/conductor.js";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
-	if (value == null) {
-		throw new Error(message);
-	}
-	return value;
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
 }
 
 describe("conductor service", () => {
-	let repoDir: string;
-	let conductorHome: string;
+  let repoDir: string;
+  let conductorHome: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
-		process.env.PI_CONDUCTOR_HOME = conductorHome;
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
 
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-	});
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		delete process.env.PI_CONDUCTOR_HOME;
-		if (existsSync(repoDir)) {
-			rmSync(repoDir, { recursive: true, force: true });
-		}
-		if (existsSync(conductorHome)) {
-			rmSync(conductorHome, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+    if (existsSync(conductorHome)) {
+      rmSync(conductorHome, { recursive: true, force: true });
+    }
+  });
 
-	it("creates and persists an empty run for a repo", () => {
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.repoRoot).toBe(repoDir);
-		expect(run.workers).toEqual([]);
-		expect(readFileSync(join(run.storageDir, "run.json"), "utf-8")).toContain("projectKey");
-	});
+  it("creates and persists an empty run for a repo", () => {
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.repoRoot).toBe(repoDir);
+    expect(run.workers).toEqual([]);
+    expect(readFileSync(join(run.storageDir, "run.json"), "utf-8")).toContain("projectKey");
+  });
 
-	it("creates a worker, worktree, and persisted worker record", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const worktreePath = requireValue(worker.worktreePath, "worker worktree missing");
-		const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
-		expect(worker.name).toBe("backend");
-		expect(worker.branch).toBe("conductor/backend");
-		expect(worker.worktreePath).toBeTruthy();
-		expect(existsSync(worktreePath)).toBe(true);
-		expect(worker.sessionFile).toBeTruthy();
-		expect(existsSync(sessionFile)).toBe(true);
+  it("creates a worker, worktree, and persisted worker record", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const worktreePath = requireValue(worker.worktreePath, "worker worktree missing");
+    const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
+    expect(worker.name).toBe("backend");
+    expect(worker.branch).toBe("conductor/backend");
+    expect(worker.worktreePath).toBeTruthy();
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(worker.sessionFile).toBeTruthy();
+    expect(existsSync(sessionFile)).toBe(true);
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers).toHaveLength(1);
-		expect(run.workers[0]?.name).toBe("backend");
-		expect(run.workers[0]?.sessionFile).toBeTruthy();
-	});
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers).toHaveLength(1);
+    expect(run.workers[0]?.name).toBe("backend");
+    expect(run.workers[0]?.sessionFile).toBeTruthy();
+  });
 });

--- a/packages/pi-conductor/__tests__/git-pr.test.ts
+++ b/packages/pi-conductor/__tests__/git-pr.test.ts
@@ -5,43 +5,43 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getPreferredBaseBranch } from "../extensions/git-pr.js";
 
 describe("git-pr helpers", () => {
-	let repoDir: string;
-	let remoteDir: string;
+  let repoDir: string;
+  let remoteDir: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		remoteDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello\n");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git init --bare", { cwd: remoteDir, stdio: "pipe" });
-		execSync(`git remote add origin ${remoteDir}`, { cwd: repoDir, stdio: "pipe" });
-		execSync("git push -u origin main", { cwd: repoDir, stdio: "pipe" });
-	});
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    remoteDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello\n");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git init --bare", { cwd: remoteDir, stdio: "pipe" });
+    execSync(`git remote add origin ${remoteDir}`, { cwd: repoDir, stdio: "pipe" });
+    execSync("git push -u origin main", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		for (const dir of [repoDir, remoteDir]) {
-			if (dir && existsSync(dir)) {
-				rmSync(dir, { recursive: true, force: true });
-			}
-		}
-	});
+  afterEach(() => {
+    for (const dir of [repoDir, remoteDir]) {
+      if (dir && existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
 
-	it("uses the current branch when it exists on origin", () => {
-		execSync("git checkout -b feature/test-base", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "feature.txt"), "feature\n");
-		execSync("git add feature.txt", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'feature commit'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git push -u origin feature/test-base", { cwd: repoDir, stdio: "pipe" });
+  it("uses the current branch when it exists on origin", () => {
+    execSync("git checkout -b feature/test-base", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "feature.txt"), "feature\n");
+    execSync("git add feature.txt", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'feature commit'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git push -u origin feature/test-base", { cwd: repoDir, stdio: "pipe" });
 
-		expect(getPreferredBaseBranch(repoDir)).toBe("feature/test-base");
-	});
+    expect(getPreferredBaseBranch(repoDir)).toBe("feature/test-base");
+  });
 
-	it("falls back to the remote default branch when the current branch is only local", () => {
-		execSync("git checkout -b feature/local-only", { cwd: repoDir, stdio: "pipe" });
-		expect(getPreferredBaseBranch(repoDir)).toBe("main");
-	});
+  it("falls back to the remote default branch when the current branch is only local", () => {
+    execSync("git checkout -b feature/local-only", { cwd: repoDir, stdio: "pipe" });
+    expect(getPreferredBaseBranch(repoDir)).toBe("main");
+  });
 });

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -3,23 +3,23 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("pi-conductor extension", () => {
-	it("registers the main conductor command group", () => {
-		const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-		expect(extension).toContain('registerCommand("conductor"');
-	});
+  it("registers the main conductor command group", () => {
+    const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+    expect(extension).toContain('registerCommand("conductor"');
+  });
 
-	it("registers conductor tools", () => {
-		const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-		expect(extension).toContain('name: "conductor_status"');
-		expect(extension).toContain('name: "conductor_start"');
-		expect(extension).toContain('name: "conductor_task_update"');
-		expect(extension).toContain('name: "conductor_recover"');
-		expect(extension).toContain('name: "conductor_summary_refresh"');
-		expect(extension).toContain('name: "conductor_cleanup"');
-		expect(extension).toContain('name: "conductor_resume"');
-		expect(extension).toContain('name: "conductor_lifecycle_update"');
-		expect(extension).toContain('name: "conductor_commit"');
-		expect(extension).toContain('name: "conductor_push"');
-		expect(extension).toContain('name: "conductor_pr_create"');
-	});
+  it("registers conductor tools", () => {
+    const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+    expect(extension).toContain('name: "conductor_status"');
+    expect(extension).toContain('name: "conductor_start"');
+    expect(extension).toContain('name: "conductor_task_update"');
+    expect(extension).toContain('name: "conductor_recover"');
+    expect(extension).toContain('name: "conductor_summary_refresh"');
+    expect(extension).toContain('name: "conductor_cleanup"');
+    expect(extension).toContain('name: "conductor_resume"');
+    expect(extension).toContain('name: "conductor_lifecycle_update"');
+    expect(extension).toContain('name: "conductor_commit"');
+    expect(extension).toContain('name: "conductor_push"');
+    expect(extension).toContain('name: "conductor_pr_create"');
+  });
 });

--- a/packages/pi-conductor/__tests__/lifecycle.test.ts
+++ b/packages/pi-conductor/__tests__/lifecycle.test.ts
@@ -4,50 +4,50 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-	createWorkerForRepo,
-	getOrCreateRunForRepo,
-	resumeWorkerForRepo,
-	updateWorkerLifecycleForRepo,
+  createWorkerForRepo,
+  getOrCreateRunForRepo,
+  resumeWorkerForRepo,
+  updateWorkerLifecycleForRepo,
 } from "../extensions/conductor.js";
 
 describe("worker lifecycle flows", () => {
-	let repoDir: string;
-	let conductorHome: string;
+  let repoDir: string;
+  let conductorHome: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
-		process.env.PI_CONDUCTOR_HOME = conductorHome;
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello\n");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-	});
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello\n");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		delete process.env.PI_CONDUCTOR_HOME;
-		for (const dir of [repoDir, conductorHome]) {
-			if (dir && existsSync(dir)) {
-				rmSync(dir, { recursive: true, force: true });
-			}
-		}
-	});
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    for (const dir of [repoDir, conductorHome]) {
+      if (dir && existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
 
-	it("resumes a healthy worker using its persisted worktree and session linkage", async () => {
-		const created = await createWorkerForRepo(repoDir, "backend");
-		const resumed = resumeWorkerForRepo(repoDir, "backend");
-		expect(resumed.workerId).toBe(created.workerId);
-		expect(resumed.worktreePath).toBe(created.worktreePath);
-		expect(resumed.sessionFile).toBe(created.sessionFile);
-	});
+  it("resumes a healthy worker using its persisted worktree and session linkage", async () => {
+    const created = await createWorkerForRepo(repoDir, "backend");
+    const resumed = resumeWorkerForRepo(repoDir, "backend");
+    expect(resumed.workerId).toBe(created.workerId);
+    expect(resumed.worktreePath).toBe(created.worktreePath);
+    expect(resumed.sessionFile).toBe(created.sessionFile);
+  });
 
-	it("updates a worker lifecycle to blocked, ready_for_pr, and done", async () => {
-		await createWorkerForRepo(repoDir, "backend");
-		expect(updateWorkerLifecycleForRepo(repoDir, "backend", "blocked").lifecycle).toBe("blocked");
-		expect(updateWorkerLifecycleForRepo(repoDir, "backend", "ready_for_pr").lifecycle).toBe("ready_for_pr");
-		expect(updateWorkerLifecycleForRepo(repoDir, "backend", "done").lifecycle).toBe("done");
-		expect(getOrCreateRunForRepo(repoDir).workers[0]?.lifecycle).toBe("done");
-	});
+  it("updates a worker lifecycle to blocked, ready_for_pr, and done", async () => {
+    await createWorkerForRepo(repoDir, "backend");
+    expect(updateWorkerLifecycleForRepo(repoDir, "backend", "blocked").lifecycle).toBe("blocked");
+    expect(updateWorkerLifecycleForRepo(repoDir, "backend", "ready_for_pr").lifecycle).toBe("ready_for_pr");
+    expect(updateWorkerLifecycleForRepo(repoDir, "backend", "done").lifecycle).toBe("done");
+    expect(getOrCreateRunForRepo(repoDir).workers[0]?.lifecycle).toBe("done");
+  });
 });

--- a/packages/pi-conductor/__tests__/pr-flow.test.ts
+++ b/packages/pi-conductor/__tests__/pr-flow.test.ts
@@ -7,148 +7,148 @@ import { runConductorCommand } from "../extensions/commands.js";
 import { getOrCreateRunForRepo } from "../extensions/conductor.js";
 
 describe("PR preparation flow", () => {
-	let repoDir: string;
-	let bareRemoteDir: string;
-	let conductorHome: string;
-	let fakeBinDir: string;
-	let originalPath: string | undefined;
+  let repoDir: string;
+  let bareRemoteDir: string;
+  let conductorHome: string;
+  let fakeBinDir: string;
+  let originalPath: string | undefined;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		bareRemoteDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
-		fakeBinDir = mkdtempSync(join(tmpdir(), "pi-conductor-bin-"));
-		originalPath = process.env.PATH;
-		process.env.PI_CONDUCTOR_HOME = conductorHome;
-		process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    bareRemoteDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    fakeBinDir = mkdtempSync(join(tmpdir(), "pi-conductor-bin-"));
+    originalPath = process.env.PATH;
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
 
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
 
-		execSync("git init --bare", { cwd: bareRemoteDir, stdio: "pipe" });
-		execSync(`git remote add origin ${bareRemoteDir}`, { cwd: repoDir, stdio: "pipe" });
-		execSync("git push -u origin main", { cwd: repoDir, stdio: "pipe" });
-	});
+    execSync("git init --bare", { cwd: bareRemoteDir, stdio: "pipe" });
+    execSync(`git remote add origin ${bareRemoteDir}`, { cwd: repoDir, stdio: "pipe" });
+    execSync("git push -u origin main", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		delete process.env.PI_CONDUCTOR_HOME;
-		process.env.PATH = originalPath;
-		for (const dir of [repoDir, bareRemoteDir, conductorHome, fakeBinDir]) {
-			if (dir && existsSync(dir)) {
-				rmSync(dir, { recursive: true, force: true });
-			}
-		}
-	});
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    process.env.PATH = originalPath;
+    for (const dir of [repoDir, bareRemoteDir, conductorHome, fakeBinDir]) {
+      if (dir && existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
 
-	function writeFakeGhScript(content: string): void {
-		const path = join(fakeBinDir, "gh");
-		writeFileSync(path, `#!/bin/sh\n${content}\n`, { encoding: "utf-8", mode: 0o755 });
-	}
+  function writeFakeGhScript(content: string): void {
+    const path = join(fakeBinDir, "gh");
+    writeFileSync(path, `#!/bin/sh\n${content}\n`, { encoding: "utf-8", mode: 0o755 });
+  }
 
-	async function createChangedWorker(): Promise<string> {
-		await runConductorCommand(repoDir, "start backend");
-		const worker = getOrCreateRunForRepo(repoDir).workers[0];
-		if (!worker?.worktreePath) {
-			throw new Error("worker worktree missing in test setup");
-		}
-		writeFileSync(join(worker.worktreePath, "backend.txt"), "backend changes\n", "utf-8");
-		return worker.worktreePath;
-	}
+  async function createChangedWorker(): Promise<string> {
+    await runConductorCommand(repoDir, "start backend");
+    const worker = getOrCreateRunForRepo(repoDir).workers[0];
+    if (!worker?.worktreePath) {
+      throw new Error("worker worktree missing in test setup");
+    }
+    writeFileSync(join(worker.worktreePath, "backend.txt"), "backend changes\n", "utf-8");
+    return worker.worktreePath;
+  }
 
-	it("commits worker changes and persists commit state", async () => {
-		const worktreePath = await createChangedWorker();
-		const text = await runConductorCommand(repoDir, "commit backend feat: add backend worker");
-		expect(text).toContain("committed worker backend");
+  it("commits worker changes and persists commit state", async () => {
+    const worktreePath = await createChangedWorker();
+    const text = await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+    expect(text).toContain("committed worker backend");
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.pushSucceeded).toBe(false);
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.pushSucceeded).toBe(false);
 
-		const log = execSync("git log -1 --pretty=%s", { cwd: worktreePath, encoding: "utf-8" }).trim();
-		expect(log).toBe("feat: add backend worker");
-	});
+    const log = execSync("git log -1 --pretty=%s", { cwd: worktreePath, encoding: "utf-8" }).trim();
+    expect(log).toBe("feat: add backend worker");
+  });
 
-	it("pushes a worker branch and persists push state", async () => {
-		await createChangedWorker();
-		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
-		const text = await runConductorCommand(repoDir, "push backend");
-		expect(text).toContain("pushed worker backend");
+  it("pushes a worker branch and persists push state", async () => {
+    await createChangedWorker();
+    await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+    const text = await runConductorCommand(repoDir, "push backend");
+    expect(text).toContain("pushed worker backend");
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
-		const remoteHead = execSync("git ls-remote --heads origin conductor/backend", {
-			cwd: repoDir,
-			encoding: "utf-8",
-		}).trim();
-		expect(remoteHead).toContain("refs/heads/conductor/backend");
-	});
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+    const remoteHead = execSync("git ls-remote --heads origin conductor/backend", {
+      cwd: repoDir,
+      encoding: "utf-8",
+    }).trim();
+    expect(remoteHead).toContain("refs/heads/conductor/backend");
+  });
 
-	it("creates a pull request and persists PR metadata", async () => {
-		writeFakeGhScript(
-			'if [ "$1" = "--version" ]; then echo \'gh version test\'; exit 0; fi\nif [ "$1 $2" = "auth status" ]; then exit 0; fi\necho \'https://github.com/example/repo/pull/123\'',
-		);
-		await createChangedWorker();
-		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
-		await runConductorCommand(repoDir, "push backend");
-		const text = await runConductorCommand(repoDir, "pr backend Backend worker PR");
-		expect(text).toContain("created PR for backend");
-		expect(text).toContain("pull/123");
+  it("creates a pull request and persists PR metadata", async () => {
+    writeFakeGhScript(
+      'if [ "$1" = "--version" ]; then echo \'gh version test\'; exit 0; fi\nif [ "$1 $2" = "auth status" ]; then exit 0; fi\necho \'https://github.com/example/repo/pull/123\'',
+    );
+    await createChangedWorker();
+    await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+    await runConductorCommand(repoDir, "push backend");
+    const text = await runConductorCommand(repoDir, "pr backend Backend worker PR");
+    expect(text).toContain("created PR for backend");
+    expect(text).toContain("pull/123");
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
-		expect(run.workers[0]?.pr.number).toBe(123);
-		expect(run.workers[0]?.pr.url).toContain("pull/123");
-	});
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
+    expect(run.workers[0]?.pr.number).toBe(123);
+    expect(run.workers[0]?.pr.url).toContain("pull/123");
+  });
 
-	it("persists partial PR state when gh pr create fails", async () => {
-		writeFakeGhScript(
-			'if [ "$1" = "--version" ]; then echo \'gh version test\'; exit 0; fi\nif [ "$1 $2" = "auth status" ]; then exit 0; fi\necho \'gh pr create failed\' >&2\nexit 1',
-		);
-		await createChangedWorker();
-		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
-		await runConductorCommand(repoDir, "push backend");
+  it("persists partial PR state when gh pr create fails", async () => {
+    writeFakeGhScript(
+      'if [ "$1" = "--version" ]; then echo \'gh version test\'; exit 0; fi\nif [ "$1 $2" = "auth status" ]; then exit 0; fi\necho \'gh pr create failed\' >&2\nexit 1',
+    );
+    await createChangedWorker();
+    await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+    await runConductorCommand(repoDir, "push backend");
 
-		await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow();
+    await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow();
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
-		expect(run.workers[0]?.pr.url).toBeNull();
-	});
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.prCreationAttempted).toBe(true);
+    expect(run.workers[0]?.pr.url).toBeNull();
+  });
 
-	it("reports a preflight error when gh is not installed", async () => {
-		writeFakeGhScript("exit 127");
-		process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
-		await createChangedWorker();
-		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
-		await runConductorCommand(repoDir, "push backend");
+  it("reports a preflight error when gh is not installed", async () => {
+    writeFakeGhScript("exit 127");
+    process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+    await createChangedWorker();
+    await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+    await runConductorCommand(repoDir, "push backend");
 
-		await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow(/GitHub CLI/i);
+    await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow(/GitHub CLI/i);
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.prCreationAttempted).toBe(false);
-	});
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.prCreationAttempted).toBe(false);
+  });
 
-	it("reports a preflight error when gh is not authenticated", async () => {
-		writeFakeGhScript(
-			'if [ "$1" = "--version" ]; then echo \'gh version test\'; exit 0; fi\nif [ "$1 $2" = "auth status" ]; then echo \'not authenticated\' >&2; exit 1; fi\necho \'unexpected call\' >&2\nexit 1',
-		);
-		await createChangedWorker();
-		await runConductorCommand(repoDir, "commit backend feat: add backend worker");
-		await runConductorCommand(repoDir, "push backend");
+  it("reports a preflight error when gh is not authenticated", async () => {
+    writeFakeGhScript(
+      'if [ "$1" = "--version" ]; then echo \'gh version test\'; exit 0; fi\nif [ "$1 $2" = "auth status" ]; then echo \'not authenticated\' >&2; exit 1; fi\necho \'unexpected call\' >&2\nexit 1',
+    );
+    await createChangedWorker();
+    await runConductorCommand(repoDir, "commit backend feat: add backend worker");
+    await runConductorCommand(repoDir, "push backend");
 
-		await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow(/authenticated/i);
+    await expect(runConductorCommand(repoDir, "pr backend Backend worker PR")).rejects.toThrow(/authenticated/i);
 
-		const run = getOrCreateRunForRepo(repoDir);
-		expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
-		expect(run.workers[0]?.pr.prCreationAttempted).toBe(false);
-	});
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers[0]?.pr.commitSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.pushSucceeded).toBe(true);
+    expect(run.workers[0]?.pr.prCreationAttempted).toBe(false);
+  });
 });

--- a/packages/pi-conductor/__tests__/project-key.test.ts
+++ b/packages/pi-conductor/__tests__/project-key.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { deriveProjectKey } from "../extensions/project-key.js";
 
 describe("deriveProjectKey", () => {
-	it("is stable for the same repo root", () => {
-		const a = deriveProjectKey("/tmp/example/repo");
-		const b = deriveProjectKey("/tmp/example/repo");
-		expect(a).toBe(b);
-	});
+  it("is stable for the same repo root", () => {
+    const a = deriveProjectKey("/tmp/example/repo");
+    const b = deriveProjectKey("/tmp/example/repo");
+    expect(a).toBe(b);
+  });
 
-	it("differs for different repo roots", () => {
-		const a = deriveProjectKey("/tmp/example/repo-a");
-		const b = deriveProjectKey("/tmp/example/repo-b");
-		expect(a).not.toBe(b);
-	});
+  it("differs for different repo roots", () => {
+    const a = deriveProjectKey("/tmp/example/repo-a");
+    const b = deriveProjectKey("/tmp/example/repo-b");
+    expect(a).not.toBe(b);
+  });
 });

--- a/packages/pi-conductor/__tests__/recovery.test.ts
+++ b/packages/pi-conductor/__tests__/recovery.test.ts
@@ -4,77 +4,77 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-	createWorkerForRepo,
-	getOrCreateRunForRepo,
-	reconcileWorkerHealth,
-	recoverWorkerForRepo,
+  createWorkerForRepo,
+  getOrCreateRunForRepo,
+  reconcileWorkerHealth,
+  recoverWorkerForRepo,
 } from "../extensions/conductor.js";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
-	if (value == null) {
-		throw new Error(message);
-	}
-	return value;
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
 }
 
 describe("recovery flows", () => {
-	let repoDir: string;
-	let conductorHome: string;
+  let repoDir: string;
+  let conductorHome: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
-		process.env.PI_CONDUCTOR_HOME = conductorHome;
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-	});
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		delete process.env.PI_CONDUCTOR_HOME;
-		if (existsSync(repoDir)) {
-			rmSync(repoDir, { recursive: true, force: true });
-		}
-		if (existsSync(conductorHome)) {
-			rmSync(conductorHome, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+    if (existsSync(conductorHome)) {
+      rmSync(conductorHome, { recursive: true, force: true });
+    }
+  });
 
-	it("marks a worker broken and recoverable when its session file is missing", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
-		rmSync(sessionFile, { force: true });
-		const updated = reconcileWorkerHealth(getOrCreateRunForRepo(repoDir));
-		expect(updated.workers[0]?.lifecycle).toBe("broken");
-		expect(updated.workers[0]?.recoverable).toBe(true);
-	});
+  it("marks a worker broken and recoverable when its session file is missing", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
+    rmSync(sessionFile, { force: true });
+    const updated = reconcileWorkerHealth(getOrCreateRunForRepo(repoDir));
+    expect(updated.workers[0]?.lifecycle).toBe("broken");
+    expect(updated.workers[0]?.recoverable).toBe(true);
+  });
 
-	it("recreates a missing session file during recovery", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
-		rmSync(sessionFile, { force: true });
-		const recovered = await recoverWorkerForRepo(repoDir, "backend");
-		const recoveredSessionFile = requireValue(recovered.sessionFile, "recovered session file missing");
-		expect(recovered.sessionFile).toBeTruthy();
-		expect(existsSync(recoveredSessionFile)).toBe(true);
-		expect(recovered.lifecycle).toBe("idle");
-		expect(recovered.recoverable).toBe(false);
-	});
+  it("recreates a missing session file during recovery", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const sessionFile = requireValue(worker.sessionFile, "worker session file missing");
+    rmSync(sessionFile, { force: true });
+    const recovered = await recoverWorkerForRepo(repoDir, "backend");
+    const recoveredSessionFile = requireValue(recovered.sessionFile, "recovered session file missing");
+    expect(recovered.sessionFile).toBeTruthy();
+    expect(existsSync(recoveredSessionFile)).toBe(true);
+    expect(recovered.lifecycle).toBe("idle");
+    expect(recovered.recoverable).toBe(false);
+  });
 
-	it("recreates a missing worktree during recovery", async () => {
-		const worker = await createWorkerForRepo(repoDir, "backend");
-		const worktreePath = requireValue(worker.worktreePath, "worker worktree missing");
-		rmSync(worktreePath, { recursive: true, force: true });
-		const recovered = await recoverWorkerForRepo(repoDir, "backend");
-		const recoveredWorktreePath = requireValue(recovered.worktreePath, "recovered worktree missing");
-		const recoveredSessionFile = requireValue(recovered.sessionFile, "recovered session file missing");
-		expect(recovered.worktreePath).toBeTruthy();
-		expect(existsSync(recoveredWorktreePath)).toBe(true);
-		expect(recovered.sessionFile).toBeTruthy();
-		expect(existsSync(recoveredSessionFile)).toBe(true);
-		expect(recovered.lifecycle).toBe("idle");
-	});
+  it("recreates a missing worktree during recovery", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const worktreePath = requireValue(worker.worktreePath, "worker worktree missing");
+    rmSync(worktreePath, { recursive: true, force: true });
+    const recovered = await recoverWorkerForRepo(repoDir, "backend");
+    const recoveredWorktreePath = requireValue(recovered.worktreePath, "recovered worktree missing");
+    const recoveredSessionFile = requireValue(recovered.sessionFile, "recovered session file missing");
+    expect(recovered.worktreePath).toBeTruthy();
+    expect(existsSync(recoveredWorktreePath)).toBe(true);
+    expect(recovered.sessionFile).toBeTruthy();
+    expect(existsSync(recoveredSessionFile)).toBe(true);
+    expect(recovered.lifecycle).toBe("idle");
+  });
 });

--- a/packages/pi-conductor/__tests__/sessions.test.ts
+++ b/packages/pi-conductor/__tests__/sessions.test.ts
@@ -5,34 +5,34 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createWorkerSessionLink } from "../extensions/sessions.js";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
-	if (value == null) {
-		throw new Error(message);
-	}
-	return value;
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
 }
 
 describe("session linkage", () => {
-	let repoDir: string;
+  let repoDir: string;
 
-	beforeEach(() => {
-		repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
-		writeFileSync(join(repoDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
-	});
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		if (repoDir && existsSync(repoDir)) {
-			rmSync(repoDir, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    if (repoDir && existsSync(repoDir)) {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
 
-	it("creates a persisted pi session file for a worker worktree", async () => {
-		const sessionFile = requireValue(await createWorkerSessionLink(repoDir), "session file missing");
-		expect(sessionFile).toBeTruthy();
-		expect(existsSync(sessionFile)).toBe(true);
-	});
+  it("creates a persisted pi session file for a worker worktree", async () => {
+    const sessionFile = requireValue(await createWorkerSessionLink(repoDir), "session file missing");
+    expect(sessionFile).toBeTruthy();
+    expect(existsSync(sessionFile)).toBe(true);
+  });
 });

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -3,40 +3,40 @@ import { formatRunStatus } from "../extensions/status.js";
 import { createEmptyRun, createWorkerRecord } from "../extensions/storage.js";
 
 describe("formatRunStatus", () => {
-	it("formats an empty run", () => {
-		const run = createEmptyRun("abc", "/tmp/repo");
-		const text = formatRunStatus(run);
-		expect(text).toContain("projectKey: abc");
-		expect(text).toContain("workers: 0");
-	});
+  it("formats an empty run", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const text = formatRunStatus(run);
+    expect(text).toContain("projectKey: abc");
+    expect(text).toContain("workers: 0");
+  });
 
-	it("includes task, session, pr, and summary staleness details", () => {
-		const run = createEmptyRun("abc", "/tmp/repo");
-		const worker = createWorkerRecord({
-			workerId: "worker-1",
-			name: "backend",
-			branch: "conductor/backend",
-			worktreePath: "/tmp/repo/.worktrees/backend",
-			sessionFile: "/tmp/session.jsonl",
-		});
-		worker.currentTask = "implement status command";
-		worker.summary.text = "Half done";
-		worker.summary.stale = true;
-		worker.pr.url = "https://github.com/example/repo/pull/123";
+  it("includes task, session, pr, and summary staleness details", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    worker.currentTask = "implement status command";
+    worker.summary.text = "Half done";
+    worker.summary.stale = true;
+    worker.pr.url = "https://github.com/example/repo/pull/123";
 
-		worker.pr.commitSucceeded = true;
-		worker.pr.pushSucceeded = true;
-		worker.pr.prCreationAttempted = true;
+    worker.pr.commitSucceeded = true;
+    worker.pr.pushSucceeded = true;
+    worker.pr.prCreationAttempted = true;
 
-		const text = formatRunStatus({ ...run, workers: [worker] });
-		expect(text).toContain("health=stale");
-		expect(text).toContain("task=implement status command");
-		expect(text).toContain("session=/tmp/session.jsonl");
-		expect(text).toContain("pr=https://github.com/example/repo/pull/123");
-		expect(text).toContain("commit=true");
-		expect(text).toContain("push=true");
-		expect(text).toContain("prAttempted=true");
-		expect(text).toContain("recoverable=false");
-		expect(text).toContain("summary=stale: Half done");
-	});
+    const text = formatRunStatus({ ...run, workers: [worker] });
+    expect(text).toContain("health=stale");
+    expect(text).toContain("task=implement status command");
+    expect(text).toContain("session=/tmp/session.jsonl");
+    expect(text).toContain("pr=https://github.com/example/repo/pull/123");
+    expect(text).toContain("commit=true");
+    expect(text).toContain("push=true");
+    expect(text).toContain("prAttempted=true");
+    expect(text).toContain("recoverable=false");
+    expect(text).toContain("summary=stale: Half done");
+  });
 });

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -2,74 +2,74 @@ import { describe, expect, it } from "vitest";
 import { addWorker, createEmptyRun, createWorkerRecord, getConductorProjectDir } from "../extensions/storage.js";
 
 describe("storage helpers", () => {
-	it("creates an empty run", () => {
-		const run = createEmptyRun("abc", "/tmp/repo");
-		expect(run.projectKey).toBe("abc");
-		expect(run.repoRoot).toBe("/tmp/repo");
-		expect(run.workers).toEqual([]);
-	});
+  it("creates an empty run", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    expect(run.projectKey).toBe("abc");
+    expect(run.repoRoot).toBe("/tmp/repo");
+    expect(run.workers).toEqual([]);
+  });
 
-	it("builds a conductor project dir", () => {
-		const dir = getConductorProjectDir("abc");
-		expect(dir).toContain(".pi/agent/conductor/projects/abc");
-	});
+  it("builds a conductor project dir", () => {
+    const dir = getConductorProjectDir("abc");
+    expect(dir).toContain(".pi/agent/conductor/projects/abc");
+  });
 
-	it("creates a worker record with default lifecycle metadata", () => {
-		const worker = createWorkerRecord({
-			workerId: "worker-1",
-			name: "backend",
-			branch: "conductor/backend",
-			worktreePath: "/tmp/repo/.worktrees/backend",
-			sessionFile: null,
-		});
+  it("creates a worker record with default lifecycle metadata", () => {
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
 
-		expect(worker.workerId).toBe("worker-1");
-		expect(worker.name).toBe("backend");
-		expect(worker.lifecycle).toBe("idle");
-		expect(worker.currentTask).toBeNull();
-		expect(worker.recoverable).toBe(false);
-		expect(worker.summary.stale).toBe(false);
-		expect(worker.pr.prCreationAttempted).toBe(false);
-	});
+    expect(worker.workerId).toBe("worker-1");
+    expect(worker.name).toBe("backend");
+    expect(worker.lifecycle).toBe("idle");
+    expect(worker.currentTask).toBeNull();
+    expect(worker.recoverable).toBe(false);
+    expect(worker.summary.stale).toBe(false);
+    expect(worker.pr.prCreationAttempted).toBe(false);
+  });
 
-	it("adds a worker and updates the run timestamp", () => {
-		const run = createEmptyRun("abc", "/tmp/repo");
-		const worker = createWorkerRecord({
-			workerId: "worker-1",
-			name: "backend",
-			branch: "conductor/backend",
-			worktreePath: "/tmp/repo/.worktrees/backend",
-			sessionFile: null,
-		});
+  it("adds a worker and updates the run timestamp", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
 
-		const updated = addWorker(run, worker);
-		expect(updated.workers).toHaveLength(1);
-		expect(updated.workers[0]?.name).toBe("backend");
-		expect(updated.updatedAt >= run.updatedAt).toBe(true);
-	});
+    const updated = addWorker(run, worker);
+    expect(updated.workers).toHaveLength(1);
+    expect(updated.workers[0]?.name).toBe("backend");
+    expect(updated.updatedAt >= run.updatedAt).toBe(true);
+  });
 
-	it("rejects duplicate worker names within a project", () => {
-		const run = createEmptyRun("abc", "/tmp/repo");
-		const worker = createWorkerRecord({
-			workerId: "worker-1",
-			name: "backend",
-			branch: "conductor/backend",
-			worktreePath: "/tmp/repo/.worktrees/backend",
-			sessionFile: null,
-		});
+  it("rejects duplicate worker names within a project", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
 
-		const updated = addWorker(run, worker);
-		expect(() =>
-			addWorker(
-				updated,
-				createWorkerRecord({
-					workerId: "worker-2",
-					name: "backend",
-					branch: "conductor/backend-2",
-					worktreePath: "/tmp/repo/.worktrees/backend-2",
-					sessionFile: null,
-				}),
-			),
-		).toThrow(/already exists/i);
-	});
+    const updated = addWorker(run, worker);
+    expect(() =>
+      addWorker(
+        updated,
+        createWorkerRecord({
+          workerId: "worker-2",
+          name: "backend",
+          branch: "conductor/backend-2",
+          worktreePath: "/tmp/repo/.worktrees/backend-2",
+          sessionFile: null,
+        }),
+      ),
+    ).toThrow(/already exists/i);
+  });
 });

--- a/packages/pi-conductor/__tests__/summaries.test.ts
+++ b/packages/pi-conductor/__tests__/summaries.test.ts
@@ -5,52 +5,52 @@ import { afterEach, describe, expect, it } from "vitest";
 import { generateWorkerSummaryFromSession } from "../extensions/summaries.js";
 
 describe("generateWorkerSummaryFromSession", () => {
-	const tempDirs: string[] = [];
+  const tempDirs: string[] = [];
 
-	afterEach(() => {
-		for (const dir of tempDirs.splice(0)) {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
-	it("extracts text from a persisted pi session file", () => {
-		const dir = mkdtempSync(join(tmpdir(), "pi-conductor-summary-"));
-		tempDirs.push(dir);
-		const sessionFile = join(dir, "worker.jsonl");
-		writeFileSync(
-			sessionFile,
-			`${[
-				JSON.stringify({
-					type: "session",
-					version: 3,
-					id: "session-1",
-					timestamp: "2026-01-01T00:00:00.000Z",
-					cwd: "/tmp/repo",
-				}),
-				JSON.stringify({
-					type: "message",
-					id: "u1",
-					parentId: null,
-					timestamp: "2026-01-01T00:00:01.000Z",
-					message: { role: "user", content: "Implement status output" },
-				}),
-				JSON.stringify({
-					type: "message",
-					id: "a1",
-					parentId: "u1",
-					timestamp: "2026-01-01T00:00:02.000Z",
-					message: {
-						role: "assistant",
-						content: [{ type: "text", text: "Added status output and worker recovery handling." }],
-					},
-				}),
-			].join("\n")}
+  it("extracts text from a persisted pi session file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-conductor-summary-"));
+    tempDirs.push(dir);
+    const sessionFile = join(dir, "worker.jsonl");
+    writeFileSync(
+      sessionFile,
+      `${[
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          cwd: "/tmp/repo",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          parentId: null,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          message: { role: "user", content: "Implement status output" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          timestamp: "2026-01-01T00:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Added status output and worker recovery handling." }],
+          },
+        }),
+      ].join("\n")}
 `,
-			"utf-8",
-		);
+      "utf-8",
+    );
 
-		expect(generateWorkerSummaryFromSession(sessionFile)).toBe(
-			"Implement status output | Added status output and worker recovery handling.",
-		);
-	});
+    expect(generateWorkerSummaryFromSession(sessionFile)).toBe(
+      "Implement status output | Added status output and worker recovery handling.",
+    );
+  });
 });

--- a/packages/pi-conductor/__tests__/workers.test.ts
+++ b/packages/pi-conductor/__tests__/workers.test.ts
@@ -3,37 +3,37 @@ import { createEmptyRun, createWorkerRecord, setWorkerTask } from "../extensions
 import { buildBranchName, createWorkerId, normalizeWorkerSlug } from "../extensions/workers.js";
 
 describe("worker helpers", () => {
-	it("normalizes worker names into branch-safe slugs", () => {
-		expect(normalizeWorkerSlug("Fix Auth")).toBe("fix-auth");
-		expect(normalizeWorkerSlug("frontend/api")).toBe("frontend-api");
-		expect(normalizeWorkerSlug("***")).toBeNull();
-	});
+  it("normalizes worker names into branch-safe slugs", () => {
+    expect(normalizeWorkerSlug("Fix Auth")).toBe("fix-auth");
+    expect(normalizeWorkerSlug("frontend/api")).toBe("frontend-api");
+    expect(normalizeWorkerSlug("***")).toBeNull();
+  });
 
-	it("builds a branch name from a normalized worker slug", () => {
-		expect(buildBranchName("worker-1", "Fix Auth")).toBe("conductor/fix-auth");
-		expect(buildBranchName("worker-1", "***")).toBe("conductor/worker-1");
-	});
+  it("builds a branch name from a normalized worker slug", () => {
+    expect(buildBranchName("worker-1", "Fix Auth")).toBe("conductor/fix-auth");
+    expect(buildBranchName("worker-1", "***")).toBe("conductor/worker-1");
+  });
 
-	it("creates stable-enough worker ids with conductor prefix", () => {
-		const id = createWorkerId();
-		expect(id.startsWith("worker-")).toBe(true);
-		expect(id.length).toBeGreaterThan(10);
-	});
+  it("creates stable-enough worker ids with conductor prefix", () => {
+    const id = createWorkerId();
+    expect(id.startsWith("worker-")).toBe(true);
+    expect(id.length).toBeGreaterThan(10);
+  });
 
-	it("updating a task marks an existing summary as stale", () => {
-		const run = createEmptyRun("abc", "/tmp/repo");
-		const worker = createWorkerRecord({
-			workerId: "worker-1",
-			name: "backend",
-			branch: "conductor/backend",
-			worktreePath: "/tmp/repo/.worktrees/backend",
-			sessionFile: "/tmp/session.jsonl",
-		});
-		worker.summary.text = "Current progress";
-		worker.summary.updatedAt = new Date().toISOString();
+  it("updating a task marks an existing summary as stale", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    worker.summary.text = "Current progress";
+    worker.summary.updatedAt = new Date().toISOString();
 
-		const updated = setWorkerTask({ ...run, workers: [worker] }, "worker-1", "implement status command");
-		expect(updated.workers[0]?.currentTask).toBe("implement status command");
-		expect(updated.workers[0]?.summary.stale).toBe(true);
-	});
+    const updated = setWorkerTask({ ...run, workers: [worker] }, "worker-1", "implement status command");
+    expect(updated.workers[0]?.currentTask).toBe("implement status command");
+    expect(updated.workers[0]?.summary.stale).toBe(true);
+  });
 });

--- a/packages/pi-conductor/__tests__/worktrees.test.ts
+++ b/packages/pi-conductor/__tests__/worktrees.test.ts
@@ -3,75 +3,75 @@ import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-	createManagedWorktree,
-	getCurrentBranch,
-	planWorktreePath,
-	recreateManagedWorktree,
+  createManagedWorktree,
+  getCurrentBranch,
+  planWorktreePath,
+  recreateManagedWorktree,
 } from "../extensions/worktrees.js";
 
 describe("worktree helpers", () => {
-	let tempDir: string;
+  let tempDir: string;
 
-	beforeEach(() => {
-		tempDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-		execSync("git init -b main", { cwd: tempDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: tempDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: tempDir, stdio: "pipe" });
-		writeFileSync(join(tempDir, "README.md"), "hello");
-		execSync("git add README.md", { cwd: tempDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: tempDir, stdio: "pipe" });
-	});
+  beforeEach(() => {
+    tempDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    execSync("git init -b main", { cwd: tempDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: tempDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: tempDir, stdio: "pipe" });
+    writeFileSync(join(tempDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: tempDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: tempDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		if (tempDir && existsSync(tempDir)) {
-			rmSync(tempDir, { recursive: true, force: true });
-		}
-		const siblingRoot = join(tempDir, "..", ".pi-conductor-worktrees", basename(tempDir));
-		if (existsSync(siblingRoot)) {
-			rmSync(siblingRoot, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+    const siblingRoot = join(tempDir, "..", ".pi-conductor-worktrees", basename(tempDir));
+    if (existsSync(siblingRoot)) {
+      rmSync(siblingRoot, { recursive: true, force: true });
+    }
+  });
 
-	it("gets the current branch from a repo root", () => {
-		expect(getCurrentBranch(tempDir)).toBe("main");
-	});
+  it("gets the current branch from a repo root", () => {
+    expect(getCurrentBranch(tempDir)).toBe("main");
+  });
 
-	it("plans a worktree path outside the repo root", () => {
-		const path = planWorktreePath(tempDir, "backend");
-		expect(path).toContain(`.pi-conductor-worktrees/${basename(tempDir)}`);
-		expect(path).toContain("backend");
-		expect(path.startsWith(tempDir)).toBe(false);
-	});
+  it("plans a worktree path outside the repo root", () => {
+    const path = planWorktreePath(tempDir, "backend");
+    expect(path).toContain(`.pi-conductor-worktrees/${basename(tempDir)}`);
+    expect(path).toContain("backend");
+    expect(path.startsWith(tempDir)).toBe(false);
+  });
 
-	it("creates a managed worktree on a conductor branch", () => {
-		const result = createManagedWorktree(tempDir, {
-			workerId: "worker-1",
-			workerName: "backend",
-		});
+  it("creates a managed worktree on a conductor branch", () => {
+    const result = createManagedWorktree(tempDir, {
+      workerId: "worker-1",
+      workerName: "backend",
+    });
 
-		expect(result.branch).toBe("conductor/backend");
-		expect(existsSync(result.worktreePath)).toBe(true);
+    expect(result.branch).toBe("conductor/backend");
+    expect(existsSync(result.worktreePath)).toBe(true);
 
-		const branch = execSync("git branch --show-current", {
-			cwd: result.worktreePath,
-			encoding: "utf-8",
-		}).trim();
-		expect(branch).toBe("conductor/backend");
-	});
+    const branch = execSync("git branch --show-current", {
+      cwd: result.worktreePath,
+      encoding: "utf-8",
+    }).trim();
+    expect(branch).toBe("conductor/backend");
+  });
 
-	it("recreates a pruned managed worktree on an existing branch", () => {
-		const created = createManagedWorktree(tempDir, {
-			workerId: "worker-1",
-			workerName: "backend",
-		});
-		rmSync(created.worktreePath, { recursive: true, force: true });
+  it("recreates a pruned managed worktree on an existing branch", () => {
+    const created = createManagedWorktree(tempDir, {
+      workerId: "worker-1",
+      workerName: "backend",
+    });
+    rmSync(created.worktreePath, { recursive: true, force: true });
 
-		const recreated = recreateManagedWorktree(tempDir, {
-			workerName: "backend",
-			branch: created.branch,
-		});
+    const recreated = recreateManagedWorktree(tempDir, {
+      workerName: "backend",
+      branch: created.branch,
+    });
 
-		expect(recreated.branch).toBe(created.branch);
-		expect(existsSync(recreated.worktreePath)).toBe(true);
-	});
+    expect(recreated.branch).toBe(created.branch);
+    expect(existsSync(recreated.worktreePath)).toBe(true);
+  });
 });

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -1,129 +1,129 @@
 import {
-	commitWorkerForRepo,
-	createWorkerForRepo,
-	createWorkerPrForRepo,
-	getOrCreateRunForRepo,
-	pushWorkerForRepo,
-	reconcileWorkerHealth,
-	recoverWorkerForRepo,
-	refreshWorkerSummaryForRepo,
-	removeWorkerForRepo,
-	resumeWorkerForRepo,
-	updateWorkerLifecycleForRepo,
-	updateWorkerTaskForRepo,
+  commitWorkerForRepo,
+  createWorkerForRepo,
+  createWorkerPrForRepo,
+  getOrCreateRunForRepo,
+  pushWorkerForRepo,
+  reconcileWorkerHealth,
+  recoverWorkerForRepo,
+  refreshWorkerSummaryForRepo,
+  removeWorkerForRepo,
+  resumeWorkerForRepo,
+  updateWorkerLifecycleForRepo,
+  updateWorkerTaskForRepo,
 } from "./conductor.js";
 import { formatRunStatus } from "./status.js";
 
 function getUsage(): string {
-	return [
-		"usage:",
-		"  /conductor status",
-		"  /conductor start <worker-name>",
-		"  /conductor task <worker-name> <task>",
-		"  /conductor resume <worker-name>",
-		"  /conductor state <worker-name> <lifecycle>",
-		"  /conductor recover <worker-name>",
-		"  /conductor summarize <worker-name>",
-		"  /conductor cleanup <worker-name>",
-		"  /conductor commit <worker-name> <message>",
-		"  /conductor push <worker-name>",
-		"  /conductor pr <worker-name> <title>",
-	].join("\n");
+  return [
+    "usage:",
+    "  /conductor status",
+    "  /conductor start <worker-name>",
+    "  /conductor task <worker-name> <task>",
+    "  /conductor resume <worker-name>",
+    "  /conductor state <worker-name> <lifecycle>",
+    "  /conductor recover <worker-name>",
+    "  /conductor summarize <worker-name>",
+    "  /conductor cleanup <worker-name>",
+    "  /conductor commit <worker-name> <message>",
+    "  /conductor push <worker-name>",
+    "  /conductor pr <worker-name> <title>",
+  ].join("\n");
 }
 
 export async function runConductorCommand(cwd: string, args: string): Promise<string> {
-	const trimmed = args.trim();
-	if (!trimmed || trimmed === "help") {
-		return getUsage();
-	}
+  const trimmed = args.trim();
+  if (!trimmed || trimmed === "help") {
+    return getUsage();
+  }
 
-	const [subcommand, ...rest] = trimmed.split(/\s+/);
-	if (subcommand === "status") {
-		return formatRunStatus(reconcileWorkerHealth(getOrCreateRunForRepo(cwd)));
-	}
-	if (subcommand === "start") {
-		const workerName = rest.join(" ").trim();
-		if (!workerName) {
-			return `${getUsage()}\n\nerror: missing worker name`;
-		}
-		const worker = await createWorkerForRepo(cwd, workerName);
-		return `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}`;
-	}
-	if (subcommand === "task") {
-		const [workerName, ...taskParts] = rest;
-		const task = taskParts.join(" ").trim();
-		if (!workerName || !task) {
-			return `${getUsage()}\n\nerror: missing worker name or task`;
-		}
-		const worker = updateWorkerTaskForRepo(cwd, workerName, task);
-		return `updated task for ${worker.name}: ${worker.currentTask}`;
-	}
-	if (subcommand === "resume") {
-		const workerName = rest.join(" ").trim();
-		if (!workerName) {
-			return `${getUsage()}\n\nerror: missing worker name`;
-		}
-		const worker = resumeWorkerForRepo(cwd, workerName);
-		return `resumed worker ${worker.name}: session=${worker.sessionFile}`;
-	}
-	if (subcommand === "state") {
-		const [workerName, lifecycle] = rest;
-		if (!workerName || !lifecycle) {
-			return `${getUsage()}\n\nerror: missing worker name or lifecycle state`;
-		}
-		const worker = updateWorkerLifecycleForRepo(cwd, workerName, lifecycle as never);
-		return `updated worker ${worker.name} state to ${worker.lifecycle}`;
-	}
-	if (subcommand === "recover") {
-		const workerName = rest.join(" ").trim();
-		if (!workerName) {
-			return `${getUsage()}\n\nerror: missing worker name`;
-		}
-		const worker = await recoverWorkerForRepo(cwd, workerName);
-		return `recovered worker ${worker.name}: session=${worker.sessionFile}`;
-	}
-	if (subcommand === "summarize") {
-		const workerName = rest.join(" ").trim();
-		if (!workerName) {
-			return `${getUsage()}\n\nerror: missing worker name`;
-		}
-		const worker = refreshWorkerSummaryForRepo(cwd, workerName);
-		return `refreshed summary for ${worker.name}: ${worker.summary.text}`;
-	}
-	if (subcommand === "cleanup") {
-		const workerName = rest.join(" ").trim();
-		if (!workerName) {
-			return `${getUsage()}\n\nerror: missing worker name`;
-		}
-		const worker = removeWorkerForRepo(cwd, workerName);
-		return `removed worker ${worker.name} [${worker.workerId}]`;
-	}
-	if (subcommand === "commit") {
-		const [workerName, ...messageParts] = rest;
-		const message = messageParts.join(" ").trim();
-		if (!workerName || !message) {
-			return `${getUsage()}\n\nerror: missing worker name or commit message`;
-		}
-		const worker = commitWorkerForRepo(cwd, workerName, message);
-		return `committed worker ${worker.name}: ${message}`;
-	}
-	if (subcommand === "push") {
-		const workerName = rest.join(" ").trim();
-		if (!workerName) {
-			return `${getUsage()}\n\nerror: missing worker name`;
-		}
-		const worker = pushWorkerForRepo(cwd, workerName);
-		return `pushed worker ${worker.name} on branch ${worker.branch}`;
-	}
-	if (subcommand === "pr") {
-		const [workerName, ...titleParts] = rest;
-		const title = titleParts.join(" ").trim();
-		if (!workerName || !title) {
-			return `${getUsage()}\n\nerror: missing worker name or PR title`;
-		}
-		const worker = createWorkerPrForRepo(cwd, workerName, title);
-		return `created PR for ${worker.name}: ${worker.pr.url}`;
-	}
+  const [subcommand, ...rest] = trimmed.split(/\s+/);
+  if (subcommand === "status") {
+    return formatRunStatus(reconcileWorkerHealth(getOrCreateRunForRepo(cwd)));
+  }
+  if (subcommand === "start") {
+    const workerName = rest.join(" ").trim();
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    const worker = await createWorkerForRepo(cwd, workerName);
+    return `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}`;
+  }
+  if (subcommand === "task") {
+    const [workerName, ...taskParts] = rest;
+    const task = taskParts.join(" ").trim();
+    if (!workerName || !task) {
+      return `${getUsage()}\n\nerror: missing worker name or task`;
+    }
+    const worker = updateWorkerTaskForRepo(cwd, workerName, task);
+    return `updated task for ${worker.name}: ${worker.currentTask}`;
+  }
+  if (subcommand === "resume") {
+    const workerName = rest.join(" ").trim();
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    const worker = resumeWorkerForRepo(cwd, workerName);
+    return `resumed worker ${worker.name}: session=${worker.sessionFile}`;
+  }
+  if (subcommand === "state") {
+    const [workerName, lifecycle] = rest;
+    if (!workerName || !lifecycle) {
+      return `${getUsage()}\n\nerror: missing worker name or lifecycle state`;
+    }
+    const worker = updateWorkerLifecycleForRepo(cwd, workerName, lifecycle as never);
+    return `updated worker ${worker.name} state to ${worker.lifecycle}`;
+  }
+  if (subcommand === "recover") {
+    const workerName = rest.join(" ").trim();
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    const worker = await recoverWorkerForRepo(cwd, workerName);
+    return `recovered worker ${worker.name}: session=${worker.sessionFile}`;
+  }
+  if (subcommand === "summarize") {
+    const workerName = rest.join(" ").trim();
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    const worker = refreshWorkerSummaryForRepo(cwd, workerName);
+    return `refreshed summary for ${worker.name}: ${worker.summary.text}`;
+  }
+  if (subcommand === "cleanup") {
+    const workerName = rest.join(" ").trim();
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    const worker = removeWorkerForRepo(cwd, workerName);
+    return `removed worker ${worker.name} [${worker.workerId}]`;
+  }
+  if (subcommand === "commit") {
+    const [workerName, ...messageParts] = rest;
+    const message = messageParts.join(" ").trim();
+    if (!workerName || !message) {
+      return `${getUsage()}\n\nerror: missing worker name or commit message`;
+    }
+    const worker = commitWorkerForRepo(cwd, workerName, message);
+    return `committed worker ${worker.name}: ${message}`;
+  }
+  if (subcommand === "push") {
+    const workerName = rest.join(" ").trim();
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    const worker = pushWorkerForRepo(cwd, workerName);
+    return `pushed worker ${worker.name} on branch ${worker.branch}`;
+  }
+  if (subcommand === "pr") {
+    const [workerName, ...titleParts] = rest;
+    const title = titleParts.join(" ").trim();
+    if (!workerName || !title) {
+      return `${getUsage()}\n\nerror: missing worker name or PR title`;
+    }
+    const worker = createWorkerPrForRepo(cwd, workerName, title);
+    return `created PR for ${worker.name}: ${worker.pr.url}`;
+  }
 
-	return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;
+  return `${getUsage()}\n\nerror: unknown subcommand '${subcommand}'`;
 }

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,302 +1,302 @@
 import { existsSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import {
-	commitAllChanges,
-	createPullRequest,
-	pushBranchToOrigin,
-	validatePrPreconditions,
-	validatePushPreconditions,
+  commitAllChanges,
+  createPullRequest,
+  pushBranchToOrigin,
+  validatePrPreconditions,
+  validatePushPreconditions,
 } from "./git-pr.js";
 import { deriveProjectKey } from "./project-key.js";
 import { createWorkerSessionLink } from "./sessions.js";
 import {
-	addWorker,
-	createEmptyRun,
-	createWorkerRecord,
-	readRun,
-	removeWorker,
-	setWorkerLifecycle,
-	setWorkerPrState,
-	setWorkerSummary,
-	setWorkerTask,
-	writeRun,
+  addWorker,
+  createEmptyRun,
+  createWorkerRecord,
+  readRun,
+  removeWorker,
+  setWorkerLifecycle,
+  setWorkerPrState,
+  setWorkerSummary,
+  setWorkerTask,
+  writeRun,
 } from "./storage.js";
 import { generateWorkerSummaryFromSession } from "./summaries.js";
 import type { RunRecord, WorkerLifecycleState, WorkerRecord } from "./types.js";
 import { createWorkerId } from "./workers.js";
 import {
-	createManagedWorktree,
-	recreateManagedWorktree,
-	removeManagedBranch,
-	removeManagedWorktree,
+  createManagedWorktree,
+  recreateManagedWorktree,
+  removeManagedBranch,
+  removeManagedWorktree,
 } from "./worktrees.js";
 
 export function getOrCreateRunForRepo(repoRoot: string): RunRecord {
-	const normalizedRoot = resolve(repoRoot);
-	const projectKey = deriveProjectKey(normalizedRoot);
-	const existing = readRun(projectKey);
-	if (existing) {
-		return existing;
-	}
-	const run = createEmptyRun(projectKey, normalizedRoot);
-	writeRun(run);
-	return run;
+  const normalizedRoot = resolve(repoRoot);
+  const projectKey = deriveProjectKey(normalizedRoot);
+  const existing = readRun(projectKey);
+  if (existing) {
+    return existing;
+  }
+  const run = createEmptyRun(projectKey, normalizedRoot);
+  writeRun(run);
+  return run;
 }
 
 export async function createWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const workerId = createWorkerId();
-	const worktree = createManagedWorktree(run.repoRoot, {
-		workerId,
-		workerName,
-	});
-	const sessionFile = await createWorkerSessionLink(worktree.worktreePath);
-	const worker = createWorkerRecord({
-		workerId,
-		name: workerName,
-		branch: worktree.branch,
-		worktreePath: worktree.worktreePath,
-		sessionFile,
-	});
-	const updatedRun = addWorker(run, worker);
-	writeRun(updatedRun);
-	return worker;
+  const run = getOrCreateRunForRepo(repoRoot);
+  const workerId = createWorkerId();
+  const worktree = createManagedWorktree(run.repoRoot, {
+    workerId,
+    workerName,
+  });
+  const sessionFile = await createWorkerSessionLink(worktree.worktreePath);
+  const worker = createWorkerRecord({
+    workerId,
+    name: workerName,
+    branch: worktree.branch,
+    worktreePath: worktree.worktreePath,
+    sessionFile,
+  });
+  const updatedRun = addWorker(run, worker);
+  writeRun(updatedRun);
+  return worker;
 }
 
 export function updateWorkerTaskForRepo(repoRoot: string, workerName: string, task: string): WorkerRecord {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	const updatedRun = setWorkerLifecycle(setWorkerTask(run, worker.workerId, task), worker.workerId, "idle");
-	writeRun(updatedRun);
-	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
-	if (!updatedWorker) {
-		throw new Error(`Worker named ${workerName} disappeared during task update`);
-	}
-	return updatedWorker;
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  const updatedRun = setWorkerLifecycle(setWorkerTask(run, worker.workerId, task), worker.workerId, "idle");
+  writeRun(updatedRun);
+  const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+  if (!updatedWorker) {
+    throw new Error(`Worker named ${workerName} disappeared during task update`);
+  }
+  return updatedWorker;
 }
 
 export function resumeWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
-	const run = reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot));
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	if (worker.lifecycle === "broken") {
-		throw new Error(`Worker named ${workerName} is broken and must be recovered before resume`);
-	}
-	return worker;
+  const run = reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot));
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (worker.lifecycle === "broken") {
+    throw new Error(`Worker named ${workerName} is broken and must be recovered before resume`);
+  }
+  return worker;
 }
 
 export function updateWorkerLifecycleForRepo(
-	repoRoot: string,
-	workerName: string,
-	lifecycle: WorkerLifecycleState,
+  repoRoot: string,
+  workerName: string,
+  lifecycle: WorkerLifecycleState,
 ): WorkerRecord {
-	if (lifecycle === "broken") {
-		throw new Error("Broken lifecycle is reserved for detected health failures");
-	}
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	const updatedRun = setWorkerLifecycle(run, worker.workerId, lifecycle);
-	writeRun(updatedRun);
-	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
-	if (!updatedWorker) {
-		throw new Error(`Worker named ${workerName} disappeared during lifecycle update`);
-	}
-	return updatedWorker;
+  if (lifecycle === "broken") {
+    throw new Error("Broken lifecycle is reserved for detected health failures");
+  }
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  const updatedRun = setWorkerLifecycle(run, worker.workerId, lifecycle);
+  writeRun(updatedRun);
+  const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+  if (!updatedWorker) {
+    throw new Error(`Worker named ${workerName} disappeared during lifecycle update`);
+  }
+  return updatedWorker;
 }
 
 export function reconcileWorkerHealth(run: RunRecord): RunRecord {
-	const workers = run.workers.map((worker) => {
-		const worktreeMissing = !worker.worktreePath || !existsSync(worker.worktreePath);
-		const sessionMissing = !worker.sessionFile || !existsSync(worker.sessionFile);
-		if (!worktreeMissing && !sessionMissing) {
-			return worker;
-		}
-		return {
-			...worker,
-			lifecycle: "broken" as const,
-			recoverable: true,
-			updatedAt: new Date().toISOString(),
-		};
-	});
-	return {
-		...run,
-		workers,
-		updatedAt: new Date().toISOString(),
-	};
+  const workers = run.workers.map((worker) => {
+    const worktreeMissing = !worker.worktreePath || !existsSync(worker.worktreePath);
+    const sessionMissing = !worker.sessionFile || !existsSync(worker.sessionFile);
+    if (!worktreeMissing && !sessionMissing) {
+      return worker;
+    }
+    return {
+      ...worker,
+      lifecycle: "broken" as const,
+      recoverable: true,
+      updatedAt: new Date().toISOString(),
+    };
+  });
+  return {
+    ...run,
+    workers,
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 export function refreshWorkerSummaryForRepo(repoRoot: string, workerName: string): WorkerRecord {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	if (!worker.sessionFile || !existsSync(worker.sessionFile)) {
-		throw new Error(`Worker named ${workerName} does not have a valid session file`);
-	}
-	const summaryText = generateWorkerSummaryFromSession(worker.sessionFile);
-	const updatedRun = setWorkerSummary(run, worker.workerId, summaryText);
-	writeRun(updatedRun);
-	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
-	if (!updatedWorker) {
-		throw new Error(`Worker named ${workerName} disappeared during summary refresh`);
-	}
-	return updatedWorker;
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (!worker.sessionFile || !existsSync(worker.sessionFile)) {
+    throw new Error(`Worker named ${workerName} does not have a valid session file`);
+  }
+  const summaryText = generateWorkerSummaryFromSession(worker.sessionFile);
+  const updatedRun = setWorkerSummary(run, worker.workerId, summaryText);
+  writeRun(updatedRun);
+  const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+  if (!updatedWorker) {
+    throw new Error(`Worker named ${workerName} disappeared during summary refresh`);
+  }
+  return updatedWorker;
 }
 
 export function removeWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	if (worker.worktreePath && existsSync(worker.worktreePath)) {
-		removeManagedWorktree(run.repoRoot, worker.worktreePath);
-	}
-	if (worker.sessionFile && existsSync(worker.sessionFile)) {
-		rmSync(worker.sessionFile, { force: true });
-	}
-	if (worker.branch) {
-		removeManagedBranch(run.repoRoot, worker.branch);
-	}
-	const updatedRun = removeWorker(run, worker.workerId);
-	writeRun(updatedRun);
-	return worker;
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (worker.worktreePath && existsSync(worker.worktreePath)) {
+    removeManagedWorktree(run.repoRoot, worker.worktreePath);
+  }
+  if (worker.sessionFile && existsSync(worker.sessionFile)) {
+    rmSync(worker.sessionFile, { force: true });
+  }
+  if (worker.branch) {
+    removeManagedBranch(run.repoRoot, worker.branch);
+  }
+  const updatedRun = removeWorker(run, worker.workerId);
+  writeRun(updatedRun);
+  return worker;
 }
 
 export function commitWorkerForRepo(repoRoot: string, workerName: string, message: string): WorkerRecord {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
-		throw new Error(`Worker named ${workerName} does not have a valid worktree`);
-	}
-	commitAllChanges(worker.worktreePath, message);
-	const updatedRun = setWorkerPrState(run, worker.workerId, {
-		commitSucceeded: true,
-		pushSucceeded: false,
-		prCreationAttempted: false,
-		url: null,
-		number: null,
-	});
-	writeRun(updatedRun);
-	return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
+    throw new Error(`Worker named ${workerName} does not have a valid worktree`);
+  }
+  commitAllChanges(worker.worktreePath, message);
+  const updatedRun = setWorkerPrState(run, worker.workerId, {
+    commitSucceeded: true,
+    pushSucceeded: false,
+    prCreationAttempted: false,
+    url: null,
+    number: null,
+  });
+  writeRun(updatedRun);
+  return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
 }
 
 export function pushWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
-		throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
-	}
-	validatePushPreconditions(run.repoRoot);
-	pushBranchToOrigin(worker.worktreePath, worker.branch);
-	const updatedRun = setWorkerPrState(run, worker.workerId, {
-		pushSucceeded: true,
-	});
-	writeRun(updatedRun);
-	return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
+    throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
+  }
+  validatePushPreconditions(run.repoRoot);
+  pushBranchToOrigin(worker.worktreePath, worker.branch);
+  const updatedRun = setWorkerPrState(run, worker.workerId, {
+    pushSucceeded: true,
+  });
+  writeRun(updatedRun);
+  return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
 }
 
 export function createWorkerPrForRepo(
-	repoRoot: string,
-	workerName: string,
-	title: string,
-	body?: string,
+  repoRoot: string,
+  workerName: string,
+  title: string,
+  body?: string,
 ): WorkerRecord {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
-	if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
-		throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
-	}
-	validatePrPreconditions(run.repoRoot);
-	const prBody = body?.trim() || worker.summary.text || worker.currentTask || `PR for ${worker.name}`;
-	try {
-		const pr = createPullRequest({
-			repoRoot: run.repoRoot,
-			worktreePath: worker.worktreePath,
-			branch: worker.branch,
-			title,
-			body: prBody,
-		});
-		const updatedRun = setWorkerPrState(run, worker.workerId, {
-			prCreationAttempted: true,
-			url: pr.url,
-			number: pr.number,
-		});
-		writeRun(updatedRun);
-		return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
-	} catch (error) {
-		const updatedRun = setWorkerPrState(run, worker.workerId, {
-			prCreationAttempted: true,
-			url: null,
-			number: null,
-		});
-		writeRun(updatedRun);
-		throw error;
-	}
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (!worker.worktreePath || !existsSync(worker.worktreePath) || !worker.branch) {
+    throw new Error(`Worker named ${workerName} does not have a valid worktree or branch`);
+  }
+  validatePrPreconditions(run.repoRoot);
+  const prBody = body?.trim() || worker.summary.text || worker.currentTask || `PR for ${worker.name}`;
+  try {
+    const pr = createPullRequest({
+      repoRoot: run.repoRoot,
+      worktreePath: worker.worktreePath,
+      branch: worker.branch,
+      title,
+      body: prBody,
+    });
+    const updatedRun = setWorkerPrState(run, worker.workerId, {
+      prCreationAttempted: true,
+      url: pr.url,
+      number: pr.number,
+    });
+    writeRun(updatedRun);
+    return updatedRun.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+  } catch (error) {
+    const updatedRun = setWorkerPrState(run, worker.workerId, {
+      prCreationAttempted: true,
+      url: null,
+      number: null,
+    });
+    writeRun(updatedRun);
+    throw error;
+  }
 }
 
 export async function recoverWorkerForRepo(repoRoot: string, workerName: string): Promise<WorkerRecord> {
-	const run = getOrCreateRunForRepo(repoRoot);
-	const worker = run.workers.find((entry) => entry.name === workerName);
-	if (!worker) {
-		throw new Error(`Worker named ${workerName} not found`);
-	}
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
 
-	let worktreePath = worker.worktreePath;
-	if (!worktreePath || !existsSync(worktreePath)) {
-		if (!worker.branch) {
-			throw new Error(`Worker named ${workerName} cannot be recovered without a valid branch`);
-		}
-		worktreePath = recreateManagedWorktree(run.repoRoot, {
-			workerName: worker.name,
-			branch: worker.branch,
-		}).worktreePath;
-	}
+  let worktreePath = worker.worktreePath;
+  if (!worktreePath || !existsSync(worktreePath)) {
+    if (!worker.branch) {
+      throw new Error(`Worker named ${workerName} cannot be recovered without a valid branch`);
+    }
+    worktreePath = recreateManagedWorktree(run.repoRoot, {
+      workerName: worker.name,
+      branch: worker.branch,
+    }).worktreePath;
+  }
 
-	let sessionFile = worker.sessionFile;
-	if (!sessionFile || !existsSync(sessionFile)) {
-		sessionFile = await createWorkerSessionLink(worktreePath);
-	}
+  let sessionFile = worker.sessionFile;
+  if (!sessionFile || !existsSync(sessionFile)) {
+    sessionFile = await createWorkerSessionLink(worktreePath);
+  }
 
-	const workers = run.workers.map((entry) =>
-		entry.workerId === worker.workerId
-			? {
-					...entry,
-					worktreePath,
-					sessionFile,
-					lifecycle: "idle" as const,
-					recoverable: false,
-					updatedAt: new Date().toISOString(),
-				}
-			: entry,
-	);
-	const updatedRun = {
-		...run,
-		workers,
-		updatedAt: new Date().toISOString(),
-	};
-	writeRun(updatedRun);
-	const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
-	if (!updatedWorker) {
-		throw new Error(`Worker named ${workerName} disappeared during recovery`);
-	}
-	return updatedWorker;
+  const workers = run.workers.map((entry) =>
+    entry.workerId === worker.workerId
+      ? {
+          ...entry,
+          worktreePath,
+          sessionFile,
+          lifecycle: "idle" as const,
+          recoverable: false,
+          updatedAt: new Date().toISOString(),
+        }
+      : entry,
+  );
+  const updatedRun = {
+    ...run,
+    workers,
+    updatedAt: new Date().toISOString(),
+  };
+  writeRun(updatedRun);
+  const updatedWorker = updatedRun.workers.find((entry) => entry.workerId === worker.workerId);
+  if (!updatedWorker) {
+    throw new Error(`Worker named ${workerName} disappeared during recovery`);
+  }
+  return updatedWorker;
 }

--- a/packages/pi-conductor/extensions/git-pr.ts
+++ b/packages/pi-conductor/extensions/git-pr.ts
@@ -1,114 +1,114 @@
 import { execSync } from "node:child_process";
 
 function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function execInCwd(cwd: string, command: string, label: string): string {
-	try {
-		return execSync(command, {
-			cwd,
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		}).trim();
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`${label} error: ${message}`);
-	}
+  try {
+    return execSync(command, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} error: ${message}`);
+  }
 }
 
 function execOrNull(cwd: string, command: string): string | null {
-	try {
-		return execInCwd(cwd, command, "git");
-	} catch {
-		return null;
-	}
+  try {
+    return execInCwd(cwd, command, "git");
+  } catch {
+    return null;
+  }
 }
 
 export function validatePushPreconditions(repoRoot: string): void {
-	const remoteUrl = execOrNull(repoRoot, "git remote get-url origin");
-	if (!remoteUrl) {
-		throw new Error("Git remote 'origin' is not configured for this repository");
-	}
+  const remoteUrl = execOrNull(repoRoot, "git remote get-url origin");
+  if (!remoteUrl) {
+    throw new Error("Git remote 'origin' is not configured for this repository");
+  }
 }
 
 export function validatePrPreconditions(repoRoot: string): void {
-	validatePushPreconditions(repoRoot);
-	try {
-		execSync("command -v gh", {
-			cwd: repoRoot,
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-			shell: "/bin/bash",
-		});
-		execInCwd(repoRoot, "gh --version", "gh");
-	} catch {
-		throw new Error("GitHub CLI (gh) is not installed or not available on PATH");
-	}
-	try {
-		execInCwd(repoRoot, "gh auth status", "gh");
-	} catch {
-		throw new Error("GitHub CLI (gh) is not authenticated");
-	}
+  validatePushPreconditions(repoRoot);
+  try {
+    execSync("command -v gh", {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: "/bin/bash",
+    });
+    execInCwd(repoRoot, "gh --version", "gh");
+  } catch {
+    throw new Error("GitHub CLI (gh) is not installed or not available on PATH");
+  }
+  try {
+    execInCwd(repoRoot, "gh auth status", "gh");
+  } catch {
+    throw new Error("GitHub CLI (gh) is not authenticated");
+  }
 }
 
 export function getPreferredBaseBranch(repoRoot: string): string {
-	const currentBranch = execInCwd(repoRoot, "git branch --show-current", "git");
-	if (currentBranch && !currentBranch.startsWith("conductor/")) {
-		try {
-			const remoteMatch = execInCwd(repoRoot, `git ls-remote --heads origin ${shellQuote(currentBranch)}`, "git");
-			if (remoteMatch.includes(`refs/heads/${currentBranch}`)) {
-				return currentBranch;
-			}
-		} catch {
-			// fall through
-		}
-	}
-	try {
-		const originHead = execInCwd(
-			repoRoot,
-			"git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'",
-			"git",
-		);
-		if (originHead) {
-			return originHead;
-		}
-	} catch {
-		// fall through
-	}
-	return "main";
+  const currentBranch = execInCwd(repoRoot, "git branch --show-current", "git");
+  if (currentBranch && !currentBranch.startsWith("conductor/")) {
+    try {
+      const remoteMatch = execInCwd(repoRoot, `git ls-remote --heads origin ${shellQuote(currentBranch)}`, "git");
+      if (remoteMatch.includes(`refs/heads/${currentBranch}`)) {
+        return currentBranch;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  try {
+    const originHead = execInCwd(
+      repoRoot,
+      "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'",
+      "git",
+    );
+    if (originHead) {
+      return originHead;
+    }
+  } catch {
+    // fall through
+  }
+  return "main";
 }
 
 export function commitAllChanges(worktreePath: string, message: string): void {
-	execInCwd(worktreePath, "git add -A", "git");
-	execInCwd(worktreePath, `git commit -m ${shellQuote(message)}`, "git");
+  execInCwd(worktreePath, "git add -A", "git");
+  execInCwd(worktreePath, `git commit -m ${shellQuote(message)}`, "git");
 }
 
 export function pushBranchToOrigin(worktreePath: string, branch: string): void {
-	execInCwd(worktreePath, `git push -u origin ${shellQuote(branch)}`, "git");
+  execInCwd(worktreePath, `git push -u origin ${shellQuote(branch)}`, "git");
 }
 
 export function createPullRequest(input: {
-	repoRoot: string;
-	worktreePath: string;
-	branch: string;
-	title: string;
-	body: string;
+  repoRoot: string;
+  worktreePath: string;
+  branch: string;
+  title: string;
+  body: string;
 }): { url: string | null; number: number | null } {
-	const base = getPreferredBaseBranch(input.repoRoot);
-	const output = execInCwd(
-		input.worktreePath,
-		`gh pr create --base ${shellQuote(base)} --head ${shellQuote(input.branch)} --title ${shellQuote(input.title)} --body ${shellQuote(input.body)}`,
-		"gh",
-	);
-	const url =
-		output
-			.split("\n")
-			.map((line) => line.trim())
-			.find((line) => line.startsWith("http")) ?? null;
-	const match = url?.match(/\/pull\/(\d+)/);
-	return {
-		url,
-		number: match ? Number.parseInt(match[1] ?? "", 10) : null,
-	};
+  const base = getPreferredBaseBranch(input.repoRoot);
+  const output = execInCwd(
+    input.worktreePath,
+    `gh pr create --base ${shellQuote(base)} --head ${shellQuote(input.branch)} --title ${shellQuote(input.title)} --body ${shellQuote(input.body)}`,
+    "gh",
+  );
+  const url =
+    output
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.startsWith("http")) ?? null;
+  const match = url?.match(/\/pull\/(\d+)/);
+  return {
+    url,
+    number: match ? Number.parseInt(match[1] ?? "", 10) : null,
+  };
 }

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -4,259 +4,259 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { runConductorCommand } from "./commands.js";
 import {
-	commitWorkerForRepo,
-	createWorkerForRepo,
-	createWorkerPrForRepo,
-	getOrCreateRunForRepo,
-	pushWorkerForRepo,
-	reconcileWorkerHealth,
-	recoverWorkerForRepo,
-	refreshWorkerSummaryForRepo,
-	removeWorkerForRepo,
-	resumeWorkerForRepo,
-	updateWorkerLifecycleForRepo,
-	updateWorkerTaskForRepo,
+  commitWorkerForRepo,
+  createWorkerForRepo,
+  createWorkerPrForRepo,
+  getOrCreateRunForRepo,
+  pushWorkerForRepo,
+  reconcileWorkerHealth,
+  recoverWorkerForRepo,
+  refreshWorkerSummaryForRepo,
+  removeWorkerForRepo,
+  resumeWorkerForRepo,
+  updateWorkerLifecycleForRepo,
+  updateWorkerTaskForRepo,
 } from "./conductor.js";
 import { deriveProjectKey } from "./project-key.js";
 import { formatRunStatus } from "./status.js";
 import { createEmptyRun, readRun, writeRun } from "./storage.js";
 
 function findRepoRoot(cwd: string): string | null {
-	try {
-		return execSync("git rev-parse --show-toplevel", {
-			cwd,
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		}).trim();
-	} catch {
-		return null;
-	}
+  try {
+    return execSync("git rev-parse --show-toplevel", {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
 }
 
 function getStatusText(cwd: string): string {
-	const repoRoot = findRepoRoot(cwd);
-	if (!repoRoot) {
-		return "pi-conductor: not inside a git repository";
-	}
+  const repoRoot = findRepoRoot(cwd);
+  if (!repoRoot) {
+    return "pi-conductor: not inside a git repository";
+  }
 
-	const projectKey = deriveProjectKey(repoRoot);
-	const run = readRun(projectKey) ?? createEmptyRun(projectKey, repoRoot);
-	if (!existsSync(run.storageDir)) {
-		writeRun(run);
-	}
+  const projectKey = deriveProjectKey(repoRoot);
+  const run = readRun(projectKey) ?? createEmptyRun(projectKey, repoRoot);
+  if (!existsSync(run.storageDir)) {
+    writeRun(run);
+  }
 
-	return formatRunStatus(reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot)));
+  return formatRunStatus(reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot)));
 }
 
 export default function conductorExtension(pi: ExtensionAPI) {
-	pi.registerCommand("conductor-status", {
-		description: "Show the current pi-conductor project status",
-		handler: async (_args, ctx) => {
-			const text = getStatusText(ctx.cwd);
-			if (ctx.hasUI) {
-				ctx.ui.notify(text, "info");
-			} else {
-				console.log(text);
-			}
-		},
-	});
+  pi.registerCommand("conductor-status", {
+    description: "Show the current pi-conductor project status",
+    handler: async (_args, ctx) => {
+      const text = getStatusText(ctx.cwd);
+      if (ctx.hasUI) {
+        ctx.ui.notify(text, "info");
+      } else {
+        console.log(text);
+      }
+    },
+  });
 
-	pi.registerCommand("conductor", {
-		description: "Manage pi-conductor workers and PR preparation",
-		handler: async (args, ctx) => {
-			const text = await runConductorCommand(ctx.cwd, args);
-			if (ctx.hasUI) {
-				ctx.ui.notify(text, "info");
-			} else {
-				console.log(text);
-			}
-		},
-	});
+  pi.registerCommand("conductor", {
+    description: "Manage pi-conductor workers and PR preparation",
+    handler: async (args, ctx) => {
+      const text = await runConductorCommand(ctx.cwd, args);
+      if (ctx.hasUI) {
+        ctx.ui.notify(text, "info");
+      } else {
+        console.log(text);
+      }
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_status",
-		label: "Conductor Status",
-		description: "Show the current pi-conductor project namespace and worker status",
-		parameters: Type.Object({}),
-		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-			const text = getStatusText(ctx.cwd);
-			return {
-				content: [{ type: "text", text }],
-				details: {},
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_status",
+    label: "Conductor Status",
+    description: "Show the current pi-conductor project namespace and worker status",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      const text = getStatusText(ctx.cwd);
+      return {
+        content: [{ type: "text", text }],
+        details: {},
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_start",
-		label: "Conductor Start",
-		description: "Create a new pi-conductor worker for the current repository",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = await createWorkerForRepo(ctx.cwd, params.name);
-			return {
-				content: [
-					{ type: "text", text: `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}` },
-				],
-				details: { workerId: worker.workerId, branch: worker.branch, worktreePath: worker.worktreePath },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_start",
+    label: "Conductor Start",
+    description: "Create a new pi-conductor worker for the current repository",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = await createWorkerForRepo(ctx.cwd, params.name);
+      return {
+        content: [
+          { type: "text", text: `created worker ${worker.name} [${worker.workerId}] on branch ${worker.branch}` },
+        ],
+        details: { workerId: worker.workerId, branch: worker.branch, worktreePath: worker.worktreePath },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_task_update",
-		label: "Conductor Task Update",
-		description: "Update the current task for a named pi-conductor worker",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-			task: Type.String({ description: "Task text" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = updateWorkerTaskForRepo(ctx.cwd, params.name, params.task);
-			return {
-				content: [{ type: "text", text: `updated task for ${worker.name}: ${worker.currentTask}` }],
-				details: { workerId: worker.workerId, task: worker.currentTask },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_task_update",
+    label: "Conductor Task Update",
+    description: "Update the current task for a named pi-conductor worker",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+      task: Type.String({ description: "Task text" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = updateWorkerTaskForRepo(ctx.cwd, params.name, params.task);
+      return {
+        content: [{ type: "text", text: `updated task for ${worker.name}: ${worker.currentTask}` }],
+        details: { workerId: worker.workerId, task: worker.currentTask },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_recover",
-		label: "Conductor Recover",
-		description: "Recover a broken pi-conductor worker with a missing session link",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = await recoverWorkerForRepo(ctx.cwd, params.name);
-			return {
-				content: [{ type: "text", text: `recovered worker ${worker.name}: session=${worker.sessionFile}` }],
-				details: { workerId: worker.workerId, sessionFile: worker.sessionFile },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_recover",
+    label: "Conductor Recover",
+    description: "Recover a broken pi-conductor worker with a missing session link",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = await recoverWorkerForRepo(ctx.cwd, params.name);
+      return {
+        content: [{ type: "text", text: `recovered worker ${worker.name}: session=${worker.sessionFile}` }],
+        details: { workerId: worker.workerId, sessionFile: worker.sessionFile },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_summary_refresh",
-		label: "Conductor Summary Refresh",
-		description: "Refresh a named pi-conductor worker summary from its persisted session",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = refreshWorkerSummaryForRepo(ctx.cwd, params.name);
-			return {
-				content: [{ type: "text", text: `refreshed summary for ${worker.name}: ${worker.summary.text}` }],
-				details: { workerId: worker.workerId, summary: worker.summary },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_summary_refresh",
+    label: "Conductor Summary Refresh",
+    description: "Refresh a named pi-conductor worker summary from its persisted session",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = refreshWorkerSummaryForRepo(ctx.cwd, params.name);
+      return {
+        content: [{ type: "text", text: `refreshed summary for ${worker.name}: ${worker.summary.text}` }],
+        details: { workerId: worker.workerId, summary: worker.summary },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_cleanup",
-		label: "Conductor Cleanup",
-		description: "Remove a named pi-conductor worker and clean up its worktree and session link",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = removeWorkerForRepo(ctx.cwd, params.name);
-			return {
-				content: [{ type: "text", text: `removed worker ${worker.name} [${worker.workerId}]` }],
-				details: { workerId: worker.workerId },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_cleanup",
+    label: "Conductor Cleanup",
+    description: "Remove a named pi-conductor worker and clean up its worktree and session link",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = removeWorkerForRepo(ctx.cwd, params.name);
+      return {
+        content: [{ type: "text", text: `removed worker ${worker.name} [${worker.workerId}]` }],
+        details: { workerId: worker.workerId },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_resume",
-		label: "Conductor Resume",
-		description: "Resume a healthy pi-conductor worker using its persisted worktree and session linkage",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = resumeWorkerForRepo(ctx.cwd, params.name);
-			return {
-				content: [{ type: "text", text: `resumed worker ${worker.name}: session=${worker.sessionFile}` }],
-				details: { workerId: worker.workerId, sessionFile: worker.sessionFile, worktreePath: worker.worktreePath },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_resume",
+    label: "Conductor Resume",
+    description: "Resume a healthy pi-conductor worker using its persisted worktree and session linkage",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = resumeWorkerForRepo(ctx.cwd, params.name);
+      return {
+        content: [{ type: "text", text: `resumed worker ${worker.name}: session=${worker.sessionFile}` }],
+        details: { workerId: worker.workerId, sessionFile: worker.sessionFile, worktreePath: worker.worktreePath },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_lifecycle_update",
-		label: "Conductor Lifecycle Update",
-		description: "Update a named pi-conductor worker lifecycle state",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-			lifecycle: Type.Union([
-				Type.Literal("idle"),
-				Type.Literal("running"),
-				Type.Literal("blocked"),
-				Type.Literal("ready_for_pr"),
-				Type.Literal("done"),
-			]),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = updateWorkerLifecycleForRepo(ctx.cwd, params.name, params.lifecycle);
-			return {
-				content: [{ type: "text", text: `updated worker ${worker.name} state to ${worker.lifecycle}` }],
-				details: { workerId: worker.workerId, lifecycle: worker.lifecycle },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_lifecycle_update",
+    label: "Conductor Lifecycle Update",
+    description: "Update a named pi-conductor worker lifecycle state",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+      lifecycle: Type.Union([
+        Type.Literal("idle"),
+        Type.Literal("running"),
+        Type.Literal("blocked"),
+        Type.Literal("ready_for_pr"),
+        Type.Literal("done"),
+      ]),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = updateWorkerLifecycleForRepo(ctx.cwd, params.name, params.lifecycle);
+      return {
+        content: [{ type: "text", text: `updated worker ${worker.name} state to ${worker.lifecycle}` }],
+        details: { workerId: worker.workerId, lifecycle: worker.lifecycle },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_commit",
-		label: "Conductor Commit",
-		description: "Commit all current worker worktree changes with a supplied commit message",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-			message: Type.String({ description: "Commit message" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = commitWorkerForRepo(ctx.cwd, params.name, params.message);
-			return {
-				content: [{ type: "text", text: `committed worker ${worker.name}: ${params.message}` }],
-				details: { workerId: worker.workerId, commitSucceeded: worker.pr.commitSucceeded },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_commit",
+    label: "Conductor Commit",
+    description: "Commit all current worker worktree changes with a supplied commit message",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+      message: Type.String({ description: "Commit message" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = commitWorkerForRepo(ctx.cwd, params.name, params.message);
+      return {
+        content: [{ type: "text", text: `committed worker ${worker.name}: ${params.message}` }],
+        details: { workerId: worker.workerId, commitSucceeded: worker.pr.commitSucceeded },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_push",
-		label: "Conductor Push",
-		description: "Push a worker branch to origin",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = pushWorkerForRepo(ctx.cwd, params.name);
-			return {
-				content: [{ type: "text", text: `pushed worker ${worker.name} on branch ${worker.branch}` }],
-				details: { workerId: worker.workerId, pushSucceeded: worker.pr.pushSucceeded },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_push",
+    label: "Conductor Push",
+    description: "Push a worker branch to origin",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = pushWorkerForRepo(ctx.cwd, params.name);
+      return {
+        content: [{ type: "text", text: `pushed worker ${worker.name} on branch ${worker.branch}` }],
+        details: { workerId: worker.workerId, pushSucceeded: worker.pr.pushSucceeded },
+      };
+    },
+  });
 
-	pi.registerTool({
-		name: "conductor_pr_create",
-		label: "Conductor PR Create",
-		description: "Create a GitHub pull request for a worker branch",
-		parameters: Type.Object({
-			name: Type.String({ description: "Worker name" }),
-			title: Type.String({ description: "PR title" }),
-			body: Type.Optional(Type.String({ description: "Optional PR body" })),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const worker = createWorkerPrForRepo(ctx.cwd, params.name, params.title, params.body);
-			return {
-				content: [{ type: "text", text: `created PR for ${worker.name}: ${worker.pr.url}` }],
-				details: { workerId: worker.workerId, pr: worker.pr },
-			};
-		},
-	});
+  pi.registerTool({
+    name: "conductor_pr_create",
+    label: "Conductor PR Create",
+    description: "Create a GitHub pull request for a worker branch",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+      title: Type.String({ description: "PR title" }),
+      body: Type.Optional(Type.String({ description: "Optional PR body" })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const worker = createWorkerPrForRepo(ctx.cwd, params.name, params.title, params.body);
+      return {
+        content: [{ type: "text", text: `created PR for ${worker.name}: ${worker.pr.url}` }],
+        details: { workerId: worker.workerId, pr: worker.pr },
+      };
+    },
+  });
 }

--- a/packages/pi-conductor/extensions/project-key.ts
+++ b/packages/pi-conductor/extensions/project-key.ts
@@ -2,18 +2,18 @@ import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 
 function sanitizeSegment(value: string): string {
-	return (
-		value
-			.replace(/[^a-zA-Z0-9._-]+/g, "-")
-			.replace(/-+/g, "-")
-			.replace(/^-|-$/g, "") || "repo"
-	);
+  return (
+    value
+      .replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "repo"
+  );
 }
 
 export function deriveProjectKey(repoRoot: string): string {
-	const normalized = resolve(repoRoot);
-	const flattened = normalized.replace(/[/:\\]/g, "-");
-	const slug = sanitizeSegment(flattened);
-	const hash = createHash("sha1").update(normalized).digest("hex").slice(0, 10);
-	return `${slug}-${hash}`;
+  const normalized = resolve(repoRoot);
+  const flattened = normalized.replace(/[/:\\]/g, "-");
+  const slug = sanitizeSegment(flattened);
+  const hash = createHash("sha1").update(normalized).digest("hex").slice(0, 10);
+  return `${slug}-${hash}`;
 }

--- a/packages/pi-conductor/extensions/sessions.ts
+++ b/packages/pi-conductor/extensions/sessions.ts
@@ -3,23 +3,23 @@ import { dirname } from "node:path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
 function ensurePersistedSessionFile(sessionManager: SessionManager, sessionFile: string): void {
-	if (existsSync(sessionFile)) {
-		return;
-	}
-	const header = sessionManager.getHeader();
-	const entries = sessionManager.getEntries();
-	mkdirSync(dirname(sessionFile), { recursive: true });
-	const lines = [header, ...entries].map((entry) => JSON.stringify(entry));
-	writeFileSync(sessionFile, `${lines.join("\n")}\n`, "utf-8");
+  if (existsSync(sessionFile)) {
+    return;
+  }
+  const header = sessionManager.getHeader();
+  const entries = sessionManager.getEntries();
+  mkdirSync(dirname(sessionFile), { recursive: true });
+  const lines = [header, ...entries].map((entry) => JSON.stringify(entry));
+  writeFileSync(sessionFile, `${lines.join("\n")}\n`, "utf-8");
 }
 
 export async function createWorkerSessionLink(worktreePath: string): Promise<string | null> {
-	const sessionManager = SessionManager.create(worktreePath);
-	await sessionManager.appendSessionInfo("pi-conductor worker");
-	const sessionFile = sessionManager.getSessionFile() ?? null;
-	if (!sessionFile) {
-		return null;
-	}
-	ensurePersistedSessionFile(sessionManager, sessionFile);
-	return sessionFile;
+  const sessionManager = SessionManager.create(worktreePath);
+  await sessionManager.appendSessionInfo("pi-conductor worker");
+  const sessionFile = sessionManager.getSessionFile() ?? null;
+  if (!sessionFile) {
+    return null;
+  }
+  ensurePersistedSessionFile(sessionManager, sessionFile);
+  return sessionFile;
 }

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -2,42 +2,42 @@ import { getConductorProjectDir } from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
 
 function getWorkerHealth(worker: WorkerRecord): "healthy" | "stale" | "broken" {
-	if (worker.lifecycle === "broken") {
-		return "broken";
-	}
-	if (worker.summary.stale || worker.lifecycle === "done") {
-		return "stale";
-	}
-	return "healthy";
+  if (worker.lifecycle === "broken") {
+    return "broken";
+  }
+  if (worker.summary.stale || worker.lifecycle === "done") {
+    return "stale";
+  }
+  return "healthy";
 }
 
 export function formatRunStatus(run: RunRecord): string {
-	const lines = [
-		`projectKey: ${run.projectKey}`,
-		`repoRoot: ${run.repoRoot}`,
-		`storageDir: ${getConductorProjectDir(run.projectKey)}`,
-		`workers: ${run.workers.length}`,
-	];
+  const lines = [
+    `projectKey: ${run.projectKey}`,
+    `repoRoot: ${run.repoRoot}`,
+    `storageDir: ${getConductorProjectDir(run.projectKey)}`,
+    `workers: ${run.workers.length}`,
+  ];
 
-	for (const worker of run.workers) {
-		const summary = worker.summary.text
-			? `${worker.summary.stale ? "stale" : "fresh"}: ${worker.summary.text}`
-			: "none";
-		lines.push(
-			`- ${worker.name} [${worker.workerId}] ` +
-				`health=${getWorkerHealth(worker)} ` +
-				`state=${worker.lifecycle} ` +
-				`recoverable=${worker.recoverable} ` +
-				`task=${worker.currentTask ?? "none"} ` +
-				`branch=${worker.branch ?? "none"} ` +
-				`session=${worker.sessionFile ?? "none"} ` +
-				`pr=${worker.pr.url ?? "none"} ` +
-				`commit=${worker.pr.commitSucceeded} ` +
-				`push=${worker.pr.pushSucceeded} ` +
-				`prAttempted=${worker.pr.prCreationAttempted} ` +
-				`summary=${summary}`,
-		);
-	}
+  for (const worker of run.workers) {
+    const summary = worker.summary.text
+      ? `${worker.summary.stale ? "stale" : "fresh"}: ${worker.summary.text}`
+      : "none";
+    lines.push(
+      `- ${worker.name} [${worker.workerId}] ` +
+        `health=${getWorkerHealth(worker)} ` +
+        `state=${worker.lifecycle} ` +
+        `recoverable=${worker.recoverable} ` +
+        `task=${worker.currentTask ?? "none"} ` +
+        `branch=${worker.branch ?? "none"} ` +
+        `session=${worker.sessionFile ?? "none"} ` +
+        `pr=${worker.pr.url ?? "none"} ` +
+        `commit=${worker.pr.commitSucceeded} ` +
+        `push=${worker.pr.pushSucceeded} ` +
+        `prAttempted=${worker.pr.prCreationAttempted} ` +
+        `summary=${summary}`,
+    );
+  }
 
-	return lines.join("\n");
+  return lines.join("\n");
 }

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -4,215 +4,215 @@ import { dirname, join, resolve } from "node:path";
 import type { RunRecord, WorkerLifecycleState, WorkerPrState, WorkerRecord } from "./types.js";
 
 function getConductorRoot(): string {
-	const override = process.env.PI_CONDUCTOR_HOME?.trim();
-	if (override) {
-		return join(resolve(override), "projects");
-	}
-	return join(homedir(), ".pi", "agent", "conductor", "projects");
+  const override = process.env.PI_CONDUCTOR_HOME?.trim();
+  if (override) {
+    return join(resolve(override), "projects");
+  }
+  return join(homedir(), ".pi", "agent", "conductor", "projects");
 }
 
 export function getConductorProjectDir(projectKey: string): string {
-	return join(getConductorRoot(), projectKey);
+  return join(getConductorRoot(), projectKey);
 }
 
 export function getRunFile(projectKey: string): string {
-	return join(getConductorProjectDir(projectKey), "run.json");
+  return join(getConductorProjectDir(projectKey), "run.json");
 }
 
 export function ensureDir(path: string): void {
-	mkdirSync(path, { recursive: true });
+  mkdirSync(path, { recursive: true });
 }
 
 export function readRun(projectKey: string): RunRecord | null {
-	const path = getRunFile(projectKey);
-	if (!existsSync(path)) {
-		return null;
-	}
-	return JSON.parse(readFileSync(path, "utf-8")) as RunRecord;
+  const path = getRunFile(projectKey);
+  if (!existsSync(path)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(path, "utf-8")) as RunRecord;
 }
 
 export function writeRun(run: RunRecord): void {
-	const path = getRunFile(run.projectKey);
-	ensureDir(dirname(path));
-	writeFileSync(path, `${JSON.stringify(run, null, 2)}\n`, "utf-8");
+  const path = getRunFile(run.projectKey);
+  ensureDir(dirname(path));
+  writeFileSync(path, `${JSON.stringify(run, null, 2)}\n`, "utf-8");
 }
 
 export function createEmptyRun(projectKey: string, repoRoot: string): RunRecord {
-	const now = new Date().toISOString();
-	return {
-		projectKey,
-		repoRoot: resolve(repoRoot),
-		storageDir: getConductorProjectDir(projectKey),
-		workers: [],
-		createdAt: now,
-		updatedAt: now,
-	};
+  const now = new Date().toISOString();
+  return {
+    projectKey,
+    repoRoot: resolve(repoRoot),
+    storageDir: getConductorProjectDir(projectKey),
+    workers: [],
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 export function createWorkerRecord(input: {
-	workerId: string;
-	name: string;
-	branch: string | null;
-	worktreePath: string | null;
-	sessionFile: string | null;
+  workerId: string;
+  name: string;
+  branch: string | null;
+  worktreePath: string | null;
+  sessionFile: string | null;
 }): WorkerRecord {
-	const now = new Date().toISOString();
-	return {
-		workerId: input.workerId,
-		name: input.name,
-		branch: input.branch,
-		worktreePath: input.worktreePath,
-		sessionFile: input.sessionFile,
-		currentTask: null,
-		lifecycle: "idle",
-		recoverable: false,
-		summary: {
-			text: null,
-			updatedAt: null,
-			stale: false,
-		},
-		pr: {
-			url: null,
-			number: null,
-			commitSucceeded: false,
-			pushSucceeded: false,
-			prCreationAttempted: false,
-		},
-		createdAt: now,
-		updatedAt: now,
-	};
+  const now = new Date().toISOString();
+  return {
+    workerId: input.workerId,
+    name: input.name,
+    branch: input.branch,
+    worktreePath: input.worktreePath,
+    sessionFile: input.sessionFile,
+    currentTask: null,
+    lifecycle: "idle",
+    recoverable: false,
+    summary: {
+      text: null,
+      updatedAt: null,
+      stale: false,
+    },
+    pr: {
+      url: null,
+      number: null,
+      commitSucceeded: false,
+      pushSucceeded: false,
+      prCreationAttempted: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 export function addWorker(run: RunRecord, worker: WorkerRecord): RunRecord {
-	if (run.workers.some((existing) => existing.name === worker.name)) {
-		throw new Error(`Worker named ${worker.name} already exists`);
-	}
+  if (run.workers.some((existing) => existing.name === worker.name)) {
+    throw new Error(`Worker named ${worker.name} already exists`);
+  }
 
-	return {
-		...run,
-		workers: [...run.workers, worker],
-		updatedAt: new Date().toISOString(),
-	};
+  return {
+    ...run,
+    workers: [...run.workers, worker],
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 export function setWorkerTask(run: RunRecord, workerId: string, task: string): RunRecord {
-	let found = false;
-	const workers = run.workers.map((worker) => {
-		if (worker.workerId !== workerId) {
-			return worker;
-		}
-		found = true;
-		return {
-			...worker,
-			currentTask: task,
-			summary: {
-				...worker.summary,
-				stale: worker.summary.text !== null ? true : worker.summary.stale,
-			},
-			updatedAt: new Date().toISOString(),
-		};
-	});
+  let found = false;
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    return {
+      ...worker,
+      currentTask: task,
+      summary: {
+        ...worker.summary,
+        stale: worker.summary.text !== null ? true : worker.summary.stale,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+  });
 
-	if (!found) {
-		throw new Error(`Worker ${workerId} not found`);
-	}
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
 
-	return {
-		...run,
-		workers,
-		updatedAt: new Date().toISOString(),
-	};
+  return {
+    ...run,
+    workers,
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 export function setWorkerSummary(run: RunRecord, workerId: string, summaryText: string): RunRecord {
-	let found = false;
-	const now = new Date().toISOString();
-	const workers = run.workers.map((worker) => {
-		if (worker.workerId !== workerId) {
-			return worker;
-		}
-		found = true;
-		return {
-			...worker,
-			summary: {
-				text: summaryText,
-				updatedAt: now,
-				stale: false,
-			},
-			updatedAt: now,
-		};
-	});
+  let found = false;
+  const now = new Date().toISOString();
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    return {
+      ...worker,
+      summary: {
+        text: summaryText,
+        updatedAt: now,
+        stale: false,
+      },
+      updatedAt: now,
+    };
+  });
 
-	if (!found) {
-		throw new Error(`Worker ${workerId} not found`);
-	}
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
 
-	return {
-		...run,
-		workers,
-		updatedAt: now,
-	};
+  return {
+    ...run,
+    workers,
+    updatedAt: now,
+  };
 }
 
 export function removeWorker(run: RunRecord, workerId: string): RunRecord {
-	const workers = run.workers.filter((worker) => worker.workerId !== workerId);
-	if (workers.length === run.workers.length) {
-		throw new Error(`Worker ${workerId} not found`);
-	}
-	return {
-		...run,
-		workers,
-		updatedAt: new Date().toISOString(),
-	};
+  const workers = run.workers.filter((worker) => worker.workerId !== workerId);
+  if (workers.length === run.workers.length) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
+  return {
+    ...run,
+    workers,
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 export function setWorkerPrState(run: RunRecord, workerId: string, pr: Partial<WorkerPrState>): RunRecord {
-	let found = false;
-	const now = new Date().toISOString();
-	const workers = run.workers.map((worker) => {
-		if (worker.workerId !== workerId) {
-			return worker;
-		}
-		found = true;
-		return {
-			...worker,
-			pr: {
-				...worker.pr,
-				...pr,
-			},
-			updatedAt: now,
-		};
-	});
-	if (!found) {
-		throw new Error(`Worker ${workerId} not found`);
-	}
-	return {
-		...run,
-		workers,
-		updatedAt: now,
-	};
+  let found = false;
+  const now = new Date().toISOString();
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    return {
+      ...worker,
+      pr: {
+        ...worker.pr,
+        ...pr,
+      },
+      updatedAt: now,
+    };
+  });
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
+  return {
+    ...run,
+    workers,
+    updatedAt: now,
+  };
 }
 
 export function setWorkerLifecycle(run: RunRecord, workerId: string, lifecycle: WorkerLifecycleState): RunRecord {
-	let found = false;
-	const now = new Date().toISOString();
-	const workers = run.workers.map((worker) => {
-		if (worker.workerId !== workerId) {
-			return worker;
-		}
-		found = true;
-		return {
-			...worker,
-			lifecycle,
-			updatedAt: now,
-		};
-	});
-	if (!found) {
-		throw new Error(`Worker ${workerId} not found`);
-	}
-	return {
-		...run,
-		workers,
-		updatedAt: now,
-	};
+  let found = false;
+  const now = new Date().toISOString();
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    return {
+      ...worker,
+      lifecycle,
+      updatedAt: now,
+    };
+  });
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
+  return {
+    ...run,
+    workers,
+    updatedAt: now,
+  };
 }

--- a/packages/pi-conductor/extensions/summaries.ts
+++ b/packages/pi-conductor/extensions/summaries.ts
@@ -3,53 +3,53 @@ import { existsSync, readFileSync } from "node:fs";
 type TextPart = { type?: string; text?: string };
 
 type SessionLine = {
-	type?: string;
-	message?: {
-		role?: string;
-		content?: string | TextPart[];
-	};
-	content?: string | TextPart[];
+  type?: string;
+  message?: {
+    role?: string;
+    content?: string | TextPart[];
+  };
+  content?: string | TextPart[];
 };
 
 function extractTextContent(content: string | TextPart[] | undefined): string[] {
-	if (typeof content === "string") {
-		return [content.trim()].filter(Boolean);
-	}
-	if (!Array.isArray(content)) {
-		return [];
-	}
-	return content
-		.filter(
-			(item): item is TextPart & { type: string; text: string } =>
-				item?.type === "text" && typeof item.text === "string",
-		)
-		.map((item) => item.text.trim())
-		.filter(Boolean);
+  if (typeof content === "string") {
+    return [content.trim()].filter(Boolean);
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content
+    .filter(
+      (item): item is TextPart & { type: string; text: string } =>
+        item?.type === "text" && typeof item.text === "string",
+    )
+    .map((item) => item.text.trim())
+    .filter(Boolean);
 }
 
 export function generateWorkerSummaryFromSession(sessionFile: string): string {
-	if (!existsSync(sessionFile)) {
-		throw new Error(`Session file not found: ${sessionFile}`);
-	}
+  if (!existsSync(sessionFile)) {
+    throw new Error(`Session file not found: ${sessionFile}`);
+  }
 
-	const snippets = readFileSync(sessionFile, "utf-8")
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean)
-		.map((line) => JSON.parse(line) as SessionLine)
-		.flatMap((entry) => {
-			if (entry.type === "message") {
-				return extractTextContent(entry.message?.content);
-			}
-			if (entry.type === "custom_message") {
-				return extractTextContent(entry.content);
-			}
-			return [];
-		});
+  const snippets = readFileSync(sessionFile, "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as SessionLine)
+    .flatMap((entry) => {
+      if (entry.type === "message") {
+        return extractTextContent(entry.message?.content);
+      }
+      if (entry.type === "custom_message") {
+        return extractTextContent(entry.content);
+      }
+      return [];
+    });
 
-	if (snippets.length === 0) {
-		return "Session exists but has no summarizable text yet.";
-	}
+  if (snippets.length === 0) {
+    return "Session exists but has no summarizable text yet.";
+  }
 
-	return snippets.slice(-3).join(" | ");
+  return snippets.slice(-3).join(" | ");
 }

--- a/packages/pi-conductor/extensions/types.ts
+++ b/packages/pi-conductor/extensions/types.ts
@@ -1,39 +1,39 @@
 export type WorkerLifecycleState = "idle" | "running" | "blocked" | "ready_for_pr" | "done" | "broken";
 
 export interface WorkerSummary {
-	text: string | null;
-	updatedAt: string | null;
-	stale: boolean;
+  text: string | null;
+  updatedAt: string | null;
+  stale: boolean;
 }
 
 export interface WorkerPrState {
-	url: string | null;
-	number: number | null;
-	commitSucceeded: boolean;
-	pushSucceeded: boolean;
-	prCreationAttempted: boolean;
+  url: string | null;
+  number: number | null;
+  commitSucceeded: boolean;
+  pushSucceeded: boolean;
+  prCreationAttempted: boolean;
 }
 
 export interface WorkerRecord {
-	workerId: string;
-	name: string;
-	branch: string | null;
-	worktreePath: string | null;
-	sessionFile: string | null;
-	currentTask: string | null;
-	lifecycle: WorkerLifecycleState;
-	recoverable: boolean;
-	summary: WorkerSummary;
-	pr: WorkerPrState;
-	createdAt: string;
-	updatedAt: string;
+  workerId: string;
+  name: string;
+  branch: string | null;
+  worktreePath: string | null;
+  sessionFile: string | null;
+  currentTask: string | null;
+  lifecycle: WorkerLifecycleState;
+  recoverable: boolean;
+  summary: WorkerSummary;
+  pr: WorkerPrState;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface RunRecord {
-	projectKey: string;
-	repoRoot: string;
-	storageDir: string;
-	workers: WorkerRecord[];
-	createdAt: string;
-	updatedAt: string;
+  projectKey: string;
+  repoRoot: string;
+  storageDir: string;
+  workers: WorkerRecord[];
+  createdAt: string;
+  updatedAt: string;
 }

--- a/packages/pi-conductor/extensions/workers.ts
+++ b/packages/pi-conductor/extensions/workers.ts
@@ -1,23 +1,23 @@
 function collapseDashes(value: string): string {
-	return value.replace(/-+/g, "-").replace(/^-|-$/g, "");
+  return value.replace(/-+/g, "-").replace(/^-|-$/g, "");
 }
 
 export function normalizeWorkerSlug(name: string): string | null {
-	const normalized = collapseDashes(
-		name
-			.toLowerCase()
-			.replace(/\s+/g, "-")
-			.replace(/[^a-z0-9._-]+/g, "-"),
-	);
-	return normalized.length > 0 ? normalized : null;
+  const normalized = collapseDashes(
+    name
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9._-]+/g, "-"),
+  );
+  return normalized.length > 0 ? normalized : null;
 }
 
 export function buildBranchName(workerId: string, name: string): string {
-	const slug = normalizeWorkerSlug(name);
-	return `conductor/${slug ?? workerId}`;
+  const slug = normalizeWorkerSlug(name);
+  return `conductor/${slug ?? workerId}`;
 }
 
 export function createWorkerId(): string {
-	const random = Math.random().toString(36).slice(2, 10);
-	return `worker-${Date.now().toString(36)}-${random}`;
+  const random = Math.random().toString(36).slice(2, 10);
+  return `worker-${Date.now().toString(36)}-${random}`;
 }

--- a/packages/pi-conductor/extensions/worktrees.ts
+++ b/packages/pi-conductor/extensions/worktrees.ts
@@ -4,68 +4,68 @@ import { ensureDir } from "./storage.js";
 import { buildBranchName, normalizeWorkerSlug } from "./workers.js";
 
 function execGit(cwd: string, command: string): string {
-	return execSync(command, {
-		cwd,
-		encoding: "utf-8",
-		stdio: ["pipe", "pipe", "pipe"],
-	}).trim();
+  return execSync(command, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
 }
 
 export function getCurrentBranch(repoRoot: string): string {
-	const branch = execGit(repoRoot, "git branch --show-current");
-	if (!branch) {
-		throw new Error("Unable to determine current branch");
-	}
-	return branch;
+  const branch = execGit(repoRoot, "git branch --show-current");
+  if (!branch) {
+    throw new Error("Unable to determine current branch");
+  }
+  return branch;
 }
 
 export function planWorktreePath(repoRoot: string, workerName: string): string {
-	const repoParent = dirname(repoRoot);
-	const repoBase = repoRoot.split("/").filter(Boolean).at(-1) ?? "repo";
-	const slug = normalizeWorkerSlug(workerName) ?? "worker";
-	return join(repoParent, ".pi-conductor-worktrees", repoBase, slug);
+  const repoParent = dirname(repoRoot);
+  const repoBase = repoRoot.split("/").filter(Boolean).at(-1) ?? "repo";
+  const slug = normalizeWorkerSlug(workerName) ?? "worker";
+  return join(repoParent, ".pi-conductor-worktrees", repoBase, slug);
 }
 
 export function createManagedWorktree(
-	repoRoot: string,
-	input: { workerId: string; workerName: string },
+  repoRoot: string,
+  input: { workerId: string; workerName: string },
 ): { branch: string; baseBranch: string; worktreePath: string } {
-	const baseBranch = getCurrentBranch(repoRoot);
-	const branch = buildBranchName(input.workerId, input.workerName);
-	const worktreePath = planWorktreePath(repoRoot, input.workerName);
-	ensureDir(dirname(worktreePath));
-	execGit(repoRoot, `git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(baseBranch)}`);
-	return { branch, baseBranch, worktreePath };
+  const baseBranch = getCurrentBranch(repoRoot);
+  const branch = buildBranchName(input.workerId, input.workerName);
+  const worktreePath = planWorktreePath(repoRoot, input.workerName);
+  ensureDir(dirname(worktreePath));
+  execGit(repoRoot, `git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(baseBranch)}`);
+  return { branch, baseBranch, worktreePath };
 }
 
 export function recreateManagedWorktree(
-	repoRoot: string,
-	input: { workerName: string; branch: string },
+  repoRoot: string,
+  input: { workerName: string; branch: string },
 ): { branch: string; worktreePath: string } {
-	const worktreePath = planWorktreePath(repoRoot, input.workerName);
-	ensureDir(dirname(worktreePath));
-	execGit(repoRoot, "git worktree prune");
-	execGit(repoRoot, `git worktree add ${shellQuote(worktreePath)} ${shellQuote(input.branch)}`);
-	return { branch: input.branch, worktreePath };
+  const worktreePath = planWorktreePath(repoRoot, input.workerName);
+  ensureDir(dirname(worktreePath));
+  execGit(repoRoot, "git worktree prune");
+  execGit(repoRoot, `git worktree add ${shellQuote(worktreePath)} ${shellQuote(input.branch)}`);
+  return { branch: input.branch, worktreePath };
 }
 
 export function removeManagedWorktree(repoRoot: string, worktreePath: string): void {
-	execGit(repoRoot, "git worktree prune");
-	try {
-		execGit(repoRoot, `git worktree remove --force ${shellQuote(worktreePath)}`);
-	} catch {
-		execGit(repoRoot, "git worktree prune");
-	}
+  execGit(repoRoot, "git worktree prune");
+  try {
+    execGit(repoRoot, `git worktree remove --force ${shellQuote(worktreePath)}`);
+  } catch {
+    execGit(repoRoot, "git worktree prune");
+  }
 }
 
 export function removeManagedBranch(repoRoot: string, branch: string): void {
-	try {
-		execGit(repoRoot, `git branch -D ${shellQuote(branch)}`);
-	} catch {
-		// Ignore missing or already-removed branches during cleanup.
-	}
+  try {
+    execGit(repoRoot, `git branch -D ${shellQuote(branch)}`);
+  } catch {
+    // Ignore missing or already-removed branches during cleanup.
+  }
 }
 
 function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/pi-conductor/package.json
+++ b/packages/pi-conductor/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "@feniix/pi-conductor",
-	"version": "0.1.0",
-	"description": "Long-lived multi-session worker orchestration for pi with git worktrees, resumable sessions, and PR flows",
-	"keywords": [
-		"pi",
-		"pi-package",
-		"pi-extension",
-		"pi-coding-agent",
-		"orchestration",
-		"worktree",
-		"git",
-		"session"
-	],
-	"type": "module",
-	"files": [
-		"extensions/",
-		"README.md",
-		"LICENSE"
-	],
-	"pi": {
-		"extensions": [
-			"./extensions/index.ts"
-		]
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"@sinclair/typebox": "*"
-	},
-	"repository": {
-		"url": "git+https://github.com/feniix/pi-extensions.git",
-		"directory": "packages/pi-conductor"
-	},
-	"author": "feniix",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/feniix/pi-extensions/issues"
-	},
-	"homepage": "https://github.com/feniix/pi-extensions/tree/main/packages/pi-conductor#readme"
+  "name": "@feniix/pi-conductor",
+  "version": "0.1.0",
+  "description": "Long-lived multi-session worker orchestration for pi with git worktrees, resumable sessions, and PR flows",
+  "keywords": [
+    "pi",
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "orchestration",
+    "worktree",
+    "git",
+    "session"
+  ],
+  "type": "module",
+  "files": [
+    "extensions/",
+    "README.md",
+    "LICENSE"
+  ],
+  "pi": {
+    "extensions": [
+      "./extensions/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*"
+  },
+  "repository": {
+    "url": "git+https://github.com/feniix/pi-extensions.git",
+    "directory": "packages/pi-conductor"
+  },
+  "author": "feniix",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/feniix/pi-extensions/issues"
+  },
+  "homepage": "https://github.com/feniix/pi-extensions/tree/main/packages/pi-conductor#readme"
 }

--- a/packages/pi-devtools/__tests__/git.integration.test.ts
+++ b/packages/pi-devtools/__tests__/git.integration.test.ts
@@ -6,218 +6,218 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { execGh, execGit, getDefaultBranch } from "../extensions/git.js";
 
 describe("pi-devtools git integration", () => {
-	let tempDir: string;
+  let tempDir: string;
 
-	beforeEach(() => {
-		// Create a unique temp directory for each test using mktemp
-		tempDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+  beforeEach(() => {
+    // Create a unique temp directory for each test using mktemp
+    tempDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
 
-		// Initialize git repo
-		execSync("git init -b main", { cwd: tempDir, stdio: "pipe" });
-		execSync("git config user.email 'test@test.com'", { cwd: tempDir, stdio: "pipe" });
-		execSync("git config user.name 'Test User'", { cwd: tempDir, stdio: "pipe" });
+    // Initialize git repo
+    execSync("git init -b main", { cwd: tempDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: tempDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: tempDir, stdio: "pipe" });
 
-		// Create initial commit
-		writeFileSync(join(tempDir, "initial.txt"), "initial");
-		execSync("git add .", { cwd: tempDir, stdio: "pipe" });
-		execSync("git commit -m 'initial commit'", { cwd: tempDir, stdio: "pipe" });
-	});
+    // Create initial commit
+    writeFileSync(join(tempDir, "initial.txt"), "initial");
+    execSync("git add .", { cwd: tempDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: tempDir, stdio: "pipe" });
+  });
 
-	afterEach(() => {
-		// Clean up temp directory
-		if (tempDir && existsSync(tempDir)) {
-			rmSync(tempDir, { recursive: true, force: true });
-		}
-	});
+  afterEach(() => {
+    // Clean up temp directory
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 
-	describe("execGit", () => {
-		it("executes git command successfully in temp repo", () => {
-			const result = execGit(`git -C ${tempDir} status`);
-			expect(result).toBeDefined();
-		});
+  describe("execGit", () => {
+    it("executes git command successfully in temp repo", () => {
+      const result = execGit(`git -C ${tempDir} status`);
+      expect(result).toBeDefined();
+    });
 
-		it("throws error for invalid command", () => {
-			expect(() => execGit("git invalid-command")).toThrow("Git error");
-		});
+    it("throws error for invalid command", () => {
+      expect(() => execGit("git invalid-command")).toThrow("Git error");
+    });
 
-		it("throws error when not in a git repo", () => {
-			// Create a non-git directory using mktemp
-			const nonGitDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-			try {
-				expect(() => execGit(`git -C ${nonGitDir} status`)).toThrow();
-			} finally {
-				rmSync(nonGitDir, { recursive: true, force: true });
-			}
-		});
+    it("throws error when not in a git repo", () => {
+      // Create a non-git directory using mktemp
+      const nonGitDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+      try {
+        expect(() => execGit(`git -C ${nonGitDir} status`)).toThrow();
+      } finally {
+        rmSync(nonGitDir, { recursive: true, force: true });
+      }
+    });
 
-		it("handles error in command execution", () => {
-			expect(() => execGit(`git -C ${tempDir} log --invalid-flag`)).toThrow();
-		});
-	});
+    it("handles error in command execution", () => {
+      expect(() => execGit(`git -C ${tempDir} log --invalid-flag`)).toThrow();
+    });
+  });
 
-	describe("getDefaultBranch", () => {
-		it("returns main in repo without origin", () => {
-			// In a fresh repo without origin, should return main via fallback
-			const result = getDefaultBranch();
-			expect(result).toBe("main");
-		});
-	});
+  describe("getDefaultBranch", () => {
+    it("returns main in repo without origin", () => {
+      // In a fresh repo without origin, should return main via fallback
+      const result = getDefaultBranch();
+      expect(result).toBe("main");
+    });
+  });
 
-	describe("createBranchTool integration", () => {
-		it("creates a branch", () => {
-			execGit(`git -C ${tempDir} checkout -b feature/test`);
+  describe("createBranchTool integration", () => {
+    it("creates a branch", () => {
+      execGit(`git -C ${tempDir} checkout -b feature/test`);
 
-			const branches = execGit(`git -C ${tempDir} branch`);
-			expect(branches).toContain("feature/test");
-		});
+      const branches = execGit(`git -C ${tempDir} branch`);
+      expect(branches).toContain("feature/test");
+    });
 
-		it("fails when branch already exists", () => {
-			execGit(`git -C ${tempDir} checkout -b feature/test`);
-			expect(() => execGit(`git -C ${tempDir} checkout -b feature/test`)).toThrow();
-		});
-	});
+    it("fails when branch already exists", () => {
+      execGit(`git -C ${tempDir} checkout -b feature/test`);
+      expect(() => execGit(`git -C ${tempDir} checkout -b feature/test`)).toThrow();
+    });
+  });
 
-	describe("commitTool integration", () => {
-		it("stages files successfully", () => {
-			writeFileSync(join(tempDir, "test.txt"), "test content");
-			execSync(`git -C ${tempDir} add .`, { stdio: "pipe" });
+  describe("commitTool integration", () => {
+    it("stages files successfully", () => {
+      writeFileSync(join(tempDir, "test.txt"), "test content");
+      execSync(`git -C ${tempDir} add .`, { stdio: "pipe" });
 
-			const staged = execGit(`git -C ${tempDir} diff --cached --name-only`);
-			expect(staged).toContain("test.txt");
-		});
+      const staged = execGit(`git -C ${tempDir} diff --cached --name-only`);
+      expect(staged).toContain("test.txt");
+    });
 
-		it("commits successfully", () => {
-			writeFileSync(join(tempDir, "test.txt"), "test content");
-			execSync(`git -C ${tempDir} add .`, { stdio: "pipe" });
-			execGit(`git -C ${tempDir} commit -m "feat: add test"`);
+    it("commits successfully", () => {
+      writeFileSync(join(tempDir, "test.txt"), "test content");
+      execSync(`git -C ${tempDir} add .`, { stdio: "pipe" });
+      execGit(`git -C ${tempDir} commit -m "feat: add test"`);
 
-			const log = execGit(`git -C ${tempDir} log --oneline -n 1`);
-			expect(log).toContain("feat: add test");
-		});
-	});
+      const log = execGit(`git -C ${tempDir} log --oneline -n 1`);
+      expect(log).toContain("feat: add test");
+    });
+  });
 
-	describe("pushTool integration", () => {
-		it("pushes to remote", () => {
-			// Setup origin using mktemp
-			const originDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
-			execSync("git init --bare", { cwd: originDir, stdio: "pipe" });
-			execSync(`git remote add origin ${originDir}`, { cwd: tempDir, stdio: "pipe" });
+  describe("pushTool integration", () => {
+    it("pushes to remote", () => {
+      // Setup origin using mktemp
+      const originDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+      execSync("git init --bare", { cwd: originDir, stdio: "pipe" });
+      execSync(`git remote add origin ${originDir}`, { cwd: tempDir, stdio: "pipe" });
 
-			execGit(`git -C ${tempDir} push -u origin main`);
+      execGit(`git -C ${tempDir} push -u origin main`);
 
-			rmSync(originDir, { recursive: true, force: true });
-		});
-	});
+      rmSync(originDir, { recursive: true, force: true });
+    });
+  });
 
-	describe("repoInfoTool integration", () => {
-		it("gets current branch", () => {
-			const branch = execGit(`git -C ${tempDir} branch --show-current`);
-			expect(branch).toBe("main");
-		});
+  describe("repoInfoTool integration", () => {
+    it("gets current branch", () => {
+      const branch = execGit(`git -C ${tempDir} branch --show-current`);
+      expect(branch).toBe("main");
+    });
 
-		it("gets status output with changes", () => {
-			writeFileSync(join(tempDir, "newfile.txt"), "content");
+    it("gets status output with changes", () => {
+      writeFileSync(join(tempDir, "newfile.txt"), "content");
 
-			const status = execGit(`git -C ${tempDir} status --porcelain`);
-			expect(status).toContain("newfile.txt");
-		});
+      const status = execGit(`git -C ${tempDir} status --porcelain`);
+      expect(status).toContain("newfile.txt");
+    });
 
-		it("parses staged and modified files", () => {
-			writeFileSync(join(tempDir, "initial.txt"), "modified content");
-			execSync(`git -C ${tempDir} add initial.txt`, { stdio: "pipe" });
+    it("parses staged and modified files", () => {
+      writeFileSync(join(tempDir, "initial.txt"), "modified content");
+      execSync(`git -C ${tempDir} add initial.txt`, { stdio: "pipe" });
 
-			writeFileSync(join(tempDir, "another.txt"), "new");
-			execSync(`git -C ${tempDir} add .`, { stdio: "pipe" });
+      writeFileSync(join(tempDir, "another.txt"), "new");
+      execSync(`git -C ${tempDir} add .`, { stdio: "pipe" });
 
-			const status = execGit(`git -C ${tempDir} status --porcelain`);
-			expect(status).toContain("initial.txt");
-			expect(status).toContain("another.txt");
-		});
-	});
+      const status = execGit(`git -C ${tempDir} status --porcelain`);
+      expect(status).toContain("initial.txt");
+      expect(status).toContain("another.txt");
+    });
+  });
 
-	describe("getLatestTagTool integration", () => {
-		it("returns empty when no tags", () => {
-			const tags = execGit(`git -C ${tempDir} tag -l 'v*' | sort -rV | head -1`);
-			expect(tags).toBe("");
-		});
+  describe("getLatestTagTool integration", () => {
+    it("returns empty when no tags", () => {
+      const tags = execGit(`git -C ${tempDir} tag -l 'v*' | sort -rV | head -1`);
+      expect(tags).toBe("");
+    });
 
-		it("returns latest tag", () => {
-			execSync(`git -C ${tempDir} tag v1.0.0`);
+    it("returns latest tag", () => {
+      execSync(`git -C ${tempDir} tag v1.0.0`);
 
-			const tags = execGit(`git -C ${tempDir} tag -l 'v*' | sort -rV | head -1`);
-			expect(tags).toBe("v1.0.0");
-		});
+      const tags = execGit(`git -C ${tempDir} tag -l 'v*' | sort -rV | head -1`);
+      expect(tags).toBe("v1.0.0");
+    });
 
-		it("returns correct tag when multiple exist", () => {
-			execSync(`git -C ${tempDir} tag v1.0.0`);
-			execSync(`git -C ${tempDir} tag v2.0.0`);
-			execSync(`git -C ${tempDir} tag v1.5.0`);
+    it("returns correct tag when multiple exist", () => {
+      execSync(`git -C ${tempDir} tag v1.0.0`);
+      execSync(`git -C ${tempDir} tag v2.0.0`);
+      execSync(`git -C ${tempDir} tag v1.5.0`);
 
-			const tags = execGit(`git -C ${tempDir} tag -l 'v*' | sort -rV | head -1`);
-			expect(tags).toBe("v2.0.0");
-		});
-	});
+      const tags = execGit(`git -C ${tempDir} tag -l 'v*' | sort -rV | head -1`);
+      expect(tags).toBe("v2.0.0");
+    });
+  });
 
-	describe("analyzeCommitsTool integration", () => {
-		it("parses conventional commits", () => {
-			writeFileSync(join(tempDir, "feat.txt"), "feat");
-			execSync("git add .", { cwd: tempDir, stdio: "pipe" });
-			execSync(`git -C ${tempDir} commit -m "feat: add feature"`, { stdio: "pipe" });
+  describe("analyzeCommitsTool integration", () => {
+    it("parses conventional commits", () => {
+      writeFileSync(join(tempDir, "feat.txt"), "feat");
+      execSync("git add .", { cwd: tempDir, stdio: "pipe" });
+      execSync(`git -C ${tempDir} commit -m "feat: add feature"`, { stdio: "pipe" });
 
-			const commits = execGit(`git -C ${tempDir} log --format="%s" -n 1`);
-			expect(commits).toContain("feat:");
-		});
+      const commits = execGit(`git -C ${tempDir} log --format="%s" -n 1`);
+      expect(commits).toContain("feat:");
+    });
 
-		it("counts commits since tag", () => {
-			execSync(`git -C ${tempDir} tag v1.0.0`);
+    it("counts commits since tag", () => {
+      execSync(`git -C ${tempDir} tag v1.0.0`);
 
-			writeFileSync(join(tempDir, "a.txt"), "a");
-			execSync("git add .", { cwd: tempDir, stdio: "pipe" });
-			execSync(`git -C ${tempDir} commit -m "fix: fix"`, { stdio: "pipe" });
+      writeFileSync(join(tempDir, "a.txt"), "a");
+      execSync("git add .", { cwd: tempDir, stdio: "pipe" });
+      execSync(`git -C ${tempDir} commit -m "fix: fix"`, { stdio: "pipe" });
 
-			const count = execGit(`git -C ${tempDir} log v1.0.0..HEAD --oneline | wc -l`).trim();
-			expect(parseInt(count, 10)).toBeGreaterThan(0);
-		});
-	});
+      const count = execGit(`git -C ${tempDir} log v1.0.0..HEAD --oneline | wc -l`).trim();
+      expect(parseInt(count, 10)).toBeGreaterThan(0);
+    });
+  });
 
-	describe("mergePrTool integration", () => {
-		it("handles pr view command", () => {
-			// This tests the gh pr view command structure
-			const prInfo = execGh("gh pr view 1 --json title,url,state 2>/dev/null || echo '{}'");
-			expect(prInfo).toBeDefined();
-		});
-	});
+  describe("mergePrTool integration", () => {
+    it("handles pr view command", () => {
+      // This tests the gh pr view command structure
+      const prInfo = execGh("gh pr view 1 --json title,url,state 2>/dev/null || echo '{}'");
+      expect(prInfo).toBeDefined();
+    });
+  });
 
-	describe("checkCiTool integration", () => {
-		it("handles gh run list command", () => {
-			// Test gh run list command
-			const runs = execGh("gh run list --limit 1 2>/dev/null || echo ''");
-			expect(runs !== undefined).toBe(true);
-		});
-	});
+  describe("checkCiTool integration", () => {
+    it("handles gh run list command", () => {
+      // Test gh run list command
+      const runs = execGh("gh run list --limit 1 2>/dev/null || echo ''");
+      expect(runs !== undefined).toBe(true);
+    });
+  });
 });
 
 describe("execGh", () => {
-	it("executes gh command successfully when a fake authenticated gh is on PATH", () => {
-		const originalPath = process.env.PATH;
-		const fakeBinDir = mkdtempSync(join(tmpdir(), "pi-devtools-gh-bin-"));
-		const ghPath = join(fakeBinDir, "gh");
-		writeFileSync(ghPath, '#!/bin/sh\nif [ "$1 $2" = "auth status" ]; then echo \'logged in\'; exit 0; fi\nexit 1\n', {
-			encoding: "utf-8",
-			mode: 0o755,
-		});
-		process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+  it("executes gh command successfully when a fake authenticated gh is on PATH", () => {
+    const originalPath = process.env.PATH;
+    const fakeBinDir = mkdtempSync(join(tmpdir(), "pi-devtools-gh-bin-"));
+    const ghPath = join(fakeBinDir, "gh");
+    writeFileSync(ghPath, '#!/bin/sh\nif [ "$1 $2" = "auth status" ]; then echo \'logged in\'; exit 0; fi\nexit 1\n', {
+      encoding: "utf-8",
+      mode: 0o755,
+    });
+    process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
 
-		try {
-			const result = execGh("gh auth status");
-			expect(result).toContain("logged in");
-		} finally {
-			process.env.PATH = originalPath;
-			rmSync(fakeBinDir, { recursive: true, force: true });
-		}
-	});
+    try {
+      const result = execGh("gh auth status");
+      expect(result).toContain("logged in");
+    } finally {
+      process.env.PATH = originalPath;
+      rmSync(fakeBinDir, { recursive: true, force: true });
+    }
+  });
 
-	it("throws error for invalid gh command", () => {
-		expect(() => execGh("gh invalid-command")).toThrow("gh error");
-	});
+  it("throws error for invalid gh command", () => {
+    expect(() => execGh("gh invalid-command")).toThrow("gh error");
+  });
 });

--- a/packages/pi-devtools/__tests__/git.unit.test.ts
+++ b/packages/pi-devtools/__tests__/git.unit.test.ts
@@ -1,89 +1,89 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { execSyncMock } = vi.hoisted(() => ({
-	execSyncMock: vi.fn(),
+  execSyncMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
-	execSync: execSyncMock,
+  execSync: execSyncMock,
 }));
 
 import {
-	compareVersions,
-	execGh,
-	execGit,
-	getCurrentBranch,
-	getGitContext,
-	getTagInfo,
-	getWorkingTreeStatus,
-	isGitRepo,
-	parseVersion,
+  compareVersions,
+  execGh,
+  execGit,
+  getCurrentBranch,
+  getGitContext,
+  getTagInfo,
+  getWorkingTreeStatus,
+  isGitRepo,
+  parseVersion,
 } from "../extensions/git.js";
 
 describe("pi-devtools git unit helpers", () => {
-	afterEach(() => {
-		execSyncMock.mockReset();
-	});
+  afterEach(() => {
+    execSyncMock.mockReset();
+  });
 
-	it("parses and compares versions", () => {
-		expect(parseVersion("v1.2.3")).toEqual([1, 2, 3]);
-		expect(parseVersion("2.0.1")).toEqual([2, 0, 1]);
-		expect(compareVersions([1, 2, 0], [1, 1, 9])).toBeGreaterThan(0);
-		expect(compareVersions([1, 2], [1, 2, 0])).toBe(0);
-	});
+  it("parses and compares versions", () => {
+    expect(parseVersion("v1.2.3")).toEqual([1, 2, 3]);
+    expect(parseVersion("2.0.1")).toEqual([2, 0, 1]);
+    expect(compareVersions([1, 2, 0], [1, 1, 9])).toBeGreaterThan(0);
+    expect(compareVersions([1, 2], [1, 2, 0])).toBe(0);
+  });
 
-	it("detects whether the cwd is inside a git repository", () => {
-		execSyncMock.mockReturnValueOnce("true\n");
-		expect(isGitRepo()).toBe(true);
+  it("detects whether the cwd is inside a git repository", () => {
+    execSyncMock.mockReturnValueOnce("true\n");
+    expect(isGitRepo()).toBe(true);
 
-		execSyncMock.mockImplementationOnce(() => {
-			throw new Error("not a repo");
-		});
-		expect(isGitRepo()).toBe(false);
-	});
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error("not a repo");
+    });
+    expect(isGitRepo()).toBe(false);
+  });
 
-	it("returns detached head branch labels when branch name is empty", () => {
-		execSyncMock.mockReturnValueOnce("\n").mockReturnValueOnce("abc123\n");
-		expect(getCurrentBranch()).toBe("Detached HEAD at abc123");
-	});
+  it("returns detached head branch labels when branch name is empty", () => {
+    execSyncMock.mockReturnValueOnce("\n").mockReturnValueOnce("abc123\n");
+    expect(getCurrentBranch()).toBe("Detached HEAD at abc123");
+  });
 
-	it("formats working tree status from porcelain output", () => {
-		execSyncMock.mockReturnValueOnce(" M file1\n?? new.txt\n M file2\n");
-		expect(getWorkingTreeStatus()).toBe("2 modified, 1 untracked");
-	});
+  it("formats working tree status from porcelain output", () => {
+    execSyncMock.mockReturnValueOnce(" M file1\n?? new.txt\n M file2\n");
+    expect(getWorkingTreeStatus()).toBe("2 modified, 1 untracked");
+  });
 
-	it("formats tag info with unreleased commit count", () => {
-		execSyncMock.mockReturnValueOnce("v1.0.0\nv1.2.0\nv1.1.5\n").mockReturnValueOnce("3\n");
-		expect(getTagInfo()).toBe("Tag: v1.2.0 (3 unreleased commits)");
-	});
+  it("formats tag info with unreleased commit count", () => {
+    execSyncMock.mockReturnValueOnce("v1.0.0\nv1.2.0\nv1.1.5\n").mockReturnValueOnce("3\n");
+    expect(getTagInfo()).toBe("Tag: v1.2.0 (3 unreleased commits)");
+  });
 
-	it("returns no tags message when tag list is empty", () => {
-		execSyncMock.mockReturnValueOnce("\n");
-		expect(getTagInfo()).toBe("No version tags found");
-	});
+  it("returns no tags message when tag list is empty", () => {
+    execSyncMock.mockReturnValueOnce("\n");
+    expect(getTagInfo()).toBe("No version tags found");
+  });
 
-	it("builds git context from branch, status, and tags", () => {
-		execSyncMock
-			.mockReturnValueOnce("true\n")
-			.mockReturnValueOnce("feature/coverage\n")
-			.mockReturnValueOnce(" M file.ts\n")
-			.mockReturnValueOnce("v1.0.0\n")
-			.mockReturnValueOnce("2\n");
+  it("builds git context from branch, status, and tags", () => {
+    execSyncMock
+      .mockReturnValueOnce("true\n")
+      .mockReturnValueOnce("feature/coverage\n")
+      .mockReturnValueOnce(" M file.ts\n")
+      .mockReturnValueOnce("v1.0.0\n")
+      .mockReturnValueOnce("2\n");
 
-		expect(getGitContext()).toBe(
-			"[devtools] Branch: feature/coverage | Status: 1 modified | Tag: v1.0.0 (2 unreleased commits)",
-		);
-	});
+    expect(getGitContext()).toBe(
+      "[devtools] Branch: feature/coverage | Status: 1 modified | Tag: v1.0.0 (2 unreleased commits)",
+    );
+  });
 
-	it("wraps git and gh command failures with clearer messages", () => {
-		execSyncMock.mockImplementationOnce(() => {
-			throw new Error("git blew up");
-		});
-		expect(() => execGit("git status")).toThrow("Git error: git blew up");
+  it("wraps git and gh command failures with clearer messages", () => {
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error("git blew up");
+    });
+    expect(() => execGit("git status")).toThrow("Git error: git blew up");
 
-		execSyncMock.mockImplementationOnce(() => {
-			throw new Error("gh blew up");
-		});
-		expect(() => execGh("gh pr view")).toThrow("gh error: gh blew up");
-	});
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error("gh blew up");
+    });
+    expect(() => execGh("gh pr view")).toThrow("gh error: gh blew up");
+  });
 });

--- a/packages/pi-devtools/__tests__/helpers.test.ts
+++ b/packages/pi-devtools/__tests__/helpers.test.ts
@@ -4,361 +4,361 @@ import { compareVersions, getGitContext, parseVersion } from "../extensions/git.
 import devtoolsExtension, { parseConventionalCommit } from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 describe("pi-devtools helpers", () => {
-	describe("parseConventionalCommit", () => {
-		it("parses feat commit", () => {
-			const result = parseConventionalCommit("feat: add new feature");
-			expect(result.type).toBe("feat");
-			expect(result.breaking).toBe(false);
-		});
+  describe("parseConventionalCommit", () => {
+    it("parses feat commit", () => {
+      const result = parseConventionalCommit("feat: add new feature");
+      expect(result.type).toBe("feat");
+      expect(result.breaking).toBe(false);
+    });
 
-		it("parses fix commit", () => {
-			const result = parseConventionalCommit("fix: fix bug");
-			expect(result.type).toBe("fix");
-			expect(result.breaking).toBe(false);
-		});
+    it("parses fix commit", () => {
+      const result = parseConventionalCommit("fix: fix bug");
+      expect(result.type).toBe("fix");
+      expect(result.breaking).toBe(false);
+    });
 
-		it("parses commit with scope", () => {
-			const result = parseConventionalCommit("feat(core): add new feature");
-			expect(result.type).toBe("feat");
-			expect(result.scope).toBe("core");
-			expect(result.breaking).toBe(false);
-		});
+    it("parses commit with scope", () => {
+      const result = parseConventionalCommit("feat(core): add new feature");
+      expect(result.type).toBe("feat");
+      expect(result.scope).toBe("core");
+      expect(result.breaking).toBe(false);
+    });
 
-		it("parses breaking commit with !", () => {
-			const result = parseConventionalCommit("feat!: breaking change");
-			expect(result.type).toBe("feat");
-			expect(result.breaking).toBe(true);
-		});
+    it("parses breaking commit with !", () => {
+      const result = parseConventionalCommit("feat!: breaking change");
+      expect(result.type).toBe("feat");
+      expect(result.breaking).toBe(true);
+    });
 
-		it("parses non-conventional commit", () => {
-			const result = parseConventionalCommit("just a regular message");
-			expect(result.type).toBe("other");
-			expect(result.breaking).toBe(false);
-		});
+    it("parses non-conventional commit", () => {
+      const result = parseConventionalCommit("just a regular message");
+      expect(result.type).toBe("other");
+      expect(result.breaking).toBe(false);
+    });
 
-		it("normalizes type to lowercase", () => {
-			const result = parseConventionalCommit("FEAT: add feature");
-			expect(result.type).toBe("feat");
-		});
+    it("normalizes type to lowercase", () => {
+      const result = parseConventionalCommit("FEAT: add feature");
+      expect(result.type).toBe("feat");
+    });
 
-		it("parses chore commit", () => {
-			const result = parseConventionalCommit("chore: update deps");
-			expect(result.type).toBe("chore");
-			expect(result.breaking).toBe(false);
-		});
+    it("parses chore commit", () => {
+      const result = parseConventionalCommit("chore: update deps");
+      expect(result.type).toBe("chore");
+      expect(result.breaking).toBe(false);
+    });
 
-		it("parses docs commit", () => {
-			const result = parseConventionalCommit("docs: update readme");
-			expect(result.type).toBe("docs");
-		});
+    it("parses docs commit", () => {
+      const result = parseConventionalCommit("docs: update readme");
+      expect(result.type).toBe("docs");
+    });
 
-		it("parses refactor commit", () => {
-			const result = parseConventionalCommit("refactor: simplify code");
-			expect(result.type).toBe("refactor");
-		});
+    it("parses refactor commit", () => {
+      const result = parseConventionalCommit("refactor: simplify code");
+      expect(result.type).toBe("refactor");
+    });
 
-		it("parses test commit", () => {
-			const result = parseConventionalCommit("test: add unit tests");
-			expect(result.type).toBe("test");
-		});
+    it("parses test commit", () => {
+      const result = parseConventionalCommit("test: add unit tests");
+      expect(result.type).toBe("test");
+    });
 
-		it("parses ci commit", () => {
-			const result = parseConventionalCommit("ci: update pipeline");
-			expect(result.type).toBe("ci");
-		});
+    it("parses ci commit", () => {
+      const result = parseConventionalCommit("ci: update pipeline");
+      expect(result.type).toBe("ci");
+    });
 
-		it("parses build commit", () => {
-			const result = parseConventionalCommit("build: compile assets");
-			expect(result.type).toBe("build");
-		});
+    it("parses build commit", () => {
+      const result = parseConventionalCommit("build: compile assets");
+      expect(result.type).toBe("build");
+    });
 
-		it("parses perf commit", () => {
-			const result = parseConventionalCommit("perf: improve performance");
-			expect(result.type).toBe("perf");
-		});
+    it("parses perf commit", () => {
+      const result = parseConventionalCommit("perf: improve performance");
+      expect(result.type).toBe("perf");
+    });
 
-		it("parses style commit", () => {
-			const result = parseConventionalCommit("style: format code");
-			expect(result.type).toBe("style");
-		});
-	});
+    it("parses style commit", () => {
+      const result = parseConventionalCommit("style: format code");
+      expect(result.type).toBe("style");
+    });
+  });
 });
 
 describe("pi-devtools extension", () => {
-	describe("tool registration", () => {
-		it("registers all tools", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+  describe("tool registration", () => {
+    it("registers all tools", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+      const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
 
-			expect(toolNames).toContain("devtools_create_branch");
-			expect(toolNames).toContain("devtools_commit");
-			expect(toolNames).toContain("devtools_push");
-			expect(toolNames).toContain("devtools_create_pr");
-			expect(toolNames).toContain("devtools_merge_pr");
-			expect(toolNames).toContain("devtools_squash_merge_pr");
-			expect(toolNames).toContain("devtools_check_ci");
-			expect(toolNames).toContain("devtools_get_repo_info");
-			expect(toolNames).toContain("devtools_get_latest_tag");
-			expect(toolNames).toContain("devtools_analyze_commits");
-			expect(toolNames).toContain("devtools_bump_version");
-			expect(toolNames).toContain("devtools_create_release");
-		});
+      expect(toolNames).toContain("devtools_create_branch");
+      expect(toolNames).toContain("devtools_commit");
+      expect(toolNames).toContain("devtools_push");
+      expect(toolNames).toContain("devtools_create_pr");
+      expect(toolNames).toContain("devtools_merge_pr");
+      expect(toolNames).toContain("devtools_squash_merge_pr");
+      expect(toolNames).toContain("devtools_check_ci");
+      expect(toolNames).toContain("devtools_get_repo_info");
+      expect(toolNames).toContain("devtools_get_latest_tag");
+      expect(toolNames).toContain("devtools_analyze_commits");
+      expect(toolNames).toContain("devtools_bump_version");
+      expect(toolNames).toContain("devtools_create_release");
+    });
 
-		it("registers exactly 12 tools", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("registers exactly 12 tools", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-			expect(toolNames).toHaveLength(12);
-		});
+      const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+      expect(toolNames).toHaveLength(12);
+    });
 
-		it("registers tools with execute functions", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("registers tools with execute functions", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			tools.forEach((tool) => {
-				expect(tool.execute).toBeDefined();
-				expect(typeof tool.execute).toBe("function");
-			});
-		});
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      tools.forEach((tool) => {
+        expect(tool.execute).toBeDefined();
+        expect(typeof tool.execute).toBe("function");
+      });
+    });
 
-		it("registers tools with labels", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("registers tools with labels", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			tools.forEach((tool) => {
-				expect(tool.label).toBeDefined();
-				expect(tool.label.length).toBeGreaterThan(0);
-			});
-		});
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      tools.forEach((tool) => {
+        expect(tool.label).toBeDefined();
+        expect(tool.label.length).toBeGreaterThan(0);
+      });
+    });
 
-		it("registers tools with descriptions", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("registers tools with descriptions", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			tools.forEach((tool) => {
-				expect(tool.description).toBeDefined();
-				expect(tool.description.length).toBeGreaterThan(0);
-			});
-		});
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      tools.forEach((tool) => {
+        expect(tool.description).toBeDefined();
+        expect(tool.description.length).toBeGreaterThan(0);
+      });
+    });
 
-		it("registers tools with parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("registers tools with parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			tools.forEach((tool) => {
-				expect(tool.parameters).toBeDefined();
-			});
-		});
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      tools.forEach((tool) => {
+        expect(tool.parameters).toBeDefined();
+      });
+    });
 
-		it("devtools_create_branch has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_create_branch has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const branchTool = tools.find((t) => t.name === "devtools_create_branch");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const branchTool = tools.find((t) => t.name === "devtools_create_branch");
 
-			expect(branchTool?.parameters).toBeDefined();
-			expect(branchTool?.label).toBe("Create Branch");
-		});
+      expect(branchTool?.parameters).toBeDefined();
+      expect(branchTool?.label).toBe("Create Branch");
+    });
 
-		it("devtools_commit has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_commit has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const commitTool = tools.find((t) => t.name === "devtools_commit");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const commitTool = tools.find((t) => t.name === "devtools_commit");
 
-			expect(commitTool?.parameters).toBeDefined();
-			expect(commitTool?.label).toBe("Git Commit");
-		});
+      expect(commitTool?.parameters).toBeDefined();
+      expect(commitTool?.label).toBe("Git Commit");
+    });
 
-		it("devtools_push has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_push has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const pushTool = tools.find((t) => t.name === "devtools_push");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const pushTool = tools.find((t) => t.name === "devtools_push");
 
-			expect(pushTool?.parameters).toBeDefined();
-			expect(pushTool?.label).toBe("Git Push");
-		});
+      expect(pushTool?.parameters).toBeDefined();
+      expect(pushTool?.label).toBe("Git Push");
+    });
 
-		it("devtools_create_pr has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_create_pr has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const prTool = tools.find((t) => t.name === "devtools_create_pr");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const prTool = tools.find((t) => t.name === "devtools_create_pr");
 
-			expect(prTool?.parameters).toBeDefined();
-			expect(prTool?.label).toBe("Create PR");
-		});
+      expect(prTool?.parameters).toBeDefined();
+      expect(prTool?.label).toBe("Create PR");
+    });
 
-		it("devtools_merge_pr has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_merge_pr has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const mergeTool = tools.find((t) => t.name === "devtools_merge_pr");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const mergeTool = tools.find((t) => t.name === "devtools_merge_pr");
 
-			expect(mergeTool?.parameters).toBeDefined();
-			expect(mergeTool?.label).toBe("Merge PR");
-		});
+      expect(mergeTool?.parameters).toBeDefined();
+      expect(mergeTool?.label).toBe("Merge PR");
+    });
 
-		it("devtools_squash_merge_pr has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_squash_merge_pr has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const squashTool = tools.find((t) => t.name === "devtools_squash_merge_pr");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const squashTool = tools.find((t) => t.name === "devtools_squash_merge_pr");
 
-			expect(squashTool?.parameters).toBeDefined();
-			expect(squashTool?.label).toBe("Squash Merge PR");
-		});
+      expect(squashTool?.parameters).toBeDefined();
+      expect(squashTool?.label).toBe("Squash Merge PR");
+    });
 
-		it("devtools_check_ci has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_check_ci has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const ciTool = tools.find((t) => t.name === "devtools_check_ci");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const ciTool = tools.find((t) => t.name === "devtools_check_ci");
 
-			expect(ciTool?.parameters).toBeDefined();
-			expect(ciTool?.label).toBe("Check CI");
-		});
+      expect(ciTool?.parameters).toBeDefined();
+      expect(ciTool?.label).toBe("Check CI");
+    });
 
-		it("devtools_get_repo_info has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_get_repo_info has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const repoInfoTool = tools.find((t) => t.name === "devtools_get_repo_info");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const repoInfoTool = tools.find((t) => t.name === "devtools_get_repo_info");
 
-			expect(repoInfoTool?.parameters).toBeDefined();
-			expect(repoInfoTool?.label).toBe("Repo Info");
-		});
+      expect(repoInfoTool?.parameters).toBeDefined();
+      expect(repoInfoTool?.label).toBe("Repo Info");
+    });
 
-		it("devtools_get_latest_tag has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_get_latest_tag has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const tagTool = tools.find((t) => t.name === "devtools_get_latest_tag");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const tagTool = tools.find((t) => t.name === "devtools_get_latest_tag");
 
-			expect(tagTool?.parameters).toBeDefined();
-			expect(tagTool?.label).toBe("Latest Tag");
-		});
+      expect(tagTool?.parameters).toBeDefined();
+      expect(tagTool?.label).toBe("Latest Tag");
+    });
 
-		it("devtools_analyze_commits has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_analyze_commits has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const analyzeTool = tools.find((t) => t.name === "devtools_analyze_commits");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const analyzeTool = tools.find((t) => t.name === "devtools_analyze_commits");
 
-			expect(analyzeTool?.parameters).toBeDefined();
-			expect(analyzeTool?.label).toBe("Analyze Commits");
-		});
+      expect(analyzeTool?.parameters).toBeDefined();
+      expect(analyzeTool?.label).toBe("Analyze Commits");
+    });
 
-		it("devtools_bump_version has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_bump_version has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const bumpTool = tools.find((t) => t.name === "devtools_bump_version");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const bumpTool = tools.find((t) => t.name === "devtools_bump_version");
 
-			expect(bumpTool?.parameters).toBeDefined();
-			expect(bumpTool?.label).toBe("Bump Version");
-		});
+      expect(bumpTool?.parameters).toBeDefined();
+      expect(bumpTool?.label).toBe("Bump Version");
+    });
 
-		it("devtools_create_release has correct parameters", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("devtools_create_release has correct parameters", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-			const releaseTool = tools.find((t) => t.name === "devtools_create_release");
+      const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+      const releaseTool = tools.find((t) => t.name === "devtools_create_release");
 
-			expect(releaseTool?.parameters).toBeDefined();
-			expect(releaseTool?.label).toBe("Create Release");
-		});
+      expect(releaseTool?.parameters).toBeDefined();
+      expect(releaseTool?.label).toBe("Create Release");
+    });
 
-		it("handles multiple extension instances", () => {
-			const mockPi1 = createMockPi();
-			const mockPi2 = createMockPi();
+    it("handles multiple extension instances", () => {
+      const mockPi1 = createMockPi();
+      const mockPi2 = createMockPi();
 
-			devtoolsExtension(mockPi1 as unknown as ExtensionAPI);
-			devtoolsExtension(mockPi2 as unknown as ExtensionAPI);
+      devtoolsExtension(mockPi1 as unknown as ExtensionAPI);
+      devtoolsExtension(mockPi2 as unknown as ExtensionAPI);
 
-			expect(mockPi1.registerTool).toHaveBeenCalledTimes(12);
-			expect(mockPi2.registerTool).toHaveBeenCalledTimes(12);
-		});
+      expect(mockPi1.registerTool).toHaveBeenCalledTimes(12);
+      expect(mockPi2.registerTool).toHaveBeenCalledTimes(12);
+    });
 
-		it("registers session_start handler", () => {
-			const mockPi = createMockPi();
-			devtoolsExtension(mockPi as unknown as ExtensionAPI);
+    it("registers session_start handler", () => {
+      const mockPi = createMockPi();
+      devtoolsExtension(mockPi as unknown as ExtensionAPI);
 
-			const events = mockPi.on.mock.calls.map(([event]) => event);
-			expect(events).toContain("session_start");
-		});
-	});
+      const events = mockPi.on.mock.calls.map(([event]) => event);
+      expect(events).toContain("session_start");
+    });
+  });
 });
 
 describe("git context functions", () => {
-	describe("parseVersion", () => {
-		it("parses basic version", () => {
-			const result = parseVersion("v1.2.3");
-			expect(result).toEqual([1, 2, 3]);
-		});
+  describe("parseVersion", () => {
+    it("parses basic version", () => {
+      const result = parseVersion("v1.2.3");
+      expect(result).toEqual([1, 2, 3]);
+    });
 
-		it("handles version without v prefix", () => {
-			const result = parseVersion("2.0.0");
-			expect(result).toEqual([2, 0, 0]);
-		});
+    it("handles version without v prefix", () => {
+      const result = parseVersion("2.0.0");
+      expect(result).toEqual([2, 0, 0]);
+    });
 
-		it("filters invalid parts", () => {
-			const result = parseVersion("1.0.0-beta.1");
-			// Parses [1, 0, 0, NaN, 1] - NaN is filtered, 1 is valid
-			expect(result).toEqual([1, 0, 0, 1]);
-		});
-	});
+    it("filters invalid parts", () => {
+      const result = parseVersion("1.0.0-beta.1");
+      // Parses [1, 0, 0, NaN, 1] - NaN is filtered, 1 is valid
+      expect(result).toEqual([1, 0, 0, 1]);
+    });
+  });
 
-	describe("compareVersions", () => {
-		it("sorts ascending", () => {
-			const tags = ["v1.0.0", "v2.0.0", "v1.1.0"];
-			tags.sort((a, b) => compareVersions(parseVersion(a), parseVersion(b)));
-			expect(tags).toEqual(["v1.0.0", "v1.1.0", "v2.0.0"]);
-		});
+  describe("compareVersions", () => {
+    it("sorts ascending", () => {
+      const tags = ["v1.0.0", "v2.0.0", "v1.1.0"];
+      tags.sort((a, b) => compareVersions(parseVersion(a), parseVersion(b)));
+      expect(tags).toEqual(["v1.0.0", "v1.1.0", "v2.0.0"]);
+    });
 
-		it("handles different length versions", () => {
-			const result = compareVersions([1, 2], [1, 2, 0]);
-			expect(result).toBe(0);
-		});
-	});
+    it("handles different length versions", () => {
+      const result = compareVersions([1, 2], [1, 2, 0]);
+      expect(result).toBe(0);
+    });
+  });
 
-	describe("getGitContext", () => {
-		it("returns empty string for non-git directory", () => {
-			// In a non-git directory, should return empty
-			// This test assumes we're not in a git repo
-			const result = getGitContext();
-			// Result is either empty or contains [devtools] prefix if git repo
-			if (result) {
-				expect(result).toMatch(/^\[devtools\]/);
-			}
-		});
-	});
+  describe("getGitContext", () => {
+    it("returns empty string for non-git directory", () => {
+      // In a non-git directory, should return empty
+      // This test assumes we're not in a git repo
+      const result = getGitContext();
+      // Result is either empty or contains [devtools] prefix if git repo
+      if (result) {
+        expect(result).toMatch(/^\[devtools\]/);
+      }
+    });
+  });
 });

--- a/packages/pi-devtools/__tests__/index.test.ts
+++ b/packages/pi-devtools/__tests__/index.test.ts
@@ -3,80 +3,80 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("pi-devtools", () => {
-	describe("package", () => {
-		it("should have correct name", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.name).toBe("@feniix/pi-devtools");
-		});
+  describe("package", () => {
+    it("should have correct name", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.name).toBe("@feniix/pi-devtools");
+    });
 
-		it("should have version", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.version).toBeTruthy();
-		});
+    it("should have version", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.version).toBeTruthy();
+    });
 
-		it("should have pi extension entry point", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.pi).toBeDefined();
-			expect(pkg.pi.extensions).toContain("./extensions/index.ts");
-		});
+    it("should have pi extension entry point", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.pi).toBeDefined();
+      expect(pkg.pi.extensions).toContain("./extensions/index.ts");
+    });
 
-		it("should have correct description", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.description).toContain("Devtools");
-		});
-	});
+    it("should have correct description", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.description).toContain("Devtools");
+    });
+  });
 
-	describe("skills", () => {
-		it("should have brpr skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/brpr/SKILL.md"), "utf-8");
-			expect(skill).toContain("brpr");
-			expect(skill).toContain("Branch, Push, and PR Workflow");
-		});
+  describe("skills", () => {
+    it("should have brpr skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/brpr/SKILL.md"), "utf-8");
+      expect(skill).toContain("brpr");
+      expect(skill).toContain("Branch, Push, and PR Workflow");
+    });
 
-		it("should have release skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/release/SKILL.md"), "utf-8");
-			expect(skill).toContain("release");
-			expect(skill).toContain("Automate the release process");
-		});
+    it("should have release skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/release/SKILL.md"), "utf-8");
+      expect(skill).toContain("release");
+      expect(skill).toContain("Automate the release process");
+    });
 
-		it("should have merge skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/merge/SKILL.md"), "utf-8");
-			expect(skill).toContain("merge");
-			expect(skill).toContain("Merge or squash-merge a pull request");
-		});
-	});
+    it("should have merge skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/merge/SKILL.md"), "utf-8");
+      expect(skill).toContain("merge");
+      expect(skill).toContain("Merge or squash-merge a pull request");
+    });
+  });
 
-	describe("tools", () => {
-		it("should register branch tools", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain("devtools_create_branch");
-			expect(extension).toContain("devtools_commit");
-			expect(extension).toContain("devtools_push");
-		});
+  describe("tools", () => {
+    it("should register branch tools", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain("devtools_create_branch");
+      expect(extension).toContain("devtools_commit");
+      expect(extension).toContain("devtools_push");
+    });
 
-		it("should register PR tools", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain("devtools_create_pr");
-			expect(extension).toContain("devtools_merge_pr");
-			expect(extension).toContain("devtools_squash_merge_pr");
-		});
+    it("should register PR tools", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain("devtools_create_pr");
+      expect(extension).toContain("devtools_merge_pr");
+      expect(extension).toContain("devtools_squash_merge_pr");
+    });
 
-		it("should register release tools", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain("devtools_get_latest_tag");
-			expect(extension).toContain("devtools_analyze_commits");
-			expect(extension).toContain("devtools_bump_version");
-			expect(extension).toContain("devtools_create_release");
-		});
+    it("should register release tools", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain("devtools_get_latest_tag");
+      expect(extension).toContain("devtools_analyze_commits");
+      expect(extension).toContain("devtools_bump_version");
+      expect(extension).toContain("devtools_create_release");
+    });
 
-		it("should register CI check tool", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain("devtools_check_ci");
-		});
+    it("should register CI check tool", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain("devtools_check_ci");
+    });
 
-		it("should register repo info tool", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain("devtools_get_repo_info");
-		});
-	});
+    it("should register repo info tool", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain("devtools_get_repo_info");
+    });
+  });
 });

--- a/packages/pi-devtools/__tests__/tools.test.ts
+++ b/packages/pi-devtools/__tests__/tools.test.ts
@@ -1,547 +1,547 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	analyzeCommitsTool,
-	bumpVersion,
-	checkCiTool,
-	commitTool,
-	createBranchTool,
-	createPrTool,
-	createReleaseTool,
-	getLatestTagTool,
-	mergePrTool,
-	pushTool,
-	repoInfoTool,
+  analyzeCommitsTool,
+  bumpVersion,
+  checkCiTool,
+  commitTool,
+  createBranchTool,
+  createPrTool,
+  createReleaseTool,
+  getLatestTagTool,
+  mergePrTool,
+  pushTool,
+  repoInfoTool,
 } from "../extensions/index.js";
 
 // Mock the git.ts module
 vi.mock("../extensions/git.js", () => ({
-	execGit: vi.fn(),
-	execGh: vi.fn(),
-	getDefaultBranch: vi.fn().mockReturnValue("main"),
+  execGit: vi.fn(),
+  execGh: vi.fn(),
+  getDefaultBranch: vi.fn().mockReturnValue("main"),
 }));
 
 import { execGh, execGit } from "../extensions/git.js";
 
 describe("pi-devtools", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.mocked(execGit).mockReset();
-		vi.mocked(execGh).mockReset();
-	});
-
-	describe("bumpVersion", () => {
-		it("bumps patch version", () => {
-			expect(bumpVersion("1.2.3", "patch")).toBe("1.2.4");
-		});
-
-		it("bumps minor version", () => {
-			expect(bumpVersion("1.2.3", "minor")).toBe("1.3.0");
-		});
-
-		it("bumps major version", () => {
-			expect(bumpVersion("1.2.3", "major")).toBe("2.0.0");
-		});
-
-		it("handles v-prefixed version", () => {
-			expect(bumpVersion("v1.2.3", "patch")).toBe("1.2.4");
-		});
-
-		it("throws on invalid version format", () => {
-			expect(() => bumpVersion("invalid", "patch")).toThrow("Invalid version format");
-		});
-
-		it("throws on incomplete version", () => {
-			expect(() => bumpVersion("1.2", "patch")).toThrow("Invalid version format");
-		});
-
-		it("throws on NaN version parts", () => {
-			expect(() => bumpVersion("1.a.3", "patch")).toThrow("Invalid version format");
-		});
-	});
-
-	describe("createBranchTool", () => {
-		it("creates branch successfully", () => {
-			vi.mocked(execGit).mockReturnValue("");
-
-			const result = createBranchTool("feature/new-feature");
-
-			expect(result.content[0].text).toContain("feature/new-feature");
-			expect(result.details.branch).toBe("feature/new-feature");
-		});
-
-		it("handles branch creation error", () => {
-			vi.mocked(execGit).mockImplementation(() => {
-				throw new Error("Branch already exists");
-			});
-
-			const result = createBranchTool("existing-branch");
-
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to create branch");
-		});
-	});
-
-	describe("commitTool", () => {
-		it("commits successfully", () => {
-			vi.mocked(execGit)
-				.mockReturnValueOnce("feature-branch")
-				.mockReturnValueOnce("")
-				.mockReturnValueOnce("file1.js")
-				.mockReturnValueOnce("");
-
-			const result = commitTool("feat: add new feature");
-
-			expect(result.content[0].text).toContain("Committed");
-			expect(result.details.message).toBe("feat: add new feature");
-		});
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(execGit).mockReset();
+    vi.mocked(execGh).mockReset();
+  });
+
+  describe("bumpVersion", () => {
+    it("bumps patch version", () => {
+      expect(bumpVersion("1.2.3", "patch")).toBe("1.2.4");
+    });
+
+    it("bumps minor version", () => {
+      expect(bumpVersion("1.2.3", "minor")).toBe("1.3.0");
+    });
+
+    it("bumps major version", () => {
+      expect(bumpVersion("1.2.3", "major")).toBe("2.0.0");
+    });
+
+    it("handles v-prefixed version", () => {
+      expect(bumpVersion("v1.2.3", "patch")).toBe("1.2.4");
+    });
+
+    it("throws on invalid version format", () => {
+      expect(() => bumpVersion("invalid", "patch")).toThrow("Invalid version format");
+    });
+
+    it("throws on incomplete version", () => {
+      expect(() => bumpVersion("1.2", "patch")).toThrow("Invalid version format");
+    });
+
+    it("throws on NaN version parts", () => {
+      expect(() => bumpVersion("1.a.3", "patch")).toThrow("Invalid version format");
+    });
+  });
+
+  describe("createBranchTool", () => {
+    it("creates branch successfully", () => {
+      vi.mocked(execGit).mockReturnValue("");
+
+      const result = createBranchTool("feature/new-feature");
+
+      expect(result.content[0].text).toContain("feature/new-feature");
+      expect(result.details.branch).toBe("feature/new-feature");
+    });
+
+    it("handles branch creation error", () => {
+      vi.mocked(execGit).mockImplementation(() => {
+        throw new Error("Branch already exists");
+      });
+
+      const result = createBranchTool("existing-branch");
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to create branch");
+    });
+  });
+
+  describe("commitTool", () => {
+    it("commits successfully", () => {
+      vi.mocked(execGit)
+        .mockReturnValueOnce("feature-branch")
+        .mockReturnValueOnce("")
+        .mockReturnValueOnce("file1.js")
+        .mockReturnValueOnce("");
+
+      const result = commitTool("feat: add new feature");
+
+      expect(result.content[0].text).toContain("Committed");
+      expect(result.details.message).toBe("feat: add new feature");
+    });
 
-		it("handles detached HEAD", () => {
-			vi.mocked(execGit).mockImplementation((cmd: string) => {
-				if (cmd === "git branch --show-current") {
-					throw new Error("detached HEAD");
-				}
-				throw new Error("Unexpected command");
-			});
-
-			const result = commitTool("feat: test");
-
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("detached HEAD");
-		});
-
-		it("handles no staged files", () => {
-			vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("").mockReturnValueOnce("");
+    it("handles detached HEAD", () => {
+      vi.mocked(execGit).mockImplementation((cmd: string) => {
+        if (cmd === "git branch --show-current") {
+          throw new Error("detached HEAD");
+        }
+        throw new Error("Unexpected command");
+      });
+
+      const result = commitTool("feat: test");
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("detached HEAD");
+    });
+
+    it("handles no staged files", () => {
+      vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("").mockReturnValueOnce("");
 
-			const result = commitTool("feat: test");
-
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("No files staged");
-		});
+      const result = commitTool("feat: test");
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("No files staged");
+    });
 
-		it("commits specific files", () => {
-			vi.mocked(execGit)
-				.mockReturnValueOnce("feature-branch")
-				.mockReturnValueOnce("")
-				.mockReturnValueOnce("specific.js")
-				.mockReturnValueOnce("");
+    it("commits specific files", () => {
+      vi.mocked(execGit)
+        .mockReturnValueOnce("feature-branch")
+        .mockReturnValueOnce("")
+        .mockReturnValueOnce("specific.js")
+        .mockReturnValueOnce("");
 
-			const result = commitTool("feat: test", ["specific.js"]);
+      const result = commitTool("feat: test", ["specific.js"]);
 
-			expect(result.isError).toBeUndefined();
-		});
+      expect(result.isError).toBeUndefined();
+    });
 
-		it("handles commit error", () => {
-			vi.mocked(execGit)
-				.mockReturnValueOnce("feature-branch")
-				.mockReturnValueOnce("")
-				.mockReturnValueOnce("file.js")
-				.mockImplementation(() => {
-					throw new Error("Commit failed");
-				});
+    it("handles commit error", () => {
+      vi.mocked(execGit)
+        .mockReturnValueOnce("feature-branch")
+        .mockReturnValueOnce("")
+        .mockReturnValueOnce("file.js")
+        .mockImplementation(() => {
+          throw new Error("Commit failed");
+        });
 
-			const result = commitTool("feat: test");
+      const result = commitTool("feat: test");
 
-			expect(result.isError).toBe(true);
-		});
-	});
+      expect(result.isError).toBe(true);
+    });
+  });
 
-	describe("pushTool", () => {
-		it("pushes branch successfully", () => {
-			vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("");
+  describe("pushTool", () => {
+    it("pushes branch successfully", () => {
+      vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("");
 
-			const result = pushTool();
+      const result = pushTool();
 
-			expect(result.content[0].text).toContain("Pushed");
-			expect(result.details.branch).toBe("feature-branch");
-		});
+      expect(result.content[0].text).toContain("Pushed");
+      expect(result.details.branch).toBe("feature-branch");
+    });
 
-		it("handles push error", () => {
-			vi.mocked(execGit).mockImplementation((cmd: string) => {
-				if (cmd === "git branch --show-current") return "feature-branch";
-				throw new Error("Push failed");
-			});
+    it("handles push error", () => {
+      vi.mocked(execGit).mockImplementation((cmd: string) => {
+        if (cmd === "git branch --show-current") return "feature-branch";
+        throw new Error("Push failed");
+      });
 
-			const result = pushTool();
+      const result = pushTool();
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Push failed");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Push failed");
+    });
+  });
 
-	describe("createPrTool", () => {
-		it("creates PR successfully", () => {
-			vi.mocked(execGit).mockReturnValue("main");
-			vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
+  describe("createPrTool", () => {
+    it("creates PR successfully", () => {
+      vi.mocked(execGit).mockReturnValue("main");
+      vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
 
-			const result = createPrTool("Add new feature", "Description");
+      const result = createPrTool("Add new feature", "Description");
 
-			expect(result.content[0].text).toContain("Created PR");
-			expect(result.details.prUrl).toContain("github.com");
-		});
+      expect(result.content[0].text).toContain("Created PR");
+      expect(result.details.prUrl).toContain("github.com");
+    });
 
-		it("creates PR without body", () => {
-			vi.mocked(execGit).mockReturnValue("main");
-			vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
+    it("creates PR without body", () => {
+      vi.mocked(execGit).mockReturnValue("main");
+      vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
 
-			const result = createPrTool("Test PR");
+      const result = createPrTool("Test PR");
 
-			expect(result.content[0].text).toContain("Created PR");
-		});
+      expect(result.content[0].text).toContain("Created PR");
+    });
 
-		it("creates draft PR", () => {
-			vi.mocked(execGit).mockReturnValue("main");
-			vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
+    it("creates draft PR", () => {
+      vi.mocked(execGit).mockReturnValue("main");
+      vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
 
-			createPrTool("Draft PR", undefined, undefined, true);
+      createPrTool("Draft PR", undefined, undefined, true);
 
-			// Capture the gh command and verify it contains --draft
-			const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
-			expect(ghCall).toContain("--draft");
-		});
+      // Capture the gh command and verify it contains --draft
+      const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
+      expect(ghCall).toContain("--draft");
+    });
 
-		it("creates PR with assignees", () => {
-			vi.mocked(execGit).mockReturnValue("main");
-			vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
+    it("creates PR with assignees", () => {
+      vi.mocked(execGit).mockReturnValue("main");
+      vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
 
-			createPrTool("Test PR", undefined, undefined, false, ["user1", "user2"]);
+      createPrTool("Test PR", undefined, undefined, false, ["user1", "user2"]);
 
-			const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
-			expect(ghCall).toContain("--assignee");
-		});
+      const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
+      expect(ghCall).toContain("--assignee");
+    });
 
-		it("handles PR creation error", () => {
-			vi.mocked(execGit).mockReturnValue("main");
-			vi.mocked(execGh).mockImplementation(() => {
-				throw new Error("gh not authenticated");
-			});
+    it("handles PR creation error", () => {
+      vi.mocked(execGit).mockReturnValue("main");
+      vi.mocked(execGh).mockImplementation(() => {
+        throw new Error("gh not authenticated");
+      });
 
-			const result = createPrTool("Test PR");
+      const result = createPrTool("Test PR");
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to create PR");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to create PR");
+    });
+  });
 
-	describe("mergePrTool", () => {
-		it("merges PR by number", () => {
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
-				.mockReturnValueOnce("");
+  describe("mergePrTool", () => {
+    it("merges PR by number", () => {
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
+        .mockReturnValueOnce("");
 
-			const result = mergePrTool(123);
+      const result = mergePrTool(123);
 
-			expect(result.content[0].text).toContain("Merged PR");
-			expect(result.details.prNumber).toBe(123);
-			expect(result.details.mergeType).toBe("merged");
-		});
+      expect(result.content[0].text).toContain("Merged PR");
+      expect(result.details.prNumber).toBe(123);
+      expect(result.details.mergeType).toBe("merged");
+    });
 
-		it("squash merges PR", () => {
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
-				.mockReturnValueOnce("");
+    it("squash merges PR", () => {
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
+        .mockReturnValueOnce("");
 
-			const result = mergePrTool(123, true);
+      const result = mergePrTool(123, true);
 
-			expect(result.details.mergeType).toBe("squash-merged");
-		});
+      expect(result.details.mergeType).toBe("squash-merged");
+    });
 
-		it("squash merges with commit title", () => {
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
-				.mockReturnValueOnce("");
+    it("squash merges with commit title", () => {
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
+        .mockReturnValueOnce("");
 
-			mergePrTool(123, true, true, "Custom Title");
+      mergePrTool(123, true, true, "Custom Title");
 
-			const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
-			expect(mergeCall).toContain("--title");
-		});
+      const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
+      expect(mergeCall).toContain("--title");
+    });
 
-		it("squash merges with commit message", () => {
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
-				.mockReturnValueOnce("");
+    it("squash merges with commit message", () => {
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
+        .mockReturnValueOnce("");
 
-			mergePrTool(123, true, true, undefined, "Custom Message");
+      mergePrTool(123, true, true, undefined, "Custom Message");
 
-			const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
-			expect(mergeCall).toContain("--body");
-		});
+      const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
+      expect(mergeCall).toContain("--body");
+    });
 
-		it("merges without deleting branch", () => {
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
-				.mockReturnValueOnce("");
+    it("merges without deleting branch", () => {
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
+        .mockReturnValueOnce("");
 
-			mergePrTool(123, false, false);
+      mergePrTool(123, false, false);
 
-			// Get the merge command (second call)
-			const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
-			expect(mergeCall).not.toContain("--delete-branch");
-		});
+      // Get the merge command (second call)
+      const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
+      expect(mergeCall).not.toContain("--delete-branch");
+    });
 
-		it("handles closed PR", () => {
-			vi.mocked(execGh).mockReturnValue(
-				JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "CLOSED" }),
-			);
+    it("handles closed PR", () => {
+      vi.mocked(execGh).mockReturnValue(
+        JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "CLOSED" }),
+      );
 
-			const result = mergePrTool(123);
+      const result = mergePrTool(123);
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("not open");
-		});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("not open");
+    });
 
-		it("detects PR from current branch", () => {
-			vi.mocked(execGit).mockReturnValue("feature-branch");
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify([{ number: 456, title: "Feature PR" }]))
-				.mockReturnValueOnce(JSON.stringify({ title: "Feature PR", url: "https://github.com/456", state: "OPEN" }))
-				.mockReturnValueOnce("");
+    it("detects PR from current branch", () => {
+      vi.mocked(execGit).mockReturnValue("feature-branch");
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify([{ number: 456, title: "Feature PR" }]))
+        .mockReturnValueOnce(JSON.stringify({ title: "Feature PR", url: "https://github.com/456", state: "OPEN" }))
+        .mockReturnValueOnce("");
 
-			const result = mergePrTool();
+      const result = mergePrTool();
 
-			expect(result.details.prNumber).toBe(456);
-		});
+      expect(result.details.prNumber).toBe(456);
+    });
 
-		it("returns error when no PR found", () => {
-			vi.mocked(execGit).mockReturnValue("feature-branch");
-			vi.mocked(execGh).mockReturnValue("");
+    it("returns error when no PR found", () => {
+      vi.mocked(execGit).mockReturnValue("feature-branch");
+      vi.mocked(execGh).mockReturnValue("");
 
-			const result = mergePrTool();
+      const result = mergePrTool();
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("No PR number provided");
-		});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("No PR number provided");
+    });
 
-		it("handles merge error", () => {
-			vi.mocked(execGh)
-				.mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
-				.mockImplementation(() => {
-					throw new Error("Merge conflict");
-				});
+    it("handles merge error", () => {
+      vi.mocked(execGh)
+        .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
+        .mockImplementation(() => {
+          throw new Error("Merge conflict");
+        });
 
-			const result = mergePrTool(123);
+      const result = mergePrTool(123);
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to merge PR");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to merge PR");
+    });
+  });
 
-	describe("checkCiTool", () => {
-		it("checks CI by PR number using gh pr checks", () => {
-			vi.mocked(execGh).mockReturnValue(
-				JSON.stringify([{ name: "Build", state: "SUCCESS", link: "https://ci", workflow: "CI" }]),
-			);
+  describe("checkCiTool", () => {
+    it("checks CI by PR number using gh pr checks", () => {
+      vi.mocked(execGh).mockReturnValue(
+        JSON.stringify([{ name: "Build", state: "SUCCESS", link: "https://ci", workflow: "CI" }]),
+      );
 
-			const result = checkCiTool(123);
+      const result = checkCiTool(123);
 
-			expect(vi.mocked(execGh)).toHaveBeenCalledWith("gh pr checks 123 --json name,state,link,workflow");
-			expect(result.content[0].text).toContain("CI Status");
-			expect(result.content[0].text).toContain("Build: SUCCESS");
-			expect(result.details.checks).toBeDefined();
-		});
+      expect(vi.mocked(execGh)).toHaveBeenCalledWith("gh pr checks 123 --json name,state,link,workflow");
+      expect(result.content[0].text).toContain("CI Status");
+      expect(result.content[0].text).toContain("Build: SUCCESS");
+      expect(result.details.checks).toBeDefined();
+    });
 
-		it("checks CI by branch", () => {
-			vi.mocked(execGh).mockReturnValue(JSON.stringify([{ workflowName: "Build", status: "in_progress" }]));
+    it("checks CI by branch", () => {
+      vi.mocked(execGh).mockReturnValue(JSON.stringify([{ workflowName: "Build", status: "in_progress" }]));
 
-			const result = checkCiTool(undefined, "feature-branch");
+      const result = checkCiTool(undefined, "feature-branch");
 
-			expect(result.content[0].text).toContain("CI Status");
-		});
+      expect(result.content[0].text).toContain("CI Status");
+    });
 
-		it("handles no CI runs found", () => {
-			vi.mocked(execGit).mockReturnValue("feature-branch");
-			vi.mocked(execGh).mockReturnValue("");
+    it("handles no CI runs found", () => {
+      vi.mocked(execGit).mockReturnValue("feature-branch");
+      vi.mocked(execGh).mockReturnValue("");
 
-			const result = checkCiTool();
+      const result = checkCiTool();
 
-			expect(result.content[0].text).toContain("No CI runs found");
-			expect(result.details.checks).toEqual([]);
-		});
+      expect(result.content[0].text).toContain("No CI runs found");
+      expect(result.details.checks).toEqual([]);
+    });
 
-		it("handles CI check error", () => {
-			vi.mocked(execGit).mockReturnValue("feature-branch");
-			vi.mocked(execGh).mockImplementation(() => {
-				throw new Error("gh not authenticated");
-			});
+    it("handles CI check error", () => {
+      vi.mocked(execGit).mockReturnValue("feature-branch");
+      vi.mocked(execGh).mockImplementation(() => {
+        throw new Error("gh not authenticated");
+      });
 
-			const result = checkCiTool();
+      const result = checkCiTool();
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to check CI");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to check CI");
+    });
+  });
 
-	describe("repoInfoTool", () => {
-		it("returns repo info successfully", () => {
-			vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("").mockReturnValueOnce("");
+  describe("repoInfoTool", () => {
+    it("returns repo info successfully", () => {
+      vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("").mockReturnValueOnce("");
 
-			const result = repoInfoTool();
+      const result = repoInfoTool();
 
-			expect(result.content[0].text).toContain("feature-branch");
-			expect(result.details.branch).toBe("feature-branch");
-		});
+      expect(result.content[0].text).toContain("feature-branch");
+      expect(result.details.branch).toBe("feature-branch");
+    });
 
-		it("handles detached HEAD", () => {
-			vi.mocked(execGit).mockImplementation((cmd: string) => {
-				if (cmd === "git branch --show-current") {
-					throw new Error("Not on a branch");
-				}
-				throw new Error("Unexpected command");
-			});
+    it("handles detached HEAD", () => {
+      vi.mocked(execGit).mockImplementation((cmd: string) => {
+        if (cmd === "git branch --show-current") {
+          throw new Error("Not on a branch");
+        }
+        throw new Error("Unexpected command");
+      });
 
-			const result = repoInfoTool();
+      const result = repoInfoTool();
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Not on a branch");
-		});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Not on a branch");
+    });
 
-		it("parses staged files", () => {
-			// Call sequence: git branch --show-current, git status --porcelain
-			vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("A  file1.js\nMM file2.ts");
+    it("parses staged files", () => {
+      // Call sequence: git branch --show-current, git status --porcelain
+      vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("A  file1.js\nMM file2.ts");
 
-			const result = repoInfoTool();
+      const result = repoInfoTool();
 
-			expect(result.details.staged).toContain("file1.js");
-			expect(result.details.modified).toContain("file2.ts");
-		});
+      expect(result.details.staged).toContain("file1.js");
+      expect(result.details.modified).toContain("file2.ts");
+    });
 
-		it("parses untracked files", () => {
-			vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("?? untracked.txt");
+    it("parses untracked files", () => {
+      vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("?? untracked.txt");
 
-			const result = repoInfoTool();
+      const result = repoInfoTool();
 
-			expect(result.details.untracked).toContain("untracked.txt");
-		});
+      expect(result.details.untracked).toContain("untracked.txt");
+    });
 
-		it("reports hasChanges correctly", () => {
-			vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("").mockReturnValueOnce("");
+    it("reports hasChanges correctly", () => {
+      vi.mocked(execGit).mockReturnValueOnce("feature-branch").mockReturnValueOnce("").mockReturnValueOnce("");
 
-			const result = repoInfoTool();
+      const result = repoInfoTool();
 
-			expect(result.details.hasChanges).toBe(false);
-		});
-	});
+      expect(result.details.hasChanges).toBe(false);
+    });
+  });
 
-	describe("getLatestTagTool", () => {
-		it("returns latest tag", () => {
-			vi.mocked(execGit).mockReturnValueOnce("v1.2.3").mockReturnValueOnce("10");
+  describe("getLatestTagTool", () => {
+    it("returns latest tag", () => {
+      vi.mocked(execGit).mockReturnValueOnce("v1.2.3").mockReturnValueOnce("10");
 
-			const result = getLatestTagTool();
+      const result = getLatestTagTool();
 
-			expect(result.content[0].text).toContain("v1.2.3");
-			expect(result.details.tag).toBe("v1.2.3");
-			expect(result.details.commitsSince).toBe(10);
-		});
+      expect(result.content[0].text).toContain("v1.2.3");
+      expect(result.details.tag).toBe("v1.2.3");
+      expect(result.details.commitsSince).toBe(10);
+    });
 
-		it("handles no tags found", () => {
-			vi.mocked(execGit).mockReturnValue("");
+    it("handles no tags found", () => {
+      vi.mocked(execGit).mockReturnValue("");
 
-			const result = getLatestTagTool();
+      const result = getLatestTagTool();
 
-			expect(result.content[0].text).toContain("No version tags found");
-			expect(result.details.tag).toBeNull();
-		});
+      expect(result.content[0].text).toContain("No version tags found");
+      expect(result.details.tag).toBeNull();
+    });
 
-		it("handles tag error", () => {
-			vi.mocked(execGit).mockImplementation(() => {
-				throw new Error("No git repository");
-			});
+    it("handles tag error", () => {
+      vi.mocked(execGit).mockImplementation(() => {
+        throw new Error("No git repository");
+      });
 
-			const result = getLatestTagTool();
+      const result = getLatestTagTool();
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to get latest tag");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to get latest tag");
+    });
+  });
 
-	describe("analyzeCommitsTool", () => {
-		it("analyzes commits and returns minor bump for feat", () => {
-			vi.mocked(execGit).mockReturnValueOnce("v1.0.0").mockReturnValueOnce("feat: add new feature");
+  describe("analyzeCommitsTool", () => {
+    it("analyzes commits and returns minor bump for feat", () => {
+      vi.mocked(execGit).mockReturnValueOnce("v1.0.0").mockReturnValueOnce("feat: add new feature");
 
-			const result = analyzeCommitsTool();
+      const result = analyzeCommitsTool();
 
-			expect(result.details.type).toBe("minor");
-			expect(result.details.currentVersion).toBe("1.0.0");
-			expect(result.details.newVersion).toBe("1.1.0");
-		});
+      expect(result.details.type).toBe("minor");
+      expect(result.details.currentVersion).toBe("1.0.0");
+      expect(result.details.newVersion).toBe("1.1.0");
+    });
 
-		it("returns patch bump for fix", () => {
-			vi.mocked(execGit).mockReturnValueOnce("v1.0.0").mockReturnValueOnce("fix: fix bug");
+    it("returns patch bump for fix", () => {
+      vi.mocked(execGit).mockReturnValueOnce("v1.0.0").mockReturnValueOnce("fix: fix bug");
 
-			const result = analyzeCommitsTool();
+      const result = analyzeCommitsTool();
 
-			expect(result.details.type).toBe("patch");
-			expect(result.details.newVersion).toBe("1.0.1");
-		});
+      expect(result.details.type).toBe("patch");
+      expect(result.details.newVersion).toBe("1.0.1");
+    });
 
-		it("returns major bump for breaking change", () => {
-			vi.mocked(execGit).mockReturnValueOnce("v1.0.0").mockReturnValueOnce("feat!: breaking change");
+    it("returns major bump for breaking change", () => {
+      vi.mocked(execGit).mockReturnValueOnce("v1.0.0").mockReturnValueOnce("feat!: breaking change");
 
-			const result = analyzeCommitsTool();
+      const result = analyzeCommitsTool();
 
-			expect(result.details.type).toBe("major");
-			expect(result.details.newVersion).toBe("2.0.0");
-		});
+      expect(result.details.type).toBe("major");
+      expect(result.details.newVersion).toBe("2.0.0");
+    });
 
-		it("handles no commits", () => {
-			vi.mocked(execGit).mockReturnValueOnce("").mockReturnValueOnce("");
+    it("handles no commits", () => {
+      vi.mocked(execGit).mockReturnValueOnce("").mockReturnValueOnce("");
 
-			const result = analyzeCommitsTool();
+      const result = analyzeCommitsTool();
 
-			expect(result.content[0].text).toContain("No commits to analyze");
-		});
+      expect(result.content[0].text).toContain("No commits to analyze");
+    });
 
-		it("groups commits by type", () => {
-			vi.mocked(execGit)
-				.mockReturnValueOnce("v1.0.0")
-				.mockReturnValueOnce("feat: add feature\nfix: fix bug\nchore: update deps");
+    it("groups commits by type", () => {
+      vi.mocked(execGit)
+        .mockReturnValueOnce("v1.0.0")
+        .mockReturnValueOnce("feat: add feature\nfix: fix bug\nchore: update deps");
 
-			const result = analyzeCommitsTool();
+      const result = analyzeCommitsTool();
 
-			expect(result.content[0].text).toContain("Features");
-			expect(result.content[0].text).toContain("Fixes");
-		});
+      expect(result.content[0].text).toContain("Features");
+      expect(result.content[0].text).toContain("Fixes");
+    });
 
-		it("handles analyze error", () => {
-			vi.mocked(execGit).mockImplementation(() => {
-				throw new Error("No git repository");
-			});
+    it("handles analyze error", () => {
+      vi.mocked(execGit).mockImplementation(() => {
+        throw new Error("No git repository");
+      });
 
-			const result = analyzeCommitsTool();
+      const result = analyzeCommitsTool();
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to analyze commits");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to analyze commits");
+    });
+  });
 
-	describe("bumpVersionTool", () => {
-		// Note: Testing bumpVersionTool requires mocking node:fs module
-		// which is complex due to ES module imports. These tests are skipped
-		// as the functionality is already covered by the bumpVersion helper tests.
-		it("placeholder test", () => {
-			expect(true).toBe(true);
-		});
-	});
+  describe("bumpVersionTool", () => {
+    // Note: Testing bumpVersionTool requires mocking node:fs module
+    // which is complex due to ES module imports. These tests are skipped
+    // as the functionality is already covered by the bumpVersion helper tests.
+    it("placeholder test", () => {
+      expect(true).toBe(true);
+    });
+  });
 
-	describe("createReleaseTool", () => {
-		it("creates release successfully", () => {
-			vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/releases/tag/v1.0.0");
+  describe("createReleaseTool", () => {
+    it("creates release successfully", () => {
+      vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/releases/tag/v1.0.0");
 
-			const result = createReleaseTool("v1.0.0", "Version 1.0.0", "Release notes");
+      const result = createReleaseTool("v1.0.0", "Version 1.0.0", "Release notes");
 
-			expect(result.content[0].text).toContain("Created release");
-			expect(result.details.tag).toBe("v1.0.0");
-		});
+      expect(result.content[0].text).toContain("Created release");
+      expect(result.details.tag).toBe("v1.0.0");
+    });
 
-		it("handles release creation error", () => {
-			vi.mocked(execGh).mockImplementation(() => {
-				throw new Error("gh not authenticated");
-			});
+    it("handles release creation error", () => {
+      vi.mocked(execGh).mockImplementation(() => {
+        throw new Error("gh not authenticated");
+      });
 
-			const result = createReleaseTool("v1.0.0", "Version 1.0.0");
+      const result = createReleaseTool("v1.0.0", "Version 1.0.0");
 
-			expect(result.isError).toBe(true);
-			expect(result.content[0].text).toContain("Failed to create release");
-		});
-	});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Failed to create release");
+    });
+  });
 });

--- a/packages/pi-devtools/extensions/git.ts
+++ b/packages/pi-devtools/extensions/git.ts
@@ -9,111 +9,111 @@ import { execSync } from "node:child_process";
 // =============================================================================
 
 export function isGitRepo(): boolean {
-	try {
-		return execGit("rev-parse --is-inside-work-tree") === "true";
-	} catch {
-		return false;
-	}
+  try {
+    return execGit("rev-parse --is-inside-work-tree") === "true";
+  } catch {
+    return false;
+  }
 }
 
 export function getCurrentBranch(): string {
-	const branch = execGit("branch --show-current");
-	if (branch) return branch;
-	const sha = execGit("rev-parse --short HEAD");
-	return sha ? `Detached HEAD at ${sha}` : "unknown";
+  const branch = execGit("branch --show-current");
+  if (branch) return branch;
+  const sha = execGit("rev-parse --short HEAD");
+  return sha ? `Detached HEAD at ${sha}` : "unknown";
 }
 
 export function getWorkingTreeStatus(): string {
-	const output = execGit("status --porcelain");
-	if (!output) return "clean";
+  const output = execGit("status --porcelain");
+  if (!output) return "clean";
 
-	const lines = output.split("\n").filter(Boolean);
-	const untracked = lines.filter((l) => l.startsWith("??")).length;
-	const modified = lines.length - untracked;
+  const lines = output.split("\n").filter(Boolean);
+  const untracked = lines.filter((l) => l.startsWith("??")).length;
+  const modified = lines.length - untracked;
 
-	const parts: string[] = [];
-	if (modified) parts.push(`${modified} modified`);
-	if (untracked) parts.push(`${untracked} untracked`);
-	return parts.length ? parts.join(", ") : "clean";
+  const parts: string[] = [];
+  if (modified) parts.push(`${modified} modified`);
+  if (untracked) parts.push(`${untracked} untracked`);
+  return parts.length ? parts.join(", ") : "clean";
 }
 
 export function parseVersion(tag: string): number[] {
-	return tag
-		.replace(/^v/, "")
-		.split(".")
-		.map((s) => parseInt(s, 10))
-		.filter((n) => Number.isInteger(n));
+  return tag
+    .replace(/^v/, "")
+    .split(".")
+    .map((s) => parseInt(s, 10))
+    .filter((n) => Number.isInteger(n));
 }
 
 export function compareVersions(a: number[], b: number[]): number {
-	for (let i = 0; i < Math.max(a.length, b.length); i++) {
-		const diff = (a[i] ?? 0) - (b[i] ?? 0);
-		if (diff !== 0) return diff;
-	}
-	return 0;
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
 }
 
 export function getTagInfo(): string {
-	const output = execGit('tag -l "v*"');
-	if (!output) return "No version tags found";
+  const output = execGit('tag -l "v*"');
+  if (!output) return "No version tags found";
 
-	const tags = output.split("\n").filter(Boolean);
-	if (tags.length === 0) return "No version tags found";
+  const tags = output.split("\n").filter(Boolean);
+  if (tags.length === 0) return "No version tags found";
 
-	tags.sort((a, b) => compareVersions(parseVersion(a), parseVersion(b)));
-	const latest = tags.at(-1) ?? tags[0];
+  tags.sort((a, b) => compareVersions(parseVersion(a), parseVersion(b)));
+  const latest = tags.at(-1) ?? tags[0];
 
-	try {
-		const count = execGit(`rev-list ${latest}..HEAD --count`);
-		if (count !== null) return `Tag: ${latest} (${count} unreleased commits)`;
-	} catch {
-		// Fall through
-	}
-	return `Tag: ${latest}`;
+  try {
+    const count = execGit(`rev-list ${latest}..HEAD --count`);
+    if (count !== null) return `Tag: ${latest} (${count} unreleased commits)`;
+  } catch {
+    // Fall through
+  }
+  return `Tag: ${latest}`;
 }
 
 export function getGitContext(): string {
-	if (!isGitRepo()) return "";
+  if (!isGitRepo()) return "";
 
-	const branch = getCurrentBranch();
-	const status = getWorkingTreeStatus();
-	const tagInfo = getTagInfo();
+  const branch = getCurrentBranch();
+  const status = getWorkingTreeStatus();
+  const tagInfo = getTagInfo();
 
-	return `[devtools] Branch: ${branch} | Status: ${status} | ${tagInfo}`;
+  return `[devtools] Branch: ${branch} | Status: ${status} | ${tagInfo}`;
 }
 
 export function execGit(command: string): string {
-	try {
-		return execSync(command, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`Git error: ${message}`);
-	}
+  try {
+    return execSync(command, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Git error: ${message}`);
+  }
 }
 
 export function execGh(command: string): string {
-	try {
-		return execSync(command, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`gh error: ${message}`);
-	}
+  try {
+    return execSync(command, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`gh error: ${message}`);
+  }
 }
 
 export function getDefaultBranch(): string {
-	try {
-		const ref = execGit("git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'");
-		if (ref) return ref;
-	} catch {
-		// Fall through to network call
-	}
+  try {
+    const ref = execGit("git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'");
+    if (ref) return ref;
+  } catch {
+    // Fall through to network call
+  }
 
-	try {
-		const remoteHead = execGit("git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //'");
-		if (remoteHead) return remoteHead.trim();
-	} catch {
-		// Fall through to fallback
-	}
+  try {
+    const remoteHead = execGit("git remote show origin 2>/dev/null | grep 'HEAD branch' | sed 's/.*: //'");
+    if (remoteHead) return remoteHead.trim();
+  } catch {
+    // Fall through to fallback
+  }
 
-	return "main";
+  return "main";
 }

--- a/packages/pi-devtools/extensions/index.ts
+++ b/packages/pi-devtools/extensions/index.ts
@@ -15,42 +15,42 @@ import { execGh, execGit, getDefaultBranch, getGitContext } from "./git.js";
 // =============================================================================
 
 interface ToolResult {
-	content: Array<{ type: "text"; text: string }>;
-	details: Record<string, unknown>;
-	isError?: boolean;
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+  isError?: boolean;
 }
 
 function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function parseConventionalCommit(message: string): { type: string; scope?: string; breaking: boolean } {
-	const match = message.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
-	if (!match) {
-		return { type: "other", breaking: false };
-	}
-	return {
-		type: match[1].toLowerCase(),
-		scope: match[2],
-		breaking: !!match[3] || message.includes("BREAKING CHANGE"),
-	};
+  const match = message.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+  if (!match) {
+    return { type: "other", breaking: false };
+  }
+  return {
+    type: match[1].toLowerCase(),
+    scope: match[2],
+    breaking: !!match[3] || message.includes("BREAKING CHANGE"),
+  };
 }
 
 function bumpVersion(version: string, type: "major" | "minor" | "patch"): string {
-	const parts = version.replace(/^v/, "").split(".").map(Number);
-	if (parts.length !== 3 || parts.some(Number.isNaN)) {
-		throw new Error(`Invalid version format: ${version}`);
-	}
+  const parts = version.replace(/^v/, "").split(".").map(Number);
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
 
-	const [major, minor, patch] = parts;
-	switch (type) {
-		case "major":
-			return `${major + 1}.0.0`;
-		case "minor":
-			return `${major}.${minor + 1}.0`;
-		case "patch":
-			return `${major}.${minor}.${patch + 1}`;
-	}
+  const [major, minor, patch] = parts;
+  switch (type) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+  }
 }
 
 // =============================================================================
@@ -58,53 +58,53 @@ function bumpVersion(version: string, type: "major" | "minor" | "patch"): string
 // =============================================================================
 
 const createBranchParams = Type.Object({
-	branchName: Type.String({ description: "Name of the branch to create (e.g., feature/add-login)" }),
-	switchBranch: Type.Optional(Type.Boolean({ description: "Whether to switch to the new branch (default: true)" })),
+  branchName: Type.String({ description: "Name of the branch to create (e.g., feature/add-login)" }),
+  switchBranch: Type.Optional(Type.Boolean({ description: "Whether to switch to the new branch (default: true)" })),
 });
 
 const commitParams = Type.Object({
-	message: Type.String({ description: "Commit message (conventional format: type: description)" }),
-	files: Type.Optional(Type.Array(Type.String(), { description: "Specific files to commit (default: all staged)" })),
-	noVerify: Type.Optional(Type.Boolean({ description: "Skip pre-commit hooks (default: false)" })),
+  message: Type.String({ description: "Commit message (conventional format: type: description)" }),
+  files: Type.Optional(Type.Array(Type.String(), { description: "Specific files to commit (default: all staged)" })),
+  noVerify: Type.Optional(Type.Boolean({ description: "Skip pre-commit hooks (default: false)" })),
 });
 
 const pushParams = Type.Object({
-	branch: Type.Optional(Type.String({ description: "Branch to push (default: current)" })),
-	setUpstream: Type.Optional(Type.Boolean({ description: "Set upstream tracking (default: true)" })),
+  branch: Type.Optional(Type.String({ description: "Branch to push (default: current)" })),
+  setUpstream: Type.Optional(Type.Boolean({ description: "Set upstream tracking (default: true)" })),
 });
 
 const createPrParams = Type.Object({
-	title: Type.String({ description: "PR title" }),
-	body: Type.Optional(Type.String({ description: "PR body/description" })),
-	base: Type.Optional(Type.String({ description: "Target branch (default: default branch)" })),
-	draft: Type.Optional(Type.Boolean({ description: "Create as draft PR (default: false)" })),
-	assignees: Type.Optional(Type.Array(Type.String(), { description: "Assignees (GitHub usernames)" })),
+  title: Type.String({ description: "PR title" }),
+  body: Type.Optional(Type.String({ description: "PR body/description" })),
+  base: Type.Optional(Type.String({ description: "Target branch (default: default branch)" })),
+  draft: Type.Optional(Type.Boolean({ description: "Create as draft PR (default: false)" })),
+  assignees: Type.Optional(Type.Array(Type.String(), { description: "Assignees (GitHub usernames)" })),
 });
 
 const mergePrParams = Type.Object({
-	prNumber: Type.Optional(Type.Integer({ description: "PR number (default: current branch PR)" })),
-	squash: Type.Optional(Type.Boolean({ description: "Squash merge (default: false)" })),
-	deleteBranch: Type.Optional(Type.Boolean({ description: "Delete source branch after merge (default: true)" })),
-	commitTitle: Type.Optional(Type.String({ description: "Title for the squash commit" })),
-	commitMessage: Type.Optional(Type.String({ description: "Message for the squash commit" })),
+  prNumber: Type.Optional(Type.Integer({ description: "PR number (default: current branch PR)" })),
+  squash: Type.Optional(Type.Boolean({ description: "Squash merge (default: false)" })),
+  deleteBranch: Type.Optional(Type.Boolean({ description: "Delete source branch after merge (default: true)" })),
+  commitTitle: Type.Optional(Type.String({ description: "Title for the squash commit" })),
+  commitMessage: Type.Optional(Type.String({ description: "Message for the squash commit" })),
 });
 
 const checkCiParams = Type.Object({
-	prNumber: Type.Optional(Type.Integer({ description: "PR number (default: current branch PR)" })),
-	branch: Type.Optional(Type.String({ description: "Branch to check (default: current)" })),
+  prNumber: Type.Optional(Type.Integer({ description: "PR number (default: current branch PR)" })),
+  branch: Type.Optional(Type.String({ description: "Branch to check (default: current)" })),
 });
 
 const bumpVersionParams = Type.Object({
-	newVersion: Type.String({ description: "New version (e.g., 1.2.3)" }),
-	file: Type.Optional(Type.String({ description: "File to update (default: package.json)" })),
+  newVersion: Type.String({ description: "New version (e.g., 1.2.3)" }),
+  file: Type.Optional(Type.String({ description: "File to update (default: package.json)" })),
 });
 
 const createReleaseParams = Type.Object({
-	tag: Type.String({ description: "Version tag (e.g., v1.2.3)" }),
-	title: Type.String({ description: "Release title" }),
-	body: Type.Optional(Type.String({ description: "Release notes/changelog" })),
-	draft: Type.Optional(Type.Boolean({ description: "Create as draft (default: false)" })),
-	prerelease: Type.Optional(Type.Boolean({ description: "Mark as prerelease (default: false)" })),
+  tag: Type.String({ description: "Version tag (e.g., v1.2.3)" }),
+  title: Type.String({ description: "Release title" }),
+  body: Type.Optional(Type.String({ description: "Release notes/changelog" })),
+  draft: Type.Optional(Type.Boolean({ description: "Create as draft (default: false)" })),
+  prerelease: Type.Optional(Type.Boolean({ description: "Mark as prerelease (default: false)" })),
 });
 
 // =============================================================================
@@ -112,371 +112,371 @@ const createReleaseParams = Type.Object({
 // =============================================================================
 
 function createBranchTool(branchName: string, switchBranch = true): ToolResult {
-	try {
-		if (switchBranch) {
-			execGit(`git checkout -b ${shellQuote(branchName)}`);
-			return {
-				content: [{ type: "text", text: `Created and switched to branch: ${branchName}` }],
-				details: { branch: branchName, switched: true },
-			};
-		}
+  try {
+    if (switchBranch) {
+      execGit(`git checkout -b ${shellQuote(branchName)}`);
+      return {
+        content: [{ type: "text", text: `Created and switched to branch: ${branchName}` }],
+        details: { branch: branchName, switched: true },
+      };
+    }
 
-		execGit(`git branch ${shellQuote(branchName)}`);
-		return {
-			content: [{ type: "text", text: `Created branch: ${branchName}` }],
-			details: { branch: branchName, switched: false },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to create branch: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    execGit(`git branch ${shellQuote(branchName)}`);
+    return {
+      content: [{ type: "text", text: `Created branch: ${branchName}` }],
+      details: { branch: branchName, switched: false },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to create branch: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 function commitTool(message: string, files?: string[], noVerify = false): ToolResult {
-	try {
-		// Get current status
-		const branch = execGit("git branch --show-current");
-		if (!branch) {
-			return {
-				content: [{ type: "text", text: "Not on a branch (detached HEAD state)" }],
-				isError: true,
-				details: { error: "detached_head" },
-			};
-		}
+  try {
+    // Get current status
+    const branch = execGit("git branch --show-current");
+    if (!branch) {
+      return {
+        content: [{ type: "text", text: "Not on a branch (detached HEAD state)" }],
+        isError: true,
+        details: { error: "detached_head" },
+      };
+    }
 
-		// Stage files
-		if (files && files.length > 0) {
-			for (const file of files) {
-				execGit(`git add -- ${shellQuote(file)}`);
-			}
-		} else {
-			execGit("git add -A");
-		}
+    // Stage files
+    if (files && files.length > 0) {
+      for (const file of files) {
+        execGit(`git add -- ${shellQuote(file)}`);
+      }
+    } else {
+      execGit("git add -A");
+    }
 
-		// Verify staged files
-		const stagedAfter = execGit("git diff --cached --name-only").split("\n").filter(Boolean);
+    // Verify staged files
+    const stagedAfter = execGit("git diff --cached --name-only").split("\n").filter(Boolean);
 
-		if (stagedAfter.length === 0) {
-			return {
-				content: [{ type: "text", text: "No files staged. Please stage files first or pass specific files." }],
-				isError: true,
-				details: { error: "no_files_staged" },
-			};
-		}
+    if (stagedAfter.length === 0) {
+      return {
+        content: [{ type: "text", text: "No files staged. Please stage files first or pass specific files." }],
+        isError: true,
+        details: { error: "no_files_staged" },
+      };
+    }
 
-		// Commit
-		const verifyFlag = noVerify ? "--no-verify" : "";
-		execGit(`git commit ${verifyFlag} -m ${shellQuote(message)}`);
+    // Commit
+    const verifyFlag = noVerify ? "--no-verify" : "";
+    execGit(`git commit ${verifyFlag} -m ${shellQuote(message)}`);
 
-		return {
-			content: [{ type: "text", text: `Committed: ${message}\n\nFiles staged: ${stagedAfter.length}` }],
-			details: { message, stagedFiles: stagedAfter },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Commit failed: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [{ type: "text", text: `Committed: ${message}\n\nFiles staged: ${stagedAfter.length}` }],
+      details: { message, stagedFiles: stagedAfter },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Commit failed: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 function pushTool(branch?: string, setUpstream = true): ToolResult {
-	try {
-		const currentBranch = branch || execGit("git branch --show-current");
-		const upstreamFlag = setUpstream ? "-u" : "";
+  try {
+    const currentBranch = branch || execGit("git branch --show-current");
+    const upstreamFlag = setUpstream ? "-u" : "";
 
-		execGit(`git push ${upstreamFlag} origin ${shellQuote(currentBranch)}`);
+    execGit(`git push ${upstreamFlag} origin ${shellQuote(currentBranch)}`);
 
-		return {
-			content: [{ type: "text", text: `Pushed ${currentBranch} to origin` }],
-			details: { branch: currentBranch },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Push failed: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [{ type: "text", text: `Pushed ${currentBranch} to origin` }],
+      details: { branch: currentBranch },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Push failed: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 function createPrTool(title: string, body?: string, base?: string, draft = false, assignees?: string[]): ToolResult {
-	try {
-		const defaultBranch = getDefaultBranch();
-		const targetBase = base || defaultBranch;
-		const headBranch = execGit("git branch --show-current");
+  try {
+    const defaultBranch = getDefaultBranch();
+    const targetBase = base || defaultBranch;
+    const headBranch = execGit("git branch --show-current");
 
-		let command = `gh pr create --title ${shellQuote(title)} --base ${shellQuote(targetBase)}`;
+    let command = `gh pr create --title ${shellQuote(title)} --base ${shellQuote(targetBase)}`;
 
-		if (body) {
-			command += ` --body ${shellQuote(body)}`;
-		}
+    if (body) {
+      command += ` --body ${shellQuote(body)}`;
+    }
 
-		if (draft) {
-			command += " --draft";
-		}
+    if (draft) {
+      command += " --draft";
+    }
 
-		if (assignees && assignees.length > 0) {
-			command += ` --assignee ${shellQuote(assignees.join(","))}`;
-		}
+    if (assignees && assignees.length > 0) {
+      command += ` --assignee ${shellQuote(assignees.join(","))}`;
+    }
 
-		const prUrl = execGh(command);
+    const prUrl = execGh(command);
 
-		return {
-			content: [
-				{ type: "text", text: `Created PR: ${prUrl}\n\nTitle: ${title}\nBase: ${targetBase} <-- ${headBranch}` },
-			],
-			details: { prUrl, title, base: targetBase, head: headBranch },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to create PR: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [
+        { type: "text", text: `Created PR: ${prUrl}\n\nTitle: ${title}\nBase: ${targetBase} <-- ${headBranch}` },
+      ],
+      details: { prUrl, title, base: targetBase, head: headBranch },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to create PR: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 type PullRequestInfo = {
-	title?: string;
-	url?: string;
-	state?: string;
+  title?: string;
+  url?: string;
+  state?: string;
 };
 
 function detectCurrentPrNumber(): number | undefined {
-	const branch = execGit("git branch --show-current");
-	const prs = execGh(`gh pr list --head ${shellQuote(branch)} --state open --json number,title`);
-	if (!prs) {
-		return undefined;
-	}
+  const branch = execGit("git branch --show-current");
+  const prs = execGh(`gh pr list --head ${shellQuote(branch)} --state open --json number,title`);
+  if (!prs) {
+    return undefined;
+  }
 
-	const parsed = JSON.parse(prs) as Array<{ number?: number }>;
-	const prNumber = parsed[0]?.number;
-	return typeof prNumber === "number" ? prNumber : undefined;
+  const parsed = JSON.parse(prs) as Array<{ number?: number }>;
+  const prNumber = parsed[0]?.number;
+  return typeof prNumber === "number" ? prNumber : undefined;
 }
 
 function getPullRequestInfo(prNumber: number): PullRequestInfo {
-	return JSON.parse(execGh(`gh pr view ${prNumber} --json title,url,state`)) as PullRequestInfo;
+  return JSON.parse(execGh(`gh pr view ${prNumber} --json title,url,state`)) as PullRequestInfo;
 }
 
 function buildMergeCommand(
-	prNumber: number,
-	squash: boolean,
-	deleteBranch: boolean,
-	commitTitle?: string,
-	commitMessage?: string,
+  prNumber: number,
+  squash: boolean,
+  deleteBranch: boolean,
+  commitTitle?: string,
+  commitMessage?: string,
 ): string {
-	const commandParts = [`gh pr merge ${prNumber}`, squash ? "--squash" : "--merge"];
+  const commandParts = [`gh pr merge ${prNumber}`, squash ? "--squash" : "--merge"];
 
-	if (squash && commitTitle) {
-		commandParts.push(`--title ${shellQuote(commitTitle)}`);
-	}
-	if (squash && commitMessage) {
-		commandParts.push(`--body ${shellQuote(commitMessage)}`);
-	}
-	if (deleteBranch) {
-		commandParts.push("--delete-branch");
-	}
+  if (squash && commitTitle) {
+    commandParts.push(`--title ${shellQuote(commitTitle)}`);
+  }
+  if (squash && commitMessage) {
+    commandParts.push(`--body ${shellQuote(commitMessage)}`);
+  }
+  if (deleteBranch) {
+    commandParts.push("--delete-branch");
+  }
 
-	return commandParts.join(" ");
+  return commandParts.join(" ");
 }
 
 function formatMergeResult(
-	prNumber: number,
-	squash: boolean,
-	deleteBranch: boolean,
-	prData: PullRequestInfo,
+  prNumber: number,
+  squash: boolean,
+  deleteBranch: boolean,
+  prData: PullRequestInfo,
 ): ToolResult {
-	const mergeType = squash ? "squash-merged" : "merged";
-	const mergeLabel = `${mergeType.charAt(0).toUpperCase() + mergeType.slice(1)} PR #${prNumber}`;
-	const titleSuffix = prData.title ? `: ${prData.title}` : "";
-	const urlSuffix = prData.url ? `\n${prData.url}` : "";
+  const mergeType = squash ? "squash-merged" : "merged";
+  const mergeLabel = `${mergeType.charAt(0).toUpperCase() + mergeType.slice(1)} PR #${prNumber}`;
+  const titleSuffix = prData.title ? `: ${prData.title}` : "";
+  const urlSuffix = prData.url ? `\n${prData.url}` : "";
 
-	return {
-		content: [{ type: "text", text: `${mergeLabel}${titleSuffix}${urlSuffix}` }],
-		details: { prNumber, mergeType, deletedBranch: deleteBranch },
-	};
+  return {
+    content: [{ type: "text", text: `${mergeLabel}${titleSuffix}${urlSuffix}` }],
+    details: { prNumber, mergeType, deletedBranch: deleteBranch },
+  };
 }
 
 function mergePrTool(
-	prNumber?: number,
-	squash = false,
-	deleteBranch = true,
-	commitTitle?: string,
-	commitMessage?: string,
+  prNumber?: number,
+  squash = false,
+  deleteBranch = true,
+  commitTitle?: string,
+  commitMessage?: string,
 ): ToolResult {
-	try {
-		const num = prNumber ?? detectCurrentPrNumber();
-		if (!num) {
-			return {
-				content: [{ type: "text", text: "No PR number provided and could not detect current PR." }],
-				isError: true,
-				details: { error: "no_pr_found" },
-			};
-		}
+  try {
+    const num = prNumber ?? detectCurrentPrNumber();
+    if (!num) {
+      return {
+        content: [{ type: "text", text: "No PR number provided and could not detect current PR." }],
+        isError: true,
+        details: { error: "no_pr_found" },
+      };
+    }
 
-		const prData = getPullRequestInfo(num);
-		if (prData.state !== "OPEN") {
-			return {
-				content: [{ type: "text", text: `PR #${num} is not open (state: ${prData.state})` }],
-				isError: true,
-				details: { error: "pr_not_open", state: prData.state },
-			};
-		}
+    const prData = getPullRequestInfo(num);
+    if (prData.state !== "OPEN") {
+      return {
+        content: [{ type: "text", text: `PR #${num} is not open (state: ${prData.state})` }],
+        isError: true,
+        details: { error: "pr_not_open", state: prData.state },
+      };
+    }
 
-		execGh(buildMergeCommand(num, squash, deleteBranch, commitTitle, commitMessage));
-		return formatMergeResult(num, squash, deleteBranch, prData);
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to merge PR: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    execGh(buildMergeCommand(num, squash, deleteBranch, commitTitle, commitMessage));
+    return formatMergeResult(num, squash, deleteBranch, prData);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to merge PR: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 type CiCheck = {
-	name?: string;
-	state?: string;
-	link?: string;
-	workflow?: string;
-	workflowName?: string;
-	status?: string;
-	conclusion?: string;
-	url?: string;
+  name?: string;
+  state?: string;
+  link?: string;
+  workflow?: string;
+  workflowName?: string;
+  status?: string;
+  conclusion?: string;
+  url?: string;
 };
 
 function getCiCheckCommand(prNumber?: number, branch?: string): string {
-	if (prNumber) {
-		return `gh pr checks ${prNumber} --json name,state,link,workflow`;
-	}
+  if (prNumber) {
+    return `gh pr checks ${prNumber} --json name,state,link,workflow`;
+  }
 
-	const targetBranch = branch ?? execGit("git branch --show-current");
-	return `gh run list --branch ${shellQuote(targetBranch)} --limit 5 --json workflowName,status,conclusion,url`;
+  const targetBranch = branch ?? execGit("git branch --show-current");
+  return `gh run list --branch ${shellQuote(targetBranch)} --limit 5 --json workflowName,status,conclusion,url`;
 }
 
 function formatCiCheck(check: CiCheck): string {
-	const status = check.conclusion ?? check.state ?? check.status ?? "unknown";
-	const name = check.name ?? check.workflowName ?? check.workflow ?? "Unknown workflow";
-	const link = check.link ?? check.url;
-	return `- ${name}: ${status}${link ? ` (${link})` : ""}`;
+  const status = check.conclusion ?? check.state ?? check.status ?? "unknown";
+  const name = check.name ?? check.workflowName ?? check.workflow ?? "Unknown workflow";
+  const link = check.link ?? check.url;
+  return `- ${name}: ${status}${link ? ` (${link})` : ""}`;
 }
 
 function checkCiTool(prNumber?: number, branch?: string): ToolResult {
-	try {
-		const checks = execGh(getCiCheckCommand(prNumber, branch));
-		if (!checks) {
-			return {
-				content: [{ type: "text", text: "No CI runs found for this PR/branch." }],
-				details: { checks: [] },
-			};
-		}
+  try {
+    const checks = execGh(getCiCheckCommand(prNumber, branch));
+    if (!checks) {
+      return {
+        content: [{ type: "text", text: "No CI runs found for this PR/branch." }],
+        details: { checks: [] },
+      };
+    }
 
-		const parsedChecks = JSON.parse(checks) as CiCheck[];
-		if (!Array.isArray(parsedChecks) || parsedChecks.length === 0) {
-			return {
-				content: [{ type: "text", text: "No CI runs found for this PR/branch." }],
-				details: { checks: [] },
-			};
-		}
+    const parsedChecks = JSON.parse(checks) as CiCheck[];
+    if (!Array.isArray(parsedChecks) || parsedChecks.length === 0) {
+      return {
+        content: [{ type: "text", text: "No CI runs found for this PR/branch." }],
+        details: { checks: [] },
+      };
+    }
 
-		const checkSummary = parsedChecks.map(formatCiCheck).join("\n");
-		return {
-			content: [{ type: "text", text: `CI Status:\n${checkSummary}` }],
-			details: { checks: parsedChecks },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to check CI: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    const checkSummary = parsedChecks.map(formatCiCheck).join("\n");
+    return {
+      content: [{ type: "text", text: `CI Status:\n${checkSummary}` }],
+      details: { checks: parsedChecks },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to check CI: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 type RepoStatus = {
-	staged: string[];
-	modified: string[];
-	untracked: string[];
+  staged: string[];
+  modified: string[];
+  untracked: string[];
 };
 
 function parseRepoStatus(statusOutput: string): RepoStatus {
-	return statusOutput
-		.split("\n")
-		.filter(Boolean)
-		.reduce<RepoStatus>(
-			(status, line) => {
-				const indexStatus = line[0];
-				const workTreeStatus = line[1];
-				const file = line.slice(3);
+  return statusOutput
+    .split("\n")
+    .filter(Boolean)
+    .reduce<RepoStatus>(
+      (status, line) => {
+        const indexStatus = line[0];
+        const workTreeStatus = line[1];
+        const file = line.slice(3);
 
-				if (indexStatus === "?" && workTreeStatus === "?") {
-					status.untracked.push(file);
-					return status;
-				}
+        if (indexStatus === "?" && workTreeStatus === "?") {
+          status.untracked.push(file);
+          return status;
+        }
 
-				if (indexStatus !== " " && indexStatus !== "?") {
-					status.staged.push(file);
-				}
-				if (workTreeStatus !== " " && workTreeStatus !== "?") {
-					status.modified.push(file);
-				}
-				return status;
-			},
-			{ staged: [], modified: [], untracked: [] },
-		);
+        if (indexStatus !== " " && indexStatus !== "?") {
+          status.staged.push(file);
+        }
+        if (workTreeStatus !== " " && workTreeStatus !== "?") {
+          status.modified.push(file);
+        }
+        return status;
+      },
+      { staged: [], modified: [], untracked: [] },
+    );
 }
 
 function hasRepoChanges(status: RepoStatus): boolean {
-	return status.staged.length > 0 || status.modified.length > 0 || status.untracked.length > 0;
+  return status.staged.length > 0 || status.modified.length > 0 || status.untracked.length > 0;
 }
 
 function formatRepoInfo(branch: string, defaultBranch: string, status: RepoStatus): string {
-	return `Repository Info:\n- Current branch: ${branch}\n- Default branch: ${defaultBranch}\n- Has changes: ${hasRepoChanges(status)}\n- Staged: ${status.staged.length}\n- Modified: ${status.modified.length}\n- Untracked: ${status.untracked.length}`;
+  return `Repository Info:\n- Current branch: ${branch}\n- Default branch: ${defaultBranch}\n- Has changes: ${hasRepoChanges(status)}\n- Staged: ${status.staged.length}\n- Modified: ${status.modified.length}\n- Untracked: ${status.untracked.length}`;
 }
 
 function repoInfoTool(): ToolResult {
-	try {
-		const branch = execGit("git branch --show-current");
-		if (!branch) {
-			return {
-				content: [{ type: "text", text: "Not on a branch (detached HEAD state)" }],
-				isError: true,
-				details: { error: "detached_head" },
-			};
-		}
+  try {
+    const branch = execGit("git branch --show-current");
+    if (!branch) {
+      return {
+        content: [{ type: "text", text: "Not on a branch (detached HEAD state)" }],
+        isError: true,
+        details: { error: "detached_head" },
+      };
+    }
 
-		const defaultBranch = getDefaultBranch();
-		const status = parseRepoStatus(execGit("git status --porcelain"));
-		return {
-			content: [{ type: "text", text: formatRepoInfo(branch, defaultBranch, status) }],
-			details: {
-				branch,
-				defaultBranch,
-				hasChanges: hasRepoChanges(status),
-				staged: status.staged,
-				modified: status.modified,
-				untracked: status.untracked,
-			},
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to get repo info: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    const defaultBranch = getDefaultBranch();
+    const status = parseRepoStatus(execGit("git status --porcelain"));
+    return {
+      content: [{ type: "text", text: formatRepoInfo(branch, defaultBranch, status) }],
+      details: {
+        branch,
+        defaultBranch,
+        hasChanges: hasRepoChanges(status),
+        staged: status.staged,
+        modified: status.modified,
+        untracked: status.untracked,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to get repo info: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 // =============================================================================
@@ -484,180 +484,180 @@ function repoInfoTool(): ToolResult {
 // =============================================================================
 
 function getLatestTagTool(): ToolResult {
-	try {
-		const tags = execGit("git tag -l 'v*' 'V*' | sort -rV | head -1");
+  try {
+    const tags = execGit("git tag -l 'v*' 'V*' | sort -rV | head -1");
 
-		if (!tags) {
-			return {
-				content: [{ type: "text", text: "No version tags found." }],
-				details: { tag: null },
-			};
-		}
+    if (!tags) {
+      return {
+        content: [{ type: "text", text: "No version tags found." }],
+        details: { tag: null },
+      };
+    }
 
-		const commitCount = execGit(`git log ${tags}..HEAD --oneline | wc -l`).trim();
+    const commitCount = execGit(`git log ${tags}..HEAD --oneline | wc -l`).trim();
 
-		return {
-			content: [{ type: "text", text: `Latest tag: ${tags}\nCommits since: ${commitCount}` }],
-			details: { tag: tags, commitsSince: parseInt(commitCount, 10) },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to get latest tag: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [{ type: "text", text: `Latest tag: ${tags}\nCommits since: ${commitCount}` }],
+      details: { tag: tags, commitsSince: parseInt(commitCount, 10) },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to get latest tag: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 function analyzeCommitsTool(): ToolResult {
-	try {
-		const tags = execGit("git tag -l 'v*' 'V*' | sort -rV | head -1");
+  try {
+    const tags = execGit("git tag -l 'v*' 'V*' | sort -rV | head -1");
 
-		let commitsSince: string[];
-		let currentVersion = "0.0.0";
+    let commitsSince: string[];
+    let currentVersion = "0.0.0";
 
-		if (tags) {
-			currentVersion = tags.replace(/^v/, "");
-			commitsSince = execGit(`git log ${tags}..HEAD --format="%s"`).split("\n").filter(Boolean);
-		} else {
-			commitsSince = execGit(`git log --format="%s" -n 100`).split("\n").filter(Boolean);
-		}
+    if (tags) {
+      currentVersion = tags.replace(/^v/, "");
+      commitsSince = execGit(`git log ${tags}..HEAD --format="%s"`).split("\n").filter(Boolean);
+    } else {
+      commitsSince = execGit(`git log --format="%s" -n 100`).split("\n").filter(Boolean);
+    }
 
-		if (commitsSince.length === 0) {
-			return {
-				content: [{ type: "text", text: "No commits to analyze." }],
-				details: { type: "patch", commits: [], currentVersion, newVersion: currentVersion },
-			};
-		}
+    if (commitsSince.length === 0) {
+      return {
+        content: [{ type: "text", text: "No commits to analyze." }],
+        details: { type: "patch", commits: [], currentVersion, newVersion: currentVersion },
+      };
+    }
 
-		// Analyze commit types
-		const commitAnalysis = commitsSince.map((msg) => ({
-			message: msg,
-			...parseConventionalCommit(msg),
-		}));
+    // Analyze commit types
+    const commitAnalysis = commitsSince.map((msg) => ({
+      message: msg,
+      ...parseConventionalCommit(msg),
+    }));
 
-		let bumpType: "major" | "minor" | "patch" = "patch";
+    let bumpType: "major" | "minor" | "patch" = "patch";
 
-		for (const commit of commitAnalysis) {
-			if (commit.breaking || commit.type.endsWith("!")) {
-				bumpType = "major";
-				break;
-			}
-			if (commit.type === "feat") {
-				bumpType = "minor";
-			}
-		}
+    for (const commit of commitAnalysis) {
+      if (commit.breaking || commit.type.endsWith("!")) {
+        bumpType = "major";
+        break;
+      }
+      if (commit.type === "feat") {
+        bumpType = "minor";
+      }
+    }
 
-		const newVersion = bumpVersion(currentVersion, bumpType);
+    const newVersion = bumpVersion(currentVersion, bumpType);
 
-		// Group commits by type
-		const grouped = commitAnalysis.reduce(
-			(acc, c) => {
-				const key = c.type === "feat" ? "features" : c.type === "fix" ? "fixes" : "other";
-				if (!acc[key]) acc[key] = [];
-				acc[key].push(c.message);
-				return acc;
-			},
-			{} as Record<string, string[]>,
-		);
+    // Group commits by type
+    const grouped = commitAnalysis.reduce(
+      (acc, c) => {
+        const key = c.type === "feat" ? "features" : c.type === "fix" ? "fixes" : "other";
+        if (!acc[key]) acc[key] = [];
+        acc[key].push(c.message);
+        return acc;
+      },
+      {} as Record<string, string[]>,
+    );
 
-		const summary = Object.entries(grouped)
-			.map(
-				([type, msgs]) =>
-					`### ${type.charAt(0).toUpperCase() + type.slice(1)}\n${msgs.map((m) => `- ${m}`).join("\n")}`,
-			)
-			.join("\n\n");
+    const summary = Object.entries(grouped)
+      .map(
+        ([type, msgs]) =>
+          `### ${type.charAt(0).toUpperCase() + type.slice(1)}\n${msgs.map((m) => `- ${m}`).join("\n")}`,
+      )
+      .join("\n\n");
 
-		return {
-			content: [
-				{
-					type: "text",
-					text: `Commit Analysis:\n\n${summary}\n\n**Version:** ${currentVersion} → ${newVersion} (${bumpType} bump)`,
-				},
-			],
-			details: { type: bumpType, commits: commitAnalysis, currentVersion, newVersion },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to analyze commits: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Commit Analysis:\n\n${summary}\n\n**Version:** ${currentVersion} → ${newVersion} (${bumpType} bump)`,
+        },
+      ],
+      details: { type: bumpType, commits: commitAnalysis, currentVersion, newVersion },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to analyze commits: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 function bumpVersionTool(newVersion: string, file = "package.json"): ToolResult {
-	try {
-		if (!existsSync(file)) {
-			return {
-				content: [{ type: "text", text: `File not found: ${file}` }],
-				isError: true,
-				details: { error: "file_not_found" },
-			};
-		}
+  try {
+    if (!existsSync(file)) {
+      return {
+        content: [{ type: "text", text: `File not found: ${file}` }],
+        isError: true,
+        details: { error: "file_not_found" },
+      };
+    }
 
-		const content = readFileSync(file, "utf-8");
-		const pkg = JSON.parse(content);
+    const content = readFileSync(file, "utf-8");
+    const pkg = JSON.parse(content);
 
-		if (typeof pkg.version !== "string") {
-			return {
-				content: [{ type: "text", text: `No version field found in ${file}` }],
-				isError: true,
-				details: { error: "no_version_field" },
-			};
-		}
+    if (typeof pkg.version !== "string") {
+      return {
+        content: [{ type: "text", text: `No version field found in ${file}` }],
+        isError: true,
+        details: { error: "no_version_field" },
+      };
+    }
 
-		const oldVersion = pkg.version;
-		pkg.version = newVersion;
+    const oldVersion = pkg.version;
+    pkg.version = newVersion;
 
-		writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
+    writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
 
-		return {
-			content: [{ type: "text", text: `Updated ${file}: ${oldVersion} → ${newVersion}` }],
-			details: { oldVersion, newVersion, file },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to update version: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [{ type: "text", text: `Updated ${file}: ${oldVersion} → ${newVersion}` }],
+      details: { oldVersion, newVersion, file },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to update version: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 function createReleaseTool(tag: string, title: string, body?: string, draft = false, prerelease = false): ToolResult {
-	try {
-		let command = `gh release create ${shellQuote(tag)} --title ${shellQuote(title)}`;
+  try {
+    let command = `gh release create ${shellQuote(tag)} --title ${shellQuote(title)}`;
 
-		if (body) {
-			command += ` --notes ${shellQuote(body)}`;
-		}
+    if (body) {
+      command += ` --notes ${shellQuote(body)}`;
+    }
 
-		if (draft) {
-			command += " --draft";
-		}
+    if (draft) {
+      command += " --draft";
+    }
 
-		if (prerelease) {
-			command += " --prerelease";
-		}
+    if (prerelease) {
+      command += " --prerelease";
+    }
 
-		const releaseUrl = execGh(command);
+    const releaseUrl = execGh(command);
 
-		return {
-			content: [{ type: "text", text: `Created release: ${releaseUrl}\n\nTag: ${tag}\nTitle: ${title}` }],
-			details: { tag, title, releaseUrl },
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			content: [{ type: "text", text: `Failed to create release: ${message}` }],
-			isError: true,
-			details: { error: message },
-		};
-	}
+    return {
+      content: [{ type: "text", text: `Created release: ${releaseUrl}\n\nTag: ${tag}\nTitle: ${title}` }],
+      details: { tag, title, releaseUrl },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to create release: ${message}` }],
+      isError: true,
+      details: { error: message },
+    };
+  }
 }
 
 // =============================================================================
@@ -665,24 +665,24 @@ function createReleaseTool(tag: string, title: string, body?: string, draft = fa
 // =============================================================================
 
 export {
-	analyzeCommitsTool,
-	bumpVersion,
-	bumpVersionTool,
-	checkCiTool,
-	commitTool,
-	createBranchTool,
-	createPrTool,
-	createReleaseTool,
-	execGh,
-	execGit,
-	getDefaultBranch,
-	getLatestTagTool,
-	mergePrTool,
-	parseConventionalCommit,
-	pushTool,
-	repoInfoTool,
-	repoInfoTool as getRepoInfo,
-	shellQuote,
+  analyzeCommitsTool,
+  bumpVersion,
+  bumpVersionTool,
+  checkCiTool,
+  commitTool,
+  createBranchTool,
+  createPrTool,
+  createReleaseTool,
+  execGh,
+  execGit,
+  getDefaultBranch,
+  getLatestTagTool,
+  mergePrTool,
+  parseConventionalCommit,
+  pushTool,
+  repoInfoTool,
+  repoInfoTool as getRepoInfo,
+  shellQuote,
 };
 
 // =============================================================================
@@ -690,169 +690,169 @@ export {
 // =============================================================================
 
 export default function devtoolsExtension(pi: ExtensionAPI) {
-	// SessionStart: print git context
-	pi.on("session_start", async () => {
-		const context = getGitContext();
-		if (context) {
-			console.log(context);
-		}
-	});
+  // SessionStart: print git context
+  pi.on("session_start", async () => {
+    const context = getGitContext();
+    if (context) {
+      console.log(context);
+    }
+  });
 
-	// Register devtools_create_branch
-	pi.registerTool({
-		name: "devtools_create_branch",
-		label: "Create Branch",
-		description: "Create a new git branch and optionally switch to it",
-		parameters: createBranchParams,
-		async execute(_toolCallId, params) {
-			const { branchName, switchBranch = true } = params as { branchName: string; switchBranch?: boolean };
-			return createBranchTool(branchName, switchBranch);
-		},
-	});
+  // Register devtools_create_branch
+  pi.registerTool({
+    name: "devtools_create_branch",
+    label: "Create Branch",
+    description: "Create a new git branch and optionally switch to it",
+    parameters: createBranchParams,
+    async execute(_toolCallId, params) {
+      const { branchName, switchBranch = true } = params as { branchName: string; switchBranch?: boolean };
+      return createBranchTool(branchName, switchBranch);
+    },
+  });
 
-	// Register devtools_commit
-	pi.registerTool({
-		name: "devtools_commit",
-		label: "Git Commit",
-		description: "Stage files and create a commit with conventional format",
-		parameters: commitParams,
-		async execute(_toolCallId, params) {
-			const { message, files, noVerify = false } = params as { message: string; files?: string[]; noVerify?: boolean };
-			return commitTool(message, files, noVerify);
-		},
-	});
+  // Register devtools_commit
+  pi.registerTool({
+    name: "devtools_commit",
+    label: "Git Commit",
+    description: "Stage files and create a commit with conventional format",
+    parameters: commitParams,
+    async execute(_toolCallId, params) {
+      const { message, files, noVerify = false } = params as { message: string; files?: string[]; noVerify?: boolean };
+      return commitTool(message, files, noVerify);
+    },
+  });
 
-	// Register devtools_push
-	pi.registerTool({
-		name: "devtools_push",
-		label: "Git Push",
-		description: "Push branch to remote with upstream tracking",
-		parameters: pushParams,
-		async execute(_toolCallId, params) {
-			const { branch, setUpstream = true } = params as { branch?: string; setUpstream?: boolean };
-			return pushTool(branch, setUpstream);
-		},
-	});
+  // Register devtools_push
+  pi.registerTool({
+    name: "devtools_push",
+    label: "Git Push",
+    description: "Push branch to remote with upstream tracking",
+    parameters: pushParams,
+    async execute(_toolCallId, params) {
+      const { branch, setUpstream = true } = params as { branch?: string; setUpstream?: boolean };
+      return pushTool(branch, setUpstream);
+    },
+  });
 
-	// Register devtools_create_pr
-	pi.registerTool({
-		name: "devtools_create_pr",
-		label: "Create PR",
-		description: "Create a GitHub pull request",
-		parameters: createPrParams,
-		async execute(_toolCallId, params) {
-			const typed = params as { title: string; body?: string; base?: string; draft?: boolean; assignees?: string[] };
-			return createPrTool(typed.title, typed.body, typed.base, typed.draft, typed.assignees);
-		},
-	});
+  // Register devtools_create_pr
+  pi.registerTool({
+    name: "devtools_create_pr",
+    label: "Create PR",
+    description: "Create a GitHub pull request",
+    parameters: createPrParams,
+    async execute(_toolCallId, params) {
+      const typed = params as { title: string; body?: string; base?: string; draft?: boolean; assignees?: string[] };
+      return createPrTool(typed.title, typed.body, typed.base, typed.draft, typed.assignees);
+    },
+  });
 
-	// Register devtools_merge_pr
-	pi.registerTool({
-		name: "devtools_merge_pr",
-		label: "Merge PR",
-		description: "Merge a pull request (optionally delete source branch)",
-		parameters: mergePrParams,
-		async execute(_toolCallId, params) {
-			const typed = params as {
-				prNumber?: number;
-				squash?: boolean;
-				deleteBranch?: boolean;
-				commitTitle?: string;
-				commitMessage?: string;
-			};
-			return mergePrTool(
-				typed.prNumber,
-				typed.squash ?? false,
-				typed.deleteBranch ?? true,
-				typed.commitTitle,
-				typed.commitMessage,
-			);
-		},
-	});
+  // Register devtools_merge_pr
+  pi.registerTool({
+    name: "devtools_merge_pr",
+    label: "Merge PR",
+    description: "Merge a pull request (optionally delete source branch)",
+    parameters: mergePrParams,
+    async execute(_toolCallId, params) {
+      const typed = params as {
+        prNumber?: number;
+        squash?: boolean;
+        deleteBranch?: boolean;
+        commitTitle?: string;
+        commitMessage?: string;
+      };
+      return mergePrTool(
+        typed.prNumber,
+        typed.squash ?? false,
+        typed.deleteBranch ?? true,
+        typed.commitTitle,
+        typed.commitMessage,
+      );
+    },
+  });
 
-	// Register devtools_squash_merge_pr
-	pi.registerTool({
-		name: "devtools_squash_merge_pr",
-		label: "Squash Merge PR",
-		description: "Squash-merge a pull request (optionally delete source branch)",
-		parameters: mergePrParams,
-		async execute(_toolCallId, params) {
-			const typed = params as {
-				prNumber?: number;
-				deleteBranch?: boolean;
-				commitTitle?: string;
-				commitMessage?: string;
-			};
-			return mergePrTool(typed.prNumber, true, typed.deleteBranch ?? true, typed.commitTitle, typed.commitMessage);
-		},
-	});
+  // Register devtools_squash_merge_pr
+  pi.registerTool({
+    name: "devtools_squash_merge_pr",
+    label: "Squash Merge PR",
+    description: "Squash-merge a pull request (optionally delete source branch)",
+    parameters: mergePrParams,
+    async execute(_toolCallId, params) {
+      const typed = params as {
+        prNumber?: number;
+        deleteBranch?: boolean;
+        commitTitle?: string;
+        commitMessage?: string;
+      };
+      return mergePrTool(typed.prNumber, true, typed.deleteBranch ?? true, typed.commitTitle, typed.commitMessage);
+    },
+  });
 
-	// Register devtools_check_ci
-	pi.registerTool({
-		name: "devtools_check_ci",
-		label: "Check CI",
-		description: "Check GitHub Actions CI status for a PR or branch",
-		parameters: checkCiParams,
-		async execute(_toolCallId, params) {
-			const { prNumber, branch } = params as { prNumber?: number; branch?: string };
-			return checkCiTool(prNumber, branch);
-		},
-	});
+  // Register devtools_check_ci
+  pi.registerTool({
+    name: "devtools_check_ci",
+    label: "Check CI",
+    description: "Check GitHub Actions CI status for a PR or branch",
+    parameters: checkCiParams,
+    async execute(_toolCallId, params) {
+      const { prNumber, branch } = params as { prNumber?: number; branch?: string };
+      return checkCiTool(prNumber, branch);
+    },
+  });
 
-	// Register devtools_get_repo_info
-	pi.registerTool({
-		name: "devtools_get_repo_info",
-		label: "Repo Info",
-		description: "Get current branch, default branch, and git status",
-		parameters: Type.Object({}),
-		async execute() {
-			return repoInfoTool();
-		},
-	});
+  // Register devtools_get_repo_info
+  pi.registerTool({
+    name: "devtools_get_repo_info",
+    label: "Repo Info",
+    description: "Get current branch, default branch, and git status",
+    parameters: Type.Object({}),
+    async execute() {
+      return repoInfoTool();
+    },
+  });
 
-	// Register devtools_get_latest_tag
-	pi.registerTool({
-		name: "devtools_get_latest_tag",
-		label: "Latest Tag",
-		description: "Get the latest version tag from git",
-		parameters: Type.Object({}),
-		async execute() {
-			return getLatestTagTool();
-		},
-	});
+  // Register devtools_get_latest_tag
+  pi.registerTool({
+    name: "devtools_get_latest_tag",
+    label: "Latest Tag",
+    description: "Get the latest version tag from git",
+    parameters: Type.Object({}),
+    async execute() {
+      return getLatestTagTool();
+    },
+  });
 
-	// Register devtools_analyze_commits
-	pi.registerTool({
-		name: "devtools_analyze_commits",
-		label: "Analyze Commits",
-		description: "Analyze commits since last tag to determine version bump type",
-		parameters: Type.Object({}),
-		async execute() {
-			return analyzeCommitsTool();
-		},
-	});
+  // Register devtools_analyze_commits
+  pi.registerTool({
+    name: "devtools_analyze_commits",
+    label: "Analyze Commits",
+    description: "Analyze commits since last tag to determine version bump type",
+    parameters: Type.Object({}),
+    async execute() {
+      return analyzeCommitsTool();
+    },
+  });
 
-	// Register devtools_bump_version
-	pi.registerTool({
-		name: "devtools_bump_version",
-		label: "Bump Version",
-		description: "Update version in package.json",
-		parameters: bumpVersionParams,
-		async execute(_toolCallId, params) {
-			const { newVersion, file = "package.json" } = params as { newVersion: string; file?: string };
-			return bumpVersionTool(newVersion, file);
-		},
-	});
+  // Register devtools_bump_version
+  pi.registerTool({
+    name: "devtools_bump_version",
+    label: "Bump Version",
+    description: "Update version in package.json",
+    parameters: bumpVersionParams,
+    async execute(_toolCallId, params) {
+      const { newVersion, file = "package.json" } = params as { newVersion: string; file?: string };
+      return bumpVersionTool(newVersion, file);
+    },
+  });
 
-	// Register devtools_create_release
-	pi.registerTool({
-		name: "devtools_create_release",
-		label: "Create Release",
-		description: "Create a GitHub release with changelog",
-		parameters: createReleaseParams,
-		async execute(_toolCallId, params) {
-			const typed = params as { tag: string; title: string; body?: string; draft?: boolean; prerelease?: boolean };
-			return createReleaseTool(typed.tag, typed.title, typed.body, typed.draft, typed.prerelease);
-		},
-	});
+  // Register devtools_create_release
+  pi.registerTool({
+    name: "devtools_create_release",
+    label: "Create Release",
+    description: "Create a GitHub release with changelog",
+    parameters: createReleaseParams,
+    async execute(_toolCallId, params) {
+      const typed = params as { tag: string; title: string; body?: string; draft?: boolean; prerelease?: boolean };
+      return createReleaseTool(typed.tag, typed.title, typed.body, typed.draft, typed.prerelease);
+    },
+  });
 }

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -7,421 +7,421 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockRequest = vi.fn();
 
 vi.mock("exa-js", () => ({
-	Exa: class {
-		request = mockRequest;
-	},
+  Exa: class {
+    request = mockRequest;
+  },
 }));
 
 import exaExtension from "../extensions/index.js";
 
 const createMockPi = (flags: Record<string, string | boolean | undefined> = {}) =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn<(name: string) => string | boolean | undefined>((name: string) => flags[name]),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn<(name: string) => string | boolean | undefined>((name: string) => flags[name]),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 const getRegisteredTool = (mockPi: ReturnType<typeof createMockPi>, name: string) => {
-	const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-	return tools.find((tool) => tool.name === name);
+  const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+  return tools.find((tool) => tool.name === name);
 };
 
 const writeTempConfig = (config: Record<string, unknown>) => {
-	const base = mkdtempSync(join(tmpdir(), "pi-exa-extension-"));
-	const configPath = join(base, "exa.json");
-	writeFileSync(configPath, `${JSON.stringify(config)}\n`, "utf-8");
-	return configPath;
+  const base = mkdtempSync(join(tmpdir(), "pi-exa-extension-"));
+  const configPath = join(base, "exa.json");
+  writeFileSync(configPath, `${JSON.stringify(config)}\n`, "utf-8");
+  return configPath;
 };
 
 describe("pi-exa extension", () => {
-	const originalApiKey = process.env.EXA_API_KEY;
-
-	beforeEach(() => {
-		mockRequest.mockReset();
-		if (originalApiKey === undefined) {
-			delete process.env.EXA_API_KEY;
-		} else {
-			process.env.EXA_API_KEY = originalApiKey;
-		}
-	});
-
-	it("registers flags", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toContain("--exa-api-key");
-		expect(flagNames).toContain("--exa-enable-advanced");
-		expect(flagNames).toContain("--exa-config");
-	});
-
-	it("registers exactly 3 flags", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toHaveLength(3);
-	});
-
-	it("registers web_search_exa by default", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-		expect(searchTool).toBeDefined();
-	});
-
-	it("registers web_fetch_exa by default", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-		expect(fetchTool).toBeDefined();
-	});
-
-	it("does not register web_search_advanced_exa by default", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-		expect(toolNames).not.toContain("web_search_advanced_exa");
-	});
-
-	it("registers web_search_advanced_exa when config enables it", () => {
-		const configPath = writeTempConfig({
-			apiKey: "config-api-key",
-			enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-		});
-		const mockPi = createMockPi({ "--exa-config": configPath });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-		expect(advancedTool).toBeDefined();
-	});
-
-	it("registers tools with execute functions", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		expect(tools.length).toBeGreaterThan(0);
-		tools.forEach((tool) => {
-			expect(tool.execute).toBeDefined();
-			expect(typeof tool.execute).toBe("function");
-		});
-	});
-
-	it("registers tools with labels", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-		expect(searchTool?.label).toBe("Exa Web Search");
-	});
-
-	it("registers tools with descriptions", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		tools.forEach((tool) => {
-			expect(tool.description).toBeDefined();
-			expect(tool.description.length).toBeGreaterThan(0);
-		});
-	});
-
-	it("registers tools with parameters", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		tools.forEach((tool) => {
-			expect(tool.parameters).toBeDefined();
-		});
-	});
-
-	it("registers flags with string type for api-key", () => {
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
-		const apiKeyFlag = flags.find((f) => f.name === "--exa-api-key");
-		expect(apiKeyFlag?.type).toBe("string");
-	});
-
-	it("handles missing API key gracefully", async () => {
-		delete process.env.EXA_API_KEY;
-
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-		const result = await searchTool?.execute("call-123", { query: "test" }, undefined, undefined, undefined);
-
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("API key not configured");
-	});
-
-	it("handles aborted signal for web_search_exa", async () => {
-		const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-		const abortedSignal = { aborted: true } as AbortSignal;
-		const result = await searchTool?.execute("call-123", { query: "test" }, abortedSignal, undefined, undefined);
-
-		expect(result.details.cancelled).toBe(true);
-	});
-
-	it("calls onUpdate callback for web_search_exa before executing", async () => {
-		mockRequest.mockResolvedValue({
-			results: [{ title: "Result", url: "https://example.com", text: "Search content" }],
-		});
-
-		const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-		const onUpdate = vi.fn();
-		const result = await searchTool?.execute(
-			"call-123",
-			{ query: "test" },
-			{ aborted: false } as AbortSignal,
-			onUpdate,
-			undefined,
-		);
-
-		expect(onUpdate).toHaveBeenCalledWith({
-			content: [{ type: "text", text: "Searching the web via Exa..." }],
-			details: { status: "pending" },
-		});
-		expect(result.content[0].text).toContain("https://example.com");
-	});
-
-	it("handles multiple extension instances", () => {
-		const mockPi1 = createMockPi();
-		const mockPi2 = createMockPi();
-
-		exaExtension(mockPi1 as unknown as ExtensionAPI);
-		exaExtension(mockPi2 as unknown as ExtensionAPI);
-
-		expect(mockPi1.registerTool).toHaveBeenCalled();
-		expect(mockPi2.registerTool).toHaveBeenCalled();
-	});
-
-	it("web_fetch_exa handles missing API key", async () => {
-		delete process.env.EXA_API_KEY;
-
-		const mockPi = createMockPi();
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-		const result = await fetchTool?.execute(
-			"call-123",
-			{ urls: ["https://example.com"] },
-			undefined,
-			undefined,
-			undefined,
-		);
-
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("API key not configured");
-	});
-
-	it("web_fetch_exa handles aborted signal", async () => {
-		const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-		const result = await fetchTool?.execute(
-			"call-123",
-			{ urls: ["https://example.com"] },
-			{ aborted: true } as AbortSignal,
-			undefined,
-			undefined,
-		);
-
-		expect(result.details.cancelled).toBe(true);
-	});
-
-	it("web_fetch_exa returns formatted content and uses the relative contents endpoint", async () => {
-		mockRequest.mockResolvedValue({
-			results: [
-				{
-					title: "Fetched Page",
-					url: "https://example.com",
-					text: "Fetched content",
-					publishedDate: "2025-01-15T10:30:00Z",
-					author: "Jane Doe",
-				},
-			],
-		});
-
-		const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-		const onUpdate = vi.fn();
-		const result = await fetchTool?.execute(
-			"call-123",
-			{ urls: ["https://example.com"], maxCharacters: 1234 },
-			{ aborted: false } as AbortSignal,
-			onUpdate,
-			undefined,
-		);
-
-		expect(onUpdate).toHaveBeenCalledWith({
-			content: [{ type: "text", text: "Fetching content via Exa..." }],
-			details: { status: "pending" },
-		});
-		expect(mockRequest).toHaveBeenCalledWith(
-			"/contents",
-			"POST",
-			expect.objectContaining({
-				ids: ["https://example.com"],
-				contents: { text: { maxCharacters: 1234 } },
-			}),
-		);
-		expect(result.details.tool).toBe("web_fetch_exa");
-		expect(result.content[0].text).toContain("Fetched Page");
-		expect(result.content[0].text).toContain("Fetched content");
-	});
-
-	it("web_fetch_exa returns an error result when the Exa request fails", async () => {
-		mockRequest.mockRejectedValue(new Error("fetch exploded"));
-
-		const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-		const result = await fetchTool?.execute(
-			"call-123",
-			{ urls: ["https://example.com"] },
-			{ aborted: false } as AbortSignal,
-			undefined,
-			undefined,
-		);
-
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("Exa fetch error: fetch exploded");
-		expect(result.details).toEqual({ tool: "web_fetch_exa", error: "fetch exploded" });
-	});
-
-	it("web_search_advanced_exa handles missing API key", async () => {
-		delete process.env.EXA_API_KEY;
-		const configPath = writeTempConfig({
-			enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-		});
-		const mockPi = createMockPi({ "--exa-config": configPath });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-		const result = await advancedTool?.execute("call-123", { query: "test" }, undefined, undefined, undefined);
-
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("API key not configured");
-	});
-
-	it("web_search_advanced_exa handles aborted signal", async () => {
-		const configPath = writeTempConfig({
-			apiKey: "config-api-key",
-			enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-		});
-		const mockPi = createMockPi({ "--exa-config": configPath });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-		const result = await advancedTool?.execute(
-			"call-123",
-			{ query: "test" },
-			{ aborted: true } as AbortSignal,
-			undefined,
-			undefined,
-		);
-
-		expect(result.details.cancelled).toBe(true);
-	});
-
-	it("web_search_advanced_exa forwards advanced options to Exa and formats the response", async () => {
-		mockRequest.mockResolvedValue({
-			results: [{ title: "Advanced Result", url: "https://example.com/advanced", text: "Advanced content" }],
-		});
-		const configPath = writeTempConfig({
-			apiKey: "config-api-key",
-			enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-		});
-		const mockPi = createMockPi({ "--exa-config": configPath });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-		const onUpdate = vi.fn();
-		const result = await advancedTool?.execute(
-			"call-123",
-			{
-				query: "latest ai tools",
-				numResults: 7,
-				category: "news",
-				type: "deep",
-				startPublishedDate: "2025-01-01",
-				endPublishedDate: "2025-02-01",
-				includeDomains: ["example.com"],
-				excludeDomains: ["spam.com"],
-				textMaxCharacters: 1200,
-				enableHighlights: true,
-				highlightsNumSentences: 5,
-			},
-			{ aborted: false } as AbortSignal,
-			onUpdate,
-			undefined,
-		);
-
-		expect(onUpdate).toHaveBeenCalledWith({
-			content: [{ type: "text", text: "Performing advanced search via Exa..." }],
-			details: { status: "pending" },
-		});
-		expect(mockRequest).toHaveBeenCalledWith(
-			"/search",
-			"POST",
-			expect.objectContaining({
-				query: "latest ai tools",
-				numResults: 7,
-				category: "news",
-				type: "deep",
-				startPublishedDate: "2025-01-01",
-				endPublishedDate: "2025-02-01",
-				includeDomains: ["example.com"],
-				excludeDomains: ["spam.com"],
-				contents: {
-					text: { maxCharacters: 1200 },
-					highlights: { highlightsPerUrl: 5 },
-				},
-			}),
-		);
-		expect(result.details.tool).toBe("web_search_advanced_exa");
-		expect(result.content[0].text).toContain("Advanced Result");
-	});
-
-	it("web_search_advanced_exa returns an error result when the Exa request fails", async () => {
-		mockRequest.mockRejectedValue(new Error("advanced exploded"));
-		const configPath = writeTempConfig({
-			apiKey: "config-api-key",
-			enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-		});
-		const mockPi = createMockPi({ "--exa-config": configPath });
-		exaExtension(mockPi as unknown as ExtensionAPI);
-
-		const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-		const result = await advancedTool?.execute(
-			"call-123",
-			{ query: "test" },
-			{ aborted: false } as AbortSignal,
-			undefined,
-			undefined,
-		);
-
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("Exa advanced search error: advanced exploded");
-		expect(result.details).toEqual({ tool: "web_search_advanced_exa", error: "advanced exploded" });
-	});
+  const originalApiKey = process.env.EXA_API_KEY;
+
+  beforeEach(() => {
+    mockRequest.mockReset();
+    if (originalApiKey === undefined) {
+      delete process.env.EXA_API_KEY;
+    } else {
+      process.env.EXA_API_KEY = originalApiKey;
+    }
+  });
+
+  it("registers flags", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toContain("--exa-api-key");
+    expect(flagNames).toContain("--exa-enable-advanced");
+    expect(flagNames).toContain("--exa-config");
+  });
+
+  it("registers exactly 3 flags", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toHaveLength(3);
+  });
+
+  it("registers web_search_exa by default", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    expect(searchTool).toBeDefined();
+  });
+
+  it("registers web_fetch_exa by default", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
+    expect(fetchTool).toBeDefined();
+  });
+
+  it("does not register web_search_advanced_exa by default", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).not.toContain("web_search_advanced_exa");
+  });
+
+  it("registers web_search_advanced_exa when config enables it", () => {
+    const configPath = writeTempConfig({
+      apiKey: "config-api-key",
+      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+    });
+    const mockPi = createMockPi({ "--exa-config": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    expect(advancedTool).toBeDefined();
+  });
+
+  it("registers tools with execute functions", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    expect(tools.length).toBeGreaterThan(0);
+    tools.forEach((tool) => {
+      expect(tool.execute).toBeDefined();
+      expect(typeof tool.execute).toBe("function");
+    });
+  });
+
+  it("registers tools with labels", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    expect(searchTool?.label).toBe("Exa Web Search");
+  });
+
+  it("registers tools with descriptions", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    tools.forEach((tool) => {
+      expect(tool.description).toBeDefined();
+      expect(tool.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("registers tools with parameters", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    tools.forEach((tool) => {
+      expect(tool.parameters).toBeDefined();
+    });
+  });
+
+  it("registers flags with string type for api-key", () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
+    const apiKeyFlag = flags.find((f) => f.name === "--exa-api-key");
+    expect(apiKeyFlag?.type).toBe("string");
+  });
+
+  it("handles missing API key gracefully", async () => {
+    delete process.env.EXA_API_KEY;
+
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    const result = await searchTool?.execute("call-123", { query: "test" }, undefined, undefined, undefined);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("API key not configured");
+  });
+
+  it("handles aborted signal for web_search_exa", async () => {
+    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    const abortedSignal = { aborted: true } as AbortSignal;
+    const result = await searchTool?.execute("call-123", { query: "test" }, abortedSignal, undefined, undefined);
+
+    expect(result.details.cancelled).toBe(true);
+  });
+
+  it("calls onUpdate callback for web_search_exa before executing", async () => {
+    mockRequest.mockResolvedValue({
+      results: [{ title: "Result", url: "https://example.com", text: "Search content" }],
+    });
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    const onUpdate = vi.fn();
+    const result = await searchTool?.execute(
+      "call-123",
+      { query: "test" },
+      { aborted: false } as AbortSignal,
+      onUpdate,
+      undefined,
+    );
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      content: [{ type: "text", text: "Searching the web via Exa..." }],
+      details: { status: "pending" },
+    });
+    expect(result.content[0].text).toContain("https://example.com");
+  });
+
+  it("handles multiple extension instances", () => {
+    const mockPi1 = createMockPi();
+    const mockPi2 = createMockPi();
+
+    exaExtension(mockPi1 as unknown as ExtensionAPI);
+    exaExtension(mockPi2 as unknown as ExtensionAPI);
+
+    expect(mockPi1.registerTool).toHaveBeenCalled();
+    expect(mockPi2.registerTool).toHaveBeenCalled();
+  });
+
+  it("web_fetch_exa handles missing API key", async () => {
+    delete process.env.EXA_API_KEY;
+
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
+    const result = await fetchTool?.execute(
+      "call-123",
+      { urls: ["https://example.com"] },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("API key not configured");
+  });
+
+  it("web_fetch_exa handles aborted signal", async () => {
+    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
+    const result = await fetchTool?.execute(
+      "call-123",
+      { urls: ["https://example.com"] },
+      { aborted: true } as AbortSignal,
+      undefined,
+      undefined,
+    );
+
+    expect(result.details.cancelled).toBe(true);
+  });
+
+  it("web_fetch_exa returns formatted content and uses the relative contents endpoint", async () => {
+    mockRequest.mockResolvedValue({
+      results: [
+        {
+          title: "Fetched Page",
+          url: "https://example.com",
+          text: "Fetched content",
+          publishedDate: "2025-01-15T10:30:00Z",
+          author: "Jane Doe",
+        },
+      ],
+    });
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
+    const onUpdate = vi.fn();
+    const result = await fetchTool?.execute(
+      "call-123",
+      { urls: ["https://example.com"], maxCharacters: 1234 },
+      { aborted: false } as AbortSignal,
+      onUpdate,
+      undefined,
+    );
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      content: [{ type: "text", text: "Fetching content via Exa..." }],
+      details: { status: "pending" },
+    });
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/contents",
+      "POST",
+      expect.objectContaining({
+        ids: ["https://example.com"],
+        contents: { text: { maxCharacters: 1234 } },
+      }),
+    );
+    expect(result.details.tool).toBe("web_fetch_exa");
+    expect(result.content[0].text).toContain("Fetched Page");
+    expect(result.content[0].text).toContain("Fetched content");
+  });
+
+  it("web_fetch_exa returns an error result when the Exa request fails", async () => {
+    mockRequest.mockRejectedValue(new Error("fetch exploded"));
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
+    const result = await fetchTool?.execute(
+      "call-123",
+      { urls: ["https://example.com"] },
+      { aborted: false } as AbortSignal,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Exa fetch error: fetch exploded");
+    expect(result.details).toEqual({ tool: "web_fetch_exa", error: "fetch exploded" });
+  });
+
+  it("web_search_advanced_exa handles missing API key", async () => {
+    delete process.env.EXA_API_KEY;
+    const configPath = writeTempConfig({
+      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+    });
+    const mockPi = createMockPi({ "--exa-config": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    const result = await advancedTool?.execute("call-123", { query: "test" }, undefined, undefined, undefined);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("API key not configured");
+  });
+
+  it("web_search_advanced_exa handles aborted signal", async () => {
+    const configPath = writeTempConfig({
+      apiKey: "config-api-key",
+      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+    });
+    const mockPi = createMockPi({ "--exa-config": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    const result = await advancedTool?.execute(
+      "call-123",
+      { query: "test" },
+      { aborted: true } as AbortSignal,
+      undefined,
+      undefined,
+    );
+
+    expect(result.details.cancelled).toBe(true);
+  });
+
+  it("web_search_advanced_exa forwards advanced options to Exa and formats the response", async () => {
+    mockRequest.mockResolvedValue({
+      results: [{ title: "Advanced Result", url: "https://example.com/advanced", text: "Advanced content" }],
+    });
+    const configPath = writeTempConfig({
+      apiKey: "config-api-key",
+      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+    });
+    const mockPi = createMockPi({ "--exa-config": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    const onUpdate = vi.fn();
+    const result = await advancedTool?.execute(
+      "call-123",
+      {
+        query: "latest ai tools",
+        numResults: 7,
+        category: "news",
+        type: "deep",
+        startPublishedDate: "2025-01-01",
+        endPublishedDate: "2025-02-01",
+        includeDomains: ["example.com"],
+        excludeDomains: ["spam.com"],
+        textMaxCharacters: 1200,
+        enableHighlights: true,
+        highlightsNumSentences: 5,
+      },
+      { aborted: false } as AbortSignal,
+      onUpdate,
+      undefined,
+    );
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      content: [{ type: "text", text: "Performing advanced search via Exa..." }],
+      details: { status: "pending" },
+    });
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/search",
+      "POST",
+      expect.objectContaining({
+        query: "latest ai tools",
+        numResults: 7,
+        category: "news",
+        type: "deep",
+        startPublishedDate: "2025-01-01",
+        endPublishedDate: "2025-02-01",
+        includeDomains: ["example.com"],
+        excludeDomains: ["spam.com"],
+        contents: {
+          text: { maxCharacters: 1200 },
+          highlights: { highlightsPerUrl: 5 },
+        },
+      }),
+    );
+    expect(result.details.tool).toBe("web_search_advanced_exa");
+    expect(result.content[0].text).toContain("Advanced Result");
+  });
+
+  it("web_search_advanced_exa returns an error result when the Exa request fails", async () => {
+    mockRequest.mockRejectedValue(new Error("advanced exploded"));
+    const configPath = writeTempConfig({
+      apiKey: "config-api-key",
+      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+    });
+    const mockPi = createMockPi({ "--exa-config": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    const result = await advancedTool?.execute(
+      "call-123",
+      { query: "test" },
+      { aborted: false } as AbortSignal,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Exa advanced search error: advanced exploded");
+    expect(result.details).toEqual({ tool: "web_search_advanced_exa", error: "advanced exploded" });
+  });
 });

--- a/packages/pi-exa/__tests__/helpers.test.ts
+++ b/packages/pi-exa/__tests__/helpers.test.ts
@@ -3,375 +3,375 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-	DEFAULT_MAX_CHARACTERS,
-	DEFAULT_NUM_RESULTS,
-	ensureDefaultConfigFile,
-	formatCrawlResults,
-	formatSearchResults,
-	getAuthStatusMessage,
-	isToolEnabledForConfig,
-	loadConfig,
-	parseConfig,
-	resolveAuth,
-	resolveConfigPath,
+  DEFAULT_MAX_CHARACTERS,
+  DEFAULT_NUM_RESULTS,
+  ensureDefaultConfigFile,
+  formatCrawlResults,
+  formatSearchResults,
+  getAuthStatusMessage,
+  isToolEnabledForConfig,
+  loadConfig,
+  parseConfig,
+  resolveAuth,
+  resolveConfigPath,
 } from "../extensions/index.js";
 
 describe("pi-exa resolveConfigPath", () => {
-	it("resolves paths starting with ~/", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(homedir());
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~/", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(homedir());
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("resolves paths starting with ~", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("returns absolute paths as-is", () => {
-		const absolute = "/absolute/path/to/config.json";
-		expect(resolveConfigPath(absolute)).toBe(absolute);
-	});
+  it("returns absolute paths as-is", () => {
+    const absolute = "/absolute/path/to/config.json";
+    expect(resolveConfigPath(absolute)).toBe(absolute);
+  });
 
-	it("resolves relative paths from cwd", () => {
-		const result = resolveConfigPath("relative/path.json");
-		expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
-	});
+  it("resolves relative paths from cwd", () => {
+    const result = resolveConfigPath("relative/path.json");
+    expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
+  });
 });
 
 describe("pi-exa parseConfig", () => {
-	it("parses valid config", () => {
-		const raw = {
-			apiKey: "test-key",
-			enabledTools: ["web_search_exa", "web_fetch_exa"],
-			advancedEnabled: true,
-		};
-		const result = parseConfig(raw);
-		expect(result).toEqual({
-			apiKey: "test-key",
-			enabledTools: ["web_search_exa", "web_fetch_exa"],
-			advancedEnabled: true,
-		});
-	});
+  it("parses valid config", () => {
+    const raw = {
+      apiKey: "test-key",
+      enabledTools: ["web_search_exa", "web_fetch_exa"],
+      advancedEnabled: true,
+    };
+    const result = parseConfig(raw);
+    expect(result).toEqual({
+      apiKey: "test-key",
+      enabledTools: ["web_search_exa", "web_fetch_exa"],
+      advancedEnabled: true,
+    });
+  });
 
-	it("returns defaults for invalid input", () => {
-		expect(parseConfig(null)).toEqual({});
-		expect(parseConfig(undefined)).toEqual({});
-		expect(parseConfig("string")).toEqual({});
-		expect(parseConfig(123)).toEqual({});
-	});
+  it("returns defaults for invalid input", () => {
+    expect(parseConfig(null)).toEqual({});
+    expect(parseConfig(undefined)).toEqual({});
+    expect(parseConfig("string")).toEqual({});
+    expect(parseConfig(123)).toEqual({});
+  });
 
-	it("filters out non-string/empty tools", () => {
-		const raw = { enabledTools: ["web_search_exa", 123, "web_fetch_exa", null, "  "] };
-		const result = parseConfig(raw);
-		expect(result.enabledTools).toEqual(["web_search_exa", "web_fetch_exa"]);
-	});
+  it("filters out non-string/empty tools", () => {
+    const raw = { enabledTools: ["web_search_exa", 123, "web_fetch_exa", null, "  "] };
+    const result = parseConfig(raw);
+    expect(result.enabledTools).toEqual(["web_search_exa", "web_fetch_exa"]);
+  });
 
-	it("defaults advancedEnabled to false", () => {
-		const result = parseConfig({ advancedEnabled: "not-a-boolean" });
-		expect(result.advancedEnabled).toBe(false);
-	});
+  it("defaults advancedEnabled to false", () => {
+    const result = parseConfig({ advancedEnabled: "not-a-boolean" });
+    expect(result.advancedEnabled).toBe(false);
+  });
 
-	it("trims api key", () => {
-		const result = parseConfig({ apiKey: "  test-key  " });
-		expect(result.apiKey).toBe("test-key");
-	});
+  it("trims api key", () => {
+    const result = parseConfig({ apiKey: "  test-key  " });
+    expect(result.apiKey).toBe("test-key");
+  });
 });
 
 describe("pi-exa formatSearchResults", () => {
-	it("formats search results", () => {
-		const results = [
-			{
-				title: "Test Article",
-				url: "https://example.com/article",
-				publishedDate: "2025-01-01",
-				highlights: ["This is a highlight", "Another highlight"],
-			},
-		];
-		const result = formatSearchResults(results);
-		expect(result).toContain("Test Article");
-		expect(result).toContain("https://example.com/article");
-		expect(result).toContain("2025-01-01");
-		expect(result).toContain("This is a highlight");
-	});
+  it("formats search results", () => {
+    const results = [
+      {
+        title: "Test Article",
+        url: "https://example.com/article",
+        publishedDate: "2025-01-01",
+        highlights: ["This is a highlight", "Another highlight"],
+      },
+    ];
+    const result = formatSearchResults(results);
+    expect(result).toContain("Test Article");
+    expect(result).toContain("https://example.com/article");
+    expect(result).toContain("2025-01-01");
+    expect(result).toContain("This is a highlight");
+  });
 
-	it("handles results without optional fields", () => {
-		const results = [{ url: "https://example.com" }];
-		const result = formatSearchResults(results);
-		expect(result).toContain("https://example.com");
-	});
+  it("handles results without optional fields", () => {
+    const results = [{ url: "https://example.com" }];
+    const result = formatSearchResults(results);
+    expect(result).toContain("https://example.com");
+  });
 
-	it("handles empty results", () => {
-		const result = formatSearchResults([]);
-		expect(result).toContain("No search results found");
-	});
+  it("handles empty results", () => {
+    const result = formatSearchResults([]);
+    expect(result).toContain("No search results found");
+  });
 
-	it("handles results with author", () => {
-		const results = [
-			{
-				url: "https://example.com",
-				author: "John Doe",
-			},
-		];
-		const result = formatSearchResults(results);
-		expect(result).toContain("John Doe");
-	});
+  it("handles results with author", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        author: "John Doe",
+      },
+    ];
+    const result = formatSearchResults(results);
+    expect(result).toContain("John Doe");
+  });
 
-	it("shows N/A for missing title", () => {
-		const results = [{ url: "https://example.com" }];
-		const result = formatSearchResults(results);
-		expect(result).toContain("N/A");
-	});
+  it("shows N/A for missing title", () => {
+    const results = [{ url: "https://example.com" }];
+    const result = formatSearchResults(results);
+    expect(result).toContain("N/A");
+  });
 
-	it("uses text when no highlights", () => {
-		const results = [
-			{
-				url: "https://example.com",
-				text: "Fallback text content",
-			},
-		];
-		const result = formatSearchResults(results);
-		expect(result).toContain("Fallback text content");
-	});
+  it("uses text when no highlights", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        text: "Fallback text content",
+      },
+    ];
+    const result = formatSearchResults(results);
+    expect(result).toContain("Fallback text content");
+  });
 });
 
 describe("pi-exa formatCrawlResults", () => {
-	it("formats crawl results with text", () => {
-		const results = [
-			{
-				url: "https://example.com",
-				text: "This is the page content",
-			},
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("https://example.com");
-		expect(result).toContain("This is the page content");
-	});
+  it("formats crawl results with text", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        text: "This is the page content",
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("https://example.com");
+    expect(result).toContain("This is the page content");
+  });
 
-	it("handles empty results", () => {
-		const result = formatCrawlResults([]);
-		expect(result).toContain("No content");
-	});
+  it("handles empty results", () => {
+    const result = formatCrawlResults([]);
+    expect(result).toContain("No content");
+  });
 
-	it("handles results with author and publishedDate", () => {
-		const results = [
-			{
-				url: "https://example.com/article",
-				text: "Content here",
-				author: "John Doe",
-				publishedDate: "2025-01-15",
-			},
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("John Doe");
-		expect(result).toContain("2025-01-15");
-	});
+  it("handles results with author and publishedDate", () => {
+    const results = [
+      {
+        url: "https://example.com/article",
+        text: "Content here",
+        author: "John Doe",
+        publishedDate: "2025-01-15",
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("John Doe");
+    expect(result).toContain("2025-01-15");
+  });
 
-	it("handles results with title", () => {
-		const results = [
-			{
-				url: "https://example.com",
-				text: "Content",
-				title: "Page Title",
-			},
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("Page Title");
-	});
+  it("handles results with title", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        text: "Content",
+        title: "Page Title",
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("Page Title");
+  });
 
-	it("handles results without title", () => {
-		const results = [
-			{
-				url: "https://example.com",
-				text: "Content",
-			},
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("(no title)");
-	});
+  it("handles results without title", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        text: "Content",
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("(no title)");
+  });
 
-	it("handles results with full datetime in publishedDate", () => {
-		const results = [
-			{
-				url: "https://example.com",
-				text: "Content",
-				publishedDate: "2025-01-15T10:30:00Z",
-			},
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("2025-01-15");
-	});
+  it("handles results with full datetime in publishedDate", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        text: "Content",
+        publishedDate: "2025-01-15T10:30:00Z",
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("2025-01-15");
+  });
 
-	it("handles results without text", () => {
-		const results = [
-			{
-				url: "https://example.com",
-			},
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("https://example.com");
-	});
+  it("handles results without text", () => {
+    const results = [
+      {
+        url: "https://example.com",
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("https://example.com");
+  });
 
-	it("handles multiple results", () => {
-		const results = [
-			{ url: "https://example.com/1", text: "First page" },
-			{ url: "https://example.com/2", text: "Second page" },
-		];
-		const result = formatCrawlResults(results);
-		expect(result).toContain("First page");
-		expect(result).toContain("Second page");
-	});
+  it("handles multiple results", () => {
+    const results = [
+      { url: "https://example.com/1", text: "First page" },
+      { url: "https://example.com/2", text: "Second page" },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("First page");
+    expect(result).toContain("Second page");
+  });
 });
 
 describe("pi-exa constants", () => {
-	it("has correct DEFAULT_MAX_CHARACTERS", () => {
-		expect(DEFAULT_MAX_CHARACTERS).toBe(3000);
-	});
+  it("has correct DEFAULT_MAX_CHARACTERS", () => {
+    expect(DEFAULT_MAX_CHARACTERS).toBe(3000);
+  });
 
-	it("has correct DEFAULT_NUM_RESULTS", () => {
-		expect(DEFAULT_NUM_RESULTS).toBe(5);
-	});
+  it("has correct DEFAULT_NUM_RESULTS", () => {
+    expect(DEFAULT_NUM_RESULTS).toBe(5);
+  });
 });
 
 describe("pi-exa ensureDefaultConfigFile", () => {
-	it("writes default config when none exists", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-config-"));
-		const projectConfigPath = join(base, "project", ".pi", "extensions", "exa.json");
-		const globalConfigPath = join(base, "global", "extensions", "exa.json");
+  it("writes default config when none exists", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-config-"));
+    const projectConfigPath = join(base, "project", ".pi", "extensions", "exa.json");
+    const globalConfigPath = join(base, "global", "extensions", "exa.json");
 
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
 
-		expect(existsSync(globalConfigPath)).toBe(true);
-		const raw = readFileSync(globalConfigPath, "utf-8");
-		const parsed = JSON.parse(raw);
-		expect(parsed).toHaveProperty("apiKey");
-		expect(parsed).toHaveProperty("enabledTools");
-	});
+    expect(existsSync(globalConfigPath)).toBe(true);
+    const raw = readFileSync(globalConfigPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    expect(parsed).toHaveProperty("apiKey");
+    expect(parsed).toHaveProperty("enabledTools");
+  });
 
-	it("does not overwrite existing config", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-config-exists-"));
-		const projectConfigPath = join(base, "project", ".pi", "extensions", "exa.json");
-		const globalConfigPath = join(base, "global", "extensions", "exa.json");
+  it("does not overwrite existing config", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-config-exists-"));
+    const projectConfigPath = join(base, "project", ".pi", "extensions", "exa.json");
+    const globalConfigPath = join(base, "global", "extensions", "exa.json");
 
-		// First call creates the file
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		const firstContent = readFileSync(globalConfigPath, "utf-8");
+    // First call creates the file
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    const firstContent = readFileSync(globalConfigPath, "utf-8");
 
-		// Second call should not overwrite
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		const secondContent = readFileSync(globalConfigPath, "utf-8");
+    // Second call should not overwrite
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    const secondContent = readFileSync(globalConfigPath, "utf-8");
 
-		expect(firstContent).toBe(secondContent);
-	});
+    expect(firstContent).toBe(secondContent);
+  });
 });
 
 describe("pi-exa auth helpers", () => {
-	it("prefers CLI flag over config and environment", () => {
-		const pi = {
-			getFlag(flag: string) {
-				if (flag === "--exa-api-key") {
-					return " cli-key ";
-				}
-				return undefined;
-			},
-		} as { getFlag: (flag: string) => unknown };
+  it("prefers CLI flag over config and environment", () => {
+    const pi = {
+      getFlag(flag: string) {
+        if (flag === "--exa-api-key") {
+          return " cli-key ";
+        }
+        return undefined;
+      },
+    } as { getFlag: (flag: string) => unknown };
 
-		process.env.EXA_API_KEY = "env-key";
-		expect(resolveAuth(pi as never)).toEqual({ apiKey: "cli-key", source: "CLI flag" });
-	});
+    process.env.EXA_API_KEY = "env-key";
+    expect(resolveAuth(pi as never)).toEqual({ apiKey: "cli-key", source: "CLI flag" });
+  });
 
-	it("uses config when CLI flag is absent", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-auth-config-"));
-		const configPath = join(base, "exa.json");
-		writeFileSync(configPath, JSON.stringify({ apiKey: "config-key" }), "utf-8");
+  it("uses config when CLI flag is absent", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-auth-config-"));
+    const configPath = join(base, "exa.json");
+    writeFileSync(configPath, JSON.stringify({ apiKey: "config-key" }), "utf-8");
 
-		const pi = {
-			getFlag(flag: string) {
-				if (flag === "--exa-config") {
-					return configPath;
-				}
-				return undefined;
-			},
-		} as { getFlag: (flag: string) => unknown };
+    const pi = {
+      getFlag(flag: string) {
+        if (flag === "--exa-config") {
+          return configPath;
+        }
+        return undefined;
+      },
+    } as { getFlag: (flag: string) => unknown };
 
-		delete process.env.EXA_API_KEY;
-		expect(resolveAuth(pi as never)).toEqual({ apiKey: "config-key", source: "config file" });
-	});
+    delete process.env.EXA_API_KEY;
+    expect(resolveAuth(pi as never)).toEqual({ apiKey: "config-key", source: "config file" });
+  });
 
-	it("builds unauthenticated status message", () => {
-		const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
-		delete process.env.EXA_API_KEY;
-		expect(getAuthStatusMessage(pi as never)).toContain("Not authenticated");
-	});
+  it("builds unauthenticated status message", () => {
+    const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
+    delete process.env.EXA_API_KEY;
+    expect(getAuthStatusMessage(pi as never)).toContain("Not authenticated");
+  });
 });
 
 describe("pi-exa tool enablement helpers", () => {
-	it("enables default tools without config", () => {
-		const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
-		expect(isToolEnabledForConfig(pi as never, null, "web_search_exa")).toBe(true);
-		expect(isToolEnabledForConfig(pi as never, null, "web_fetch_exa")).toBe(true);
-	});
+  it("enables default tools without config", () => {
+    const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
+    expect(isToolEnabledForConfig(pi as never, null, "web_search_exa")).toBe(true);
+    expect(isToolEnabledForConfig(pi as never, null, "web_fetch_exa")).toBe(true);
+  });
 
-	it("respects advanced tool flag override", () => {
-		const pi = {
-			getFlag(flag: string) {
-				return flag === "--exa-enable-advanced" ? true : undefined;
-			},
-		} as { getFlag: (flag: string) => unknown };
-		const config = { advancedEnabled: false };
-		expect(isToolEnabledForConfig(pi as never, config, "web_search_advanced_exa")).toBe(true);
-	});
+  it("respects advanced tool flag override", () => {
+    const pi = {
+      getFlag(flag: string) {
+        return flag === "--exa-enable-advanced" ? true : undefined;
+      },
+    } as { getFlag: (flag: string) => unknown };
+    const config = { advancedEnabled: false };
+    expect(isToolEnabledForConfig(pi as never, config, "web_search_advanced_exa")).toBe(true);
+  });
 
-	it("respects explicit enabled tools list", () => {
-		const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
-		const config = { enabledTools: ["web_search_advanced_exa"] };
-		expect(isToolEnabledForConfig(pi as never, config, "web_search_exa")).toBe(false);
-		expect(isToolEnabledForConfig(pi as never, config, "web_search_advanced_exa")).toBe(true);
-	});
+  it("respects explicit enabled tools list", () => {
+    const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
+    const config = { enabledTools: ["web_search_advanced_exa"] };
+    expect(isToolEnabledForConfig(pi as never, config, "web_search_exa")).toBe(false);
+    expect(isToolEnabledForConfig(pi as never, config, "web_search_advanced_exa")).toBe(true);
+  });
 });
 
 describe("pi-exa loadConfig", () => {
-	it("returns null when no config exists", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-load-"));
-		const configPath = join(base, "nonexistent.json");
-		const result = loadConfig(configPath);
-		expect(result).toBeNull();
-	});
+  it("returns null when no config exists", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-load-"));
+    const configPath = join(base, "nonexistent.json");
+    const result = loadConfig(configPath);
+    expect(result).toBeNull();
+  });
 
-	it("loads valid config file", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-load-valid-"));
-		const configPath = join(base, "exa.json");
-		const config = { apiKey: "test-api-key", enabledTools: ["web_search_exa"] };
-		writeFileSync(configPath, JSON.stringify(config), "utf-8");
+  it("loads valid config file", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-load-valid-"));
+    const configPath = join(base, "exa.json");
+    const config = { apiKey: "test-api-key", enabledTools: ["web_search_exa"] };
+    writeFileSync(configPath, JSON.stringify(config), "utf-8");
 
-		const result = loadConfig(configPath);
-		expect(result?.apiKey).toBe("test-api-key");
-		expect(result?.enabledTools).toContain("web_search_exa");
-	});
+    const result = loadConfig(configPath);
+    expect(result?.apiKey).toBe("test-api-key");
+    expect(result?.enabledTools).toContain("web_search_exa");
+  });
 
-	it("returns null on invalid JSON", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-load-invalid-"));
-		const configPath = join(base, "invalid.json");
-		writeFileSync(configPath, "not valid json", "utf-8");
+  it("returns null on invalid JSON", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-load-invalid-"));
+    const configPath = join(base, "invalid.json");
+    writeFileSync(configPath, "not valid json", "utf-8");
 
-		expect(loadConfig(configPath)).toBeNull();
-	});
+    expect(loadConfig(configPath)).toBeNull();
+  });
 
-	it("loads from environment config path", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-exa-load-env-"));
-		const configPath = join(base, "env-config.json");
-		const config = { apiKey: "env-api-key" };
-		writeFileSync(configPath, JSON.stringify(config), "utf-8");
+  it("loads from environment config path", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-exa-load-env-"));
+    const configPath = join(base, "env-config.json");
+    const config = { apiKey: "env-api-key" };
+    writeFileSync(configPath, JSON.stringify(config), "utf-8");
 
-		const result = loadConfig(configPath);
-		expect(result?.apiKey).toBe("env-api-key");
-	});
+    const result = loadConfig(configPath);
+    expect(result?.apiKey).toBe("env-api-key");
+  });
 
-	it("returns default config for empty config path", () => {
-		const result = loadConfig(undefined);
-		// Creates default config and returns it
-		expect(result).not.toBeNull();
-		expect(result).toHaveProperty("enabledTools");
-		expect(result?.enabledTools).toContain("web_search_exa");
-	});
+  it("returns default config for empty config path", () => {
+    const result = loadConfig(undefined);
+    // Creates default config and returns it
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("enabledTools");
+    expect(result?.enabledTools).toContain("web_search_exa");
+  });
 });

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -3,68 +3,68 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("pi-exa", () => {
-	describe("package", () => {
-		it("should have correct name", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.name).toBe("@feniix/pi-exa");
-		});
+  describe("package", () => {
+    it("should have correct name", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.name).toBe("@feniix/pi-exa");
+    });
 
-		it("should have version", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.version).toBeTruthy();
-		});
+    it("should have version", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.version).toBeTruthy();
+    });
 
-		it("should have pi extension entry point", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.pi).toBeDefined();
-			expect(pkg.pi.extensions).toContain("./extensions/index.ts");
-		});
+    it("should have pi extension entry point", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.pi).toBeDefined();
+      expect(pkg.pi.extensions).toContain("./extensions/index.ts");
+    });
 
-		it("should have exa-js dependency", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.dependencies).toHaveProperty("exa-js");
-		});
+    it("should have exa-js dependency", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.dependencies).toHaveProperty("exa-js");
+    });
 
-		it("should use relative Exa SDK endpoints instead of full API URLs", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain('exa.request<ExaSearchResponse>("/search", "POST", searchRequest)');
-			expect(extension).toContain('}>("/contents", "POST", crawlRequest)');
-			expect(extension).not.toContain(
-				'exa.request<ExaSearchResponse>("https://api.exa.ai/search", "POST", searchRequest)',
-			);
-			expect(extension).not.toContain('}>("https://api.exa.ai/contents", "POST", crawlRequest)');
-		});
-	});
+    it("should use relative Exa SDK endpoints instead of full API URLs", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain('exa.request<ExaSearchResponse>("/search", "POST", searchRequest)');
+      expect(extension).toContain('}>("/contents", "POST", crawlRequest)');
+      expect(extension).not.toContain(
+        'exa.request<ExaSearchResponse>("https://api.exa.ai/search", "POST", searchRequest)',
+      );
+      expect(extension).not.toContain('}>("https://api.exa.ai/contents", "POST", crawlRequest)');
+    });
+  });
 
-	describe("skills", () => {
-		it("should have code-search skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/code-search/SKILL.md"), "utf-8");
-			expect(skill).toContain("web_search_exa");
-		});
+  describe("skills", () => {
+    it("should have code-search skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/code-search/SKILL.md"), "utf-8");
+      expect(skill).toContain("web_search_exa");
+    });
 
-		it("should have company-research skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/company-research/SKILL.md"), "utf-8");
-			expect(skill).toContain("web_search_exa");
-		});
+    it("should have company-research skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/company-research/SKILL.md"), "utf-8");
+      expect(skill).toContain("web_search_exa");
+    });
 
-		it("should have people-research skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/people-research/SKILL.md"), "utf-8");
-			expect(skill).toContain("web_search_exa");
-		});
+    it("should have people-research skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/people-research/SKILL.md"), "utf-8");
+      expect(skill).toContain("web_search_exa");
+    });
 
-		it("should have research-paper-search skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/research-paper-search/SKILL.md"), "utf-8");
-			expect(skill).toContain("web_search_exa");
-		});
+    it("should have research-paper-search skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/research-paper-search/SKILL.md"), "utf-8");
+      expect(skill).toContain("web_search_exa");
+    });
 
-		it("should have financial-report-search skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/financial-report-search/SKILL.md"), "utf-8");
-			expect(skill).toContain("web_search_exa");
-		});
+    it("should have financial-report-search skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/financial-report-search/SKILL.md"), "utf-8");
+      expect(skill).toContain("web_search_exa");
+    });
 
-		it("should have personal-site-search skill", () => {
-			const skill = readFileSync(join(__dirname, "../skills/personal-site-search/SKILL.md"), "utf-8");
-			expect(skill).toContain("web_search_exa");
-		});
-	});
+    it("should have personal-site-search skill", () => {
+      const skill = readFileSync(join(__dirname, "../skills/personal-site-search/SKILL.md"), "utf-8");
+      expect(skill).toContain("web_search_exa");
+    });
+  });
 });

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -42,36 +42,36 @@ const DEFAULT_NUM_RESULTS = 5;
 // =============================================================================
 
 interface ExaConfig {
-	apiKey?: string;
-	enabledTools?: string[];
-	advancedEnabled?: boolean;
+  apiKey?: string;
+  enabledTools?: string[];
+  advancedEnabled?: boolean;
 }
 
 interface AuthResolution {
-	apiKey: string;
-	source?: "CLI flag" | "EXA_API_KEY env var" | "config file";
+  apiKey: string;
+  source?: "CLI flag" | "EXA_API_KEY env var" | "config file";
 }
 
 function normalizeString(value: unknown): string | undefined {
-	if (typeof value !== "string") {
-		return undefined;
-	}
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 interface SearchResult {
-	title?: string;
-	url: string;
-	publishedDate?: string;
-	author?: string;
-	highlights?: string[];
-	text?: string;
+  title?: string;
+  url: string;
+  publishedDate?: string;
+  author?: string;
+  highlights?: string[];
+  text?: string;
 }
 
 interface ExaSearchResponse {
-	results?: SearchResult[];
-	searchTime?: number;
+  results?: SearchResult[];
+  searchTime?: number;
 }
 
 // =============================================================================
@@ -79,143 +79,143 @@ interface ExaSearchResponse {
 // =============================================================================
 
 function resolveConfigPath(configPath: string): string {
-	const trimmed = configPath.trim();
-	if (trimmed.startsWith("~/")) {
-		return join(homedir(), trimmed.slice(2));
-	}
-	if (trimmed.startsWith("~")) {
-		return join(homedir(), trimmed.slice(1));
-	}
-	if (isAbsolute(trimmed)) {
-		return trimmed;
-	}
-	return resolve(process.cwd(), trimmed);
+  const trimmed = configPath.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(homedir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
 }
 
 function parseConfig(raw: unknown): ExaConfig {
-	if (typeof raw !== "object" || raw === null) {
-		return {};
-	}
-	const obj = raw as Record<string, unknown>;
-	return {
-		apiKey: normalizeString(obj.apiKey),
-		enabledTools: Array.isArray(obj.enabledTools)
-			? obj.enabledTools
-					.filter((t): t is string => typeof t === "string")
-					.map((t) => t.trim())
-					.filter((t) => t.length > 0)
-			: undefined,
-		advancedEnabled: typeof obj.advancedEnabled === "boolean" ? obj.advancedEnabled : false,
-	};
+  if (typeof raw !== "object" || raw === null) {
+    return {};
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    apiKey: normalizeString(obj.apiKey),
+    enabledTools: Array.isArray(obj.enabledTools)
+      ? obj.enabledTools
+          .filter((t): t is string => typeof t === "string")
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0)
+      : undefined,
+    advancedEnabled: typeof obj.advancedEnabled === "boolean" ? obj.advancedEnabled : false,
+  };
 }
 
 function loadConfig(configPath?: string): ExaConfig | null {
-	const candidates: string[] = [];
+  const candidates: string[] = [];
 
-	if (configPath) {
-		candidates.push(resolveConfigPath(configPath));
-	} else if (process.env.EXA_CONFIG) {
-		candidates.push(resolveConfigPath(process.env.EXA_CONFIG));
-	} else {
-		const projectConfigPath = join(process.cwd(), ".pi", "extensions", "exa.json");
-		const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "exa.json");
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		candidates.push(projectConfigPath, globalConfigPath);
-	}
+  if (configPath) {
+    candidates.push(resolveConfigPath(configPath));
+  } else if (process.env.EXA_CONFIG) {
+    candidates.push(resolveConfigPath(process.env.EXA_CONFIG));
+  } else {
+    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "exa.json");
+    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "exa.json");
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    candidates.push(projectConfigPath, globalConfigPath);
+  }
 
-	for (const candidate of candidates) {
-		if (!existsSync(candidate)) {
-			continue;
-		}
-		try {
-			const raw = readFileSync(candidate, "utf-8");
-			const parsed = JSON.parse(raw);
-			return parseConfig(parsed);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			console.warn(`[pi-exa] Failed to parse config ${candidate}: ${message}`);
-		}
-	}
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    try {
+      const raw = readFileSync(candidate, "utf-8");
+      const parsed = JSON.parse(raw);
+      return parseConfig(parsed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[pi-exa] Failed to parse config ${candidate}: ${message}`);
+    }
+  }
 
-	return null;
+  return null;
 }
 
 function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-	if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-		return;
-	}
+  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
+    return;
+  }
 
-	const defaultConfig = {
-		apiKey: null,
-		enabledTools: ["web_search_exa", "web_fetch_exa"],
-		advancedEnabled: false,
-	};
+  const defaultConfig = {
+    apiKey: null,
+    enabledTools: ["web_search_exa", "web_fetch_exa"],
+    advancedEnabled: false,
+  };
 
-	try {
-		mkdirSync(dirname(globalConfigPath), { recursive: true });
-		writeFileSync(globalConfigPath, `${JSON.stringify(defaultConfig, null, 2)}\n`, "utf-8");
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		console.warn(`[pi-exa] Failed to write ${globalConfigPath}: ${message}`);
-	}
+  try {
+    mkdirSync(dirname(globalConfigPath), { recursive: true });
+    writeFileSync(globalConfigPath, `${JSON.stringify(defaultConfig, null, 2)}\n`, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-exa] Failed to write ${globalConfigPath}: ${message}`);
+  }
 }
 
 function getConfigOverrideFlag(pi: ExtensionAPI): string | undefined {
-	return normalizeString(pi.getFlag("--exa-config"));
+  return normalizeString(pi.getFlag("--exa-config"));
 }
 
 function getResolvedConfig(pi: ExtensionAPI): ExaConfig | null {
-	return loadConfig(getConfigOverrideFlag(pi));
+  return loadConfig(getConfigOverrideFlag(pi));
 }
 
 function resolveAuth(pi: ExtensionAPI): AuthResolution {
-	const apiKeyFlag = normalizeString(pi.getFlag("--exa-api-key"));
-	if (apiKeyFlag) {
-		return { apiKey: apiKeyFlag, source: "CLI flag" };
-	}
+  const apiKeyFlag = normalizeString(pi.getFlag("--exa-api-key"));
+  if (apiKeyFlag) {
+    return { apiKey: apiKeyFlag, source: "CLI flag" };
+  }
 
-	const configApiKey = normalizeString(getResolvedConfig(pi)?.apiKey);
-	if (configApiKey) {
-		return { apiKey: configApiKey, source: "config file" };
-	}
+  const configApiKey = normalizeString(getResolvedConfig(pi)?.apiKey);
+  if (configApiKey) {
+    return { apiKey: configApiKey, source: "config file" };
+  }
 
-	const envApiKey = normalizeString(process.env.EXA_API_KEY);
-	if (envApiKey) {
-		return { apiKey: envApiKey, source: "EXA_API_KEY env var" };
-	}
+  const envApiKey = normalizeString(process.env.EXA_API_KEY);
+  if (envApiKey) {
+    return { apiKey: envApiKey, source: "EXA_API_KEY env var" };
+  }
 
-	return { apiKey: "" };
+  return { apiKey: "" };
 }
 
 function getAuthStatusMessage(pi: ExtensionAPI): string {
-	const auth = resolveAuth(pi);
-	return auth.source
-		? `[exa] Authenticated via ${auth.source}`
-		: "[exa] Not authenticated. Set EXA_API_KEY or use --exa-api-key flag.";
+  const auth = resolveAuth(pi);
+  return auth.source
+    ? `[exa] Authenticated via ${auth.source}`
+    : "[exa] Not authenticated. Set EXA_API_KEY or use --exa-api-key flag.";
 }
 
 function isAdvancedToolEnabled(pi: ExtensionAPI, config: ExaConfig | null): boolean {
-	const advancedFlag = pi.getFlag("--exa-enable-advanced");
-	if (typeof advancedFlag === "boolean") {
-		return advancedFlag;
-	}
-	return config?.advancedEnabled ?? false;
+  const advancedFlag = pi.getFlag("--exa-enable-advanced");
+  if (typeof advancedFlag === "boolean") {
+    return advancedFlag;
+  }
+  return config?.advancedEnabled ?? false;
 }
 
 function isToolEnabledForConfig(pi: ExtensionAPI, config: ExaConfig | null, toolName: string): boolean {
-	if (config?.enabledTools && Array.isArray(config.enabledTools)) {
-		return config.enabledTools.includes(toolName);
-	}
+  if (config?.enabledTools && Array.isArray(config.enabledTools)) {
+    return config.enabledTools.includes(toolName);
+  }
 
-	if (toolName === "web_search_exa" || toolName === "web_fetch_exa") {
-		return true;
-	}
+  if (toolName === "web_search_exa" || toolName === "web_fetch_exa") {
+    return true;
+  }
 
-	if (toolName === "web_search_advanced_exa") {
-		return isAdvancedToolEnabled(pi, config);
-	}
+  if (toolName === "web_search_advanced_exa") {
+    return isAdvancedToolEnabled(pi, config);
+  }
 
-	return false;
+  return false;
 }
 
 // =============================================================================
@@ -223,49 +223,49 @@ function isToolEnabledForConfig(pi: ExtensionAPI, config: ExaConfig | null, tool
 // =============================================================================
 
 const webSearchParams = Type.Object(
-	{
-		query: Type.String({
-			description:
-				"Natural language search query. Should be a semantically rich description of the ideal page, not just keywords.",
-		}),
-		numResults: Type.Optional(
-			Type.Integer({ description: "Number of search results to return (1-20, default: 5)", minimum: 1, maximum: 20 }),
-		),
-	},
-	{ additionalProperties: true },
+  {
+    query: Type.String({
+      description:
+        "Natural language search query. Should be a semantically rich description of the ideal page, not just keywords.",
+    }),
+    numResults: Type.Optional(
+      Type.Integer({ description: "Number of search results to return (1-20, default: 5)", minimum: 1, maximum: 20 }),
+    ),
+  },
+  { additionalProperties: true },
 );
 
 const webFetchParams = Type.Object(
-	{
-		urls: Type.Array(Type.String({ description: "URLs to read. Batch multiple URLs in one call." }), {
-			description: "URLs to read",
-		}),
-		maxCharacters: Type.Optional(
-			Type.Integer({ description: "Maximum characters to extract per page (default: 3000)", minimum: 1 }),
-		),
-	},
-	{ additionalProperties: true },
+  {
+    urls: Type.Array(Type.String({ description: "URLs to read. Batch multiple URLs in one call." }), {
+      description: "URLs to read",
+    }),
+    maxCharacters: Type.Optional(
+      Type.Integer({ description: "Maximum characters to extract per page (default: 3000)", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: true },
 );
 
 const webSearchAdvancedParams = Type.Object(
-	{
-		query: Type.String({ description: "Search query" }),
-		numResults: Type.Optional(Type.Integer({ description: "Number of results (1-100)", minimum: 1, maximum: 100 })),
-		category: Type.Optional(
-			Type.String({
-				description: "Category filter: company, research paper, financial report, people, news, etc.",
-			}),
-		),
-		type: Type.Optional(Type.String({ description: "Search type: auto, fast, deep, neural" })),
-		startPublishedDate: Type.Optional(Type.String({ description: "ISO date filter (e.g., 2024-01-01)" })),
-		endPublishedDate: Type.Optional(Type.String({ description: "ISO date filter (e.g., 2024-12-31)" })),
-		includeDomains: Type.Optional(Type.Array(Type.String())),
-		excludeDomains: Type.Optional(Type.Array(Type.String())),
-		textMaxCharacters: Type.Optional(Type.Integer()),
-		enableHighlights: Type.Optional(Type.Boolean()),
-		highlightsNumSentences: Type.Optional(Type.Integer()),
-	},
-	{ additionalProperties: true },
+  {
+    query: Type.String({ description: "Search query" }),
+    numResults: Type.Optional(Type.Integer({ description: "Number of results (1-100)", minimum: 1, maximum: 100 })),
+    category: Type.Optional(
+      Type.String({
+        description: "Category filter: company, research paper, financial report, people, news, etc.",
+      }),
+    ),
+    type: Type.Optional(Type.String({ description: "Search type: auto, fast, deep, neural" })),
+    startPublishedDate: Type.Optional(Type.String({ description: "ISO date filter (e.g., 2024-01-01)" })),
+    endPublishedDate: Type.Optional(Type.String({ description: "ISO date filter (e.g., 2024-12-31)" })),
+    includeDomains: Type.Optional(Type.Array(Type.String())),
+    excludeDomains: Type.Optional(Type.Array(Type.String())),
+    textMaxCharacters: Type.Optional(Type.Integer()),
+    enableHighlights: Type.Optional(Type.Boolean()),
+    highlightsNumSentences: Type.Optional(Type.Integer()),
+  },
+  { additionalProperties: true },
 );
 
 // =============================================================================
@@ -273,189 +273,189 @@ const webSearchAdvancedParams = Type.Object(
 // =============================================================================
 
 function formatSearchResults(results: SearchResult[]): string {
-	if (results.length === 0) {
-		return "No search results found. Please try a different query.";
-	}
+  if (results.length === 0) {
+    return "No search results found. Please try a different query.";
+  }
 
-	return results
-		.map((r) => {
-			const lines: string[] = [
-				`Title: ${r.title || "N/A"}`,
-				`URL: ${r.url}`,
-				`Published: ${r.publishedDate || "N/A"}`,
-				`Author: ${r.author || "N/A"}`,
-			];
-			if (Array.isArray(r.highlights) && r.highlights.length > 0) {
-				lines.push(`Highlights:\n${r.highlights.join("\n")}`);
-			} else if (r.text) {
-				lines.push(`Text: ${r.text}`);
-			}
-			return lines.join("\n");
-		})
-		.join("\n\n---\n\n");
+  return results
+    .map((r) => {
+      const lines: string[] = [
+        `Title: ${r.title || "N/A"}`,
+        `URL: ${r.url}`,
+        `Published: ${r.publishedDate || "N/A"}`,
+        `Author: ${r.author || "N/A"}`,
+      ];
+      if (Array.isArray(r.highlights) && r.highlights.length > 0) {
+        lines.push(`Highlights:\n${r.highlights.join("\n")}`);
+      } else if (r.text) {
+        lines.push(`Text: ${r.text}`);
+      }
+      return lines.join("\n");
+    })
+    .join("\n\n---\n\n");
 }
 
 function formatCrawlResults(
-	results: Array<{
-		title?: string;
-		url: string;
-		publishedDate?: string;
-		author?: string;
-		text?: string;
-	}>,
+  results: Array<{
+    title?: string;
+    url: string;
+    publishedDate?: string;
+    author?: string;
+    text?: string;
+  }>,
 ): string {
-	if (results.length === 0) {
-		return "No content found.";
-	}
+  if (results.length === 0) {
+    return "No content found.";
+  }
 
-	return results
-		.map((r) => {
-			const lines: string[] = [`# ${r.title || "(no title)"}`, `URL: ${r.url}`];
-			if (r.publishedDate) {
-				lines.push(`Published: ${r.publishedDate.split("T")[0]}`);
-			}
-			if (r.author) {
-				lines.push(`Author: ${r.author}`);
-			}
-			lines.push("");
-			if (r.text) {
-				lines.push(r.text);
-			}
-			lines.push("");
-			return lines.join("\n");
-		})
-		.join("\n");
+  return results
+    .map((r) => {
+      const lines: string[] = [`# ${r.title || "(no title)"}`, `URL: ${r.url}`];
+      if (r.publishedDate) {
+        lines.push(`Published: ${r.publishedDate.split("T")[0]}`);
+      }
+      if (r.author) {
+        lines.push(`Author: ${r.author}`);
+      }
+      lines.push("");
+      if (r.text) {
+        lines.push(r.text);
+      }
+      lines.push("");
+      return lines.join("\n");
+    })
+    .join("\n");
 }
 
 async function performWebSearch(apiKey: string, query: string, numResults: number): Promise<string> {
-	const exa = new Exa(apiKey);
+  const exa = new Exa(apiKey);
 
-	const searchRequest = {
-		query,
-		type: "auto",
-		numResults,
-		contents: {
-			highlights: { query },
-			text: { maxCharacters: 300 },
-		},
-	};
+  const searchRequest = {
+    query,
+    type: "auto",
+    numResults,
+    contents: {
+      highlights: { query },
+      text: { maxCharacters: 300 },
+    },
+  };
 
-	// Exa SDK already prefixes requests with its configured baseURL.
-	// Pass a relative endpoint here, not a full URL, or the SDK will build
-	// an invalid URL like "https://api.exa.aihttps://api.exa.ai/search".
-	const response = await exa.request<ExaSearchResponse>("/search", "POST", searchRequest);
+  // Exa SDK already prefixes requests with its configured baseURL.
+  // Pass a relative endpoint here, not a full URL, or the SDK will build
+  // an invalid URL like "https://api.exa.aihttps://api.exa.ai/search".
+  const response = await exa.request<ExaSearchResponse>("/search", "POST", searchRequest);
 
-	if (!response?.results || response.results.length === 0) {
-		return "No search results found. Please try a different query.";
-	}
+  if (!response?.results || response.results.length === 0) {
+    return "No search results found. Please try a different query.";
+  }
 
-	return formatSearchResults(response.results);
+  return formatSearchResults(response.results);
 }
 
 async function performWebFetch(apiKey: string, urls: string[], maxCharacters: number): Promise<string> {
-	const exa = new Exa(apiKey);
+  const exa = new Exa(apiKey);
 
-	const crawlRequest = {
-		ids: urls,
-		contents: {
-			text: {
-				maxCharacters,
-			},
-		},
-	};
+  const crawlRequest = {
+    ids: urls,
+    contents: {
+      text: {
+        maxCharacters,
+      },
+    },
+  };
 
-	const response = await exa.request<{
-		results?: Array<{
-			title?: string;
-			url: string;
-			publishedDate?: string;
-			author?: string;
-			text?: string;
-		}>;
-	}>("/contents", "POST", crawlRequest);
+  const response = await exa.request<{
+    results?: Array<{
+      title?: string;
+      url: string;
+      publishedDate?: string;
+      author?: string;
+      text?: string;
+    }>;
+  }>("/contents", "POST", crawlRequest);
 
-	if (!response?.results || response.results.length === 0) {
-		return "No content found for the requested URLs.";
-	}
+  if (!response?.results || response.results.length === 0) {
+    return "No content found for the requested URLs.";
+  }
 
-	return formatCrawlResults(response.results);
+  return formatCrawlResults(response.results);
 }
 
 async function performAdvancedSearch(
-	apiKey: string,
-	query: string,
-	options: {
-		numResults?: number;
-		category?: string;
-		type?: string;
-		startPublishedDate?: string;
-		endPublishedDate?: string;
-		includeDomains?: string[];
-		excludeDomains?: string[];
-		textMaxCharacters?: number;
-		enableHighlights?: boolean;
-		highlightsNumSentences?: number;
-	},
+  apiKey: string,
+  query: string,
+  options: {
+    numResults?: number;
+    category?: string;
+    type?: string;
+    startPublishedDate?: string;
+    endPublishedDate?: string;
+    includeDomains?: string[];
+    excludeDomains?: string[];
+    textMaxCharacters?: number;
+    enableHighlights?: boolean;
+    highlightsNumSentences?: number;
+  },
 ): Promise<string> {
-	const exa = new Exa(apiKey);
+  const exa = new Exa(apiKey);
 
-	const searchRequest: Record<string, unknown> = {
-		query,
-		numResults: options.numResults || 10,
-		contents: {
-			text: { maxCharacters: options.textMaxCharacters || 3000 },
-		},
-	};
+  const searchRequest: Record<string, unknown> = {
+    query,
+    numResults: options.numResults || 10,
+    contents: {
+      text: { maxCharacters: options.textMaxCharacters || 3000 },
+    },
+  };
 
-	if (options.category) {
-		searchRequest.category = options.category;
-	}
-	if (options.type) {
-		searchRequest.type = options.type;
-	}
-	if (options.startPublishedDate) {
-		searchRequest.startPublishedDate = options.startPublishedDate;
-	}
-	if (options.endPublishedDate) {
-		searchRequest.endPublishedDate = options.endPublishedDate;
-	}
-	if (options.includeDomains && options.includeDomains.length > 0) {
-		searchRequest.includeDomains = options.includeDomains;
-	}
-	if (options.excludeDomains && options.excludeDomains.length > 0) {
-		searchRequest.excludeDomains = options.excludeDomains;
-	}
-	if (options.enableHighlights) {
-		const existingContents = searchRequest.contents as Record<string, unknown>;
-		searchRequest.contents = {
-			...existingContents,
-			highlights: {
-				highlightsPerUrl: options.highlightsNumSentences || 3,
-			},
-		};
-	}
+  if (options.category) {
+    searchRequest.category = options.category;
+  }
+  if (options.type) {
+    searchRequest.type = options.type;
+  }
+  if (options.startPublishedDate) {
+    searchRequest.startPublishedDate = options.startPublishedDate;
+  }
+  if (options.endPublishedDate) {
+    searchRequest.endPublishedDate = options.endPublishedDate;
+  }
+  if (options.includeDomains && options.includeDomains.length > 0) {
+    searchRequest.includeDomains = options.includeDomains;
+  }
+  if (options.excludeDomains && options.excludeDomains.length > 0) {
+    searchRequest.excludeDomains = options.excludeDomains;
+  }
+  if (options.enableHighlights) {
+    const existingContents = searchRequest.contents as Record<string, unknown>;
+    searchRequest.contents = {
+      ...existingContents,
+      highlights: {
+        highlightsPerUrl: options.highlightsNumSentences || 3,
+      },
+    };
+  }
 
-	const response = await exa.request<ExaSearchResponse>("/search", "POST", searchRequest);
+  const response = await exa.request<ExaSearchResponse>("/search", "POST", searchRequest);
 
-	if (!response?.results || response.results.length === 0) {
-		return "No search results found. Please try a different query.";
-	}
+  if (!response?.results || response.results.length === 0) {
+    return "No search results found. Please try a different query.";
+  }
 
-	return formatSearchResults(response.results);
+  return formatSearchResults(response.results);
 }
 
 export {
-	DEFAULT_MAX_CHARACTERS,
-	DEFAULT_NUM_RESULTS,
-	ensureDefaultConfigFile,
-	formatCrawlResults,
-	formatSearchResults,
-	getAuthStatusMessage,
-	isToolEnabledForConfig,
-	loadConfig,
-	parseConfig,
-	resolveAuth,
-	resolveConfigPath,
+  DEFAULT_MAX_CHARACTERS,
+  DEFAULT_NUM_RESULTS,
+  ensureDefaultConfigFile,
+  formatCrawlResults,
+  formatSearchResults,
+  getAuthStatusMessage,
+  isToolEnabledForConfig,
+  loadConfig,
+  parseConfig,
+  resolveAuth,
+  resolveConfigPath,
 };
 
 // =============================================================================
@@ -463,202 +463,202 @@ export {
 // =============================================================================
 
 export default function exaExtension(pi: ExtensionAPI) {
-	// SessionStart: check auth and print status
-	pi.on("session_start", async () => {
-		console.log(getAuthStatusMessage(pi));
-	});
+  // SessionStart: check auth and print status
+  pi.on("session_start", async () => {
+    console.log(getAuthStatusMessage(pi));
+  });
 
-	// Register CLI flags
-	pi.registerFlag("--exa-api-key", {
-		description: "Exa AI API key for search operations",
-		type: "string",
-	});
-	pi.registerFlag("--exa-enable-advanced", {
-		description: "Enable web_search_advanced_exa tool",
-		type: "boolean",
-	});
-	pi.registerFlag("--exa-config", {
-		description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/exa.json)",
-		type: "string",
-	});
+  // Register CLI flags
+  pi.registerFlag("--exa-api-key", {
+    description: "Exa AI API key for search operations",
+    type: "string",
+  });
+  pi.registerFlag("--exa-enable-advanced", {
+    description: "Enable web_search_advanced_exa tool",
+    type: "boolean",
+  });
+  pi.registerFlag("--exa-config", {
+    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/exa.json)",
+    type: "string",
+  });
 
-	const getApiKey = (): string => resolveAuth(pi).apiKey;
+  const getApiKey = (): string => resolveAuth(pi).apiKey;
 
-	const isToolEnabled = (toolName: string): boolean => isToolEnabledForConfig(pi, getResolvedConfig(pi), toolName);
+  const isToolEnabled = (toolName: string): boolean => isToolEnabledForConfig(pi, getResolvedConfig(pi), toolName);
 
-	// Register web_search_exa tool
-	if (isToolEnabled("web_search_exa")) {
-		pi.registerTool({
-			name: "web_search_exa",
-			label: "Exa Web Search",
-			description:
-				"Search the web for any topic and get clean, ready-to-use content. " +
-				"Best for: Finding current information, news, facts, or answering questions. " +
-				"Query tips: describe the ideal page, not keywords. 'blog post comparing React and Vue' not 'React Vue'.",
-			parameters: webSearchParams,
-			async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-				const apiKey = getApiKey();
-				if (!apiKey) {
-					return {
-						content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-						isError: true,
-						details: { tool: "web_search_exa", error: "missing_api_key" },
-					};
-				}
+  // Register web_search_exa tool
+  if (isToolEnabled("web_search_exa")) {
+    pi.registerTool({
+      name: "web_search_exa",
+      label: "Exa Web Search",
+      description:
+        "Search the web for any topic and get clean, ready-to-use content. " +
+        "Best for: Finding current information, news, facts, or answering questions. " +
+        "Query tips: describe the ideal page, not keywords. 'blog post comparing React and Vue' not 'React Vue'.",
+      parameters: webSearchParams,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+          return {
+            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
+            isError: true,
+            details: { tool: "web_search_exa", error: "missing_api_key" },
+          };
+        }
 
-				if (signal?.aborted) {
-					return {
-						content: [{ type: "text", text: "Cancelled." }],
-						details: { cancelled: true },
-					};
-				}
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled." }],
+            details: { cancelled: true },
+          };
+        }
 
-				onUpdate?.({
-					content: [{ type: "text", text: "Searching the web via Exa..." }],
-					details: { status: "pending" },
-				});
+        onUpdate?.({
+          content: [{ type: "text", text: "Searching the web via Exa..." }],
+          details: { status: "pending" },
+        });
 
-				try {
-					const typedParams = params as { query: string; numResults?: number };
-					const result = await performWebSearch(
-						apiKey,
-						typedParams.query,
-						typedParams.numResults || DEFAULT_NUM_RESULTS,
-					);
-					return { content: [{ type: "text", text: result }], details: { tool: "web_search_exa" } };
-				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					return {
-						content: [{ type: "text", text: `Exa search error: ${message}` }],
-						isError: true,
-						details: { tool: "web_search_exa", error: message },
-					};
-				}
-			},
-		});
-	}
+        try {
+          const typedParams = params as { query: string; numResults?: number };
+          const result = await performWebSearch(
+            apiKey,
+            typedParams.query,
+            typedParams.numResults || DEFAULT_NUM_RESULTS,
+          );
+          return { content: [{ type: "text", text: result }], details: { tool: "web_search_exa" } };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: `Exa search error: ${message}` }],
+            isError: true,
+            details: { tool: "web_search_exa", error: message },
+          };
+        }
+      },
+    });
+  }
 
-	// Register web_fetch_exa tool
-	if (isToolEnabled("web_fetch_exa")) {
-		pi.registerTool({
-			name: "web_fetch_exa",
-			label: "Exa Web Fetch",
-			description:
-				"Read a webpage's full content as clean markdown. " +
-				"Use after web_search_exa when highlights are insufficient or to read any URL. " +
-				"Best for: Extracting full content from known URLs. Batch multiple URLs in one call.",
-			parameters: webFetchParams,
-			async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-				const apiKey = getApiKey();
-				if (!apiKey) {
-					return {
-						content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-						isError: true,
-						details: { tool: "web_fetch_exa", error: "missing_api_key" },
-					};
-				}
+  // Register web_fetch_exa tool
+  if (isToolEnabled("web_fetch_exa")) {
+    pi.registerTool({
+      name: "web_fetch_exa",
+      label: "Exa Web Fetch",
+      description:
+        "Read a webpage's full content as clean markdown. " +
+        "Use after web_search_exa when highlights are insufficient or to read any URL. " +
+        "Best for: Extracting full content from known URLs. Batch multiple URLs in one call.",
+      parameters: webFetchParams,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+          return {
+            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
+            isError: true,
+            details: { tool: "web_fetch_exa", error: "missing_api_key" },
+          };
+        }
 
-				if (signal?.aborted) {
-					return {
-						content: [{ type: "text", text: "Cancelled." }],
-						details: { cancelled: true },
-					};
-				}
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled." }],
+            details: { cancelled: true },
+          };
+        }
 
-				onUpdate?.({
-					content: [{ type: "text", text: "Fetching content via Exa..." }],
-					details: { status: "pending" },
-				});
+        onUpdate?.({
+          content: [{ type: "text", text: "Fetching content via Exa..." }],
+          details: { status: "pending" },
+        });
 
-				try {
-					const typedParams = params as { urls: string[]; maxCharacters?: number };
-					const result = await performWebFetch(
-						apiKey,
-						typedParams.urls,
-						typedParams.maxCharacters || DEFAULT_MAX_CHARACTERS,
-					);
-					return { content: [{ type: "text", text: result }], details: { tool: "web_fetch_exa" } };
-				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					return {
-						content: [{ type: "text", text: `Exa fetch error: ${message}` }],
-						isError: true,
-						details: { tool: "web_fetch_exa", error: message },
-					};
-				}
-			},
-		});
-	}
+        try {
+          const typedParams = params as { urls: string[]; maxCharacters?: number };
+          const result = await performWebFetch(
+            apiKey,
+            typedParams.urls,
+            typedParams.maxCharacters || DEFAULT_MAX_CHARACTERS,
+          );
+          return { content: [{ type: "text", text: result }], details: { tool: "web_fetch_exa" } };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: `Exa fetch error: ${message}` }],
+            isError: true,
+            details: { tool: "web_fetch_exa", error: message },
+          };
+        }
+      },
+    });
+  }
 
-	// Register web_search_advanced_exa tool (disabled by default)
-	if (isToolEnabled("web_search_advanced_exa")) {
-		pi.registerTool({
-			name: "web_search_advanced_exa",
-			label: "Exa Advanced Search",
-			description:
-				"Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, " +
-				"highlights, summaries, and subpage crawling. Requires --exa-enable-advanced flag or advancedEnabled in config.",
-			parameters: webSearchAdvancedParams,
-			async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-				const apiKey = getApiKey();
-				if (!apiKey) {
-					return {
-						content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-						isError: true,
-						details: { tool: "web_search_advanced_exa", error: "missing_api_key" },
-					};
-				}
+  // Register web_search_advanced_exa tool (disabled by default)
+  if (isToolEnabled("web_search_advanced_exa")) {
+    pi.registerTool({
+      name: "web_search_advanced_exa",
+      label: "Exa Advanced Search",
+      description:
+        "Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, " +
+        "highlights, summaries, and subpage crawling. Requires --exa-enable-advanced flag or advancedEnabled in config.",
+      parameters: webSearchAdvancedParams,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+          return {
+            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
+            isError: true,
+            details: { tool: "web_search_advanced_exa", error: "missing_api_key" },
+          };
+        }
 
-				if (signal?.aborted) {
-					return {
-						content: [{ type: "text", text: "Cancelled." }],
-						details: { cancelled: true },
-					};
-				}
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled." }],
+            details: { cancelled: true },
+          };
+        }
 
-				onUpdate?.({
-					content: [{ type: "text", text: "Performing advanced search via Exa..." }],
-					details: { status: "pending" },
-				});
+        onUpdate?.({
+          content: [{ type: "text", text: "Performing advanced search via Exa..." }],
+          details: { status: "pending" },
+        });
 
-				try {
-					const typedParams = params as {
-						query: string;
-						numResults?: number;
-						category?: string;
-						type?: string;
-						startPublishedDate?: string;
-						endPublishedDate?: string;
-						includeDomains?: string[];
-						excludeDomains?: string[];
-						textMaxCharacters?: number;
-						enableHighlights?: boolean;
-						highlightsNumSentences?: number;
-					};
+        try {
+          const typedParams = params as {
+            query: string;
+            numResults?: number;
+            category?: string;
+            type?: string;
+            startPublishedDate?: string;
+            endPublishedDate?: string;
+            includeDomains?: string[];
+            excludeDomains?: string[];
+            textMaxCharacters?: number;
+            enableHighlights?: boolean;
+            highlightsNumSentences?: number;
+          };
 
-					const result = await performAdvancedSearch(apiKey, typedParams.query, {
-						numResults: typedParams.numResults,
-						category: typedParams.category,
-						type: typedParams.type,
-						startPublishedDate: typedParams.startPublishedDate,
-						endPublishedDate: typedParams.endPublishedDate,
-						includeDomains: typedParams.includeDomains,
-						excludeDomains: typedParams.excludeDomains,
-						textMaxCharacters: typedParams.textMaxCharacters,
-						enableHighlights: typedParams.enableHighlights,
-						highlightsNumSentences: typedParams.highlightsNumSentences,
-					});
+          const result = await performAdvancedSearch(apiKey, typedParams.query, {
+            numResults: typedParams.numResults,
+            category: typedParams.category,
+            type: typedParams.type,
+            startPublishedDate: typedParams.startPublishedDate,
+            endPublishedDate: typedParams.endPublishedDate,
+            includeDomains: typedParams.includeDomains,
+            excludeDomains: typedParams.excludeDomains,
+            textMaxCharacters: typedParams.textMaxCharacters,
+            enableHighlights: typedParams.enableHighlights,
+            highlightsNumSentences: typedParams.highlightsNumSentences,
+          });
 
-					return { content: [{ type: "text", text: result }], details: { tool: "web_search_advanced_exa" } };
-				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					return {
-						content: [{ type: "text", text: `Exa advanced search error: ${message}` }],
-						isError: true,
-						details: { tool: "web_search_advanced_exa", error: message },
-					};
-				}
-			},
-		});
-	}
+          return { content: [{ type: "text", text: result }], details: { tool: "web_search_advanced_exa" } };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: `Exa advanced search error: ${message}` }],
+            isError: true,
+            details: { tool: "web_search_advanced_exa", error: message },
+          };
+        }
+      },
+    });
+  }
 }

--- a/packages/pi-notion/__tests__/extension.runtime.test.ts
+++ b/packages/pi-notion/__tests__/extension.runtime.test.ts
@@ -3,44 +3,44 @@ import { describe, expect, it, vi } from "vitest";
 import notion from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 const getEventHandler = (mockPi: ReturnType<typeof createMockPi>, eventName: string) => {
-	const entry = mockPi.on.mock.calls.find(([event]) => event === eventName);
-	return entry?.[1];
+  const entry = mockPi.on.mock.calls.find(([event]) => event === eventName);
+  return entry?.[1];
 };
 
 describe("pi-notion extension runtime", () => {
-	it("warns for incorrect notion-search inputs", async () => {
-		const mockPi = createMockPi();
-		notion(mockPi as unknown as ExtensionAPI);
-		const toolCall = getEventHandler(mockPi, "tool_call");
-		const notify = vi.fn();
+  it("warns for incorrect notion-search inputs", async () => {
+    const mockPi = createMockPi();
+    notion(mockPi as unknown as ExtensionAPI);
+    const toolCall = getEventHandler(mockPi, "tool_call");
+    const notify = vi.fn();
 
-		await toolCall?.({ toolName: "mcp__notion-search", input: { query: "meeting notes" } }, { ui: { notify } });
+    await toolCall?.({ toolName: "mcp__notion-search", input: { query: "meeting notes" } }, { ui: { notify } });
 
-		expect(notify).toHaveBeenCalledWith(
-			expect.stringContaining("content_search_mode is not 'workspace_search'"),
-			"warning",
-		);
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("'filters' key is missing"), "warning");
-	});
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("content_search_mode is not 'workspace_search'"),
+      "warning",
+    );
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("'filters' key is missing"), "warning");
+  });
 
-	it("warns for raw fetch ids and empty meeting note filters", async () => {
-		const mockPi = createMockPi();
-		notion(mockPi as unknown as ExtensionAPI);
-		const toolCall = getEventHandler(mockPi, "tool_call");
-		const notify = vi.fn();
+  it("warns for raw fetch ids and empty meeting note filters", async () => {
+    const mockPi = createMockPi();
+    notion(mockPi as unknown as ExtensionAPI);
+    const toolCall = getEventHandler(mockPi, "tool_call");
+    const notify = vi.fn();
 
-		await toolCall?.({ toolName: "mcp__notion-fetch", input: { id: "12345" } }, { ui: { notify } });
-		await toolCall?.({ toolName: "mcp__notion-query-meeting-notes", input: { filter: {} } }, { ui: { notify } });
+    await toolCall?.({ toolName: "mcp__notion-fetch", input: { id: "12345" } }, { ui: { notify } });
+    await toolCall?.({ toolName: "mcp__notion-query-meeting-notes", input: { filter: {} } }, { ui: { notify } });
 
-		expect(notify).toHaveBeenNthCalledWith(1, expect.stringContaining("Prefer the 'url' field"), "warning");
-		expect(notify).toHaveBeenNthCalledWith(2, expect.stringContaining("Empty filter {} will fail"), "warning");
-	});
+    expect(notify).toHaveBeenNthCalledWith(1, expect.stringContaining("Prefer the 'url' field"), "warning");
+    expect(notify).toHaveBeenNthCalledWith(2, expect.stringContaining("Empty filter {} will fail"), "warning");
+  });
 });

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -3,406 +3,406 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-	formatBlocks,
-	formatDatabase,
-	formatPage,
-	formatSearch,
-	getTitleFromProperties,
-	loadConfig,
-	resolveConfigPath,
+  formatBlocks,
+  formatDatabase,
+  formatPage,
+  formatSearch,
+  getTitleFromProperties,
+  loadConfig,
+  resolveConfigPath,
 } from "../extensions/index.js";
 
 describe("pi-notion resolveConfigPath", () => {
-	it("resolves paths starting with ~/", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(homedir());
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~/", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(homedir());
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("resolves paths starting with ~", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("returns absolute paths as-is", () => {
-		const absolute = "/absolute/path/to/config.json";
-		expect(resolveConfigPath(absolute)).toBe(absolute);
-	});
+  it("returns absolute paths as-is", () => {
+    const absolute = "/absolute/path/to/config.json";
+    expect(resolveConfigPath(absolute)).toBe(absolute);
+  });
 
-	it("resolves relative paths from cwd", () => {
-		const result = resolveConfigPath("relative/path.json");
-		expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
-	});
+  it("resolves relative paths from cwd", () => {
+    const result = resolveConfigPath("relative/path.json");
+    expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
+  });
 
-	it("handles whitespace in paths", () => {
-		const result = resolveConfigPath("  ~/.pi/config.json  ");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("handles whitespace in paths", () => {
+    const result = resolveConfigPath("  ~/.pi/config.json  ");
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("handles path with only tilde", () => {
-		const result = resolveConfigPath("~");
-		expect(result).toBe(homedir());
-	});
+  it("handles path with only tilde", () => {
+    const result = resolveConfigPath("~");
+    expect(result).toBe(homedir());
+  });
 });
 
 describe("pi-notion getTitleFromProperties", () => {
-	it("extracts title from property with type title", () => {
-		const props = { Name: { type: "title", title: [{ plain_text: "My Page" }] } };
-		expect(getTitleFromProperties(props)).toBe("My Page");
-	});
+  it("extracts title from property with type title", () => {
+    const props = { Name: { type: "title", title: [{ plain_text: "My Page" }] } };
+    expect(getTitleFromProperties(props)).toBe("My Page");
+  });
 
-	it("extracts title from another title property", () => {
-		const props = { Title: { type: "title", title: [{ plain_text: "Another Page" }] } };
-		expect(getTitleFromProperties(props)).toBe("Another Page");
-	});
+  it("extracts title from another title property", () => {
+    const props = { Title: { type: "title", title: [{ plain_text: "Another Page" }] } };
+    expect(getTitleFromProperties(props)).toBe("Another Page");
+  });
 
-	it("returns Untitled when no title found", () => {
-		expect(getTitleFromProperties({})).toBe("Untitled");
-		expect(getTitleFromProperties({ other: { type: "text", text: "test" } })).toBe("Untitled");
-	});
+  it("returns Untitled when no title found", () => {
+    expect(getTitleFromProperties({})).toBe("Untitled");
+    expect(getTitleFromProperties({ other: { type: "text", text: "test" } })).toBe("Untitled");
+  });
 
-	it("handles empty title array", () => {
-		expect(getTitleFromProperties({ Name: { type: "title", title: [] } })).toBe("Untitled");
-	});
+  it("handles empty title array", () => {
+    expect(getTitleFromProperties({ Name: { type: "title", title: [] } })).toBe("Untitled");
+  });
 
-	it("handles multiple text parts", () => {
-		const props = {
-			Name: {
-				type: "title",
-				title: [{ plain_text: "Part 1 " }, { plain_text: "Part 2" }],
-			},
-		};
-		expect(getTitleFromProperties(props)).toBe("Part 1 Part 2");
-	});
+  it("handles multiple text parts", () => {
+    const props = {
+      Name: {
+        type: "title",
+        title: [{ plain_text: "Part 1 " }, { plain_text: "Part 2" }],
+      },
+    };
+    expect(getTitleFromProperties(props)).toBe("Part 1 Part 2");
+  });
 
-	it("finds title in nested properties", () => {
-		const props = {
-			Status: { type: "status" },
-			Name: { type: "title", title: [{ plain_text: "Nested Title" }] },
-			Description: { type: "rich_text" },
-		};
-		expect(getTitleFromProperties(props)).toBe("Nested Title");
-	});
+  it("finds title in nested properties", () => {
+    const props = {
+      Status: { type: "status" },
+      Name: { type: "title", title: [{ plain_text: "Nested Title" }] },
+      Description: { type: "rich_text" },
+    };
+    expect(getTitleFromProperties(props)).toBe("Nested Title");
+  });
 });
 
 describe("pi-notion formatPage", () => {
-	it("formats page with properties", () => {
-		const page = {
-			id: "abc123",
-			url: "https://notion.so/abc123",
-			properties: { Name: { title: [{ plain_text: "Test Page" }] } },
-		};
-		const result = formatPage(page);
-		expect(result).toContain("Test Page");
-		expect(result).toContain("abc123");
-	});
+  it("formats page with properties", () => {
+    const page = {
+      id: "abc123",
+      url: "https://notion.so/abc123",
+      properties: { Name: { title: [{ plain_text: "Test Page" }] } },
+    };
+    const result = formatPage(page);
+    expect(result).toContain("Test Page");
+    expect(result).toContain("abc123");
+  });
 
-	it("handles page without properties", () => {
-		const page = { id: "abc123", url: "https://notion.so/abc123", properties: {} };
-		const result = formatPage(page);
-		expect(result).toContain("Untitled");
-	});
+  it("handles page without properties", () => {
+    const page = { id: "abc123", url: "https://notion.so/abc123", properties: {} };
+    const result = formatPage(page);
+    expect(result).toContain("Untitled");
+  });
 
-	it("formats page with title property", () => {
-		const page = {
-			id: "xyz789",
-			url: "https://notion.so/xyz789",
-			properties: { title: { title: [{ plain_text: "Title Property" }] } },
-		};
-		const result = formatPage(page);
-		expect(result).toContain("Title Property");
-	});
+  it("formats page with title property", () => {
+    const page = {
+      id: "xyz789",
+      url: "https://notion.so/xyz789",
+      properties: { title: { title: [{ plain_text: "Title Property" }] } },
+    };
+    const result = formatPage(page);
+    expect(result).toContain("Title Property");
+  });
 
-	it("formats page with multiple properties", () => {
-		const page = {
-			id: "multi",
-			url: "https://notion.so/multi",
-			properties: {
-				Name: { title: [{ plain_text: "Multi Page" }] },
-				Status: { status: { name: "Active" } },
-				Date: { date: { start: "2025-01-01" } },
-			},
-		};
-		const result = formatPage(page);
-		expect(result).toContain("Multi Page");
-		expect(result).toContain("## Properties");
-	});
+  it("formats page with multiple properties", () => {
+    const page = {
+      id: "multi",
+      url: "https://notion.so/multi",
+      properties: {
+        Name: { title: [{ plain_text: "Multi Page" }] },
+        Status: { status: { name: "Active" } },
+        Date: { date: { start: "2025-01-01" } },
+      },
+    };
+    const result = formatPage(page);
+    expect(result).toContain("Multi Page");
+    expect(result).toContain("## Properties");
+  });
 });
 
 describe("pi-notion formatDatabase", () => {
-	it("formats database", () => {
-		const db = {
-			id: "def456",
-			title: [{ plain_text: "Test Database" }],
-			properties: { Name: {}, Status: {} },
-		};
-		const result = formatDatabase(db);
-		expect(result).toContain("Test Database");
-		expect(result).toContain("def456");
-	});
+  it("formats database", () => {
+    const db = {
+      id: "def456",
+      title: [{ plain_text: "Test Database" }],
+      properties: { Name: {}, Status: {} },
+    };
+    const result = formatDatabase(db);
+    expect(result).toContain("Test Database");
+    expect(result).toContain("def456");
+  });
 
-	it("handles empty title", () => {
-		const db = { id: "def456", title: [], properties: {} };
-		const result = formatDatabase(db);
-		expect(result).toContain("Untitled");
-		expect(result).toContain("def456");
-	});
+  it("handles empty title", () => {
+    const db = { id: "def456", title: [], properties: {} };
+    const result = formatDatabase(db);
+    expect(result).toContain("Untitled");
+    expect(result).toContain("def456");
+  });
 
-	it("formats database with multiple properties", () => {
-		const db = {
-			id: "db123",
-			title: [{ plain_text: "Multi Property DB" }],
-			properties: {
-				Name: { type: "title" },
-				Status: { type: "status" },
-				Count: { type: "number" },
-			},
-		};
-		const result = formatDatabase(db);
-		expect(result).toContain("Multi Property DB");
-		expect(result).toContain("Name");
-		expect(result).toContain("Status");
-	});
+  it("formats database with multiple properties", () => {
+    const db = {
+      id: "db123",
+      title: [{ plain_text: "Multi Property DB" }],
+      properties: {
+        Name: { type: "title" },
+        Status: { type: "status" },
+        Count: { type: "number" },
+      },
+    };
+    const result = formatDatabase(db);
+    expect(result).toContain("Multi Property DB");
+    expect(result).toContain("Name");
+    expect(result).toContain("Status");
+  });
 
-	it("handles undefined title", () => {
-		const db = { id: "no-title", title: undefined, properties: {} };
-		const result = formatDatabase(db);
-		expect(result).toContain("Untitled");
-	});
+  it("handles undefined title", () => {
+    const db = { id: "no-title", title: undefined, properties: {} };
+    const result = formatDatabase(db);
+    expect(result).toContain("Untitled");
+  });
 });
 
 describe("pi-notion formatBlocks", () => {
-	it("formats blocks", () => {
-		const result = formatBlocks({
-			results: [
-				{ type: "paragraph", id: "1", paragraph: { text: [{ plain_text: "Hello" }] } },
-				{ type: "heading_1", id: "2", heading_1: { text: [{ plain_text: "Title" }] } },
-			],
-		});
-		expect(result).toContain("paragraph");
-		expect(result).toContain("Hello");
-		expect(result).toContain("Title");
-	});
+  it("formats blocks", () => {
+    const result = formatBlocks({
+      results: [
+        { type: "paragraph", id: "1", paragraph: { text: [{ plain_text: "Hello" }] } },
+        { type: "heading_1", id: "2", heading_1: { text: [{ plain_text: "Title" }] } },
+      ],
+    });
+    expect(result).toContain("paragraph");
+    expect(result).toContain("Hello");
+    expect(result).toContain("Title");
+  });
 
-	it("handles empty results", () => {
-		const result = formatBlocks({ results: [] });
-		expect(result).toBe("No blocks found.");
-	});
+  it("handles empty results", () => {
+    const result = formatBlocks({ results: [] });
+    expect(result).toBe("No blocks found.");
+  });
 
-	it("handles unknown block types", () => {
-		const result = formatBlocks({
-			results: [{ type: "unknown_type", id: "1" }],
-		});
-		expect(result).toContain("unknown_type");
-	});
+  it("handles unknown block types", () => {
+    const result = formatBlocks({
+      results: [{ type: "unknown_type", id: "1" }],
+    });
+    expect(result).toContain("unknown_type");
+  });
 
-	it("handles blocks with empty content", () => {
-		const result = formatBlocks({
-			results: [
-				{ type: "paragraph", id: "1", paragraph: {} },
-				{ type: "code", id: "2", code: { text: [] } },
-			],
-		});
-		expect(result).toContain("paragraph");
-		expect(result).toContain("code");
-	});
+  it("handles blocks with empty content", () => {
+    const result = formatBlocks({
+      results: [
+        { type: "paragraph", id: "1", paragraph: {} },
+        { type: "code", id: "2", code: { text: [] } },
+      ],
+    });
+    expect(result).toContain("paragraph");
+    expect(result).toContain("code");
+  });
 
-	it("handles null results", () => {
-		const result = formatBlocks({ results: null as unknown as [] });
-		expect(result).toBe("No blocks found.");
-	});
+  it("handles null results", () => {
+    const result = formatBlocks({ results: null as unknown as [] });
+    expect(result).toBe("No blocks found.");
+  });
 
-	it("handles blocks with multiple text items", () => {
-		const result = formatBlocks({
-			results: [
-				{
-					type: "paragraph",
-					id: "1",
-					paragraph: { text: [{ plain_text: "Part 1" }, { plain_text: "Part 2" }] },
-				},
-			],
-		});
-		expect(result).toContain("Part 1");
-		expect(result).toContain("Part 2");
-	});
+  it("handles blocks with multiple text items", () => {
+    const result = formatBlocks({
+      results: [
+        {
+          type: "paragraph",
+          id: "1",
+          paragraph: { text: [{ plain_text: "Part 1" }, { plain_text: "Part 2" }] },
+        },
+      ],
+    });
+    expect(result).toContain("Part 1");
+    expect(result).toContain("Part 2");
+  });
 });
 
 describe("pi-notion formatSearch", () => {
-	it("formats search results", () => {
-		const result = formatSearch({
-			results: [
-				{ object: "page", id: "1", properties: { Name: { title: [{ plain_text: "Page 1" }] } } },
-				{ object: "database", id: "2", title: [{ plain_text: "DB 1" }] },
-			],
-		});
-		expect(result).toContain("page");
-		expect(result).toContain("Untitled"); // depends on how title is extracted
-		expect(result).toContain("database");
-	});
+  it("formats search results", () => {
+    const result = formatSearch({
+      results: [
+        { object: "page", id: "1", properties: { Name: { title: [{ plain_text: "Page 1" }] } } },
+        { object: "database", id: "2", title: [{ plain_text: "DB 1" }] },
+      ],
+    });
+    expect(result).toContain("page");
+    expect(result).toContain("Untitled"); // depends on how title is extracted
+    expect(result).toContain("database");
+  });
 
-	it("handles empty results", () => {
-		const result = formatSearch({ results: [] });
-		expect(result).toBe("No results found.");
-	});
+  it("handles empty results", () => {
+    const result = formatSearch({ results: [] });
+    expect(result).toBe("No results found.");
+  });
 });
 
 describe("pi-notion loadConfig", () => {
-	it("returns null when no config exists", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-notion-load-"));
-		const configPath = join(base, "nonexistent.json");
-		const result = loadConfig(configPath);
-		expect(result).toBeNull();
-	});
+  it("returns null when no config exists", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-notion-load-"));
+    const configPath = join(base, "nonexistent.json");
+    const result = loadConfig(configPath);
+    expect(result).toBeNull();
+  });
 
-	it("loads valid config file", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-notion-load-valid-"));
-		const configPath = join(base, "notion.json");
-		const config = { token: "test-token-123", oauth: null };
-		writeFileSync(configPath, JSON.stringify(config), "utf-8");
+  it("loads valid config file", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-notion-load-valid-"));
+    const configPath = join(base, "notion.json");
+    const config = { token: "test-token-123", oauth: null };
+    writeFileSync(configPath, JSON.stringify(config), "utf-8");
 
-		const result = loadConfig(configPath);
-		expect(result?.token).toBe("test-token-123");
-	});
+    const result = loadConfig(configPath);
+    expect(result?.token).toBe("test-token-123");
+  });
 
-	it("handles invalid JSON gracefully", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-notion-load-invalid-"));
-		const configPath = join(base, "invalid.json");
-		writeFileSync(configPath, "not valid json", "utf-8");
+  it("handles invalid JSON gracefully", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-notion-load-invalid-"));
+    const configPath = join(base, "invalid.json");
+    writeFileSync(configPath, "not valid json", "utf-8");
 
-		const result = loadConfig(configPath);
-		expect(result).toBeNull();
-	});
+    const result = loadConfig(configPath);
+    expect(result).toBeNull();
+  });
 
-	it("returns default config when a default config file exists in an isolated environment", () => {
-		const originalHome = process.env.HOME;
-		const originalCwd = process.cwd();
-		const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-load-default-home-"));
-		const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-load-default-project-"));
-		const configDir = join(tempHome, ".pi", "agent", "extensions");
-		const configPath = join(configDir, "notion.json");
+  it("returns default config when a default config file exists in an isolated environment", () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-load-default-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-load-default-project-"));
+    const configDir = join(tempHome, ".pi", "agent", "extensions");
+    const configPath = join(configDir, "notion.json");
 
-		mkdirSync(configDir, { recursive: true });
-		writeFileSync(configPath, JSON.stringify({ token: null }), "utf-8");
-		process.env.HOME = tempHome;
-		process.chdir(tempProject);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ token: null }), "utf-8");
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
 
-		try {
-			const result = loadConfig(undefined);
-			expect(result).toEqual({ token: null });
-		} finally {
-			process.chdir(originalCwd);
-			if (originalHome) process.env.HOME = originalHome;
-			else delete process.env.HOME;
-		}
-	});
+    try {
+      const result = loadConfig(undefined);
+      expect(result).toEqual({ token: null });
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
+  });
 });
 
 describe("pi-notion checkNotionAuth", () => {
-	async function importCheckNotionAuthInIsolatedEnv(apiKey?: string) {
-		const originalHome = process.env.HOME;
-		const originalApiKey = process.env.NOTION_API_KEY;
-		const originalCwd = process.cwd();
-		const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-auth-home-"));
-		const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-auth-project-"));
+  async function importCheckNotionAuthInIsolatedEnv(apiKey?: string) {
+    const originalHome = process.env.HOME;
+    const originalApiKey = process.env.NOTION_API_KEY;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-auth-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-auth-project-"));
 
-		mkdirSync(join(tempHome, ".pi", "agent", "extensions"), { recursive: true });
-		mkdirSync(join(tempProject, ".pi", "extensions"), { recursive: true });
+    mkdirSync(join(tempHome, ".pi", "agent", "extensions"), { recursive: true });
+    mkdirSync(join(tempProject, ".pi", "extensions"), { recursive: true });
 
-		process.env.HOME = tempHome;
-		process.chdir(tempProject);
-		if (apiKey) process.env.NOTION_API_KEY = apiKey;
-		else delete process.env.NOTION_API_KEY;
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    if (apiKey) process.env.NOTION_API_KEY = apiKey;
+    else delete process.env.NOTION_API_KEY;
 
-		vi.resetModules();
+    vi.resetModules();
 
-		try {
-			const { checkNotionAuth } = await import("../extensions/index.js");
-			return checkNotionAuth();
-		} finally {
-			process.chdir(originalCwd);
-			if (originalHome) process.env.HOME = originalHome;
-			else delete process.env.HOME;
-			if (originalApiKey) process.env.NOTION_API_KEY = originalApiKey;
-			else delete process.env.NOTION_API_KEY;
-		}
-	}
+    try {
+      const { checkNotionAuth } = await import("../extensions/index.js");
+      return checkNotionAuth();
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (originalApiKey) process.env.NOTION_API_KEY = originalApiKey;
+      else delete process.env.NOTION_API_KEY;
+    }
+  }
 
-	it("returns not authenticated when no config exists", async () => {
-		const result = await importCheckNotionAuthInIsolatedEnv();
-		expect(result.authenticated).toBe(false);
-		expect(result.message).toContain("Not authenticated");
-	});
+  it("returns not authenticated when no config exists", async () => {
+    const result = await importCheckNotionAuthInIsolatedEnv();
+    expect(result.authenticated).toBe(false);
+    expect(result.message).toContain("Not authenticated");
+  });
 
-	it("detects NOTION_API_KEY but still requires MCP auth", async () => {
-		const result = await importCheckNotionAuthInIsolatedEnv("test-key");
-		expect(result.authenticated).toBe(false);
-		expect(result.message).toContain("NOTION_API_KEY");
-		expect(result.message).toContain("MCP OAuth is still required");
-	});
+  it("detects NOTION_API_KEY but still requires MCP auth", async () => {
+    const result = await importCheckNotionAuthInIsolatedEnv("test-key");
+    expect(result.authenticated).toBe(false);
+    expect(result.message).toContain("NOTION_API_KEY");
+    expect(result.message).toContain("MCP OAuth is still required");
+  });
 });
 
 describe("pi-notion tool guardrails", async () => {
-	const { toolChecks } = await import("../extensions/index.js");
+  const { toolChecks } = await import("../extensions/index.js");
 
-	describe("checkNotionSearch", () => {
-		it("warns when content_search_mode is not workspace_search", () => {
-			const warnings = toolChecks["notion-search"]({ query: "test", filters: {} });
-			expect(warnings.some((w: string) => w.includes("content_search_mode"))).toBe(true);
-		});
+  describe("checkNotionSearch", () => {
+    it("warns when content_search_mode is not workspace_search", () => {
+      const warnings = toolChecks["notion-search"]({ query: "test", filters: {} });
+      expect(warnings.some((w: string) => w.includes("content_search_mode"))).toBe(true);
+    });
 
-		it("warns when filters key is missing", () => {
-			const warnings = toolChecks["notion-search"]({ query: "test", content_search_mode: "workspace_search" });
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]).toContain("filters");
-		});
+    it("warns when filters key is missing", () => {
+      const warnings = toolChecks["notion-search"]({ query: "test", content_search_mode: "workspace_search" });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("filters");
+    });
 
-		it("returns no warnings when correctly configured", () => {
-			const warnings = toolChecks["notion-search"]({
-				query: "test",
-				content_search_mode: "workspace_search",
-				filters: {},
-			});
-			expect(warnings).toHaveLength(0);
-		});
-	});
+    it("returns no warnings when correctly configured", () => {
+      const warnings = toolChecks["notion-search"]({
+        query: "test",
+        content_search_mode: "workspace_search",
+        filters: {},
+      });
+      expect(warnings).toHaveLength(0);
+    });
+  });
 
-	describe("checkNotionFetch", () => {
-		it("warns when using view:// URLs", () => {
-			const warnings = toolChecks["notion-fetch"]({ id: "view://abc123" });
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]).toContain("view://");
-		});
+  describe("checkNotionFetch", () => {
+    it("warns when using view:// URLs", () => {
+      const warnings = toolChecks["notion-fetch"]({ id: "view://abc123" });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("view://");
+    });
 
-		it("warns when using raw ID instead of URL", () => {
-			const warnings = toolChecks["notion-fetch"]({ id: "abc123def456" });
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]).toContain("raw ID");
-		});
+    it("warns when using raw ID instead of URL", () => {
+      const warnings = toolChecks["notion-fetch"]({ id: "abc123def456" });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("raw ID");
+    });
 
-		it("returns no warnings for https URLs", () => {
-			const warnings = toolChecks["notion-fetch"]({ id: "https://notion.so/page123" });
-			expect(warnings).toHaveLength(0);
-		});
-	});
+    it("returns no warnings for https URLs", () => {
+      const warnings = toolChecks["notion-fetch"]({ id: "https://notion.so/page123" });
+      expect(warnings).toHaveLength(0);
+    });
+  });
 
-	describe("checkMeetingNotes", () => {
-		it("warns when filter is missing", () => {
-			const warnings = toolChecks["notion-query-meeting-notes"]({});
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]).toContain("filter");
-		});
+  describe("checkMeetingNotes", () => {
+    it("warns when filter is missing", () => {
+      const warnings = toolChecks["notion-query-meeting-notes"]({});
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("filter");
+    });
 
-		it("warns when filter is empty object", () => {
-			const warnings = toolChecks["notion-query-meeting-notes"]({ filter: {} });
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]).toContain("operator");
-		});
+    it("warns when filter is empty object", () => {
+      const warnings = toolChecks["notion-query-meeting-notes"]({ filter: {} });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("operator");
+    });
 
-		it("returns no warnings when filter has operator", () => {
-			const warnings = toolChecks["notion-query-meeting-notes"]({
-				filter: { operator: "and", filters: [] },
-			});
-			expect(warnings).toHaveLength(0);
-		});
-	});
+    it("returns no warnings when filter has operator", () => {
+      const warnings = toolChecks["notion-query-meeting-notes"]({
+        filter: { operator: "and", filters: [] },
+      });
+      expect(warnings).toHaveLength(0);
+    });
+  });
 });

--- a/packages/pi-notion/__tests__/index.test.ts
+++ b/packages/pi-notion/__tests__/index.test.ts
@@ -3,65 +3,65 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("pi-notion", () => {
-	describe("package", () => {
-		it("should have correct name", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.name).toBe("@feniix/pi-notion");
-		});
+  describe("package", () => {
+    it("should have correct name", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.name).toBe("@feniix/pi-notion");
+    });
 
-		it("should have version", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.version).toBeTruthy();
-		});
+    it("should have version", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.version).toBeTruthy();
+    });
 
-		it("should have pi extension entry point", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.pi).toBeDefined();
-			expect(pkg.pi.extensions).toContain("./extensions/index.ts");
-		});
+    it("should have pi extension entry point", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.pi).toBeDefined();
+      expect(pkg.pi.extensions).toContain("./extensions/index.ts");
+    });
 
-		it("should have axios dependency", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.dependencies).toHaveProperty("axios");
-		});
+    it("should have axios dependency", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.dependencies).toHaveProperty("axios");
+    });
 
-		it("should have skills declared", () => {
-			const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
-			expect(pkg.pi.skills).toBeDefined();
-		});
-	});
+    it("should have skills declared", () => {
+      const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+      expect(pkg.pi.skills).toBeDefined();
+    });
+  });
 
-	describe("index.ts", () => {
-		it("should export utility functions", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain("formatPage");
-			expect(extension).toContain("formatDatabase");
-			expect(extension).toContain("formatBlocks");
-			expect(extension).toContain("formatSearch");
-			expect(extension).toContain("getTitleFromProperties");
-			expect(extension).toContain("loadConfig");
-			expect(extension).toContain("resolveConfigPath");
-		});
+  describe("index.ts", () => {
+    it("should export utility functions", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain("formatPage");
+      expect(extension).toContain("formatDatabase");
+      expect(extension).toContain("formatBlocks");
+      expect(extension).toContain("formatSearch");
+      expect(extension).toContain("getTitleFromProperties");
+      expect(extension).toContain("loadConfig");
+      expect(extension).toContain("resolveConfigPath");
+    });
 
-		it("should have session_start handler", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain('pi.on("session_start"');
-			expect(extension).toContain("checkNotionAuth");
-		});
+    it("should have session_start handler", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain('pi.on("session_start"');
+      expect(extension).toContain("checkNotionAuth");
+    });
 
-		it("should have tool_call guardrails handler", () => {
-			const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
-			expect(extension).toContain('pi.on("tool_call"');
-			expect(extension).toContain("checkNotionSearch");
-			expect(extension).toContain("checkNotionFetch");
-		});
+    it("should have tool_call guardrails handler", () => {
+      const extension = readFileSync(join(__dirname, "../extensions/index.ts"), "utf-8");
+      expect(extension).toContain('pi.on("tool_call"');
+      expect(extension).toContain("checkNotionSearch");
+      expect(extension).toContain("checkNotionFetch");
+    });
 
-		it("should register tools in mcp-client.ts", () => {
-			const mcpClient = readFileSync(join(__dirname, "../extensions/mcp-client.ts"), "utf-8");
-			expect(mcpClient).toContain("registerTool");
-			expect(mcpClient).toContain("notion_mcp_connect");
-			expect(mcpClient).toContain("notion_mcp_disconnect");
-			expect(mcpClient).toContain("notion_mcp_status");
-		});
-	});
+    it("should register tools in mcp-client.ts", () => {
+      const mcpClient = readFileSync(join(__dirname, "../extensions/mcp-client.ts"), "utf-8");
+      expect(mcpClient).toContain("registerTool");
+      expect(mcpClient).toContain("notion_mcp_connect");
+      expect(mcpClient).toContain("notion_mcp_disconnect");
+      expect(mcpClient).toContain("notion_mcp_status");
+    });
+  });
 });

--- a/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
@@ -1,0 +1,293 @@
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildAuthorizationUrl,
+  buildHtmlResponse,
+  coerceNumericProperties,
+  connectWithSavedConfig,
+  createPkceChallenge,
+  createRegisteredToolExecutor,
+  createUiNotifier,
+  disconnectClient,
+  ensureConnected,
+  FileTokenStorage,
+  finalizeConnection,
+  getConnectedStatusMessage,
+  getConnectionStatusText,
+  NotionMCPClient,
+  resolveAccessToken,
+  resolveCallbackResult,
+  startOAuthCallbackServer,
+  storage,
+  toolError,
+  toolResult,
+} from "../extensions/mcp-client.js";
+
+describe("pi-notion mcp client runtime helpers", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("builds an HTML response with headers", () => {
+    const html = "<html>ok</html>";
+    const response = buildHtmlResponse("HTTP/1.1 200 OK", html);
+    expect(response).toContain("HTTP/1.1 200 OK");
+    expect(response).toContain("Content-Length");
+    expect(response).toContain(html);
+  });
+
+  it("resolves callback results for success and failure paths", () => {
+    const mismatch = resolveCallbackResult(new URLSearchParams("state=bad"), "expected");
+    expect(mismatch.result.error).toBe("State mismatch");
+
+    const error = resolveCallbackResult(
+      new URLSearchParams("state=expected&error=denied&error_description=nope"),
+      "expected",
+    );
+    expect(error.result.error).toBe("denied");
+    expect(error.result.errorDescription).toBe("nope");
+
+    const token = resolveCallbackResult(new URLSearchParams("state=expected&access_token=token-123"), "expected");
+    expect(token.result.accessToken).toBe("token-123");
+
+    const code = resolveCallbackResult(new URLSearchParams("state=expected&code=code-123"), "expected");
+    expect(code.result.code).toBe("code-123");
+  });
+
+  it("creates a PKCE challenge pair and authorization URL", () => {
+    const { codeVerifier, codeChallenge } = createPkceChallenge();
+    expect(codeVerifier).toBeTruthy();
+    expect(codeChallenge).toBeTruthy();
+
+    const url = buildAuthorizationUrl({ client_id: "client-1" }, "http://localhost:3333/callback", codeChallenge, "state-1");
+    expect(url).toContain("client_id=client-1");
+    expect(url).toContain("code_challenge_method=S256");
+    expect(url).toContain("prompt=consent");
+  });
+
+  it("coerces numeric properties recursively", () => {
+    const coerced = coerceNumericProperties({
+      properties: {
+        limit: "5",
+        nested: { value: "3" },
+      },
+      list: ["1", { properties: { count: "2" } }],
+    }) as {
+      properties: { limit: number; nested: { value: string } };
+      list: Array<string | { properties: { count: number } }>;
+    };
+
+    expect(coerced.properties.limit).toBe(5);
+    expect(coerced.properties.nested.value).toBe("3");
+    expect(coerced.list[0]).toBe("1");
+    expect((coerced.list[1] as { properties: { count: number } }).properties.count).toBe(2);
+  });
+
+  it("formats tool success and error results", () => {
+    expect(toolResult("demo", "ok")).toEqual({
+      content: [{ type: "text", text: "ok" }],
+      details: { tool: "demo" },
+    });
+    expect(toolError("demo", "bad")).toEqual({
+      content: [{ type: "text", text: "bad" }],
+      isError: true,
+      details: { tool: "demo" },
+    });
+  });
+
+  it("connects, discovers tools, formats status, and calls tools", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json", "mcp-session-id": "session-12345678" }),
+        json: async () => ({ result: { ok: true } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ result: { tools: [{ name: "notion-search", description: "Search", inputSchema: {} }] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        text: async () => "",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ result: { content: [{ type: "text", text: "hello" }] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        text: async () => "",
+      });
+
+    global.fetch = fetchMock as typeof fetch;
+
+    const client = new NotionMCPClient();
+    await client.connect("https://mcp.notion.com/mcp", "token-123");
+
+    expect(client.state.connected).toBe(true);
+    expect(client.getTools()).toHaveLength(1);
+    expect(getConnectionStatusText(client)).toContain("Connected: Yes");
+    expect(getConnectedStatusMessage(client)).toContain("Connected to Notion MCP");
+
+    const result = await client.callTool("https://mcp.notion.com/mcp", "notion-search", { properties: { count: "2" } });
+    expect(result).toContain("hello");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://mcp.notion.com/mcp",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    await client.disconnect();
+    expect(client.state.connected).toBe(false);
+  });
+
+  it("handles SSE responses and request errors", async () => {
+    const client = new NotionMCPClient();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "text/event-stream", "mcp-session-id": "session-sse" }),
+        text: async () => 'data: {"result":{"ok":true}}\n',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "text/event-stream" }),
+        text: async () => 'data: {"result":{"tools":[]}}\n',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        text: async () => "",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "text/event-stream" }),
+        text: async () => 'data: {"result":{"content":[{"type":"text","text":"from sse"}]}}\n',
+      });
+    global.fetch = fetchMock as typeof fetch;
+
+    await client.connect("https://mcp.notion.com/mcp", "token-123");
+    const result = await client.callTool("https://mcp.notion.com/mcp", "demo", {});
+    expect(result).toContain("from sse");
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers({ "content-type": "text/plain" }),
+      text: async () => "boom",
+    }) as typeof fetch;
+    await expect(client.callTool("https://mcp.notion.com/mcp", "demo", {})).rejects.toThrow("HTTP 500: boom");
+  });
+
+  it("resolves access tokens from direct callbacks and code exchanges", async () => {
+    const notify = vi.fn();
+    expect(
+      await resolveAccessToken({ accessToken: "direct-token" }, "http://localhost/callback", "verifier", { client_id: "client" }, notify),
+    ).toBe("direct-token");
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ access_token: "exchanged-token" }),
+    }) as typeof fetch;
+
+    expect(
+      await resolveAccessToken({ code: "code-123" }, "http://localhost/callback", "verifier", { client_id: "client" }, notify),
+    ).toBe("exchanged-token");
+    expect(notify).toHaveBeenCalledWith("Exchanging authorization code for token...");
+
+    await expect(
+      resolveAccessToken({ error: "denied" }, "http://localhost/callback", "verifier", { client_id: "client" }, notify),
+    ).rejects.toThrow("Authorization failed: denied");
+  });
+
+  it("creates registered tool executors for connected and disconnected clients", async () => {
+    const disconnectedClient = new NotionMCPClient();
+    const disconnectedExecute = createRegisteredToolExecutor(disconnectedClient, "https://mcp.notion.com/mcp", {
+      name: "notion-search",
+      description: "Search",
+      inputSchema: {},
+    });
+    const disconnectedResult = await disconnectedExecute("id", {}, new AbortController().signal, undefined, undefined);
+    expect(disconnectedResult.isError).toBe(true);
+
+    const connectedClient = new NotionMCPClient();
+    connectedClient.state.connected = true;
+    vi.spyOn(connectedClient, "callTool").mockResolvedValue("done");
+    const execute = createRegisteredToolExecutor(connectedClient, "https://mcp.notion.com/mcp", {
+      name: "notion-search",
+      description: "Search",
+      inputSchema: {},
+    });
+    const success = await execute("id", { query: "docs" }, new AbortController().signal, undefined, undefined);
+    expect(success.content[0]?.text).toBe("done");
+  });
+
+  it("saves and clears config files with file token storage", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-notion-mcp-storage-"));
+    const tokenStorage = new FileTokenStorage();
+    (tokenStorage as unknown as { path: string }).path = join(dir, "notion-mcp.json");
+
+    await tokenStorage.save({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" });
+    expect(existsSync(join(dir, "notion-mcp.json"))).toBe(true);
+    expect(await tokenStorage.load()).toMatchObject({ accessToken: "token-123" });
+    await tokenStorage.clear();
+    expect(await tokenStorage.load()).toBeNull();
+  });
+
+  it("creates UI notifiers and connection helpers", async () => {
+    const emit = vi.fn();
+    const notify = createUiNotifier({ events: { emit } } as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI);
+    notify("hello");
+    expect(emit).toHaveBeenCalledWith("ui:notify", { message: "hello", type: "info" });
+
+    const client = new NotionMCPClient();
+    vi.spyOn(storage, "load").mockResolvedValueOnce({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" });
+    vi.spyOn(client, "connect").mockResolvedValueOnce();
+    expect(await connectWithSavedConfig(client, vi.fn())).toBe(true);
+
+    const disconnected = new NotionMCPClient();
+    disconnected.state.connected = true;
+    vi.spyOn(disconnected, "disconnect").mockResolvedValueOnce();
+    const clearSpy = vi.spyOn(storage, "clear").mockResolvedValueOnce();
+    await disconnectClient(disconnected);
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it("finalizes and ensures connections", async () => {
+    const client = new NotionMCPClient();
+    vi.spyOn(client, "connect").mockResolvedValue();
+    const saveSpy = vi.spyOn(storage, "save").mockResolvedValue();
+    const registerTools = vi.fn();
+    await finalizeConnection(client, { client_id: "client-1", client_secret: "secret-1" }, "token-123", registerTools, vi.fn());
+    expect(saveSpy).toHaveBeenCalled();
+    expect(registerTools).toHaveBeenCalled();
+
+    const reuseClient = new NotionMCPClient();
+    const savedSpy = vi.spyOn(storage, "load").mockResolvedValueOnce({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" });
+    vi.spyOn(reuseClient, "connect").mockResolvedValueOnce();
+    const reused = await ensureConnected(reuseClient, vi.fn(), vi.fn());
+    expect(reused).toEqual({ reusedSavedConfig: true });
+    expect(savedSpy).toHaveBeenCalled();
+  });
+
+  it("runs an OAuth callback server and resolves callback results", async () => {
+    const state = "state-123";
+    const server = await startOAuthCallbackServer(4300, state, 5000);
+
+    await fetch(`http://127.0.0.1:${server.port}/callback?state=${state}&code=auth-code`);
+    await expect(server.result).resolves.toEqual({ code: "auth-code" });
+  });
+});

--- a/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
@@ -67,7 +67,12 @@ describe("pi-notion mcp client runtime helpers", () => {
     expect(codeVerifier).toBeTruthy();
     expect(codeChallenge).toBeTruthy();
 
-    const url = buildAuthorizationUrl({ client_id: "client-1" }, "http://localhost:3333/callback", codeChallenge, "state-1");
+    const url = buildAuthorizationUrl(
+      { client_id: "client-1" },
+      "http://localhost:3333/callback",
+      codeChallenge,
+      "state-1",
+    );
     expect(url).toContain("client_id=client-1");
     expect(url).toContain("code_challenge_method=S256");
     expect(url).toContain("prompt=consent");
@@ -104,7 +109,8 @@ describe("pi-notion mcp client runtime helpers", () => {
   });
 
   it("connects, discovers tools, formats status, and calls tools", async () => {
-    const fetchMock = vi.fn()
+    const fetchMock = vi
+      .fn()
       .mockResolvedValueOnce({
         ok: true,
         headers: new Headers({ "content-type": "application/json", "mcp-session-id": "session-12345678" }),
@@ -143,10 +149,7 @@ describe("pi-notion mcp client runtime helpers", () => {
 
     const result = await client.callTool("https://mcp.notion.com/mcp", "notion-search", { properties: { count: "2" } });
     expect(result).toContain("hello");
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://mcp.notion.com/mcp",
-      expect.objectContaining({ method: "POST" }),
-    );
+    expect(fetchMock).toHaveBeenCalledWith("https://mcp.notion.com/mcp", expect.objectContaining({ method: "POST" }));
 
     await client.disconnect();
     expect(client.state.connected).toBe(false);
@@ -154,7 +157,8 @@ describe("pi-notion mcp client runtime helpers", () => {
 
   it("handles SSE responses and request errors", async () => {
     const client = new NotionMCPClient();
-    const fetchMock = vi.fn()
+    const fetchMock = vi
+      .fn()
       .mockResolvedValueOnce({
         ok: true,
         headers: new Headers({ "content-type": "text/event-stream", "mcp-session-id": "session-sse" }),
@@ -193,7 +197,13 @@ describe("pi-notion mcp client runtime helpers", () => {
   it("resolves access tokens from direct callbacks and code exchanges", async () => {
     const notify = vi.fn();
     expect(
-      await resolveAccessToken({ accessToken: "direct-token" }, "http://localhost/callback", "verifier", { client_id: "client" }, notify),
+      await resolveAccessToken(
+        { accessToken: "direct-token" },
+        "http://localhost/callback",
+        "verifier",
+        { client_id: "client" },
+        notify,
+      ),
     ).toBe("direct-token");
 
     global.fetch = vi.fn().mockResolvedValue({
@@ -204,7 +214,13 @@ describe("pi-notion mcp client runtime helpers", () => {
     }) as typeof fetch;
 
     expect(
-      await resolveAccessToken({ code: "code-123" }, "http://localhost/callback", "verifier", { client_id: "client" }, notify),
+      await resolveAccessToken(
+        { code: "code-123" },
+        "http://localhost/callback",
+        "verifier",
+        { client_id: "client" },
+        notify,
+      ),
     ).toBe("exchanged-token");
     expect(notify).toHaveBeenCalledWith("Exchanging authorization code for token...");
 
@@ -249,7 +265,9 @@ describe("pi-notion mcp client runtime helpers", () => {
 
   it("creates UI notifiers and connection helpers", async () => {
     const emit = vi.fn();
-    const notify = createUiNotifier({ events: { emit } } as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI);
+    const notify = createUiNotifier({
+      events: { emit },
+    } as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI);
     notify("hello");
     expect(emit).toHaveBeenCalledWith("ui:notify", { message: "hello", type: "info" });
 
@@ -271,12 +289,20 @@ describe("pi-notion mcp client runtime helpers", () => {
     vi.spyOn(client, "connect").mockResolvedValue();
     const saveSpy = vi.spyOn(storage, "save").mockResolvedValue();
     const registerTools = vi.fn();
-    await finalizeConnection(client, { client_id: "client-1", client_secret: "secret-1" }, "token-123", registerTools, vi.fn());
+    await finalizeConnection(
+      client,
+      { client_id: "client-1", client_secret: "secret-1" },
+      "token-123",
+      registerTools,
+      vi.fn(),
+    );
     expect(saveSpy).toHaveBeenCalled();
     expect(registerTools).toHaveBeenCalled();
 
     const reuseClient = new NotionMCPClient();
-    const savedSpy = vi.spyOn(storage, "load").mockResolvedValueOnce({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" });
+    const savedSpy = vi
+      .spyOn(storage, "load")
+      .mockResolvedValueOnce({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" });
     vi.spyOn(reuseClient, "connect").mockResolvedValueOnce();
     const reused = await ensureConnected(reuseClient, vi.fn(), vi.fn());
     expect(reused).toEqual({ reusedSavedConfig: true });

--- a/packages/pi-notion/__tests__/mcp-client.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.test.ts
@@ -9,71 +9,71 @@ import { describe, expect, it } from "vitest";
 const mcpClientPath = join(__dirname, "../extensions/mcp-client.ts");
 
 function readMcpClient(): string {
-	return readFileSync(mcpClientPath, "utf-8");
+  return readFileSync(mcpClientPath, "utf-8");
 }
 
 describe("pi-notion MCP Client File Structure", () => {
-	it("contains NotionMCPClient class", () => {
-		const content = readMcpClient();
-		expect(content).toContain("class NotionMCPClient");
-	});
+  it("contains NotionMCPClient class", () => {
+    const content = readMcpClient();
+    expect(content).toContain("class NotionMCPClient");
+  });
 
-	it("contains OAuth callback handling", () => {
-		const content = readMcpClient();
-		expect(content).toContain("startOAuthCallbackServer");
-		expect(content).toContain("openBrowser");
-	});
+  it("contains OAuth callback handling", () => {
+    const content = readMcpClient();
+    expect(content).toContain("startOAuthCallbackServer");
+    expect(content).toContain("openBrowser");
+  });
 
-	it("contains JSON-RPC protocol handling", () => {
-		const content = readMcpClient();
-		expect(content).toContain("jsonrpc");
-		expect(content).toContain("tools/list");
-		expect(content).toContain("tools/call");
-	});
+  it("contains JSON-RPC protocol handling", () => {
+    const content = readMcpClient();
+    expect(content).toContain("jsonrpc");
+    expect(content).toContain("tools/list");
+    expect(content).toContain("tools/call");
+  });
 
-	it("contains extension and command registration", () => {
-		const content = readMcpClient();
-		expect(content).toContain("export default function notionMCPClientExtension");
-		expect(content).toContain('registerCommand("notion"');
-		expect(content).toContain("registerTool");
-	});
+  it("contains extension and command registration", () => {
+    const content = readMcpClient();
+    expect(content).toContain("export default function notionMCPClientExtension");
+    expect(content).toContain('registerCommand("notion"');
+    expect(content).toContain("registerTool");
+  });
 
-	it("registers core MCP management tools", () => {
-		const content = readMcpClient();
-		expect(content).toContain("notion_mcp_connect");
-		expect(content).toContain("notion_mcp_disconnect");
-		expect(content).toContain("notion_mcp_status");
-	});
+  it("registers core MCP management tools", () => {
+    const content = readMcpClient();
+    expect(content).toContain("notion_mcp_connect");
+    expect(content).toContain("notion_mcp_disconnect");
+    expect(content).toContain("notion_mcp_status");
+  });
 
-	it("includes Notion MCP endpoint constants", () => {
-		const content = readMcpClient();
-		expect(content).toContain("NOTION_MCP_URL");
-		expect(content).toContain("https://mcp.notion.com/mcp");
-	});
+  it("includes Notion MCP endpoint constants", () => {
+    const content = readMcpClient();
+    expect(content).toContain("NOTION_MCP_URL");
+    expect(content).toContain("https://mcp.notion.com/mcp");
+  });
 
-	it("handles browser opening per platform", () => {
-		const content = readMcpClient();
-		expect(content).toContain("darwin");
-		expect(content).toContain("win32");
-		expect(content).toContain("xdg-open");
-	});
+  it("handles browser opening per platform", () => {
+    const content = readMcpClient();
+    expect(content).toContain("darwin");
+    expect(content).toContain("win32");
+    expect(content).toContain("xdg-open");
+  });
 
-	it("captures session and auth headers", () => {
-		const content = readMcpClient();
-		expect(content).toContain("mcp-session-id");
-		expect(content).toContain("Authorization");
-		expect(content).toContain("Bearer");
-	});
+  it("captures session and auth headers", () => {
+    const content = readMcpClient();
+    expect(content).toContain("mcp-session-id");
+    expect(content).toContain("Authorization");
+    expect(content).toContain("Bearer");
+  });
 
-	it("contains error handling for HTTP and JSON-RPC failures", () => {
-		const content = readMcpClient();
-		expect(content).toContain("response.ok");
-		expect(content).toContain("HTTP");
-		expect(content).toContain("MCP Error");
-	});
+  it("contains error handling for HTTP and JSON-RPC failures", () => {
+    const content = readMcpClient();
+    expect(content).toContain("response.ok");
+    expect(content).toContain("HTTP");
+    expect(content).toContain("MCP Error");
+  });
 
-	it("uses protocol version 2024-11-05", () => {
-		const content = readMcpClient();
-		expect(content).toContain("2024-11-05");
-	});
+  it("uses protocol version 2024-11-05", () => {
+    const content = readMcpClient();
+    expect(content).toContain("2024-11-05");
+  });
 });

--- a/packages/pi-notion/__tests__/notion-client.test.ts
+++ b/packages/pi-notion/__tests__/notion-client.test.ts
@@ -11,7 +11,7 @@ const mcpClientPath = join(__dirname, "../extensions/mcp-client.ts");
 const oauthPath = join(__dirname, "../extensions/oauth.ts");
 
 function read(path: string): string {
-	return readFileSync(path, "utf-8");
+  return readFileSync(path, "utf-8");
 }
 
 // =============================================================================
@@ -19,58 +19,58 @@ function read(path: string): string {
 // =============================================================================
 
 describe("pi-notion Extension File Structure", () => {
-	it("index.ts contains NotionConfig interface", () => {
-		const content = read(indexPath);
-		expect(content).toContain("NotionConfig");
-	});
+  it("index.ts contains NotionConfig interface", () => {
+    const content = read(indexPath);
+    expect(content).toContain("NotionConfig");
+  });
 
-	it("index.ts contains config loading functions", () => {
-		const content = read(indexPath);
+  it("index.ts contains config loading functions", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("resolveConfigPath");
-		expect(content).toContain("loadConfig");
-		expect(content).toContain("homedir");
-		expect(content).toContain("NOTION_CONFIG");
-	});
+    expect(content).toContain("resolveConfigPath");
+    expect(content).toContain("loadConfig");
+    expect(content).toContain("homedir");
+    expect(content).toContain("NOTION_CONFIG");
+  });
 
-	it("index.ts contains formatting functions", () => {
-		const content = read(indexPath);
+  it("index.ts contains formatting functions", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("formatPage");
-		expect(content).toContain("formatDatabase");
-		expect(content).toContain("formatBlocks");
-		expect(content).toContain("formatSearch");
-		expect(content).toContain("getTitleFromProperties");
-	});
+    expect(content).toContain("formatPage");
+    expect(content).toContain("formatDatabase");
+    expect(content).toContain("formatBlocks");
+    expect(content).toContain("formatSearch");
+    expect(content).toContain("getTitleFromProperties");
+  });
 
-	it("index.ts exports utility functions", () => {
-		const content = read(indexPath);
+  it("index.ts exports utility functions", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("export {");
-		expect(content).toContain("formatBlocks");
-		expect(content).toContain("loadConfig");
-		expect(content).toContain("resolveConfigPath");
-	});
+    expect(content).toContain("export {");
+    expect(content).toContain("formatBlocks");
+    expect(content).toContain("loadConfig");
+    expect(content).toContain("resolveConfigPath");
+  });
 
-	it("index.ts has extension entry point and session hooks", () => {
-		const content = read(indexPath);
+  it("index.ts has extension entry point and session hooks", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("export default function notion");
-		expect(content).toContain('pi.on("session_start"');
-		expect(content).toContain('pi.on("tool_call"');
-	});
+    expect(content).toContain("export default function notion");
+    expect(content).toContain('pi.on("session_start"');
+    expect(content).toContain('pi.on("tool_call"');
+  });
 
-	it("mcp-client.ts exists and has default export", () => {
-		const content = read(mcpClientPath);
-		expect(content).toContain("export default");
-	});
+  it("mcp-client.ts exists and has default export", () => {
+    const content = read(mcpClientPath);
+    expect(content).toContain("export default");
+  });
 
-	it("oauth.ts exists and has expected exports", () => {
-		const content = read(oauthPath);
+  it("oauth.ts exists and has expected exports", () => {
+    const content = read(oauthPath);
 
-		expect(content).toContain("export function generateCodeVerifier");
-		expect(content).toContain("export class FileTokenStorage");
-	});
+    expect(content).toContain("export function generateCodeVerifier");
+    expect(content).toContain("export class FileTokenStorage");
+  });
 });
 
 // =============================================================================
@@ -78,39 +78,39 @@ describe("pi-notion Extension File Structure", () => {
 // =============================================================================
 
 describe("pi-notion Formatting Functions", () => {
-	it("formatPage formats page with title and properties", () => {
-		const content = read(indexPath);
+  it("formatPage formats page with title and properties", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("function formatPage");
-		expect(content).toContain("getTitleFromProperties");
-		expect(content).toContain("JSON.stringify");
-	});
+    expect(content).toContain("function formatPage");
+    expect(content).toContain("getTitleFromProperties");
+    expect(content).toContain("JSON.stringify");
+  });
 
-	it("formatDatabase formats database with title", () => {
-		const content = read(indexPath);
+  it("formatDatabase formats database with title", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("function formatDatabase");
-		expect(content).toContain("plain_text");
-	});
+    expect(content).toContain("function formatDatabase");
+    expect(content).toContain("plain_text");
+  });
 
-	it("formatBlocks handles empty results", () => {
-		const content = read(indexPath);
+  it("formatBlocks handles empty results", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("function formatBlocks");
-		expect(content).toContain("No blocks found");
-	});
+    expect(content).toContain("function formatBlocks");
+    expect(content).toContain("No blocks found");
+  });
 
-	it("formatSearch handles empty results", () => {
-		const content = read(indexPath);
+  it("formatSearch handles empty results", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("function formatSearch");
-		expect(content).toContain("No results found");
-	});
+    expect(content).toContain("function formatSearch");
+    expect(content).toContain("No results found");
+  });
 
-	it("getTitleFromProperties extracts title from properties", () => {
-		const content = read(indexPath);
+  it("getTitleFromProperties extracts title from properties", () => {
+    const content = read(indexPath);
 
-		expect(content).toContain("function getTitleFromProperties");
-		expect(content).toContain("Untitled");
-	});
+    expect(content).toContain("function getTitleFromProperties");
+    expect(content).toContain("Untitled");
+  });
 });

--- a/packages/pi-notion/__tests__/oauth.callback.test.ts
+++ b/packages/pi-notion/__tests__/oauth.callback.test.ts
@@ -61,7 +61,11 @@ describe("pi-notion oauth callback helpers", () => {
     const first = processCallbackChunk("", Buffer.from("GET /callback?state=good"), "good");
     expect(first.outcome.type).toBe("ignore");
 
-    const second = processCallbackChunk(first.buffer, Buffer.from("&code=abc HTTP/1.1\r\nHost: localhost\r\n\r\n"), "good");
+    const second = processCallbackChunk(
+      first.buffer,
+      Buffer.from("&code=abc HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+      "good",
+    );
     expect(second.outcome).toMatchObject({ type: "resolve", result: { code: "abc" } });
   });
 });

--- a/packages/pi-notion/__tests__/oauth.callback.test.ts
+++ b/packages/pi-notion/__tests__/oauth.callback.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  extractCallbackParams,
+  FileTokenStorage,
+  getAuthorizationErrorHtml,
+  getAuthorizationSuccessHtml,
+  getStateMismatchHtml,
+  handleCallbackParams,
+  parseQueryParams,
+  processCallbackChunk,
+  writeHtmlResponse,
+  writeOutcomeResponse,
+} from "../extensions/oauth.js";
+
+describe("pi-notion oauth callback helpers", () => {
+  it("parses query params and callback requests", () => {
+    expect(parseQueryParams("http://localhost/callback?code=abc&state=xyz")).toEqual({ code: "abc", state: "xyz" });
+    expect(extractCallbackParams("GET /callback?code=abc&state=xyz HTTP/1.1\r\nHost: localhost\r\n\r\n")).toEqual({
+      code: "abc",
+      state: "xyz",
+    });
+    expect(extractCallbackParams("GET /other HTTP/1.1\r\n\r\n")).toBeNull();
+  });
+
+  it("renders callback html messages", () => {
+    expect(getStateMismatchHtml()).toContain("State mismatch");
+    expect(getAuthorizationErrorHtml({ error: "denied", error_description: "nope" })).toContain("denied");
+    expect(getAuthorizationSuccessHtml()).toContain("Authorization successful");
+  });
+
+  it("handles callback outcomes for mismatch, error, and success", () => {
+    expect(handleCallbackParams({ state: "bad" }, "good")).toMatchObject({ type: "reject" });
+    expect(handleCallbackParams({ state: "good", error: "denied" }, "good")).toMatchObject({
+      type: "resolve",
+      result: { error: "denied" },
+    });
+    expect(handleCallbackParams({ state: "good", code: "abc" }, "good")).toMatchObject({
+      type: "resolve",
+      result: { code: "abc", state: "good" },
+    });
+    expect(handleCallbackParams({ state: "good" }, "good")).toMatchObject({ type: "ignore" });
+  });
+
+  it("writes html and outcome responses to sockets", () => {
+    const socket = { write: vi.fn(), end: vi.fn() } as unknown as NodeJS.WritableStream;
+    writeHtmlResponse(socket, "HTTP/1.1 200 OK", "<html>ok</html>");
+    expect((socket as unknown as { write: ReturnType<typeof vi.fn> }).write).toHaveBeenCalled();
+
+    writeOutcomeResponse(socket as unknown as NodeJS.Socket, {
+      type: "resolve",
+      html: "<html>ok</html>",
+      result: { code: "abc", state: "good" },
+    });
+    expect((socket as unknown as { end: ReturnType<typeof vi.fn> }).end).toHaveBeenCalled();
+  });
+
+  it("processes callback chunks incrementally", () => {
+    const first = processCallbackChunk("", Buffer.from("GET /callback?state=good"), "good");
+    expect(first.outcome.type).toBe("ignore");
+
+    const second = processCallbackChunk(first.buffer, Buffer.from("&code=abc HTTP/1.1\r\nHost: localhost\r\n\r\n"), "good");
+    expect(second.outcome).toMatchObject({ type: "resolve", result: { code: "abc" } });
+  });
+});
+
+describe("pi-notion oauth file storage", () => {
+  it("persists, reads, and clears tokens and user info", async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), "pi-notion-oauth-storage-"));
+    const basePath = join(baseDir, "notion.json");
+    const storage = new FileTokenStorage(basePath);
+
+    await storage.save(
+      {
+        accessToken: "access",
+        refreshToken: "refresh",
+        tokenType: "Bearer",
+        expiresAt: Date.now() + 1000,
+      },
+      {
+        workspaceId: "ws",
+        workspaceName: "Workspace",
+        botId: "bot",
+      },
+    );
+
+    const raw = readFileSync(basePath.replace(/\.json$/, "-tokens.json"), "utf-8");
+    expect(raw).toContain("access");
+    expect(await storage.load()).toMatchObject({ accessToken: "access" });
+    expect(await storage.getUserInfo()).toMatchObject({ workspaceId: "ws" });
+
+    await storage.clear();
+    expect(await storage.load()).toBeNull();
+  });
+});

--- a/packages/pi-notion/__tests__/oauth.runtime.test.ts
+++ b/packages/pi-notion/__tests__/oauth.runtime.test.ts
@@ -1,163 +1,213 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { axiosPostMock } = vi.hoisted(() => ({
-	axiosPostMock: vi.fn(),
+  axiosPostMock: vi.fn(),
 }));
 
 vi.mock("axios", () => ({
-	default: {
-		post: axiosPostMock,
-	},
+  default: {
+    post: axiosPostMock,
+  },
 }));
 
 import {
-	exchangeCodeForTokens,
-	getValidAccessToken,
-	type OAuthConfig,
-	type OAuthTokens,
-	refreshTokens,
-	type TokenStorage,
+  exchangeCodeForTokens,
+  executeOAuthFlow,
+  getValidAccessToken,
+  type OAuthConfig,
+  type OAuthTokens,
+  refreshTokens,
+  type TokenStorage,
 } from "../extensions/oauth.js";
 
 const config: OAuthConfig = {
-	clientId: "client-id",
-	clientSecret: "client-secret",
-	redirectUri: "http://localhost:3000/callback",
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  redirectUri: "http://localhost:3000/callback",
 };
 
 describe("pi-notion oauth runtime", () => {
-	beforeEach(() => {
-		axiosPostMock.mockReset();
-	});
+  beforeEach(() => {
+    axiosPostMock.mockReset();
+    vi.restoreAllMocks();
+  });
 
-	it("exchanges authorization codes for tokens and owner info", async () => {
-		axiosPostMock.mockResolvedValueOnce({
-			data: {
-				access_token: "access-token",
-				refresh_token: "refresh-token",
-				token_type: "bearer",
-				workspace_id: "ws-1",
-				workspace_name: "Workspace",
-				workspace_icon: "📝",
-				bot_id: "bot-1",
-				owner: {
-					user: {
-						name: "Test User",
-						person: { email: "user@example.com" },
-					},
-				},
-			},
-		});
+  it("exchanges authorization codes for tokens and owner info", async () => {
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        token_type: "bearer",
+        workspace_id: "ws-1",
+        workspace_name: "Workspace",
+        workspace_icon: "📝",
+        bot_id: "bot-1",
+        owner: {
+          user: {
+            name: "Test User",
+            person: { email: "user@example.com" },
+          },
+        },
+      },
+    });
 
-		const result = await exchangeCodeForTokens(config, "auth-code", "verifier");
+    const result = await exchangeCodeForTokens(config, "auth-code", "verifier");
 
-		expect(axiosPostMock).toHaveBeenCalledWith(
-			expect.stringContaining("/oauth/token"),
-			expect.objectContaining({
-				grant_type: "authorization_code",
-				code: "auth-code",
-				code_verifier: "verifier",
-			}),
-			expect.any(Object),
-		);
-		expect(result.accessToken).toBe("access-token");
-		expect(result.refreshToken).toBe("refresh-token");
-		expect(result.owner).toEqual({
-			workspaceId: "ws-1",
-			workspaceName: "Workspace",
-			workspaceIcon: "📝",
-			botId: "bot-1",
-			ownerEmail: "user@example.com",
-			ownerName: "Test User",
-		});
-	});
+    expect(axiosPostMock).toHaveBeenCalledWith(
+      expect.stringContaining("/oauth/token"),
+      expect.objectContaining({
+        grant_type: "authorization_code",
+        code: "auth-code",
+        code_verifier: "verifier",
+      }),
+      expect.any(Object),
+    );
+    expect(result.accessToken).toBe("access-token");
+    expect(result.refreshToken).toBe("refresh-token");
+    expect(result.owner).toEqual({
+      workspaceId: "ws-1",
+      workspaceName: "Workspace",
+      workspaceIcon: "📝",
+      botId: "bot-1",
+      ownerEmail: "user@example.com",
+      ownerName: "Test User",
+    });
+  });
 
-	it("refreshes tokens and preserves the old refresh token when omitted", async () => {
-		axiosPostMock.mockResolvedValueOnce({
-			data: {
-				access_token: "new-access",
-				token_type: "bearer",
-			},
-		});
+  it("refreshes tokens and preserves the old refresh token when omitted", async () => {
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        access_token: "new-access",
+        token_type: "bearer",
+      },
+    });
 
-		const result = await refreshTokens(config, "existing-refresh");
-		expect(result.accessToken).toBe("new-access");
-		expect(result.refreshToken).toBe("existing-refresh");
-	});
+    const result = await refreshTokens(config, "existing-refresh");
+    expect(result.accessToken).toBe("new-access");
+    expect(result.refreshToken).toBe("existing-refresh");
+  });
 
-	it("returns an existing token when it is still valid", async () => {
-		const storage: TokenStorage = {
-			save: vi.fn(),
-			load: vi.fn(
-				async () =>
-					({
-						accessToken: "still-valid",
-						refreshToken: "refresh",
-						tokenType: "bearer",
-						expiresAt: Date.now() + 60 * 60 * 1000,
-					}) satisfies OAuthTokens,
-			),
-			clear: vi.fn(),
-			getUserInfo: vi.fn(async () => null),
-		};
+  it("returns an existing token when it is still valid", async () => {
+    const storage: TokenStorage = {
+      save: vi.fn(),
+      load: vi.fn(
+        async () =>
+          ({
+            accessToken: "still-valid",
+            refreshToken: "refresh",
+            tokenType: "bearer",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          }) satisfies OAuthTokens,
+      ),
+      clear: vi.fn(),
+      getUserInfo: vi.fn(async () => null),
+    };
 
-		const token = await getValidAccessToken(config, storage);
-		expect(token).toBe("still-valid");
-		expect(axiosPostMock).not.toHaveBeenCalled();
-	});
+    const token = await getValidAccessToken(config, storage);
+    expect(token).toBe("still-valid");
+    expect(axiosPostMock).not.toHaveBeenCalled();
+  });
 
-	it("refreshes tokens through storage when the token is near expiry", async () => {
-		axiosPostMock.mockResolvedValueOnce({
-			data: {
-				access_token: "refreshed-access",
-				refresh_token: "refreshed-refresh",
-				token_type: "bearer",
-			},
-		});
+  it("refreshes tokens through storage when the token is near expiry", async () => {
+    axiosPostMock.mockResolvedValueOnce({
+      data: {
+        access_token: "refreshed-access",
+        refresh_token: "refreshed-refresh",
+        token_type: "bearer",
+      },
+    });
 
-		const save = vi.fn();
-		const storage: TokenStorage = {
-			save,
-			load: vi.fn(
-				async () =>
-					({
-						accessToken: "old-access",
-						refreshToken: "old-refresh",
-						tokenType: "bearer",
-						expiresAt: Date.now() + 60 * 1000,
-					}) satisfies OAuthTokens,
-			),
-			clear: vi.fn(),
-			getUserInfo: vi.fn(async () => ({ workspaceId: "ws", workspaceName: "WS", botId: "bot" })),
-		};
+    const save = vi.fn();
+    const storage: TokenStorage = {
+      save,
+      load: vi.fn(
+        async () =>
+          ({
+            accessToken: "old-access",
+            refreshToken: "old-refresh",
+            tokenType: "bearer",
+            expiresAt: Date.now() + 60 * 1000,
+          }) satisfies OAuthTokens,
+      ),
+      clear: vi.fn(),
+      getUserInfo: vi.fn(async () => ({ workspaceId: "ws", workspaceName: "WS", botId: "bot" })),
+    };
 
-		const token = await getValidAccessToken(config, storage);
-		expect(token).toBe("refreshed-access");
-		expect(save).toHaveBeenCalledWith(
-			expect.objectContaining({ accessToken: "refreshed-access", refreshToken: "refreshed-refresh" }),
-			expect.objectContaining({ workspaceId: "ws" }),
-		);
-	});
+    const token = await getValidAccessToken(config, storage);
+    expect(token).toBe("refreshed-access");
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: "refreshed-access", refreshToken: "refreshed-refresh" }),
+      expect.objectContaining({ workspaceId: "ws" }),
+    );
+  });
 
-	it("clears storage and throws when token refresh fails", async () => {
-		axiosPostMock.mockRejectedValueOnce(new Error("refresh failed"));
-		const clear = vi.fn();
-		const storage: TokenStorage = {
-			save: vi.fn(),
-			load: vi.fn(
-				async () =>
-					({
-						accessToken: "old-access",
-						refreshToken: "old-refresh",
-						tokenType: "bearer",
-						expiresAt: Date.now() - 1000,
-					}) satisfies OAuthTokens,
-			),
-			clear,
-			getUserInfo: vi.fn(async () => null),
-		};
+  it("clears storage and throws when token refresh fails", async () => {
+    axiosPostMock.mockRejectedValueOnce(new Error("refresh failed"));
+    const clear = vi.fn();
+    const storage: TokenStorage = {
+      save: vi.fn(),
+      load: vi.fn(
+        async () =>
+          ({
+            accessToken: "old-access",
+            refreshToken: "old-refresh",
+            tokenType: "bearer",
+            expiresAt: Date.now() - 1000,
+          }) satisfies OAuthTokens,
+      ),
+      clear,
+      getUserInfo: vi.fn(async () => null),
+    };
 
-		await expect(getValidAccessToken(config, storage)).rejects.toThrow("Token refresh failed: refresh failed");
-		expect(clear).toHaveBeenCalled();
-	});
+    await expect(getValidAccessToken(config, storage)).rejects.toThrow("Token refresh failed: refresh failed");
+    expect(clear).toHaveBeenCalled();
+  });
+
+  it("returns null when no token is stored", async () => {
+    const storage: TokenStorage = {
+      save: vi.fn(),
+      load: vi.fn(async () => null),
+      clear: vi.fn(),
+      getUserInfo: vi.fn(async () => null),
+    };
+
+    await expect(getValidAccessToken(config, storage)).resolves.toBeNull();
+  });
+
+  it("executes the complete OAuth flow", async () => {
+    const storage: TokenStorage = {
+      save: vi.fn(),
+      load: vi.fn(async () => null),
+      clear: vi.fn(),
+      getUserInfo: vi.fn(async () => null),
+    };
+    const openBrowser = vi.fn();
+    const notify = vi.fn();
+
+    const result = await executeOAuthFlow(config, storage, openBrowser, notify, {
+      generateCodeVerifierFn: () => "verifier",
+      generateCodeChallengeFn: () => "challenge",
+      generateStateFn: () => "state-123",
+      startCallbackServerFn: async () => ({ code: "auth-code", state: "state-123" }),
+      exchangeCodeForTokensFn: async () => ({
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        tokenType: "bearer",
+        expiresAt: Date.now() + 3600 * 1000,
+        owner: {
+          workspaceId: "ws-1",
+          workspaceName: "Workspace",
+          botId: "bot-1",
+          ownerEmail: "user@example.com",
+          ownerName: "Test User",
+        },
+      }),
+    });
+
+    expect(openBrowser).toHaveBeenCalled();
+    expect(storage.save).toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith("OAuth authorization successful!", "success");
+    expect(result.tokens.accessToken).toBe("access-token");
+    expect(result.userInfo.workspaceId).toBe("ws-1");
+  });
 });

--- a/packages/pi-notion/__tests__/oauth.test.ts
+++ b/packages/pi-notion/__tests__/oauth.test.ts
@@ -7,11 +7,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-	buildAuthorizationUrl,
-	FileTokenStorage,
-	generateCodeChallenge,
-	generateCodeVerifier,
-	generateState,
+  buildAuthorizationUrl,
+  FileTokenStorage,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateState,
 } from "../extensions/oauth.js";
 
 // =============================================================================
@@ -19,76 +19,76 @@ import {
 // =============================================================================
 
 describe("pi-notion OAuth PKCE Utilities", () => {
-	describe("generateCodeVerifier", () => {
-		it("generates a non-empty string", () => {
-			const verifier = generateCodeVerifier();
-			expect(verifier).toBeTruthy();
-			expect(typeof verifier).toBe("string");
-		});
+  describe("generateCodeVerifier", () => {
+    it("generates a non-empty string", () => {
+      const verifier = generateCodeVerifier();
+      expect(verifier).toBeTruthy();
+      expect(typeof verifier).toBe("string");
+    });
 
-		it("generates unique values", () => {
-			const verifiers = new Set(Array.from({ length: 100 }, () => generateCodeVerifier()));
-			expect(verifiers.size).toBe(100);
-		});
+    it("generates unique values", () => {
+      const verifiers = new Set(Array.from({ length: 100 }, () => generateCodeVerifier()));
+      expect(verifiers.size).toBe(100);
+    });
 
-		it("generates URL-safe base64 string", () => {
-			const verifier = generateCodeVerifier();
-			expect(verifier).not.toMatch(/[+/=]/);
-		});
+    it("generates URL-safe base64 string", () => {
+      const verifier = generateCodeVerifier();
+      expect(verifier).not.toMatch(/[+/=]/);
+    });
 
-		it("generates verifier of sufficient length", () => {
-			const verifier = generateCodeVerifier();
-			expect(verifier.length).toBeGreaterThanOrEqual(32);
-		});
-	});
+    it("generates verifier of sufficient length", () => {
+      const verifier = generateCodeVerifier();
+      expect(verifier.length).toBeGreaterThanOrEqual(32);
+    });
+  });
 
-	describe("generateCodeChallenge", () => {
-		it("generates a non-empty string", () => {
-			const verifier = generateCodeVerifier();
-			const challenge = generateCodeChallenge(verifier);
-			expect(challenge).toBeTruthy();
-			expect(typeof challenge).toBe("string");
-		});
+  describe("generateCodeChallenge", () => {
+    it("generates a non-empty string", () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+      expect(challenge).toBeTruthy();
+      expect(typeof challenge).toBe("string");
+    });
 
-		it("generates consistent challenge for same verifier", () => {
-			const verifier = "test-verifier-string";
-			const challenge1 = generateCodeChallenge(verifier);
-			const challenge2 = generateCodeChallenge(verifier);
-			expect(challenge1).toBe(challenge2);
-		});
+    it("generates consistent challenge for same verifier", () => {
+      const verifier = "test-verifier-string";
+      const challenge1 = generateCodeChallenge(verifier);
+      const challenge2 = generateCodeChallenge(verifier);
+      expect(challenge1).toBe(challenge2);
+    });
 
-		it("generates different challenges for different verifiers", () => {
-			const verifier1 = "verifier-1";
-			const verifier2 = "verifier-2";
-			const challenge1 = generateCodeChallenge(verifier1);
-			const challenge2 = generateCodeChallenge(verifier2);
-			expect(challenge1).not.toBe(challenge2);
-		});
+    it("generates different challenges for different verifiers", () => {
+      const verifier1 = "verifier-1";
+      const verifier2 = "verifier-2";
+      const challenge1 = generateCodeChallenge(verifier1);
+      const challenge2 = generateCodeChallenge(verifier2);
+      expect(challenge1).not.toBe(challenge2);
+    });
 
-		it("generates URL-safe base64 string", () => {
-			const verifier = generateCodeVerifier();
-			const challenge = generateCodeChallenge(verifier);
-			expect(challenge).not.toMatch(/[+/=]/);
-		});
-	});
+    it("generates URL-safe base64 string", () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+      expect(challenge).not.toMatch(/[+/=]/);
+    });
+  });
 
-	describe("generateState", () => {
-		it("generates a non-empty hex string", () => {
-			const state = generateState();
-			expect(state).toBeTruthy();
-			expect(state).toMatch(/^[0-9a-f]+$/);
-		});
+  describe("generateState", () => {
+    it("generates a non-empty hex string", () => {
+      const state = generateState();
+      expect(state).toBeTruthy();
+      expect(state).toMatch(/^[0-9a-f]+$/);
+    });
 
-		it("generates unique values", () => {
-			const states = new Set(Array.from({ length: 100 }, () => generateState()));
-			expect(states.size).toBe(100);
-		});
+    it("generates unique values", () => {
+      const states = new Set(Array.from({ length: 100 }, () => generateState()));
+      expect(states.size).toBe(100);
+    });
 
-		it("generates 16 bytes (32 hex chars)", () => {
-			const state = generateState();
-			expect(state.length).toBe(32);
-		});
-	});
+    it("generates 16 bytes (32 hex chars)", () => {
+      const state = generateState();
+      expect(state.length).toBe(32);
+    });
+  });
 });
 
 // =============================================================================
@@ -96,43 +96,43 @@ describe("pi-notion OAuth PKCE Utilities", () => {
 // =============================================================================
 
 describe("pi-notion OAuth URL Builder", () => {
-	const mockConfig = {
-		clientId: "test-client-id",
-		clientSecret: "test-client-secret",
-		redirectUri: "http://localhost:3000/callback",
-	};
+  const mockConfig = {
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+    redirectUri: "http://localhost:3000/callback",
+  };
 
-	it("builds authorization URL with required parameters", () => {
-		const codeChallenge = "test-challenge";
-		const state = "test-state";
-		const url = buildAuthorizationUrl(mockConfig, codeChallenge, state);
+  it("builds authorization URL with required parameters", () => {
+    const codeChallenge = "test-challenge";
+    const state = "test-state";
+    const url = buildAuthorizationUrl(mockConfig, codeChallenge, state);
 
-		expect(url).toContain("https://api.notion.com/v1/oauth/authorize");
-		expect(url).toContain(`client_id=${mockConfig.clientId}`);
-		expect(url).toContain(`redirect_uri=${encodeURIComponent(mockConfig.redirectUri)}`);
-		expect(url).toContain(`code_challenge=${codeChallenge}`);
-		expect(url).toContain("code_challenge_method=S256");
-		expect(url).toContain(`state=${state}`);
-	});
+    expect(url).toContain("https://api.notion.com/v1/oauth/authorize");
+    expect(url).toContain(`client_id=${mockConfig.clientId}`);
+    expect(url).toContain(`redirect_uri=${encodeURIComponent(mockConfig.redirectUri)}`);
+    expect(url).toContain(`code_challenge=${codeChallenge}`);
+    expect(url).toContain("code_challenge_method=S256");
+    expect(url).toContain(`state=${state}`);
+  });
 
-	it("includes response_type as code", () => {
-		const url = buildAuthorizationUrl(mockConfig, "challenge", "state");
-		expect(url).toContain("response_type=code");
-	});
+  it("includes response_type as code", () => {
+    const url = buildAuthorizationUrl(mockConfig, "challenge", "state");
+    expect(url).toContain("response_type=code");
+  });
 
-	it("includes owner=user", () => {
-		const url = buildAuthorizationUrl(mockConfig, "challenge", "state");
-		expect(url).toContain("owner=user");
-	});
+  it("includes owner=user", () => {
+    const url = buildAuthorizationUrl(mockConfig, "challenge", "state");
+    expect(url).toContain("owner=user");
+  });
 
-	it("URL encodes special characters in redirect URI", () => {
-		const configWithSpecialChars = {
-			...mockConfig,
-			redirectUri: "http://localhost:3000/callback?foo=bar&baz=qux",
-		};
-		const url = buildAuthorizationUrl(configWithSpecialChars, "challenge", "state");
-		expect(url).toContain("callback%3Ffoo%3Dbar%26baz%3Dqux");
-	});
+  it("URL encodes special characters in redirect URI", () => {
+    const configWithSpecialChars = {
+      ...mockConfig,
+      redirectUri: "http://localhost:3000/callback?foo=bar&baz=qux",
+    };
+    const url = buildAuthorizationUrl(configWithSpecialChars, "challenge", "state");
+    expect(url).toContain("callback%3Ffoo%3Dbar%26baz%3Dqux");
+  });
 });
 
 // =============================================================================
@@ -140,111 +140,111 @@ describe("pi-notion OAuth URL Builder", () => {
 // =============================================================================
 
 describe("pi-notion FileTokenStorage", () => {
-	let tempDir: string;
-	let storage: FileTokenStorage;
-	let basePath: string;
+  let tempDir: string;
+  let storage: FileTokenStorage;
+  let basePath: string;
 
-	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "pi-notion-storage-"));
-		basePath = join(tempDir, "notion.json");
-		storage = new FileTokenStorage(basePath);
-	});
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "pi-notion-storage-"));
+    basePath = join(tempDir, "notion.json");
+    storage = new FileTokenStorage(basePath);
+  });
 
-	describe("save and load", () => {
-		it("saves and loads tokens", async () => {
-			const tokens = {
-				accessToken: "test-access",
-				refreshToken: "test-refresh",
-				tokenType: "Bearer",
-				expiresAt: Date.now() + 3600000,
-			};
+  describe("save and load", () => {
+    it("saves and loads tokens", async () => {
+      const tokens = {
+        accessToken: "test-access",
+        refreshToken: "test-refresh",
+        tokenType: "Bearer",
+        expiresAt: Date.now() + 3600000,
+      };
 
-			await storage.save(tokens);
-			const loaded = await storage.load();
+      await storage.save(tokens);
+      const loaded = await storage.load();
 
-			expect(loaded).toEqual(tokens);
-		});
+      expect(loaded).toEqual(tokens);
+    });
 
-		it("saves and loads user info", async () => {
-			const tokens = {
-				accessToken: "access",
-				refreshToken: "refresh",
-				tokenType: "Bearer",
-				expiresAt: Date.now() + 3600000,
-			};
+    it("saves and loads user info", async () => {
+      const tokens = {
+        accessToken: "access",
+        refreshToken: "refresh",
+        tokenType: "Bearer",
+        expiresAt: Date.now() + 3600000,
+      };
 
-			const userInfo = {
-				workspaceId: "ws-123",
-				workspaceName: "Test Workspace",
-				workspaceIcon: "🏢",
-				botId: "bot-123",
-				ownerEmail: "user@example.com",
-				ownerName: "Test User",
-			};
+      const userInfo = {
+        workspaceId: "ws-123",
+        workspaceName: "Test Workspace",
+        workspaceIcon: "🏢",
+        botId: "bot-123",
+        ownerEmail: "user@example.com",
+        ownerName: "Test User",
+      };
 
-			await storage.save(tokens, userInfo);
-			const loadedUserInfo = await storage.getUserInfo();
+      await storage.save(tokens, userInfo);
+      const loadedUserInfo = await storage.getUserInfo();
 
-			expect(loadedUserInfo).toEqual(userInfo);
-		});
+      expect(loadedUserInfo).toEqual(userInfo);
+    });
 
-		it("saves without user info", async () => {
-			const tokens = {
-				accessToken: "access",
-				refreshToken: "refresh",
-				tokenType: "Bearer",
-				expiresAt: Date.now() + 3600000,
-			};
+    it("saves without user info", async () => {
+      const tokens = {
+        accessToken: "access",
+        refreshToken: "refresh",
+        tokenType: "Bearer",
+        expiresAt: Date.now() + 3600000,
+      };
 
-			await storage.save(tokens);
+      await storage.save(tokens);
 
-			const loadedTokens = await storage.load();
-			const loadedUserInfo = await storage.getUserInfo();
+      const loadedTokens = await storage.load();
+      const loadedUserInfo = await storage.getUserInfo();
 
-			expect(loadedTokens).toEqual(tokens);
-			expect(loadedUserInfo).toBeNull();
-		});
-	});
+      expect(loadedTokens).toEqual(tokens);
+      expect(loadedUserInfo).toBeNull();
+    });
+  });
 
-	describe("load", () => {
-		it("returns null when no tokens saved", async () => {
-			const result = await storage.load();
-			expect(result).toBeNull();
-		});
-	});
+  describe("load", () => {
+    it("returns null when no tokens saved", async () => {
+      const result = await storage.load();
+      expect(result).toBeNull();
+    });
+  });
 
-	describe("getUserInfo", () => {
-		it("returns null when no user info saved", async () => {
-			const result = await storage.getUserInfo();
-			expect(result).toBeNull();
-		});
-	});
+  describe("getUserInfo", () => {
+    it("returns null when no user info saved", async () => {
+      const result = await storage.getUserInfo();
+      expect(result).toBeNull();
+    });
+  });
 
-	describe("clear", () => {
-		it("clears tokens and user info", async () => {
-			const tokens = {
-				accessToken: "access",
-				refreshToken: "refresh",
-				tokenType: "Bearer",
-				expiresAt: Date.now() + 3600000,
-			};
+  describe("clear", () => {
+    it("clears tokens and user info", async () => {
+      const tokens = {
+        accessToken: "access",
+        refreshToken: "refresh",
+        tokenType: "Bearer",
+        expiresAt: Date.now() + 3600000,
+      };
 
-			await storage.save(tokens, {
-				workspaceId: "ws",
-				workspaceName: "WS",
-				botId: "bot",
-			});
+      await storage.save(tokens, {
+        workspaceId: "ws",
+        workspaceName: "WS",
+        botId: "bot",
+      });
 
-			await storage.clear();
+      await storage.clear();
 
-			expect(await storage.load()).toBeNull();
-			expect(await storage.getUserInfo()).toBeNull();
-		});
+      expect(await storage.load()).toBeNull();
+      expect(await storage.getUserInfo()).toBeNull();
+    });
 
-		it("clears when no files exist", async () => {
-			await expect(storage.clear()).resolves.toBeUndefined();
-		});
-	});
+    it("clears when no files exist", async () => {
+      await expect(storage.clear()).resolves.toBeUndefined();
+    });
+  });
 });
 
 // =============================================================================
@@ -252,43 +252,43 @@ describe("pi-notion FileTokenStorage", () => {
 // =============================================================================
 
 describe("pi-notion OAuth File Structure", () => {
-	const oauthPath = join(__dirname, "../extensions/oauth.ts");
+  const oauthPath = join(__dirname, "../extensions/oauth.ts");
 
-	it("oauth.ts contains PKCE functions", () => {
-		const content = readFileSync(oauthPath, "utf-8");
+  it("oauth.ts contains PKCE functions", () => {
+    const content = readFileSync(oauthPath, "utf-8");
 
-		expect(content).toContain("generateCodeVerifier");
-		expect(content).toContain("generateCodeChallenge");
-		expect(content).toContain("generateState");
-	});
+    expect(content).toContain("generateCodeVerifier");
+    expect(content).toContain("generateCodeChallenge");
+    expect(content).toContain("generateState");
+  });
 
-	it("oauth.ts contains token exchange functions", () => {
-		const content = readFileSync(oauthPath, "utf-8");
+  it("oauth.ts contains token exchange functions", () => {
+    const content = readFileSync(oauthPath, "utf-8");
 
-		expect(content).toContain("exchangeCodeForTokens");
-		expect(content).toContain("refreshTokens");
-	});
+    expect(content).toContain("exchangeCodeForTokens");
+    expect(content).toContain("refreshTokens");
+  });
 
-	it("oauth.ts contains storage class", () => {
-		const content = readFileSync(oauthPath, "utf-8");
+  it("oauth.ts contains storage class", () => {
+    const content = readFileSync(oauthPath, "utf-8");
 
-		expect(content).toContain("FileTokenStorage");
-		expect(content).toContain("TokenStorage");
-	});
+    expect(content).toContain("FileTokenStorage");
+    expect(content).toContain("TokenStorage");
+  });
 
-	it("oauth.ts contains OAuth flow functions", () => {
-		const content = readFileSync(oauthPath, "utf-8");
+  it("oauth.ts contains OAuth flow functions", () => {
+    const content = readFileSync(oauthPath, "utf-8");
 
-		expect(content).toContain("executeOAuthFlow");
-		expect(content).toContain("getValidAccessToken");
-		expect(content).toContain("buildAuthorizationUrl");
-	});
+    expect(content).toContain("executeOAuthFlow");
+    expect(content).toContain("getValidAccessToken");
+    expect(content).toContain("buildAuthorizationUrl");
+  });
 
-	it("oauth.ts contains type definitions", () => {
-		const content = readFileSync(oauthPath, "utf-8");
+  it("oauth.ts contains type definitions", () => {
+    const content = readFileSync(oauthPath, "utf-8");
 
-		expect(content).toContain("OAuthConfig");
-		expect(content).toContain("OAuthTokens");
-		expect(content).toContain("OAuthUserInfo");
-	});
+    expect(content).toContain("OAuthConfig");
+    expect(content).toContain("OAuthTokens");
+    expect(content).toContain("OAuthUserInfo");
+  });
 });

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -25,25 +25,25 @@ const LEGACY_TOKEN_FILE = join(process.cwd(), ".pi", "extensions", "notion.json"
 // =============================================================================
 
 interface OAuthTokens {
-	accessToken: string;
-	refreshToken: string;
-	tokenType: string;
-	expiresAt: number;
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  expiresAt: number;
 }
 
 interface NotionUserInfo {
-	workspaceId: string;
-	workspaceName: string;
-	workspaceIcon?: string;
-	botId: string;
-	ownerEmail?: string;
-	ownerName?: string;
+  workspaceId: string;
+  workspaceName: string;
+  workspaceIcon?: string;
+  botId: string;
+  ownerEmail?: string;
+  ownerName?: string;
 }
 
 interface AuthStatus {
-	authenticated: boolean;
-	workspaceName?: string;
-	message: string;
+  authenticated: boolean;
+  workspaceName?: string;
+  message: string;
 }
 
 // =============================================================================
@@ -51,76 +51,76 @@ interface AuthStatus {
 // =============================================================================
 
 function readJsonIfExists<T>(path: string): T | null {
-	if (!existsSync(path)) return null;
-	try {
-		return JSON.parse(readFileSync(path, "utf-8")) as T;
-	} catch {
-		return null;
-	}
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    return null;
+  }
 }
 
 function getMcpConfigAuthStatus(): AuthStatus | null {
-	const config = readJsonIfExists<{ accessToken?: string; mcpUrl?: string }>(MCP_CONFIG_FILE);
-	if (typeof config?.accessToken !== "string" || config.accessToken.trim().length === 0) return null;
+  const config = readJsonIfExists<{ accessToken?: string; mcpUrl?: string }>(MCP_CONFIG_FILE);
+  if (typeof config?.accessToken !== "string" || config.accessToken.trim().length === 0) return null;
 
-	return {
-		authenticated: true,
-		message: `[notion] MCP config found (${config.mcpUrl ?? "https://mcp.notion.com/mcp"})`,
-	};
+  return {
+    authenticated: true,
+    message: `[notion] MCP config found (${config.mcpUrl ?? "https://mcp.notion.com/mcp"})`,
+  };
 }
 
 function getOAuthTokenAuthStatus(): AuthStatus | null {
-	const tokens = readJsonIfExists<OAuthTokens>(TOKEN_FILE);
-	if (!tokens?.accessToken || tokens.expiresAt <= Date.now()) return null;
+  const tokens = readJsonIfExists<OAuthTokens>(TOKEN_FILE);
+  if (!tokens?.accessToken || tokens.expiresAt <= Date.now()) return null;
 
-	const userInfoPath = TOKEN_FILE.replace("-tokens.json", "-user.json");
-	const userInfo = readJsonIfExists<NotionUserInfo>(userInfoPath);
-	if (!userInfo) {
-		return {
-			authenticated: true,
-			message: "[notion] Authenticated (OAuth tokens valid)",
-		};
-	}
+  const userInfoPath = TOKEN_FILE.replace("-tokens.json", "-user.json");
+  const userInfo = readJsonIfExists<NotionUserInfo>(userInfoPath);
+  if (!userInfo) {
+    return {
+      authenticated: true,
+      message: "[notion] Authenticated (OAuth tokens valid)",
+    };
+  }
 
-	return {
-		authenticated: true,
-		workspaceName: userInfo.workspaceName,
-		message: `[notion] Authenticated as ${userInfo.workspaceName || "Unknown workspace"}`,
-	};
+  return {
+    authenticated: true,
+    workspaceName: userInfo.workspaceName,
+    message: `[notion] Authenticated as ${userInfo.workspaceName || "Unknown workspace"}`,
+  };
 }
 
 function getLegacyEnvAuthStatus(): AuthStatus | null {
-	const apiKey = process.env.NOTION_API_KEY ?? process.env.NOTION_TOKEN;
-	if (!apiKey) return null;
+  const apiKey = process.env.NOTION_API_KEY ?? process.env.NOTION_TOKEN;
+  if (!apiKey) return null;
 
-	return {
-		authenticated: false,
-		message: process.env.NOTION_API_KEY
-			? "[notion] NOTION_API_KEY detected (legacy direct API token). MCP OAuth is still required: run /notion."
-			: "[notion] NOTION_TOKEN detected (legacy). MCP OAuth is still required: run /notion.",
-	};
+  return {
+    authenticated: false,
+    message: process.env.NOTION_API_KEY
+      ? "[notion] NOTION_API_KEY detected (legacy direct API token). MCP OAuth is still required: run /notion."
+      : "[notion] NOTION_TOKEN detected (legacy). MCP OAuth is still required: run /notion.",
+  };
 }
 
 function getLegacyConfigAuthStatus(): AuthStatus | null {
-	const config = readJsonIfExists<{ token?: string }>(LEGACY_TOKEN_FILE);
-	if (!config?.token) return null;
+  const config = readJsonIfExists<{ token?: string }>(LEGACY_TOKEN_FILE);
+  if (!config?.token) return null;
 
-	return {
-		authenticated: false,
-		message: "[notion] Legacy notion.json token detected. MCP OAuth is still required: run /notion.",
-	};
+  return {
+    authenticated: false,
+    message: "[notion] Legacy notion.json token detected. MCP OAuth is still required: run /notion.",
+  };
 }
 
 function checkNotionAuth(): AuthStatus {
-	return (
-		getMcpConfigAuthStatus() ??
-		getOAuthTokenAuthStatus() ??
-		getLegacyEnvAuthStatus() ??
-		getLegacyConfigAuthStatus() ?? {
-			authenticated: false,
-			message: "[notion] Not authenticated. Use /notion to connect your Notion workspace.",
-		}
-	);
+  return (
+    getMcpConfigAuthStatus() ??
+    getOAuthTokenAuthStatus() ??
+    getLegacyEnvAuthStatus() ??
+    getLegacyConfigAuthStatus() ?? {
+      authenticated: false,
+      message: "[notion] Not authenticated. Use /notion to connect your Notion workspace.",
+    }
+  );
 }
 
 // =============================================================================
@@ -130,81 +130,81 @@ function checkNotionAuth(): AuthStatus {
 type CheckFn = (input: Record<string, unknown>) => string[];
 
 function checkNotionSearch(input: Record<string, unknown>): string[] {
-	const warnings: string[] = [];
+  const warnings: string[] = [];
 
-	if (input.content_search_mode !== "workspace_search") {
-		warnings.push(
-			"⚠ notion-search: content_search_mode is not 'workspace_search'. Default 'ai_search' returns calendar events. Use 'workspace_search' for workspace content.",
-		);
-	}
+  if (input.content_search_mode !== "workspace_search") {
+    warnings.push(
+      "⚠ notion-search: content_search_mode is not 'workspace_search'. Default 'ai_search' returns calendar events. Use 'workspace_search' for workspace content.",
+    );
+  }
 
-	if (!("filters" in input)) {
-		warnings.push("⚠ notion-search: 'filters' key is missing. Add at minimum 'filters': {}.");
-	}
+  if (!("filters" in input)) {
+    warnings.push("⚠ notion-search: 'filters' key is missing. Add at minimum 'filters': {}.");
+  }
 
-	return warnings;
+  return warnings;
 }
 
 function checkNotionFetch(input: Record<string, unknown>): string[] {
-	const warnings: string[] = [];
-	const id = String(input.id ?? "");
+  const warnings: string[] = [];
+  const id = String(input.id ?? "");
 
-	if (!id) return warnings;
+  if (!id) return warnings;
 
-	if (id.startsWith("view://")) {
-		warnings.push("⚠ notion-fetch: 'view://' URLs can't be fetched — use notion-query-database-view instead.");
-	} else if (!id.startsWith("https://") && !id.startsWith("collection://")) {
-		warnings.push("⚠ notion-fetch: Using raw ID. Prefer the 'url' field from search results for reliability.");
-	}
+  if (id.startsWith("view://")) {
+    warnings.push("⚠ notion-fetch: 'view://' URLs can't be fetched — use notion-query-database-view instead.");
+  } else if (!id.startsWith("https://") && !id.startsWith("collection://")) {
+    warnings.push("⚠ notion-fetch: Using raw ID. Prefer the 'url' field from search results for reliability.");
+  }
 
-	return warnings;
+  return warnings;
 }
 
 function checkMeetingNotes(input: Record<string, unknown>): string[] {
-	const warnings: string[] = [];
+  const warnings: string[] = [];
 
-	if (!("filter" in input)) {
-		warnings.push(
-			'⚠ notion-query-meeting-notes: \'filter\' is required. Use {"filter": {"operator": "and", "filters": []}} at minimum.',
-		);
-	} else {
-		const filter = input.filter as Record<string, unknown> | null;
-		if (filter && typeof filter === "object" && !("operator" in filter)) {
-			warnings.push(
-				'⚠ notion-query-meeting-notes: Empty filter {} will fail. Use {"filter": {"operator": "and", "filters": []}}.',
-			);
-		}
-	}
+  if (!("filter" in input)) {
+    warnings.push(
+      '⚠ notion-query-meeting-notes: \'filter\' is required. Use {"filter": {"operator": "and", "filters": []}} at minimum.',
+    );
+  } else {
+    const filter = input.filter as Record<string, unknown> | null;
+    if (filter && typeof filter === "object" && !("operator" in filter)) {
+      warnings.push(
+        '⚠ notion-query-meeting-notes: Empty filter {} will fail. Use {"filter": {"operator": "and", "filters": []}}.',
+      );
+    }
+  }
 
-	return warnings;
+  return warnings;
 }
 
 const toolChecks: Record<string, CheckFn> = {
-	"notion-search": checkNotionSearch,
-	"notion-fetch": checkNotionFetch,
-	"notion-query-meeting-notes": checkMeetingNotes,
+  "notion-search": checkNotionSearch,
+  "notion-fetch": checkNotionFetch,
+  "notion-query-meeting-notes": checkMeetingNotes,
 };
 
 function extractShortName(toolName: string): string {
-	const parts = toolName.split("__");
-	return parts.at(-1) ?? toolName;
+  const parts = toolName.split("__");
+  return parts.at(-1) ?? toolName;
 }
 
 async function handleToolGuardrails(
-	event: { toolName: string; input?: Record<string, unknown> },
-	ctx: ExtensionContext,
+  event: { toolName: string; input?: Record<string, unknown> },
+  ctx: ExtensionContext,
 ) {
-	// Only check Notion MCP tools
-	if (!event.toolName.includes("notion")) return;
+  // Only check Notion MCP tools
+  if (!event.toolName.includes("notion")) return;
 
-	const shortName = extractShortName(event.toolName);
-	const checkFn = toolChecks[shortName];
-	if (!checkFn) return;
+  const shortName = extractShortName(event.toolName);
+  const checkFn = toolChecks[shortName];
+  if (!checkFn) return;
 
-	const warnings = checkFn(event.input ?? {});
-	if (warnings.length > 0) {
-		ctx.ui.notify(`[notion]\n${warnings.join("\n")}`, "warning");
-	}
+  const warnings = checkFn(event.input ?? {});
+  if (warnings.length > 0) {
+    ctx.ui.notify(`[notion]\n${warnings.join("\n")}`, "warning");
+  }
 }
 
 // =============================================================================
@@ -218,26 +218,26 @@ export { checkNotionAuth, extractShortName, toolChecks };
 // =============================================================================
 
 export default function notion(pi: ExtensionAPI) {
-	// SessionStart: check auth and print status
-	pi.on("session_start", async () => {
-		// Ensure config directory exists
-		if (!existsSync(CONFIG_DIR)) {
-			try {
-				mkdirSync(CONFIG_DIR, { recursive: true });
-				writeFileSync(join(CONFIG_DIR, "notion-mcp.json"), JSON.stringify({}), "utf-8");
-			} catch {
-				// Ignore if can't create
-			}
-		}
+  // SessionStart: check auth and print status
+  pi.on("session_start", async () => {
+    // Ensure config directory exists
+    if (!existsSync(CONFIG_DIR)) {
+      try {
+        mkdirSync(CONFIG_DIR, { recursive: true });
+        writeFileSync(join(CONFIG_DIR, "notion-mcp.json"), JSON.stringify({}), "utf-8");
+      } catch {
+        // Ignore if can't create
+      }
+    }
 
-		const auth = checkNotionAuth();
-		console.log(auth.message);
-	});
+    const auth = checkNotionAuth();
+    console.log(auth.message);
+  });
 
-	// Tool call: advisory guardrails for Notion tools
-	pi.on("tool_call", async (event, ctx) => {
-		await handleToolGuardrails(event, ctx);
-	});
+  // Tool call: advisory guardrails for Notion tools
+  pi.on("tool_call", async (event, ctx) => {
+    await handleToolGuardrails(event, ctx);
+  });
 }
 
 // =============================================================================
@@ -245,95 +245,95 @@ export default function notion(pi: ExtensionAPI) {
 // =============================================================================
 
 interface NotionConfig {
-	token?: string;
+  token?: string;
 }
 
 function resolveConfigPath(configPath: string): string {
-	const trimmed = configPath.trim();
-	if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-	if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
-	return resolve(process.cwd(), trimmed);
+  const trimmed = configPath.trim();
+  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+  if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
+  return resolve(process.cwd(), trimmed);
 }
 
 function loadConfig(configPath?: string): NotionConfig | null {
-	const candidates: string[] = [];
-	if (configPath) candidates.push(resolveConfigPath(configPath));
-	else if (process.env.NOTION_CONFIG) candidates.push(resolveConfigPath(process.env.NOTION_CONFIG));
-	else {
-		const projectConfigPath = join(process.cwd(), ".pi", "extensions", "notion.json");
-		const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "notion.json");
-		candidates.push(projectConfigPath, globalConfigPath);
-	}
-	for (const candidate of candidates) {
-		if (existsSync(candidate)) {
-			try {
-				return JSON.parse(readFileSync(candidate, "utf-8"));
-			} catch {}
-		}
-	}
-	return null;
+  const candidates: string[] = [];
+  if (configPath) candidates.push(resolveConfigPath(configPath));
+  else if (process.env.NOTION_CONFIG) candidates.push(resolveConfigPath(process.env.NOTION_CONFIG));
+  else {
+    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "notion.json");
+    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "notion.json");
+    candidates.push(projectConfigPath, globalConfigPath);
+  }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      try {
+        return JSON.parse(readFileSync(candidate, "utf-8"));
+      } catch {}
+    }
+  }
+  return null;
 }
 
 interface TitleProp {
-	type?: string;
-	title?: Array<{ plain_text: string }>;
+  type?: string;
+  title?: Array<{ plain_text: string }>;
 }
 
 function getTitleFromProperties(properties: Record<string, unknown>): string {
-	const titleProp = Object.values(properties).find((p: unknown) => (p as TitleProp)?.type === "title") as
-		| TitleProp
-		| undefined;
-	if (titleProp?.title) {
-		return titleProp.title.map((t) => t.plain_text).join("") || "Untitled";
-	}
-	return "Untitled";
+  const titleProp = Object.values(properties).find((p: unknown) => (p as TitleProp)?.type === "title") as
+    | TitleProp
+    | undefined;
+  if (titleProp?.title) {
+    return titleProp.title.map((t) => t.plain_text).join("") || "Untitled";
+  }
+  return "Untitled";
 }
 
 function formatPage(page: { id: string; url: string; properties: Record<string, unknown> }) {
-	const title = getTitleFromProperties(page.properties);
-	return `# Page: ${page.id}\nURL: ${page.url}\nTitle: ${title}\n\n## Properties\n${JSON.stringify(page.properties, null, 2)}`;
+  const title = getTitleFromProperties(page.properties);
+  return `# Page: ${page.id}\nURL: ${page.url}\nTitle: ${title}\n\n## Properties\n${JSON.stringify(page.properties, null, 2)}`;
 }
 
 function formatDatabase(database: {
-	id: string;
-	title?: Array<{ plain_text: string }>;
-	properties: Record<string, unknown>;
+  id: string;
+  title?: Array<{ plain_text: string }>;
+  properties: Record<string, unknown>;
 }) {
-	const title = database.title?.map((t) => t.plain_text).join("") || "Untitled";
-	return `# Database: ${database.id}\nTitle: ${title}\n\n## Properties\n${JSON.stringify(database.properties, null, 2)}`;
+  const title = database.title?.map((t) => t.plain_text).join("") || "Untitled";
+  return `# Database: ${database.id}\nTitle: ${title}\n\n## Properties\n${JSON.stringify(database.properties, null, 2)}`;
 }
 
 function formatBlocks(result: { results: Array<{ type: string; [key: string]: unknown }> }) {
-	if (!result.results?.length) return "No blocks found.";
-	return result.results
-		.map((block) => {
-			const type = block.type || "unknown";
-			const content = (block[type] as Record<string, unknown>) || {};
-			const text = (content.text as Array<{ plain_text: string }>)?.map((t) => t.plain_text).join("") || "";
-			return `[${type}] ${text}`;
-		})
-		.join("\n");
+  if (!result.results?.length) return "No blocks found.";
+  return result.results
+    .map((block) => {
+      const type = block.type || "unknown";
+      const content = (block[type] as Record<string, unknown>) || {};
+      const text = (content.text as Array<{ plain_text: string }>)?.map((t) => t.plain_text).join("") || "";
+      return `[${type}] ${text}`;
+    })
+    .join("\n");
 }
 
 function formatSearch(result: { results: unknown[] }) {
-	if (!result.results?.length) return "No results found.";
-	return result.results
-		.map((item: unknown) => {
-			const obj = item as { object: string; id: string; properties?: Record<string, unknown> };
-			const type = obj.object;
-			const title = obj.properties ? getTitleFromProperties(obj.properties) : "Untitled";
-			return `- [${type}] ${title} (${obj.id})`;
-		})
-		.join("\n");
+  if (!result.results?.length) return "No results found.";
+  return result.results
+    .map((item: unknown) => {
+      const obj = item as { object: string; id: string; properties?: Record<string, unknown> };
+      const type = obj.object;
+      const title = obj.properties ? getTitleFromProperties(obj.properties) : "Untitled";
+      return `- [${type}] ${title} (${obj.id})`;
+    })
+    .join("\n");
 }
 
 // Re-export utilities
 export {
-	formatBlocks,
-	formatDatabase,
-	formatPage,
-	formatSearch,
-	getTitleFromProperties,
-	loadConfig,
-	resolveConfigPath,
+  formatBlocks,
+  formatDatabase,
+  formatPage,
+  formatSearch,
+  getTitleFromProperties,
+  loadConfig,
+  resolveConfigPath,
 };

--- a/packages/pi-notion/extensions/mcp-client.ts
+++ b/packages/pi-notion/extensions/mcp-client.ts
@@ -740,13 +740,18 @@ async function disconnectClient(client: NotionMCPClient): Promise<void> {
 }
 
 export {
-  buildHtmlResponse,
   buildAuthorizationUrl,
+  buildHtmlResponse,
   coerceNumericProperties,
   coercePropertyMap,
+  connectWithSavedConfig,
   createPkceChallenge,
   createRegisteredToolExecutor,
+  createUiNotifier,
+  disconnectClient,
+  ensureConnected,
   FileTokenStorage,
+  finalizeConnection,
   getConnectedStatusMessage,
   getConnectionStatusText,
   isNumericString,
@@ -758,11 +763,6 @@ export {
   storage,
   toolError,
   toolResult,
-  connectWithSavedConfig,
-  createUiNotifier,
-  disconnectClient,
-  ensureConnected,
-  finalizeConnection,
 };
 
 export default function notionMCPClientExtension(pi: ExtensionAPI) {

--- a/packages/pi-notion/extensions/mcp-client.ts
+++ b/packages/pi-notion/extensions/mcp-client.ts
@@ -30,9 +30,9 @@ type NotifyLevel = "info" | "error";
 type NotifyFn = (message: string, type?: NotifyLevel) => void;
 
 type ToolExecutionResult = {
-	content: Array<{ type: "text"; text: string }>;
-	isError?: boolean;
-	details: Record<string, unknown>;
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+  details: Record<string, unknown>;
 };
 
 // =============================================================================
@@ -40,17 +40,17 @@ type ToolExecutionResult = {
 // =============================================================================
 
 interface MCPTool {
-	name: string;
-	description: string;
-	inputSchema: Record<string, unknown>;
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
 }
 
 interface MCPClientState {
-	connected: boolean;
-	authenticated: boolean;
-	sessionId: string | null;
-	accessToken: string | null;
-	mcpUrl: string | null;
+  connected: boolean;
+  authenticated: boolean;
+  sessionId: string | null;
+  accessToken: string | null;
+  mcpUrl: string | null;
 }
 
 // =============================================================================
@@ -58,142 +58,142 @@ interface MCPClientState {
 // =============================================================================
 
 interface OAuthCallbackResult {
-	code?: string;
-	accessToken?: string;
-	error?: string;
-	errorDescription?: string;
+  code?: string;
+  accessToken?: string;
+  error?: string;
+  errorDescription?: string;
 }
 
 interface OAuthCallbackServerResult {
-	port: number;
-	result: Promise<OAuthCallbackResult>;
+  port: number;
+  result: Promise<OAuthCallbackResult>;
 }
 
 function buildHtmlResponse(statusLine: string, html: string): string {
-	return `${statusLine}\r\nContent-Length: ${html.length}\r\nContent-Type: text/html\r\n\r\n${html}`;
+  return `${statusLine}\r\nContent-Length: ${html.length}\r\nContent-Type: text/html\r\n\r\n${html}`;
 }
 
 function writeHtmlResponse(socket: NodeJS.WritableStream, statusLine: string, html: string): void {
-	socket.write(buildHtmlResponse(statusLine, html));
+  socket.write(buildHtmlResponse(statusLine, html));
 }
 
 function extractCallbackParams(buffer: string): URLSearchParams | null {
-	if (!buffer.includes(HTTP_REQUEST_COMPLETE_MARKER)) return null;
+  if (!buffer.includes(HTTP_REQUEST_COMPLETE_MARKER)) return null;
 
-	const requestLine = buffer.split("\r\n", 1)[0] ?? "";
-	if (!requestLine.startsWith(CALLBACK_PATH_PREFIX)) return null;
+  const requestLine = buffer.split("\r\n", 1)[0] ?? "";
+  if (!requestLine.startsWith(CALLBACK_PATH_PREFIX)) return null;
 
-	const queryString = requestLine.slice(CALLBACK_PATH_PREFIX.length).split(" ", 1)[0] ?? "";
-	return new URLSearchParams(queryString);
+  const queryString = requestLine.slice(CALLBACK_PATH_PREFIX.length).split(" ", 1)[0] ?? "";
+  return new URLSearchParams(queryString);
 }
 
 function resolveCallbackResult(
-	params: URLSearchParams,
-	expectedState: string,
+  params: URLSearchParams,
+  expectedState: string,
 ): {
-	response: { statusLine: string; html: string };
-	result: OAuthCallbackResult;
+  response: { statusLine: string; html: string };
+  result: OAuthCallbackResult;
 } {
-	if (params.get("state") !== expectedState) {
-		return {
-			response: {
-				statusLine: "HTTP/1.1 400 Bad Request",
-				html: `<html><body><h1>State mismatch</h1><p>Please try again.</p></body></html>`,
-			},
-			result: { error: "State mismatch" },
-		};
-	}
+  if (params.get("state") !== expectedState) {
+    return {
+      response: {
+        statusLine: "HTTP/1.1 400 Bad Request",
+        html: `<html><body><h1>State mismatch</h1><p>Please try again.</p></body></html>`,
+      },
+      result: { error: "State mismatch" },
+    };
+  }
 
-	const error = params.get("error");
-	if (error) {
-		return {
-			response: {
-				statusLine: "HTTP/1.1 400 Bad Request",
-				html: `<html><body><h1>Authorization failed</h1><p>Error: ${error}</p><p>${params.get("error_description") || ""}</p></body></html>`,
-			},
-			result: {
-				error,
-				errorDescription: params.get("error_description") || undefined,
-			},
-		};
-	}
+  const error = params.get("error");
+  if (error) {
+    return {
+      response: {
+        statusLine: "HTTP/1.1 400 Bad Request",
+        html: `<html><body><h1>Authorization failed</h1><p>Error: ${error}</p><p>${params.get("error_description") || ""}</p></body></html>`,
+      },
+      result: {
+        error,
+        errorDescription: params.get("error_description") || undefined,
+      },
+    };
+  }
 
-	const accessToken = params.get("access_token");
-	if (accessToken) {
-		return {
-			response: {
-				statusLine: "HTTP/1.1 200 OK",
-				html: `<html><body><h1>Authorized!</h1><p>You can close this window.</p><script>window.close();</script></body></html>`,
-			},
-			result: { accessToken },
-		};
-	}
+  const accessToken = params.get("access_token");
+  if (accessToken) {
+    return {
+      response: {
+        statusLine: "HTTP/1.1 200 OK",
+        html: `<html><body><h1>Authorized!</h1><p>You can close this window.</p><script>window.close();</script></body></html>`,
+      },
+      result: { accessToken },
+    };
+  }
 
-	const code = params.get("code");
-	if (code) {
-		return {
-			response: {
-				statusLine: "HTTP/1.1 200 OK",
-				html: `<html><body><h1>Authorized!</h1><p>You can close this window.</p><script>window.close();</script></body></html>`,
-			},
-			result: { code },
-		};
-	}
+  const code = params.get("code");
+  if (code) {
+    return {
+      response: {
+        statusLine: "HTTP/1.1 200 OK",
+        html: `<html><body><h1>Authorized!</h1><p>You can close this window.</p><script>window.close();</script></body></html>`,
+      },
+      result: { code },
+    };
+  }
 
-	return {
-		response: {
-			statusLine: "HTTP/1.1 400 Bad Request",
-			html: `<html><body><h1>Authorization failed</h1><p>No code or token in callback.</p></body></html>`,
-		},
-		result: { error: "No code or token in callback" },
-	};
+  return {
+    response: {
+      statusLine: "HTTP/1.1 400 Bad Request",
+      html: `<html><body><h1>Authorization failed</h1><p>No code or token in callback.</p></body></html>`,
+    },
+    result: { error: "No code or token in callback" },
+  };
 }
 
 async function startOAuthCallbackServer(
-	preferredPort: number,
-	state: string,
-	timeoutMs = 300000,
+  preferredPort: number,
+  state: string,
+  timeoutMs = 300000,
 ): Promise<OAuthCallbackServerResult> {
-	const port = await lookupPort({ port: preferredPort });
+  const port = await lookupPort({ port: preferredPort });
 
-	const resultPromise = new Promise<OAuthCallbackResult>((resolve, reject) => {
-		const server = createServer();
-		const finish = (result: OAuthCallbackResult) => {
-			clearTimeout(timeout);
-			server.close();
-			resolve(result);
-		};
-		const timeout = setTimeout(() => {
-			server.close();
-			reject(new Error("OAuth callback timed out (5 minutes)"));
-		}, timeoutMs);
+  const resultPromise = new Promise<OAuthCallbackResult>((resolve, reject) => {
+    const server = createServer();
+    const finish = (result: OAuthCallbackResult) => {
+      clearTimeout(timeout);
+      server.close();
+      resolve(result);
+    };
+    const timeout = setTimeout(() => {
+      server.close();
+      reject(new Error("OAuth callback timed out (5 minutes)"));
+    }, timeoutMs);
 
-		server.on("connection", (socket) => {
-			let buffer = "";
+    server.on("connection", (socket) => {
+      let buffer = "";
 
-			socket.on("data", (chunk) => {
-				buffer += chunk.toString();
-				const params = extractCallbackParams(buffer);
-				if (!params) return;
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString();
+        const params = extractCallbackParams(buffer);
+        if (!params) return;
 
-				const { response, result } = resolveCallbackResult(params, state);
-				writeHtmlResponse(socket, response.statusLine, response.html);
-				socket.end();
-				finish(result);
-			});
+        const { response, result } = resolveCallbackResult(params, state);
+        writeHtmlResponse(socket, response.statusLine, response.html);
+        socket.end();
+        finish(result);
+      });
 
-			socket.on("error", () => {});
-		});
+      socket.on("error", () => {});
+    });
 
-		server.on("error", (err: NodeJS.ErrnoException) => {
-			clearTimeout(timeout);
-			reject(new Error(`Callback server error: ${err.message}`));
-		});
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      clearTimeout(timeout);
+      reject(new Error(`Callback server error: ${err.message}`));
+    });
 
-		server.listen(port, "127.0.0.1", () => {});
-	});
+    server.listen(port, "127.0.0.1", () => {});
+  });
 
-	return { port, result: resultPromise };
+  return { port, result: resultPromise };
 }
 
 // =============================================================================
@@ -201,31 +201,31 @@ async function startOAuthCallbackServer(
 // =============================================================================
 
 interface ClientRegistration {
-	client_id: string;
-	client_secret?: string;
+  client_id: string;
+  client_secret?: string;
 }
 
 async function registerClient(redirectUri: string): Promise<ClientRegistration> {
-	const response = await fetch("https://mcp.notion.com/register", {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			redirect_uris: [redirectUri],
-			token_endpoint_auth_method: "client_secret_post",
-			grant_types: ["authorization_code", "refresh_token"],
-			response_types: ["code"],
-			client_name: "pi-notion",
-		}),
-	});
+  const response = await fetch("https://mcp.notion.com/register", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_method: "client_secret_post",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      client_name: "pi-notion",
+    }),
+  });
 
-	if (!response.ok) {
-		const error = await response.text();
-		throw new Error(`Client registration failed: ${response.status} - ${error}`);
-	}
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Client registration failed: ${response.status} - ${error}`);
+  }
 
-	return (await response.json()) as ClientRegistration;
+  return (await response.json()) as ClientRegistration;
 }
 
 // =============================================================================
@@ -233,91 +233,91 @@ async function registerClient(redirectUri: string): Promise<ClientRegistration> 
 // =============================================================================
 
 async function exchangeCodeForToken(
-	code: string,
-	redirectUri: string,
-	codeVerifier: string,
-	clientId: string,
-	clientSecret?: string,
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+  clientId: string,
+  clientSecret?: string,
 ): Promise<{ accessToken: string }> {
-	const params: Record<string, string> = {
-		grant_type: "authorization_code",
-		client_id: clientId,
-		code,
-		redirect_uri: redirectUri,
-		code_verifier: codeVerifier,
-	};
-	if (clientSecret) {
-		params.client_secret = clientSecret;
-	}
-	const body = new URLSearchParams(params);
-	const response = await fetch("https://mcp.notion.com/token", {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-		},
-		body: body.toString(),
-	});
+  const params: Record<string, string> = {
+    grant_type: "authorization_code",
+    client_id: clientId,
+    code,
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+  };
+  if (clientSecret) {
+    params.client_secret = clientSecret;
+  }
+  const body = new URLSearchParams(params);
+  const response = await fetch("https://mcp.notion.com/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+  });
 
-	if (!response.ok) {
-		const error = await response.text();
-		throw new Error(`Token exchange failed: ${response.status} - ${error}`);
-	}
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Token exchange failed: ${response.status} - ${error}`);
+  }
 
-	const data = (await response.json()) as { access_token: string };
-	return { accessToken: data.access_token };
+  const data = (await response.json()) as { access_token: string };
+  return { accessToken: data.access_token };
 }
 
 function createPkceChallenge(): { codeVerifier: string; codeChallenge: string } {
-	const codeVerifier = randomBytes(32).toString("base64url");
-	const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
-	return { codeVerifier, codeChallenge };
+  const codeVerifier = randomBytes(32).toString("base64url");
+  const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+  return { codeVerifier, codeChallenge };
 }
 
 function buildAuthorizationUrl(
-	registration: ClientRegistration,
-	callbackUrl: string,
-	codeChallenge: string,
-	state: string,
+  registration: ClientRegistration,
+  callbackUrl: string,
+  codeChallenge: string,
+  state: string,
 ): string {
-	const authUrl = new URL("https://mcp.notion.com/authorize");
-	authUrl.searchParams.set("response_type", "code");
-	authUrl.searchParams.set("client_id", registration.client_id);
-	authUrl.searchParams.set("redirect_uri", callbackUrl);
-	authUrl.searchParams.set("code_challenge", codeChallenge);
-	authUrl.searchParams.set("code_challenge_method", "S256");
-	authUrl.searchParams.set("state", state);
-	authUrl.searchParams.set("prompt", "consent");
-	return authUrl.toString();
+  const authUrl = new URL("https://mcp.notion.com/authorize");
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", registration.client_id);
+  authUrl.searchParams.set("redirect_uri", callbackUrl);
+  authUrl.searchParams.set("code_challenge", codeChallenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("prompt", "consent");
+  return authUrl.toString();
 }
 
 async function resolveAccessToken(
-	callbackResult: OAuthCallbackResult,
-	callbackUrl: string,
-	codeVerifier: string,
-	registration: ClientRegistration,
-	notify: NotifyFn,
+  callbackResult: OAuthCallbackResult,
+  callbackUrl: string,
+  codeVerifier: string,
+  registration: ClientRegistration,
+  notify: NotifyFn,
 ): Promise<string> {
-	if (callbackResult.error) {
-		throw new Error(`Authorization failed: ${callbackResult.error}`);
-	}
+  if (callbackResult.error) {
+    throw new Error(`Authorization failed: ${callbackResult.error}`);
+  }
 
-	if (callbackResult.accessToken) {
-		return callbackResult.accessToken;
-	}
+  if (callbackResult.accessToken) {
+    return callbackResult.accessToken;
+  }
 
-	if (!callbackResult.code) {
-		throw new Error("No authorization code received");
-	}
+  if (!callbackResult.code) {
+    throw new Error("No authorization code received");
+  }
 
-	notify("Exchanging authorization code for token...");
-	const tokenResult = await exchangeCodeForToken(
-		callbackResult.code,
-		callbackUrl,
-		codeVerifier,
-		registration.client_id,
-		registration.client_secret,
-	);
-	return tokenResult.accessToken;
+  notify("Exchanging authorization code for token...");
+  const tokenResult = await exchangeCodeForToken(
+    callbackResult.code,
+    callbackUrl,
+    codeVerifier,
+    registration.client_id,
+    registration.client_secret,
+  );
+  return tokenResult.accessToken;
 }
 
 // =============================================================================
@@ -325,201 +325,201 @@ async function resolveAccessToken(
 // =============================================================================
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isNumericString(value: unknown): value is string {
-	return typeof value === "string" && value.trim() !== "" && !Number.isNaN(Number(value));
+  return typeof value === "string" && value.trim() !== "" && !Number.isNaN(Number(value));
 }
 
 function coercePropertyMap(properties: Record<string, unknown>): Record<string, unknown> {
-	return Object.fromEntries(
-		Object.entries(properties).map(([propName, propValue]) => [
-			propName,
-			isNumericString(propValue) ? Number(propValue) : coerceNumericProperties(propValue),
-		]),
-	);
+  return Object.fromEntries(
+    Object.entries(properties).map(([propName, propValue]) => [
+      propName,
+      isNumericString(propValue) ? Number(propValue) : coerceNumericProperties(propValue),
+    ]),
+  );
 }
 
 function coerceNumericProperties(obj: unknown): unknown {
-	if (obj === null || obj === undefined) return obj;
-	if (Array.isArray(obj)) return obj.map(coerceNumericProperties);
-	if (!isRecord(obj)) return obj;
+  if (obj === null || obj === undefined) return obj;
+  if (Array.isArray(obj)) return obj.map(coerceNumericProperties);
+  if (!isRecord(obj)) return obj;
 
-	return Object.fromEntries(
-		Object.entries(obj).map(([key, value]) => [
-			key,
-			key === "properties" && isRecord(value) ? coercePropertyMap(value) : coerceNumericProperties(value),
-		]),
-	);
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [
+      key,
+      key === "properties" && isRecord(value) ? coercePropertyMap(value) : coerceNumericProperties(value),
+    ]),
+  );
 }
 
 class NotionMCPClient {
-	state: MCPClientState = {
-		connected: false,
-		authenticated: false,
-		sessionId: null,
-		accessToken: null,
-		mcpUrl: null,
-	};
+  state: MCPClientState = {
+    connected: false,
+    authenticated: false,
+    sessionId: null,
+    accessToken: null,
+    mcpUrl: null,
+  };
 
-	private messageId = 0;
-	private sessionId: string | null = null;
-	private _accessToken: string | null = null;
-	private _tools: MCPTool[] = [];
+  private messageId = 0;
+  private sessionId: string | null = null;
+  private _accessToken: string | null = null;
+  private _tools: MCPTool[] = [];
 
-	async connect(mcpUrl: string, accessToken: string): Promise<void> {
-		this._accessToken = accessToken;
-		this.state.accessToken = accessToken;
-		this.state.mcpUrl = mcpUrl;
-		this.state.authenticated = true;
+  async connect(mcpUrl: string, accessToken: string): Promise<void> {
+    this._accessToken = accessToken;
+    this.state.accessToken = accessToken;
+    this.state.mcpUrl = mcpUrl;
+    this.state.authenticated = true;
 
-		// Initialize MCP connection (session ID captured from response header in sendRequest)
-		await this.sendRequest(mcpUrl, "initialize", {
-			protocolVersion: "2024-11-05",
-			capabilities: {},
-			clientInfo: { name: "pi-notion", version: "1.0.0" },
-		});
+    // Initialize MCP connection (session ID captured from response header in sendRequest)
+    await this.sendRequest(mcpUrl, "initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "pi-notion", version: "1.0.0" },
+    });
 
-		// If server didn't return a session ID, generate one locally
-		if (!this.sessionId) {
-			this.sessionId = randomBytes(16).toString("hex");
-			this.state.sessionId = this.sessionId;
-		}
-		this.state.connected = true;
+    // If server didn't return a session ID, generate one locally
+    if (!this.sessionId) {
+      this.sessionId = randomBytes(16).toString("hex");
+      this.state.sessionId = this.sessionId;
+    }
+    this.state.connected = true;
 
-		// Discover tools
-		await this.discoverTools(mcpUrl);
+    // Discover tools
+    await this.discoverTools(mcpUrl);
 
-		// Send initialized notification
-		await this.sendNotification(mcpUrl, "initialized", {});
-	}
+    // Send initialized notification
+    await this.sendNotification(mcpUrl, "initialized", {});
+  }
 
-	async disconnect(): Promise<void> {
-		if (this.sessionId && this.state.mcpUrl) {
-			try {
-				await fetch(`${this.state.mcpUrl}/${this.sessionId}`, {
-					method: "DELETE",
-					headers: {
-						"Content-Type": "application/json",
-						Authorization: this._accessToken ? `Bearer ${this._accessToken}` : "",
-					},
-				});
-			} catch {
-				// Ignore errors on disconnect
-			}
-		}
-		this.state = {
-			connected: false,
-			authenticated: false,
-			sessionId: null,
-			accessToken: null,
-			mcpUrl: null,
-		};
-		this.sessionId = null;
-		this._accessToken = null;
-		this._tools = [];
-	}
+  async disconnect(): Promise<void> {
+    if (this.sessionId && this.state.mcpUrl) {
+      try {
+        await fetch(`${this.state.mcpUrl}/${this.sessionId}`, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: this._accessToken ? `Bearer ${this._accessToken}` : "",
+          },
+        });
+      } catch {
+        // Ignore errors on disconnect
+      }
+    }
+    this.state = {
+      connected: false,
+      authenticated: false,
+      sessionId: null,
+      accessToken: null,
+      mcpUrl: null,
+    };
+    this.sessionId = null;
+    this._accessToken = null;
+    this._tools = [];
+  }
 
-	private getHeaders(): Record<string, string> {
-		const headers: Record<string, string> = {
-			"Content-Type": "application/json",
-			Accept: "application/json, text/event-stream",
-		};
-		if (this.sessionId) {
-			headers["MCP-Session-Id"] = this.sessionId;
-		}
-		if (this._accessToken) {
-			headers.Authorization = `Bearer ${this._accessToken}`;
-		}
-		return headers;
-	}
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    };
+    if (this.sessionId) {
+      headers["MCP-Session-Id"] = this.sessionId;
+    }
+    if (this._accessToken) {
+      headers.Authorization = `Bearer ${this._accessToken}`;
+    }
+    return headers;
+  }
 
-	private async sendRequest(mcpUrl: string, method: string, params: Record<string, unknown>): Promise<unknown> {
-		const id = ++this.messageId;
-		const request = { jsonrpc: "2.0", id, method, params };
+  private async sendRequest(mcpUrl: string, method: string, params: Record<string, unknown>): Promise<unknown> {
+    const id = ++this.messageId;
+    const request = { jsonrpc: "2.0", id, method, params };
 
-		const response = await fetch(mcpUrl, {
-			method: "POST",
-			headers: this.getHeaders(),
-			body: JSON.stringify(request),
-		});
+    const response = await fetch(mcpUrl, {
+      method: "POST",
+      headers: this.getHeaders(),
+      body: JSON.stringify(request),
+    });
 
-		if (!response.ok) {
-			const errorText = await response.text();
-			throw new Error(`HTTP ${response.status}: ${errorText}`);
-		}
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
+    }
 
-		// Capture session ID from response headers
-		const sessionHeader = response.headers.get("mcp-session-id");
-		if (sessionHeader) {
-			this.sessionId = sessionHeader;
-			this.state.sessionId = sessionHeader;
-		}
+    // Capture session ID from response headers
+    const sessionHeader = response.headers.get("mcp-session-id");
+    if (sessionHeader) {
+      this.sessionId = sessionHeader;
+      this.state.sessionId = sessionHeader;
+    }
 
-		const contentType = response.headers.get("content-type") || "";
-		const data: { result?: unknown; error?: { message: string } } = contentType.includes("text/event-stream")
-			? await this.parseSSEResponse(response)
-			: await response.json();
+    const contentType = response.headers.get("content-type") || "";
+    const data: { result?: unknown; error?: { message: string } } = contentType.includes("text/event-stream")
+      ? await this.parseSSEResponse(response)
+      : await response.json();
 
-		if (data.error) {
-			throw new Error(`MCP Error: ${data.error.message}`);
-		}
-		return data.result;
-	}
+    if (data.error) {
+      throw new Error(`MCP Error: ${data.error.message}`);
+    }
+    return data.result;
+  }
 
-	private async parseSSEResponse(response: Response): Promise<{ result?: unknown; error?: { message: string } }> {
-		const text = await response.text();
-		const lines = text.split("\n");
-		for (const line of lines) {
-			if (line.startsWith("data: ")) {
-				const jsonStr = line.slice(6).trim();
-				if (jsonStr) {
-					return JSON.parse(jsonStr);
-				}
-			}
-		}
-		throw new Error("No data found in SSE response");
-	}
+  private async parseSSEResponse(response: Response): Promise<{ result?: unknown; error?: { message: string } }> {
+    const text = await response.text();
+    const lines = text.split("\n");
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const jsonStr = line.slice(6).trim();
+        if (jsonStr) {
+          return JSON.parse(jsonStr);
+        }
+      }
+    }
+    throw new Error("No data found in SSE response");
+  }
 
-	private async sendNotification(mcpUrl: string, method: string, params: Record<string, unknown>): Promise<void> {
-		const notification = { jsonrpc: "2.0", method, params };
-		await fetch(mcpUrl, {
-			method: "POST",
-			headers: this.getHeaders(),
-			body: JSON.stringify(notification),
-		});
-	}
+  private async sendNotification(mcpUrl: string, method: string, params: Record<string, unknown>): Promise<void> {
+    const notification = { jsonrpc: "2.0", method, params };
+    await fetch(mcpUrl, {
+      method: "POST",
+      headers: this.getHeaders(),
+      body: JSON.stringify(notification),
+    });
+  }
 
-	private async discoverTools(mcpUrl: string): Promise<void> {
-		try {
-			const result = await this.sendRequest(mcpUrl, "tools/list", {});
-			const tools = (result as { tools?: MCPTool[] })?.tools || [];
-			this._tools = tools.map((tool) => ({
-				name: tool.name,
-				description: tool.description || "",
-				inputSchema: (tool.inputSchema as Record<string, unknown>) || {},
-			}));
-		} catch {
-			this._tools = [];
-		}
-	}
+  private async discoverTools(mcpUrl: string): Promise<void> {
+    try {
+      const result = await this.sendRequest(mcpUrl, "tools/list", {});
+      const tools = (result as { tools?: MCPTool[] })?.tools || [];
+      this._tools = tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description || "",
+        inputSchema: (tool.inputSchema as Record<string, unknown>) || {},
+      }));
+    } catch {
+      this._tools = [];
+    }
+  }
 
-	async callTool(mcpUrl: string, name: string, args: Record<string, unknown>): Promise<string> {
-		const coerced = coerceNumericProperties(args);
-		const result = await this.sendRequest(mcpUrl, "tools/call", { name, arguments: coerced });
+  async callTool(mcpUrl: string, name: string, args: Record<string, unknown>): Promise<string> {
+    const coerced = coerceNumericProperties(args);
+    const result = await this.sendRequest(mcpUrl, "tools/call", { name, arguments: coerced });
 
-		// Format result
-		const content = (result as { content?: Array<{ type: string; text?: string }> })?.content;
-		if (content && Array.isArray(content)) {
-			return content.map((c) => (c.type === "text" ? c.text : JSON.stringify(c))).join("\n");
-		}
-		return JSON.stringify(result);
-	}
+    // Format result
+    const content = (result as { content?: Array<{ type: string; text?: string }> })?.content;
+    if (content && Array.isArray(content)) {
+      return content.map((c) => (c.type === "text" ? c.text : JSON.stringify(c))).join("\n");
+    }
+    return JSON.stringify(result);
+  }
 
-	getTools(): MCPTool[] {
-		return this._tools;
-	}
+  getTools(): MCPTool[] {
+    return this._tools;
+  }
 }
 
 // =============================================================================
@@ -527,50 +527,50 @@ class NotionMCPClient {
 // =============================================================================
 
 interface StoredConfig {
-	mcpUrl: string;
-	accessToken: string;
-	clientId?: string;
-	clientSecret?: string;
+  mcpUrl: string;
+  accessToken: string;
+  clientId?: string;
+  clientSecret?: string;
 }
 
 class FileTokenStorage {
-	private path: string;
+  private path: string;
 
-	constructor() {
-		const configDir = join(homedir(), ".pi", "agent", "extensions");
-		this.path = join(configDir, "notion-mcp.json");
-	}
+  constructor() {
+    const configDir = join(homedir(), ".pi", "agent", "extensions");
+    this.path = join(configDir, "notion-mcp.json");
+  }
 
-	async save(config: StoredConfig): Promise<void> {
-		try {
-			mkdirSync(dirname(this.path), { recursive: true });
-			writeFileSync(this.path, JSON.stringify(config, null, 2), "utf-8");
-		} catch (error) {
-			console.error("Failed to save config:", error);
-		}
-	}
+  async save(config: StoredConfig): Promise<void> {
+    try {
+      mkdirSync(dirname(this.path), { recursive: true });
+      writeFileSync(this.path, JSON.stringify(config, null, 2), "utf-8");
+    } catch (error) {
+      console.error("Failed to save config:", error);
+    }
+  }
 
-	async load(): Promise<StoredConfig | null> {
-		if (!existsSync(this.path)) {
-			return null;
-		}
-		try {
-			return JSON.parse(readFileSync(this.path, "utf-8")) as StoredConfig;
-		} catch {
-			return null;
-		}
-	}
+  async load(): Promise<StoredConfig | null> {
+    if (!existsSync(this.path)) {
+      return null;
+    }
+    try {
+      return JSON.parse(readFileSync(this.path, "utf-8")) as StoredConfig;
+    } catch {
+      return null;
+    }
+  }
 
-	async clear(): Promise<void> {
-		if (existsSync(this.path)) {
-			try {
-				const { unlinkSync } = await import("node:fs");
-				unlinkSync(this.path);
-			} catch {
-				// Ignore
-			}
-		}
-	}
+  async clear(): Promise<void> {
+    if (existsSync(this.path)) {
+      try {
+        const { unlinkSync } = await import("node:fs");
+        unlinkSync(this.path);
+      } catch {
+        // Ignore
+      }
+    }
+  }
 }
 
 // =============================================================================
@@ -581,43 +581,43 @@ let mcpClient: NotionMCPClient | null = null;
 const storage = new FileTokenStorage();
 
 async function openBrowser(url: string): Promise<void> {
-	const { exec } = await import("node:child_process");
-	const platform = process.platform;
-	const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
-	exec(`${cmd} "${url}"`);
+  const { exec } = await import("node:child_process");
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+  exec(`${cmd} "${url}"`);
 }
 
 function createUiNotifier(pi: ExtensionAPI): NotifyFn {
-	return (message, type = "info") => {
-		try {
-			pi.events.emit("ui:notify", { message, type });
-		} catch {
-			console.log(`[pi-notion] ${message}`);
-		}
-	};
+  return (message, type = "info") => {
+    try {
+      pi.events.emit("ui:notify", { message, type });
+    } catch {
+      console.log(`[pi-notion] ${message}`);
+    }
+  };
 }
 
 function toolResult(tool: string, text: string, details: Record<string, unknown> = {}): ToolExecutionResult {
-	return {
-		content: [{ type: "text", text }],
-		details: { tool, ...details },
-	};
+  return {
+    content: [{ type: "text", text }],
+    details: { tool, ...details },
+  };
 }
 
 function toolError(tool: string, text: string, details: Record<string, unknown> = {}): ToolExecutionResult {
-	return {
-		content: [{ type: "text", text }],
-		isError: true,
-		details: { tool, ...details },
-	};
+  return {
+    content: [{ type: "text", text }],
+    isError: true,
+    details: { tool, ...details },
+  };
 }
 
 function getConnectionStatusText(client: NotionMCPClient): string {
-	const { connected, sessionId, mcpUrl } = client.state;
-	const tools = client.getTools();
-	const toolList = tools.length > 0 ? `\n\nAvailable tools:\n${tools.map((t) => `- ${t.name}`).join("\n")}` : "";
+  const { connected, sessionId, mcpUrl } = client.state;
+  const tools = client.getTools();
+  const toolList = tools.length > 0 ? `\n\nAvailable tools:\n${tools.map((t) => `- ${t.name}`).join("\n")}` : "";
 
-	return `Notion MCP Status:
+  return `Notion MCP Status:
 - Connected: ${connected ? "Yes" : "No"}
 - URL: ${mcpUrl || "None"}
 - Session: ${sessionId ? `${sessionId.slice(0, 8)}...` : "None"}
@@ -626,242 +626,268 @@ ${!connected ? "\nRun /notion to connect." : ""}`;
 }
 
 function getConnectedStatusMessage(client: NotionMCPClient): string {
-	const { sessionId, mcpUrl } = client.state;
-	const tools = client.getTools();
-	return `Connected to Notion MCP
+  const { sessionId, mcpUrl } = client.state;
+  const tools = client.getTools();
+  return `Connected to Notion MCP
 URL: ${mcpUrl}
 Session: ${sessionId?.slice(0, 8)}...
 Tools: ${tools.length} available`;
 }
 
 function createRegisteredToolExecutor(
-	client: NotionMCPClient,
-	mcpUrl: string,
-	tool: MCPTool,
+  client: NotionMCPClient,
+  mcpUrl: string,
+  tool: MCPTool,
 ): (
-	_toolCallId: string,
-	params: unknown,
-	_signal: AbortSignal,
-	_onUpdate: unknown,
-	_ctx: unknown,
+  _toolCallId: string,
+  params: unknown,
+  _signal: AbortSignal,
+  _onUpdate: unknown,
+  _ctx: unknown,
 ) => Promise<ToolExecutionResult> {
-	return async (_toolCallId, params) => {
-		if (!client.state.connected) {
-			return toolError(tool.name, "Not connected to Notion MCP. Run /notion to connect.", { tool: tool.name });
-		}
+  return async (_toolCallId, params) => {
+    if (!client.state.connected) {
+      return toolError(tool.name, "Not connected to Notion MCP. Run /notion to connect.", { tool: tool.name });
+    }
 
-		try {
-			const result = await client.callTool(mcpUrl, tool.name, params as Record<string, unknown>);
-			return toolResult(tool.name, result || "", { tool: tool.name });
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			return toolError(tool.name, `Error: ${message}`, { tool: tool.name, error: message });
-		}
-	};
+    try {
+      const result = await client.callTool(mcpUrl, tool.name, params as Record<string, unknown>);
+      return toolResult(tool.name, result || "", { tool: tool.name });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return toolError(tool.name, `Error: ${message}`, { tool: tool.name, error: message });
+    }
+  };
 }
 
 interface OAuthConnectionData {
-	accessToken: string;
-	registration: ClientRegistration;
+  accessToken: string;
+  registration: ClientRegistration;
 }
 
 async function connectWithSavedConfig(client: NotionMCPClient, notify: NotifyFn): Promise<boolean> {
-	const savedConfig = await storage.load();
-	if (!savedConfig) return false;
+  const savedConfig = await storage.load();
+  if (!savedConfig) return false;
 
-	notify("Connecting to saved Notion MCP...");
-	try {
-		await client.connect(savedConfig.mcpUrl, savedConfig.accessToken);
-		return true;
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		notify(`Connection failed: ${message}`, "error");
-		await storage.clear();
-		return false;
-	}
+  notify("Connecting to saved Notion MCP...");
+  try {
+    await client.connect(savedConfig.mcpUrl, savedConfig.accessToken);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    notify(`Connection failed: ${message}`, "error");
+    await storage.clear();
+    return false;
+  }
 }
 
 async function performOAuthConnection(notify: NotifyFn): Promise<OAuthConnectionData> {
-	const state = randomBytes(16).toString("hex");
-	const callbackServer = await startOAuthCallbackServer(3000, state);
-	const callbackUrl = `http://localhost:${callbackServer.port}/callback`;
+  const state = randomBytes(16).toString("hex");
+  const callbackServer = await startOAuthCallbackServer(3000, state);
+  const callbackUrl = `http://localhost:${callbackServer.port}/callback`;
 
-	notify("Registering OAuth client...");
-	const registration = await registerClient(callbackUrl);
-	const { codeVerifier, codeChallenge } = createPkceChallenge();
-	const authUrl = buildAuthorizationUrl(registration, callbackUrl, codeChallenge, state);
+  notify("Registering OAuth client...");
+  const registration = await registerClient(callbackUrl);
+  const { codeVerifier, codeChallenge } = createPkceChallenge();
+  const authUrl = buildAuthorizationUrl(registration, callbackUrl, codeChallenge, state);
 
-	notify("Opening Notion authorization page...");
-	await openBrowser(authUrl);
-	notify("Waiting for authorization callback...");
+  notify("Opening Notion authorization page...");
+  await openBrowser(authUrl);
+  notify("Waiting for authorization callback...");
 
-	const callbackResult = await callbackServer.result;
-	const accessToken = await resolveAccessToken(callbackResult, callbackUrl, codeVerifier, registration, notify);
-	return { accessToken, registration };
+  const callbackResult = await callbackServer.result;
+  const accessToken = await resolveAccessToken(callbackResult, callbackUrl, codeVerifier, registration, notify);
+  return { accessToken, registration };
 }
 
 async function finalizeConnection(
-	client: NotionMCPClient,
-	registration: ClientRegistration | null,
-	accessToken: string,
-	registerMCPTools: () => void,
-	notify: NotifyFn,
+  client: NotionMCPClient,
+  registration: ClientRegistration | null,
+  accessToken: string,
+  registerMCPTools: () => void,
+  notify: NotifyFn,
 ): Promise<void> {
-	notify("Connecting to MCP server...");
-	await client.connect(NOTION_MCP_URL, accessToken);
-	await storage.save({
-		mcpUrl: NOTION_MCP_URL,
-		accessToken,
-		clientId: registration?.client_id,
-		clientSecret: registration?.client_secret,
-	});
-	registerMCPTools();
+  notify("Connecting to MCP server...");
+  await client.connect(NOTION_MCP_URL, accessToken);
+  await storage.save({
+    mcpUrl: NOTION_MCP_URL,
+    accessToken,
+    clientId: registration?.client_id,
+    clientSecret: registration?.client_secret,
+  });
+  registerMCPTools();
 }
 
 async function ensureConnected(
-	client: NotionMCPClient,
-	registerMCPTools: () => void,
-	notify: NotifyFn,
+  client: NotionMCPClient,
+  registerMCPTools: () => void,
+  notify: NotifyFn,
 ): Promise<{ reusedSavedConfig: boolean }> {
-	const connectedFromSavedConfig = await connectWithSavedConfig(client, notify);
-	if (connectedFromSavedConfig) {
-		registerMCPTools();
-		return { reusedSavedConfig: true };
-	}
+  const connectedFromSavedConfig = await connectWithSavedConfig(client, notify);
+  if (connectedFromSavedConfig) {
+    registerMCPTools();
+    return { reusedSavedConfig: true };
+  }
 
-	const { accessToken, registration } = await performOAuthConnection(notify);
-	await finalizeConnection(client, registration, accessToken, registerMCPTools, notify);
-	return { reusedSavedConfig: false };
+  const { accessToken, registration } = await performOAuthConnection(notify);
+  await finalizeConnection(client, registration, accessToken, registerMCPTools, notify);
+  return { reusedSavedConfig: false };
 }
 
 async function disconnectClient(client: NotionMCPClient): Promise<void> {
-	await client.disconnect();
-	await storage.clear();
+  await client.disconnect();
+  await storage.clear();
 }
 
+export {
+  buildHtmlResponse,
+  buildAuthorizationUrl,
+  coerceNumericProperties,
+  coercePropertyMap,
+  createPkceChallenge,
+  createRegisteredToolExecutor,
+  FileTokenStorage,
+  getConnectedStatusMessage,
+  getConnectionStatusText,
+  isNumericString,
+  isRecord,
+  NotionMCPClient,
+  resolveAccessToken,
+  resolveCallbackResult,
+  startOAuthCallbackServer,
+  storage,
+  toolError,
+  toolResult,
+  connectWithSavedConfig,
+  createUiNotifier,
+  disconnectClient,
+  ensureConnected,
+  finalizeConnection,
+};
+
 export default function notionMCPClientExtension(pi: ExtensionAPI) {
-	mcpClient = new NotionMCPClient();
-	const notify = createUiNotifier(pi);
+  mcpClient = new NotionMCPClient();
+  const notify = createUiNotifier(pi);
 
-	// Register dynamic MCP tools after connection
-	const registerMCPTools = () => {
-		if (!mcpClient?.state.mcpUrl) return;
+  // Register dynamic MCP tools after connection
+  const registerMCPTools = () => {
+    if (!mcpClient?.state.mcpUrl) return;
 
-		const tools = mcpClient.getTools();
-		const mcpUrl = mcpClient.state.mcpUrl;
+    const tools = mcpClient.getTools();
+    const mcpUrl = mcpClient.state.mcpUrl;
 
-		for (const tool of tools) {
-			if (pi.getAllTools().find((t) => t.name === tool.name)) continue;
+    for (const tool of tools) {
+      if (pi.getAllTools().find((t) => t.name === tool.name)) continue;
 
-			pi.registerTool({
-				name: tool.name,
-				label: `Notion: ${tool.name.replace(/_/g, " ")}`,
-				description: tool.description || `Notion MCP tool: ${tool.name}`,
-				parameters: Type.Unsafe(tool.inputSchema),
-				execute: createRegisteredToolExecutor(mcpClient, mcpUrl, tool),
-			});
-		}
+      pi.registerTool({
+        name: tool.name,
+        label: `Notion: ${tool.name.replace(/_/g, " ")}`,
+        description: tool.description || `Notion MCP tool: ${tool.name}`,
+        parameters: Type.Unsafe(tool.inputSchema),
+        execute: createRegisteredToolExecutor(mcpClient, mcpUrl, tool),
+      });
+    }
 
-		if (tools.length > 0) {
-			notify(`Registered ${tools.length} Notion MCP tools!`);
-		}
-	};
+    if (tools.length > 0) {
+      notify(`Registered ${tools.length} Notion MCP tools!`);
+    }
+  };
 
-	// /notion command
-	pi.registerCommand("notion", {
-		description: "Connect to Notion MCP, show status, or disconnect",
-		async handler(_args, ctx) {
-			if (!mcpClient) {
-				ctx.ui.notify("Notion MCP not initialized", "error");
-				return;
-			}
+  // /notion command
+  pi.registerCommand("notion", {
+    description: "Connect to Notion MCP, show status, or disconnect",
+    async handler(_args, ctx) {
+      if (!mcpClient) {
+        ctx.ui.notify("Notion MCP not initialized", "error");
+        return;
+      }
 
-			if (!mcpClient.state.connected) {
-				const uiNotify: NotifyFn = (message, type = "info") => ctx.ui.notify(message, type);
-				try {
-					await ensureConnected(mcpClient, registerMCPTools, uiNotify);
-					ctx.ui.notify(`Connected! Session: ${mcpClient.state.sessionId?.slice(0, 8)}...`, "info");
-				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					ctx.ui.notify(`Connection failed: ${message}`, "error");
-				}
-				return;
-			}
+      if (!mcpClient.state.connected) {
+        const uiNotify: NotifyFn = (message, type = "info") => ctx.ui.notify(message, type);
+        try {
+          await ensureConnected(mcpClient, registerMCPTools, uiNotify);
+          ctx.ui.notify(`Connected! Session: ${mcpClient.state.sessionId?.slice(0, 8)}...`, "info");
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          ctx.ui.notify(`Connection failed: ${message}`, "error");
+        }
+        return;
+      }
 
-			const choice = await ctx.ui.select(getConnectedStatusMessage(mcpClient), ["Disconnect", "Cancel"]);
-			if (choice === "Disconnect") {
-				await disconnectClient(mcpClient);
-				ctx.ui.notify("Disconnected from Notion MCP", "info");
-			}
-		},
-	});
+      const choice = await ctx.ui.select(getConnectedStatusMessage(mcpClient), ["Disconnect", "Cancel"]);
+      if (choice === "Disconnect") {
+        await disconnectClient(mcpClient);
+        ctx.ui.notify("Disconnected from Notion MCP", "info");
+      }
+    },
+  });
 
-	// Connect tool
-	pi.registerTool({
-		name: "notion_mcp_connect",
-		label: "Notion MCP Connect",
-		description: "Connect to Notion via the official MCP server using OAuth",
-		parameters: Type.Object({}),
-		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
-			if (!mcpClient) {
-				return toolError("notion_mcp_connect", "MCP client not initialized");
-			}
+  // Connect tool
+  pi.registerTool({
+    name: "notion_mcp_connect",
+    label: "Notion MCP Connect",
+    description: "Connect to Notion via the official MCP server using OAuth",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+      if (!mcpClient) {
+        return toolError("notion_mcp_connect", "MCP client not initialized");
+      }
 
-			if (mcpClient.state.connected) {
-				const tools = mcpClient.getTools();
-				return toolResult(
-					"notion_mcp_connect",
-					`Already connected to Notion MCP!\n\n${tools.length} tools available: ${tools.map((t) => t.name).join(", ")}`,
-				);
-			}
+      if (mcpClient.state.connected) {
+        const tools = mcpClient.getTools();
+        return toolResult(
+          "notion_mcp_connect",
+          `Already connected to Notion MCP!\n\n${tools.length} tools available: ${tools.map((t) => t.name).join(", ")}`,
+        );
+      }
 
-			try {
-				await ensureConnected(mcpClient, registerMCPTools, notify);
-				const tools = mcpClient.getTools();
-				return toolResult(
-					"notion_mcp_connect",
-					`Connected to Notion MCP!\n\n${tools.length} tools available.\n\nYou can now ask things like:\n- "Search my Notion for meeting notes"\n- "Get page abc123"\n- "Create a page in my workspace"`,
-				);
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return toolError("notion_mcp_connect", `Connection failed: ${message}`, { error: message });
-			}
-		},
-	});
+      try {
+        await ensureConnected(mcpClient, registerMCPTools, notify);
+        const tools = mcpClient.getTools();
+        return toolResult(
+          "notion_mcp_connect",
+          `Connected to Notion MCP!\n\n${tools.length} tools available.\n\nYou can now ask things like:\n- "Search my Notion for meeting notes"\n- "Get page abc123"\n- "Create a page in my workspace"`,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return toolError("notion_mcp_connect", `Connection failed: ${message}`, { error: message });
+      }
+    },
+  });
 
-	// Disconnect tool
-	pi.registerTool({
-		name: "notion_mcp_disconnect",
-		label: "Notion MCP Disconnect",
-		description: "Disconnect from Notion MCP server and clear stored config",
-		parameters: Type.Object({}),
-		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
-			if (!mcpClient) {
-				return toolError("notion_mcp_disconnect", "MCP client not initialized");
-			}
+  // Disconnect tool
+  pi.registerTool({
+    name: "notion_mcp_disconnect",
+    label: "Notion MCP Disconnect",
+    description: "Disconnect from Notion MCP server and clear stored config",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+      if (!mcpClient) {
+        return toolError("notion_mcp_disconnect", "MCP client not initialized");
+      }
 
-			await disconnectClient(mcpClient);
-			return toolResult("notion_mcp_disconnect", "Disconnected from Notion MCP and cleared config");
-		},
-	});
+      await disconnectClient(mcpClient);
+      return toolResult("notion_mcp_disconnect", "Disconnected from Notion MCP and cleared config");
+    },
+  });
 
-	// Status tool
-	pi.registerTool({
-		name: "notion_mcp_status",
-		label: "Notion MCP Status",
-		description: "Check connection status to Notion MCP",
-		parameters: Type.Object({}),
-		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
-			if (!mcpClient) {
-				return toolError("notion_mcp_status", "MCP client not initialized");
-			}
+  // Status tool
+  pi.registerTool({
+    name: "notion_mcp_status",
+    label: "Notion MCP Status",
+    description: "Check connection status to Notion MCP",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+      if (!mcpClient) {
+        return toolError("notion_mcp_status", "MCP client not initialized");
+      }
 
-			const { connected, sessionId, mcpUrl } = mcpClient.state;
-			return toolResult("notion_mcp_status", getConnectionStatusText(mcpClient), {
-				connected,
-				sessionId,
-				mcpUrl,
-			});
-		},
-	});
+      const { connected, sessionId, mcpUrl } = mcpClient.state;
+      return toolResult("notion_mcp_status", getConnectionStatusText(mcpClient), {
+        connected,
+        sessionId,
+        mcpUrl,
+      });
+    },
+  });
 }

--- a/packages/pi-notion/extensions/oauth.ts
+++ b/packages/pi-notion/extensions/oauth.ts
@@ -14,25 +14,25 @@ import { getPort as lookupPort } from "portfinder";
 // =============================================================================
 
 export interface OAuthConfig {
-	clientId: string;
-	clientSecret: string;
-	redirectUri: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
 }
 
 export interface OAuthTokens {
-	accessToken: string;
-	refreshToken: string;
-	tokenType: string;
-	expiresAt: number;
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  expiresAt: number;
 }
 
 export interface OAuthUserInfo {
-	workspaceId: string;
-	workspaceName: string;
-	workspaceIcon?: string;
-	botId: string;
-	ownerEmail?: string;
-	ownerName?: string;
+  workspaceId: string;
+  workspaceName: string;
+  workspaceIcon?: string;
+  botId: string;
+  ownerEmail?: string;
+  ownerName?: string;
 }
 
 // =============================================================================
@@ -43,22 +43,22 @@ export interface OAuthUserInfo {
  * Generate a random code verifier for PKCE
  */
 export function generateCodeVerifier(): string {
-	return randomBytes(32).toString("base64url");
+  return randomBytes(32).toString("base64url");
 }
 
 /**
  * Generate code challenge from verifier using S256 method
  */
 export function generateCodeChallenge(verifier: string): string {
-	const hash = createHash("sha256").update(verifier).digest();
-	return hash.toString("base64url");
+  const hash = createHash("sha256").update(verifier).digest();
+  return hash.toString("base64url");
 }
 
 /**
  * Generate random state parameter for CSRF protection
  */
 export function generateState(): string {
-	return randomBytes(16).toString("hex");
+  return randomBytes(16).toString("hex");
 }
 
 // =============================================================================
@@ -68,17 +68,17 @@ export function generateState(): string {
 const NOTION_AUTH_URL = "https://api.notion.com/v1/oauth/authorize";
 
 export function buildAuthorizationUrl(config: OAuthConfig, codeChallenge: string, state: string): string {
-	const params = new URLSearchParams({
-		client_id: config.clientId,
-		redirect_uri: config.redirectUri,
-		response_type: "code",
-		owner: "user",
-		code_challenge: codeChallenge,
-		code_challenge_method: "S256",
-		state,
-	});
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    response_type: "code",
+    owner: "user",
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+  });
 
-	return `${NOTION_AUTH_URL}?${params.toString()}`;
+  return `${NOTION_AUTH_URL}?${params.toString()}`;
 }
 
 // =============================================================================
@@ -88,76 +88,76 @@ export function buildAuthorizationUrl(config: OAuthConfig, codeChallenge: string
 const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
 
 export async function exchangeCodeForTokens(
-	config: OAuthConfig,
-	code: string,
-	codeVerifier: string,
+  config: OAuthConfig,
+  code: string,
+  codeVerifier: string,
 ): Promise<OAuthTokens & { owner?: OAuthUserInfo }> {
-	const response = await axios.post(
-		NOTION_TOKEN_URL,
-		{
-			grant_type: "authorization_code",
-			code,
-			redirect_uri: config.redirectUri,
-			client_id: config.clientId,
-			client_secret: config.clientSecret,
-			code_verifier: codeVerifier,
-		},
-		{
-			headers: {
-				"Content-Type": "application/json",
-			},
-		},
-	);
+  const response = await axios.post(
+    NOTION_TOKEN_URL,
+    {
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: config.redirectUri,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      code_verifier: codeVerifier,
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
 
-	const data = response.data;
+  const data = response.data;
 
-	const tokens: OAuthTokens = {
-		accessToken: data.access_token,
-		refreshToken: data.refresh_token,
-		tokenType: data.token_type,
-		expiresAt: Date.now() + 3600 * 1000, // Notion tokens typically last 1 hour
-	};
+  const tokens: OAuthTokens = {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    tokenType: data.token_type,
+    expiresAt: Date.now() + 3600 * 1000, // Notion tokens typically last 1 hour
+  };
 
-	const result: OAuthTokens & { owner?: OAuthUserInfo } = { ...tokens };
+  const result: OAuthTokens & { owner?: OAuthUserInfo } = { ...tokens };
 
-	if (data.owner?.user) {
-		result.owner = {
-			workspaceId: data.workspace_id,
-			workspaceName: data.workspace_name,
-			workspaceIcon: data.workspace_icon,
-			botId: data.bot_id,
-			ownerEmail: data.owner.user.person?.email,
-			ownerName: data.owner.user.name,
-		};
-	}
+  if (data.owner?.user) {
+    result.owner = {
+      workspaceId: data.workspace_id,
+      workspaceName: data.workspace_name,
+      workspaceIcon: data.workspace_icon,
+      botId: data.bot_id,
+      ownerEmail: data.owner.user.person?.email,
+      ownerName: data.owner.user.name,
+    };
+  }
 
-	return result;
+  return result;
 }
 
 export async function refreshTokens(config: OAuthConfig, refreshToken: string): Promise<OAuthTokens> {
-	const response = await axios.post(
-		NOTION_TOKEN_URL,
-		{
-			grant_type: "refresh_token",
-			refresh_token: refreshToken,
-			client_id: config.clientId,
-			client_secret: config.clientSecret,
-		},
-		{
-			headers: {
-				"Content-Type": "application/json",
-			},
-		},
-	);
+  const response = await axios.post(
+    NOTION_TOKEN_URL,
+    {
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
 
-	const data = response.data;
+  const data = response.data;
 
-	return {
-		accessToken: data.access_token,
-		refreshToken: data.refresh_token || refreshToken, // Keep old if not provided
-		tokenType: data.token_type,
-		expiresAt: Date.now() + 3600 * 1000,
-	};
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token || refreshToken, // Keep old if not provided
+    tokenType: data.token_type,
+    expiresAt: Date.now() + 3600 * 1000,
+  };
 }
 
 // =============================================================================
@@ -165,166 +165,166 @@ export async function refreshTokens(config: OAuthConfig, refreshToken: string): 
 // =============================================================================
 
 interface CallbackResult {
-	code: string;
-	state: string;
-	error?: string;
+  code: string;
+  state: string;
+  error?: string;
 }
 
 const CALLBACK_REQUEST_PREFIX = "GET /callback?";
 const HTTP_REQUEST_COMPLETE_MARKER = "\r\n\r\n";
 
-function parseQueryParams(url: string): Record<string, string> {
-	const urlObj = new URL(url);
-	const params: Record<string, string> = {};
-	urlObj.searchParams.forEach((value, key) => {
-		params[key] = value;
-	});
-	return params;
+export function parseQueryParams(url: string): Record<string, string> {
+  const urlObj = new URL(url, "http://localhost");
+  const params: Record<string, string> = {};
+  urlObj.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return params;
 }
 
-function writeHtmlResponse(socket: NodeJS.WritableStream, statusLine: string, html: string): void {
-	socket.write(`${statusLine}\r\n`);
-	socket.write(`Content-Length: ${html.length}\r\n`);
-	socket.write("Content-Type: text/html\r\n\r\n");
-	socket.write(html);
+export function writeHtmlResponse(socket: NodeJS.WritableStream, statusLine: string, html: string): void {
+  socket.write(`${statusLine}\r\n`);
+  socket.write(`Content-Length: ${html.length}\r\n`);
+  socket.write("Content-Type: text/html\r\n\r\n");
+  socket.write(html);
 }
 
-function extractCallbackParams(buffer: string): Record<string, string> | null {
-	if (!buffer.includes(HTTP_REQUEST_COMPLETE_MARKER)) return null;
+export function extractCallbackParams(buffer: string): Record<string, string> | null {
+  if (!buffer.includes(HTTP_REQUEST_COMPLETE_MARKER)) return null;
 
-	const requestLine = buffer.split("\r\n", 1)[0] ?? "";
-	if (!requestLine.startsWith(CALLBACK_REQUEST_PREFIX)) return null;
+  const requestLine = buffer.split("\r\n", 1)[0] ?? "";
+  if (!requestLine.startsWith(CALLBACK_REQUEST_PREFIX)) return null;
 
-	const queryString = requestLine.slice(CALLBACK_REQUEST_PREFIX.length).split(" ", 1)[0] ?? "";
-	return parseQueryParams(`/?${queryString}`);
+  const queryString = requestLine.slice(CALLBACK_REQUEST_PREFIX.length).split(" ", 1)[0] ?? "";
+  return parseQueryParams(`/?${queryString}`);
 }
 
-function getStateMismatchHtml(): string {
-	return `<html><body><h1>State mismatch error</h1><p>The OAuth state does not match. Please try again.</p></body></html>`;
+export function getStateMismatchHtml(): string {
+  return `<html><body><h1>State mismatch error</h1><p>The OAuth state does not match. Please try again.</p></body></html>`;
 }
 
-function getAuthorizationErrorHtml(params: Record<string, string>): string {
-	return `<html><body><h1>Authorization failed</h1><p>Error: ${params.error}</p><p>${params.error_description || ""}</p></body></html>`;
+export function getAuthorizationErrorHtml(params: Record<string, string>): string {
+  return `<html><body><h1>Authorization failed</h1><p>Error: ${params.error}</p><p>${params.error_description || ""}</p></body></html>`;
 }
 
-function getAuthorizationSuccessHtml(): string {
-	return `<html><body><h1>Authorization successful!</h1><p>You can close this window and return to the terminal.</p><script>window.close();</script></body></html>`;
+export function getAuthorizationSuccessHtml(): string {
+  return `<html><body><h1>Authorization successful!</h1><p>You can close this window and return to the terminal.</p><script>window.close();</script></body></html>`;
 }
 
 type CallbackOutcome =
-	| { type: "ignore" }
-	| { type: "reject"; html: string; error: Error }
-	| { type: "resolve"; html: string; result: CallbackResult };
+  | { type: "ignore" }
+  | { type: "reject"; html: string; error: Error }
+  | { type: "resolve"; html: string; result: CallbackResult };
 
-function handleCallbackParams(params: Record<string, string>, expectedState: string): CallbackOutcome {
-	if (params.state !== expectedState) {
-		return {
-			type: "reject",
-			html: getStateMismatchHtml(),
-			error: new Error("State mismatch - possible CSRF attack"),
-		};
-	}
+export function handleCallbackParams(params: Record<string, string>, expectedState: string): CallbackOutcome {
+  if (params.state !== expectedState) {
+    return {
+      type: "reject",
+      html: getStateMismatchHtml(),
+      error: new Error("State mismatch - possible CSRF attack"),
+    };
+  }
 
-	if (params.error) {
-		return {
-			type: "resolve",
-			html: getAuthorizationErrorHtml(params),
-			result: { code: "", state: expectedState, error: params.error },
-		};
-	}
+  if (params.error) {
+    return {
+      type: "resolve",
+      html: getAuthorizationErrorHtml(params),
+      result: { code: "", state: expectedState, error: params.error },
+    };
+  }
 
-	if (!params.code) {
-		return { type: "ignore" };
-	}
+  if (!params.code) {
+    return { type: "ignore" };
+  }
 
-	return {
-		type: "resolve",
-		html: getAuthorizationSuccessHtml(),
-		result: { code: params.code, state: params.state },
-	};
+  return {
+    type: "resolve",
+    html: getAuthorizationSuccessHtml(),
+    result: { code: params.code, state: params.state },
+  };
 }
 
-function writeOutcomeResponse(
-	clientSocket: NodeJS.Socket,
-	outcome: Exclude<CallbackOutcome, { type: "ignore" }>,
+export function writeOutcomeResponse(
+  clientSocket: NodeJS.Socket,
+  outcome: Exclude<CallbackOutcome, { type: "ignore" }>,
 ): void {
-	writeHtmlResponse(
-		clientSocket,
-		outcome.type === "resolve" && !outcome.result.error ? "HTTP/1.1 200 OK" : "HTTP/1.1 400 Bad Request",
-		outcome.html,
-	);
-	clientSocket.end();
+  writeHtmlResponse(
+    clientSocket,
+    outcome.type === "resolve" && !outcome.result.error ? "HTTP/1.1 200 OK" : "HTTP/1.1 400 Bad Request",
+    outcome.html,
+  );
+  clientSocket.end();
 }
 
-function processCallbackChunk(
-	buffer: string,
-	chunk: Buffer,
-	expectedState: string,
+export function processCallbackChunk(
+  buffer: string,
+  chunk: Buffer,
+  expectedState: string,
 ): { buffer: string; outcome: CallbackOutcome } {
-	const nextBuffer = buffer + chunk.toString();
-	const params = extractCallbackParams(nextBuffer);
-	return {
-		buffer: nextBuffer,
-		outcome: params ? handleCallbackParams(params, expectedState) : { type: "ignore" },
-	};
+  const nextBuffer = buffer + chunk.toString();
+  const params = extractCallbackParams(nextBuffer);
+  return {
+    buffer: nextBuffer,
+    outcome: params ? handleCallbackParams(params, expectedState) : { type: "ignore" },
+  };
 }
 
 /**
  * Start a local callback server and wait for the OAuth redirect
  */
 export async function startCallbackServer(expectedState: string, timeoutMs = 120000): Promise<CallbackResult> {
-	const port = await lookupPort({ port: 3000 });
+  const port = await lookupPort({ port: 3000 });
 
-	return new Promise((resolve, reject) => {
-		const callbackServer = createServer();
-		const timeout = setTimeout(() => {
-			callbackServer.close();
-			reject(new Error("OAuth callback timed out"));
-		}, timeoutMs);
-		const cleanup = () => {
-			clearTimeout(timeout);
-			callbackServer.close();
-		};
+  return new Promise((resolve, reject) => {
+    const callbackServer = createServer();
+    const timeout = setTimeout(() => {
+      callbackServer.close();
+      reject(new Error("OAuth callback timed out"));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      callbackServer.close();
+    };
 
-		callbackServer.on("connection", (clientSocket) => {
-			let buffer = "";
+    callbackServer.on("connection", (clientSocket) => {
+      let buffer = "";
 
-			clientSocket.on("data", (chunk) => {
-				const processed = processCallbackChunk(buffer, chunk, expectedState);
-				buffer = processed.buffer;
-				if (processed.outcome.type === "ignore") return;
+      clientSocket.on("data", (chunk) => {
+        const processed = processCallbackChunk(buffer, chunk, expectedState);
+        buffer = processed.buffer;
+        if (processed.outcome.type === "ignore") return;
 
-				writeOutcomeResponse(clientSocket, processed.outcome);
-				cleanup();
+        writeOutcomeResponse(clientSocket, processed.outcome);
+        cleanup();
 
-				if (processed.outcome.type === "reject") {
-					reject(processed.outcome.error);
-					return;
-				}
+        if (processed.outcome.type === "reject") {
+          reject(processed.outcome.error);
+          return;
+        }
 
-				resolve(processed.outcome.result);
-			});
+        resolve(processed.outcome.result);
+      });
 
-			clientSocket.on("error", () => {
-				// Ignore connection errors
-			});
-		});
+      clientSocket.on("error", () => {
+        // Ignore connection errors
+      });
+    });
 
-		callbackServer.on("error", (err: NodeJS.ErrnoException) => {
-			cleanup();
-			if (err.code === "EADDRINUSE") {
-				lookupPort({ port: 3001 }).then((newPort: number) => {
-					reject(new Error(`Port ${newPort} already in use`));
-				});
-				return;
-			}
-			reject(err);
-		});
+    callbackServer.on("error", (err: NodeJS.ErrnoException) => {
+      cleanup();
+      if (err.code === "EADDRINUSE") {
+        lookupPort({ port: 3001 }).then((newPort: number) => {
+          reject(new Error(`Port ${newPort} already in use`));
+        });
+        return;
+      }
+      reject(err);
+    });
 
-		callbackServer.listen(port, "127.0.0.1", () => {
-			// Server started, will handle callback
-		});
-	});
+    callbackServer.listen(port, "127.0.0.1", () => {
+      // Server started, will handle callback
+    });
+  });
 }
 
 // =============================================================================
@@ -332,55 +332,55 @@ export async function startCallbackServer(expectedState: string, timeoutMs = 120
 // =============================================================================
 
 export interface TokenStorage {
-	save(tokens: OAuthTokens, userInfo?: OAuthUserInfo): Promise<void>;
-	load(): Promise<OAuthTokens | null>;
-	clear(): Promise<void>;
-	getUserInfo(): Promise<OAuthUserInfo | null>;
+  save(tokens: OAuthTokens, userInfo?: OAuthUserInfo): Promise<void>;
+  load(): Promise<OAuthTokens | null>;
+  clear(): Promise<void>;
+  getUserInfo(): Promise<OAuthUserInfo | null>;
 }
 
 export class FileTokenStorage implements TokenStorage {
-	private path: string;
-	private userInfoPath: string;
+  private path: string;
+  private userInfoPath: string;
 
-	constructor(basePath: string) {
-		// Store tokens in same directory as config
-		this.path = basePath.replace(/\.json$/, "-tokens.json");
-		this.userInfoPath = basePath.replace(/\.json$/, "-user.json");
-	}
+  constructor(basePath: string) {
+    // Store tokens in same directory as config
+    this.path = basePath.replace(/\.json$/, "-tokens.json");
+    this.userInfoPath = basePath.replace(/\.json$/, "-user.json");
+  }
 
-	async save(tokens: OAuthTokens, userInfo?: OAuthUserInfo): Promise<void> {
-		const { writeFileSync } = await import("node:fs");
-		writeFileSync(this.path, JSON.stringify(tokens, null, 2), "utf-8");
-		if (userInfo) {
-			writeFileSync(this.userInfoPath, JSON.stringify(userInfo, null, 2), "utf-8");
-		}
-	}
+  async save(tokens: OAuthTokens, userInfo?: OAuthUserInfo): Promise<void> {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(this.path, JSON.stringify(tokens, null, 2), "utf-8");
+    if (userInfo) {
+      writeFileSync(this.userInfoPath, JSON.stringify(userInfo, null, 2), "utf-8");
+    }
+  }
 
-	async load(): Promise<OAuthTokens | null> {
-		const { existsSync, readFileSync } = await import("node:fs");
-		if (!existsSync(this.path)) {
-			return null;
-		}
-		return JSON.parse(readFileSync(this.path, "utf-8")) as OAuthTokens;
-	}
+  async load(): Promise<OAuthTokens | null> {
+    const { existsSync, readFileSync } = await import("node:fs");
+    if (!existsSync(this.path)) {
+      return null;
+    }
+    return JSON.parse(readFileSync(this.path, "utf-8")) as OAuthTokens;
+  }
 
-	async clear(): Promise<void> {
-		const { existsSync, unlinkSync } = await import("node:fs");
-		if (existsSync(this.path)) {
-			unlinkSync(this.path);
-		}
-		if (existsSync(this.userInfoPath)) {
-			unlinkSync(this.userInfoPath);
-		}
-	}
+  async clear(): Promise<void> {
+    const { existsSync, unlinkSync } = await import("node:fs");
+    if (existsSync(this.path)) {
+      unlinkSync(this.path);
+    }
+    if (existsSync(this.userInfoPath)) {
+      unlinkSync(this.userInfoPath);
+    }
+  }
 
-	async getUserInfo(): Promise<OAuthUserInfo | null> {
-		const { existsSync, readFileSync } = await import("node:fs");
-		if (!existsSync(this.userInfoPath)) {
-			return null;
-		}
-		return JSON.parse(readFileSync(this.userInfoPath, "utf-8")) as OAuthUserInfo;
-	}
+  async getUserInfo(): Promise<OAuthUserInfo | null> {
+    const { existsSync, readFileSync } = await import("node:fs");
+    if (!existsSync(this.userInfoPath)) {
+      return null;
+    }
+    return JSON.parse(readFileSync(this.userInfoPath, "utf-8")) as OAuthUserInfo;
+  }
 }
 
 // =============================================================================
@@ -388,8 +388,20 @@ export class FileTokenStorage implements TokenStorage {
 // =============================================================================
 
 export interface OAuthFlowResult {
-	tokens: OAuthTokens;
-	userInfo: OAuthUserInfo;
+  tokens: OAuthTokens;
+  userInfo: OAuthUserInfo;
+}
+
+interface OAuthFlowDependencies {
+  generateCodeVerifierFn?: () => string;
+  generateCodeChallengeFn?: (verifier: string) => string;
+  generateStateFn?: () => string;
+  startCallbackServerFn?: (expectedState: string) => Promise<CallbackResult>;
+  exchangeCodeForTokensFn?: (
+    config: OAuthConfig,
+    code: string,
+    codeVerifier: string,
+  ) => Promise<OAuthTokens & { owner?: OAuthUserInfo }>;
 }
 
 /**
@@ -401,94 +413,101 @@ export interface OAuthFlowResult {
  * 5. Store tokens
  */
 export async function executeOAuthFlow(
-	config: OAuthConfig,
-	storage: TokenStorage,
-	openBrowserFn: (url: string) => void,
-	notifyFn: (message: string, type: "info" | "success" | "error") => void,
+  config: OAuthConfig,
+  storage: TokenStorage,
+  openBrowserFn: (url: string) => void,
+  notifyFn: (message: string, type: "info" | "success" | "error") => void,
+  deps: OAuthFlowDependencies = {},
 ): Promise<OAuthFlowResult> {
-	// Generate PKCE parameters
-	const codeVerifier = generateCodeVerifier();
-	const codeChallenge = generateCodeChallenge(codeVerifier);
-	const state = generateState();
+  const generateCodeVerifierFn = deps.generateCodeVerifierFn ?? generateCodeVerifier;
+  const generateCodeChallengeFn = deps.generateCodeChallengeFn ?? generateCodeChallenge;
+  const generateStateFn = deps.generateStateFn ?? generateState;
+  const startCallbackServerFn = deps.startCallbackServerFn ?? startCallbackServer;
+  const exchangeCodeForTokensFn = deps.exchangeCodeForTokensFn ?? exchangeCodeForTokens;
 
-	// Build authorization URL
-	const authUrl = buildAuthorizationUrl(config, codeChallenge, state);
+  // Generate PKCE parameters
+  const codeVerifier = generateCodeVerifierFn();
+  const codeChallenge = generateCodeChallengeFn(codeVerifier);
+  const state = generateStateFn();
 
-	// Start callback server (need to do this before opening browser)
-	const callbackPromise = startCallbackServer(state);
+  // Build authorization URL
+  const authUrl = buildAuthorizationUrl(config, codeChallenge, state);
 
-	// Open browser
-	notifyFn("Opening Notion authorization page in your browser...", "info");
-	openBrowserFn(authUrl);
+  // Start callback server (need to do this before opening browser)
+  const callbackPromise = startCallbackServerFn(state);
 
-	// Wait for callback
-	notifyFn("Waiting for authorization callback...", "info");
+  // Open browser
+  notifyFn("Opening Notion authorization page in your browser...", "info");
+  openBrowserFn(authUrl);
 
-	let callbackResult: CallbackResult;
-	try {
-		callbackResult = await callbackPromise;
-	} catch (error) {
-		throw new Error(`OAuth callback failed: ${error instanceof Error ? error.message : String(error)}`);
-	}
+  // Wait for callback
+  notifyFn("Waiting for authorization callback...", "info");
 
-	if (callbackResult.error) {
-		throw new Error(`Authorization failed: ${callbackResult.error}`);
-	}
+  let callbackResult: CallbackResult;
+  try {
+    callbackResult = await callbackPromise;
+  } catch (error) {
+    throw new Error(`OAuth callback failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
 
-	// Exchange code for tokens
-	notifyFn("Exchanging authorization code for access token...", "info");
+  if (callbackResult.error) {
+    throw new Error(`Authorization failed: ${callbackResult.error}`);
+  }
 
-	try {
-		const result = await exchangeCodeForTokens(config, callbackResult.code, codeVerifier);
+  // Exchange code for tokens
+  notifyFn("Exchanging authorization code for access token...", "info");
 
-		// Save tokens and user info
-		await storage.save(result, result.owner || undefined);
+  try {
+    const result = await exchangeCodeForTokensFn(config, callbackResult.code, codeVerifier);
 
-		notifyFn("OAuth authorization successful!", "success");
+    // Save tokens and user info
+    await storage.save(result, result.owner || undefined);
 
-		if (result.owner) {
-			notifyFn(`Connected to workspace: ${result.owner.workspaceName}`, "info");
-		}
+    notifyFn("OAuth authorization successful!", "success");
 
-		return {
-			tokens: result,
-			userInfo: result.owner ?? {
-				workspaceId: "",
-				workspaceName: "Unknown",
-				botId: "",
-			},
-		};
-	} catch (error) {
-		throw new Error(`Token exchange failed: ${error instanceof Error ? error.message : String(error)}`);
-	}
+    if (result.owner) {
+      notifyFn(`Connected to workspace: ${result.owner.workspaceName}`, "info");
+    }
+
+    return {
+      tokens: result,
+      userInfo: result.owner ?? {
+        workspaceId: "",
+        workspaceName: "Unknown",
+        botId: "",
+      },
+    };
+  } catch (error) {
+    throw new Error(`Token exchange failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 /**
  * Get a valid access token, refreshing if necessary
  */
 export async function getValidAccessToken(config: OAuthConfig, storage: TokenStorage): Promise<string | null> {
-	const tokens = await storage.load();
-	if (!tokens) {
-		return null;
-	}
+  const tokens = await storage.load();
+  if (!tokens) {
+    return null;
+  }
 
-	// Check if token needs refresh (refresh 5 minutes before expiry)
-	const refreshThreshold = 5 * 60 * 1000;
-	const needsRefresh = Date.now() > tokens.expiresAt - refreshThreshold;
+  // Check if token needs refresh (refresh 5 minutes before expiry)
+  const refreshThreshold = 5 * 60 * 1000;
+  const needsRefresh = Date.now() > tokens.expiresAt - refreshThreshold;
 
-	if (!needsRefresh) {
-		return tokens.accessToken;
-	}
+  if (!needsRefresh) {
+    return tokens.accessToken;
+  }
 
-	// Refresh the token
-	try {
-		const newTokens = await refreshTokens(config, tokens.refreshToken);
-		const userInfo = await storage.getUserInfo();
-		await storage.save(newTokens, userInfo || undefined);
-		return newTokens.accessToken;
-	} catch (error) {
-		// Refresh failed, clear tokens
-		await storage.clear();
-		throw new Error(`Token refresh failed: ${error instanceof Error ? error.message : String(error)}`);
-	}
+  // Refresh the token
+  try {
+    const newTokens = await refreshTokens(config, tokens.refreshToken);
+    const userInfo = await storage.getUserInfo();
+    await storage.save(newTokens, userInfo || undefined);
+    return newTokens.accessToken;
+  } catch (error) {
+    // Refresh failed, clear tokens
+    await storage.clear();
+    throw new Error(`Token refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }

--- a/packages/pi-ref-tools/__tests__/helpers.test.ts
+++ b/packages/pi-ref-tools/__tests__/helpers.test.ts
@@ -3,362 +3,363 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	DEFAULT_CONFIG_FILE,
-	ensureDefaultConfigFile,
-	formatToolOutput,
-	isJsonRpcResponse,
-	isRecord,
-	normalizeNumber,
-	parseConfig,
-	parseTimeoutMs,
-	redactApiKey,
-	resolveConfigPath,
-	resolveEffectiveLimits,
-	splitParams,
-	toJsonString,
-	writeTempFile,
+  DEFAULT_CONFIG_FILE,
+  ensureDefaultConfigFile,
+  formatToolOutput,
+  isJsonRpcResponse,
+  isRecord,
+  normalizeNumber,
+  parseConfig,
+  parseTimeoutMs,
+  redactApiKey,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  splitParams,
+  toJsonString,
+  writeTempFile,
 } from "../extensions/index.js";
 
 describe("pi-ref-tools helpers", () => {
-	it("splits params and clamps limits", () => {
-		const { mcpArgs, requestedLimits } = splitParams({
-			piMaxBytes: "100",
-			piMaxLines: 5,
-			query: "hello",
-		});
-		expect(mcpArgs).toEqual({ query: "hello" });
-		expect(requestedLimits).toEqual({ maxBytes: 100, maxLines: 5 });
+  it("splits params and clamps limits", () => {
+    const { mcpArgs, requestedLimits } = splitParams({
+      piMaxBytes: "100",
+      piMaxLines: 5,
+      query: "hello",
+    });
+    expect(mcpArgs).toEqual({ query: "hello" });
+    expect(requestedLimits).toEqual({ maxBytes: 100, maxLines: 5 });
 
-		const effective = resolveEffectiveLimits({ maxBytes: 200, maxLines: 2 }, { maxBytes: 120, maxLines: 10 });
-		expect(effective).toEqual({ maxBytes: 120, maxLines: 2 });
-	});
+    const effective = resolveEffectiveLimits({ maxBytes: 200, maxLines: 2 }, { maxBytes: 120, maxLines: 10 });
+    expect(effective).toEqual({ maxBytes: 120, maxLines: 2 });
+  });
 
-	it("resolves effective limits using defaults when not requested", () => {
-		const effective = resolveEffectiveLimits({}, { maxBytes: 51200, maxLines: 2000 });
-		expect(effective).toEqual({ maxBytes: 51200, maxLines: 2000 });
-	});
+  it("resolves effective limits using defaults when not requested", () => {
+    const effective = resolveEffectiveLimits({}, { maxBytes: 51200, maxLines: 2000 });
+    expect(effective).toEqual({ maxBytes: 51200, maxLines: 2000 });
+  });
 
-	it("resolves effective limits with only bytes requested", () => {
-		const effective = resolveEffectiveLimits({ maxBytes: 100 }, { maxBytes: 51200, maxLines: 2000 });
-		expect(effective.maxBytes).toBe(100);
-		expect(effective.maxLines).toBe(2000);
-	});
+  it("resolves effective limits with only bytes requested", () => {
+    const effective = resolveEffectiveLimits({ maxBytes: 100 }, { maxBytes: 51200, maxLines: 2000 });
+    expect(effective.maxBytes).toBe(100);
+    expect(effective.maxLines).toBe(2000);
+  });
 
-	it("resolves effective limits with only lines requested", () => {
-		const effective = resolveEffectiveLimits({ maxLines: 500 }, { maxBytes: 51200, maxLines: 2000 });
-		expect(effective.maxBytes).toBe(51200);
-		expect(effective.maxLines).toBe(500);
-	});
+  it("resolves effective limits with only lines requested", () => {
+    const effective = resolveEffectiveLimits({ maxLines: 500 }, { maxBytes: 51200, maxLines: 2000 });
+    expect(effective.maxBytes).toBe(51200);
+    expect(effective.maxLines).toBe(500);
+  });
 
-	it("parses timeout values", () => {
-		expect(parseTimeoutMs("250", 10)).toBe(250);
-		expect(parseTimeoutMs("0", 10)).toBe(10);
-		expect(parseTimeoutMs(undefined, 30000)).toBe(30000);
-		expect(parseTimeoutMs("abc", 500)).toBe(500);
-	});
+  it("parses timeout values", () => {
+    expect(parseTimeoutMs("250", 10)).toBe(250);
+    expect(parseTimeoutMs("0", 10)).toBe(10);
+    expect(parseTimeoutMs(undefined, 30000)).toBe(30000);
+    expect(parseTimeoutMs("abc", 500)).toBe(500);
+  });
 
-	it("normalizes numbers from strings and numbers", () => {
-		expect(normalizeNumber(42)).toBe(42);
-		expect(normalizeNumber("123")).toBe(123);
-		expect(normalizeNumber("abc")).toBeUndefined();
-		expect(normalizeNumber(null)).toBeUndefined();
-		expect(normalizeNumber(undefined)).toBeUndefined();
-		expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
-	});
+  it("normalizes numbers from strings and numbers", () => {
+    expect(normalizeNumber(42)).toBe(42);
+    expect(normalizeNumber("123")).toBe(123);
+    expect(normalizeNumber("abc")).toBeUndefined();
+    expect(normalizeNumber(null)).toBeUndefined();
+    expect(normalizeNumber(undefined)).toBeUndefined();
+    expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
 
-	it("redacts API keys", () => {
-		expect(redactApiKey(undefined)).toBe("(none)");
-		expect(redactApiKey("short")).toBe("***");
-		expect(redactApiKey("abcdefghijklmnop")).toBe("abcd...mnop");
-	});
+  it("redacts API keys", () => {
+    expect(redactApiKey(undefined)).toBe("(none)");
+    expect(redactApiKey("short")).toBe("***");
+    expect(redactApiKey("abcdefghijklmnop")).toBe("abcd...mnop");
+  });
 
-	it("writes default config when none exists", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-ref-config-"));
-		const projectConfigPath = join(base, "project", ".pi", "extensions", "ref-tools.json");
-		const globalConfigPath = join(base, "global", "extensions", "ref-tools.json");
+  it("writes default config when none exists", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-ref-config-"));
+    const projectConfigPath = join(base, "project", ".pi", "extensions", "ref-tools.json");
+    const globalConfigPath = join(base, "global", "extensions", "ref-tools.json");
 
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
 
-		expect(existsSync(globalConfigPath)).toBe(true);
-		const raw = readFileSync(globalConfigPath, "utf-8");
-		expect(JSON.parse(raw)).toEqual(DEFAULT_CONFIG_FILE);
-	});
+    expect(existsSync(globalConfigPath)).toBe(true);
+    const raw = readFileSync(globalConfigPath, "utf-8");
+    expect(JSON.parse(raw)).toEqual(DEFAULT_CONFIG_FILE);
+  });
 
-	it("does not overwrite existing config", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-ref-config-exists-"));
-		const projectConfigPath = join(base, "project", ".pi", "extensions", "ref-tools.json");
-		const globalConfigPath = join(base, "global", "extensions", "ref-tools.json");
+  it("does not overwrite existing config", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-ref-config-exists-"));
+    const projectConfigPath = join(base, "project", ".pi", "extensions", "ref-tools.json");
+    const globalConfigPath = join(base, "global", "extensions", "ref-tools.json");
 
-		// First call creates the file
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		const firstContent = readFileSync(globalConfigPath, "utf-8");
+    // First call creates the file
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    const firstContent = readFileSync(globalConfigPath, "utf-8");
 
-		// Second call should not overwrite
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		const secondContent = readFileSync(globalConfigPath, "utf-8");
+    // Second call should not overwrite
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    const secondContent = readFileSync(globalConfigPath, "utf-8");
 
-		expect(firstContent).toBe(secondContent);
-	});
+    expect(firstContent).toBe(secondContent);
+  });
 });
 
 describe("pi-ref-tools type guards", () => {
-	it("isRecord returns true for plain objects", () => {
-		expect(isRecord({})).toBe(true);
-		expect(isRecord({ a: 1 })).toBe(true);
-		expect(isRecord({ nested: { deep: true } })).toBe(true);
-	});
+  it("isRecord returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+    expect(isRecord({ nested: { deep: true } })).toBe(true);
+  });
 
-	it("isRecord returns false for non-objects", () => {
-		expect(isRecord(null)).toBe(false);
-		expect(isRecord(undefined)).toBe(false);
-		expect(isRecord("string")).toBe(false);
-		expect(isRecord(123)).toBe(false);
-		expect(isRecord(true)).toBe(false);
-		expect(isRecord([])).toBe(false);
-		expect(isRecord([1, 2, 3])).toBe(false);
-	});
+  it("isRecord returns false for non-objects", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord("string")).toBe(false);
+    expect(isRecord(123)).toBe(false);
+    expect(isRecord(true)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+  });
 
-	it("isRecord returns true for objects with special keys", () => {
-		expect(isRecord({ __proto__: { admin: true } })).toBe(true);
-		expect(isRecord({ constructor: () => {} })).toBe(true);
-	});
+  it("isRecord returns true for objects with special keys", () => {
+    expect(isRecord({ __proto__: { admin: true } })).toBe(true);
+    expect(isRecord({ constructor: () => {} })).toBe(true);
+  });
 
-	it("isJsonRpcResponse returns true for valid responses", () => {
-		expect(isJsonRpcResponse({ jsonrpc: "2.0", result: {} })).toBe(true);
-		expect(isJsonRpcResponse({ jsonrpc: "2.0", id: 1, result: "test" })).toBe(true);
-		expect(isJsonRpcResponse({ jsonrpc: "2.0", id: "abc", error: { code: -32600, message: "Invalid" } })).toBe(true);
-	});
+  it("isJsonRpcResponse returns true for valid responses", () => {
+    expect(isJsonRpcResponse({ jsonrpc: "2.0", result: {} })).toBe(true);
+    expect(isJsonRpcResponse({ jsonrpc: "2.0", id: 1, result: "test" })).toBe(true);
+    expect(isJsonRpcResponse({ jsonrpc: "2.0", id: "abc", error: { code: -32600, message: "Invalid" } })).toBe(true);
+  });
 
-	it("isJsonRpcResponse returns false for invalid responses", () => {
-		expect(isJsonRpcResponse({})).toBe(false);
-		expect(isJsonRpcResponse({ jsonrpc: "1.0" })).toBe(false);
-		expect(isJsonRpcResponse({ jsonrpc: "2.0", id: 1 })).toBe(true); // passes isRecord and has jsonrpc 2.0
-		expect(isJsonRpcResponse(null)).toBe(false);
-		expect(isJsonRpcResponse("string")).toBe(false);
-	});
+  it("isJsonRpcResponse returns false for invalid responses", () => {
+    expect(isJsonRpcResponse({})).toBe(false);
+    expect(isJsonRpcResponse({ jsonrpc: "1.0" })).toBe(false);
+    expect(isJsonRpcResponse({ jsonrpc: "2.0", id: 1 })).toBe(true); // passes isRecord and has jsonrpc 2.0
+    expect(isJsonRpcResponse(null)).toBe(false);
+    expect(isJsonRpcResponse("string")).toBe(false);
+  });
 
-	it("isJsonRpcResponse handles edge cases", () => {
-		expect(isJsonRpcResponse({ jsonrpc: "2.0", error: { code: -32600 } })).toBe(true);
-		expect(isJsonRpcResponse({ jsonrpc: "2.0", result: null })).toBe(true);
-	});
+  it("isJsonRpcResponse handles edge cases", () => {
+    expect(isJsonRpcResponse({ jsonrpc: "2.0", error: { code: -32600 } })).toBe(true);
+    expect(isJsonRpcResponse({ jsonrpc: "2.0", result: null })).toBe(true);
+  });
 });
 
 describe("pi-ref-tools toJsonString", () => {
-	it("returns strings as-is", () => {
-		expect(toJsonString("hello")).toBe("hello");
-		expect(toJsonString("")).toBe("");
-	});
+  it("returns strings as-is", () => {
+    expect(toJsonString("hello")).toBe("hello");
+    expect(toJsonString("")).toBe("");
+  });
 
-	it("stringifies objects", () => {
-		const result = toJsonString({ a: 1, b: 2 });
-		expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
-	});
+  it("stringifies objects", () => {
+    const result = toJsonString({ a: 1, b: 2 });
+    expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
+  });
 
-	it("converts primitives", () => {
-		expect(toJsonString(42)).toBe("42");
-		expect(toJsonString(true)).toBe("true");
-		expect(toJsonString(null)).toBe("null");
-	});
+  it("converts primitives", () => {
+    expect(toJsonString(42)).toBe("42");
+    expect(toJsonString(true)).toBe("true");
+    expect(toJsonString(null)).toBe("null");
+  });
 });
 
 describe("pi-ref-tools resolveConfigPath", () => {
-	it("resolves paths starting with ~/", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(homedir());
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~/", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(homedir());
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("resolves paths starting with ~", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("returns absolute paths as-is", () => {
-		const absolute = "/absolute/path/to/config.json";
-		expect(resolveConfigPath(absolute)).toBe(absolute);
-	});
+  it("returns absolute paths as-is", () => {
+    const absolute = "/absolute/path/to/config.json";
+    expect(resolveConfigPath(absolute)).toBe(absolute);
+  });
 
-	it("resolves relative paths from cwd", () => {
-		const result = resolveConfigPath("relative/path.json");
-		expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
-	});
+  it("resolves relative paths from cwd", () => {
+    const result = resolveConfigPath("relative/path.json");
+    expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
+  });
 
-	it("trims whitespace", () => {
-		const result = resolveConfigPath("  ~/.pi/config.json  ");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("trims whitespace", () => {
+    const result = resolveConfigPath("  ~/.pi/config.json  ");
+    expect(result).toContain(".pi/config.json");
+  });
 });
 
 describe("pi-ref-tools parseConfig", () => {
-	it("parses valid config", () => {
-		const raw = {
-			url: "https://api.example.com/mcp",
-			apiKey: "secret-key",
-			timeoutMs: 15000,
-			protocolVersion: "2025-01-01",
-			maxBytes: 1024,
-			maxLines: 500,
-		};
-		const result = parseConfig(raw, "/path/to/config.json");
-		expect(result).toEqual({
-			url: "https://api.example.com/mcp",
-			apiKey: "secret-key",
-			timeoutMs: 15000,
-			protocolVersion: "2025-01-01",
-			maxBytes: 1024,
-			maxLines: 500,
-		});
-	});
+  it("parses valid config", () => {
+    const raw = {
+      url: "https://api.example.com/mcp",
+      apiKey: "secret-key",
+      timeoutMs: 15000,
+      protocolVersion: "2025-01-01",
+      maxBytes: 1024,
+      maxLines: 500,
+    };
+    const result = parseConfig(raw, "/path/to/config.json");
+    expect(result).toEqual({
+      url: "https://api.example.com/mcp",
+      apiKey: "secret-key",
+      timeoutMs: 15000,
+      protocolVersion: "2025-01-01",
+      maxBytes: 1024,
+      maxLines: 500,
+    });
+  });
 
-	it("normalizes string values", () => {
-		const raw = { url: "  https://api.example.com  ", apiKey: "  " };
-		const result = parseConfig(raw, "/path");
-		expect(result.url).toBe("https://api.example.com");
-		expect(result.apiKey).toBeUndefined(); // empty after trim
-	});
+  it("normalizes string values", () => {
+    const raw = { url: "  https://api.example.com  ", apiKey: "  " };
+    const result = parseConfig(raw, "/path");
+    expect(result.url).toBe("https://api.example.com");
+    expect(result.apiKey).toBeUndefined(); // empty after trim
+  });
 
-	it("ignores null/undefined values", () => {
-		const raw = { url: null, apiKey: undefined, timeoutMs: NaN };
-		const result = parseConfig(raw, "/path");
-		expect(result.url).toBeUndefined();
-		expect(result.apiKey).toBeUndefined();
-		expect(result.timeoutMs).toBeUndefined(); // NaN is not finite
-	});
+  it("ignores null/undefined values", () => {
+    const raw = { url: null, apiKey: undefined, timeoutMs: NaN };
+    const result = parseConfig(raw, "/path");
+    expect(result.url).toBeUndefined();
+    expect(result.apiKey).toBeUndefined();
+    expect(result.timeoutMs).toBeUndefined(); // NaN is not finite
+  });
 
-	it("throws for non-object config", () => {
-		expect(() => parseConfig(null, "/path")).toThrow("Invalid Ref MCP config");
-		expect(() => parseConfig("string", "/path")).toThrow("Invalid Ref MCP config");
-		expect(() => parseConfig(123, "/path")).toThrow("Invalid Ref MCP config");
-	});
+  it("throws for non-object config", () => {
+    expect(() => parseConfig(null, "/path")).toThrow("Invalid Ref MCP config");
+    expect(() => parseConfig("string", "/path")).toThrow("Invalid Ref MCP config");
+    expect(() => parseConfig(123, "/path")).toThrow("Invalid Ref MCP config");
+  });
 
-	it("handles negative timeout", () => {
-		const raw = { timeoutMs: -100 };
-		const result = parseConfig(raw, "/path");
-		expect(result.timeoutMs).toBe(-100); // negative numbers are finite
-	});
+  it("handles negative timeout", () => {
+    const raw = { timeoutMs: -100 };
+    const result = parseConfig(raw, "/path");
+    expect(result.timeoutMs).toBe(-100); // negative numbers are finite
+  });
 
-	it("handles zero timeout", () => {
-		const raw = { timeoutMs: 0 };
-		const result = parseConfig(raw, "/path");
-		expect(result.timeoutMs).toBe(0); // 0 is finite
-	});
+  it("handles zero timeout", () => {
+    const raw = { timeoutMs: 0 };
+    const result = parseConfig(raw, "/path");
+    expect(result.timeoutMs).toBe(0); // 0 is finite
+  });
 
-	it("normalizes whitespace in protocol version", () => {
-		const raw = { protocolVersion: "  2025-01-01  " };
-		const result = parseConfig(raw, "/path");
-		expect(result.protocolVersion).toBe("2025-01-01");
-	});
+  it("normalizes whitespace in protocol version", () => {
+    const raw = { protocolVersion: "  2025-01-01  " };
+    const result = parseConfig(raw, "/path");
+    expect(result.protocolVersion).toBe("2025-01-01");
+  });
 });
 
 describe("pi-ref-tools formatToolOutput", () => {
-	it("formats simple text result", () => {
-		const result = formatToolOutput(
-			"test_tool",
-			"https://api.example.com",
-			{ content: [{ type: "text", text: "Hello World" }] },
-			{ maxBytes: 50000, maxLines: 2000 },
-		);
-		expect(result.text).toBe("Hello World");
-		expect(result.details.truncated).toBe(false);
-	});
+  it("formats simple text result", () => {
+    const result = formatToolOutput(
+      "test_tool",
+      "https://api.example.com",
+      { content: [{ type: "text", text: "Hello World" }] },
+      { maxBytes: 50000, maxLines: 2000 },
+    );
+    expect(result.text).toBe("Hello World");
+    expect(result.details.truncated).toBe(false);
+  });
 
-	it("formats result without content array", () => {
-		// biome-ignore lint/suspicious/noExplicitAny: testing edge case with non-standard result format
-		const result = formatToolOutput("test_tool", "https://api.example.com", { result: "data" } as any);
-		expect(result.text).toContain("data");
-	});
+  it("formats result without content array", () => {
+    const result = formatToolOutput("test_tool", "https://api.example.com", { result: "data" } as unknown as Parameters<
+      typeof formatToolOutput
+    >[2]);
+    expect(result.text).toContain("data");
+  });
 
-	it("handles multiple content blocks", () => {
-		const result = formatToolOutput("test_tool", "https://api.example.com", {
-			content: [
-				{ type: "text", text: "Block 1" },
-				{ type: "text", text: "Block 2" },
-			],
-		});
-		expect(result.text).toContain("Block 1");
-		expect(result.text).toContain("Block 2");
-	});
+  it("handles multiple content blocks", () => {
+    const result = formatToolOutput("test_tool", "https://api.example.com", {
+      content: [
+        { type: "text", text: "Block 1" },
+        { type: "text", text: "Block 2" },
+      ],
+    });
+    expect(result.text).toContain("Block 1");
+    expect(result.text).toContain("Block 2");
+  });
 
-	it("handles non-text content blocks", () => {
-		const result = formatToolOutput("test_tool", "https://api.example.com", {
-			content: [
-				{ type: "image", url: "https://example.com/img.png" },
-				{ type: "text", text: "Description" },
-			],
-		});
-		expect(result.text).toContain("Description");
-	});
+  it("handles non-text content blocks", () => {
+    const result = formatToolOutput("test_tool", "https://api.example.com", {
+      content: [
+        { type: "image", url: "https://example.com/img.png" },
+        { type: "text", text: "Description" },
+      ],
+    });
+    expect(result.text).toContain("Description");
+  });
 
-	it("truncates when exceeding maxLines", () => {
-		const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`).join("\n");
-		const result = formatToolOutput(
-			"test_tool",
-			"https://api.example.com",
-			{ content: [{ type: "text", text: lines }] },
-			{ maxBytes: 100000, maxLines: 10 },
-		);
-		expect(result.details.truncated).toBe(true);
-		expect(result.details.truncation?.truncatedBy).toBe("lines");
-	});
+  it("truncates when exceeding maxLines", () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`).join("\n");
+    const result = formatToolOutput(
+      "test_tool",
+      "https://api.example.com",
+      { content: [{ type: "text", text: lines }] },
+      { maxBytes: 100000, maxLines: 10 },
+    );
+    expect(result.details.truncated).toBe(true);
+    expect(result.details.truncation?.truncatedBy).toBe("lines");
+  });
 
-	it("truncates when exceeding maxBytes", () => {
-		const longText = "a".repeat(10000);
-		const result = formatToolOutput(
-			"test_tool",
-			"https://api.example.com",
-			{ content: [{ type: "text", text: longText }] },
-			{ maxBytes: 1000, maxLines: 5000 },
-		);
-		expect(result.details.truncated).toBe(true);
-		expect(result.details.truncation?.truncatedBy).toBe("bytes");
-	});
+  it("truncates when exceeding maxBytes", () => {
+    const longText = "a".repeat(10000);
+    const result = formatToolOutput(
+      "test_tool",
+      "https://api.example.com",
+      { content: [{ type: "text", text: longText }] },
+      { maxBytes: 1000, maxLines: 5000 },
+    );
+    expect(result.details.truncated).toBe(true);
+    expect(result.details.truncation?.truncatedBy).toBe("bytes");
+  });
 
-	it("includes temp file path when truncated", () => {
-		const longText = "x".repeat(10000);
-		const result = formatToolOutput(
-			"test_tool",
-			"https://api.example.com",
-			{ content: [{ type: "text", text: longText }] },
-			{ maxBytes: 100, maxLines: 10 },
-		);
-		expect(result.details.tempFile).toBeDefined();
-		expect(result.text).toContain("Full output saved to:");
-	});
+  it("includes temp file path when truncated", () => {
+    const longText = "x".repeat(10000);
+    const result = formatToolOutput(
+      "test_tool",
+      "https://api.example.com",
+      { content: [{ type: "text", text: longText }] },
+      { maxBytes: 100, maxLines: 10 },
+    );
+    expect(result.details.tempFile).toBeDefined();
+    expect(result.text).toContain("Full output saved to:");
+  });
 });
 
 describe("pi-ref-tools writeTempFile", () => {
-	const tempFiles: string[] = [];
+  const tempFiles: string[] = [];
 
-	afterEach(() => {
-		import("node:fs").then(({ unlinkSync }) => {
-			tempFiles.forEach((f) => {
-				try {
-					unlinkSync(f);
-				} catch {
-					// ignore cleanup errors
-				}
-			});
-		});
-	});
+  afterEach(() => {
+    import("node:fs").then(({ unlinkSync }) => {
+      tempFiles.forEach((f) => {
+        try {
+          unlinkSync(f);
+        } catch {
+          // ignore cleanup errors
+        }
+      });
+    });
+  });
 
-	it("writes temp file and returns path", () => {
-		const path = writeTempFile("test_tool", "content here");
-		tempFiles.push(path);
-		expect(path).toContain("pi-ref-tools-test_tool");
-		expect(path).toContain(".txt");
-		expect(existsSync(path)).toBe(true);
-	});
+  it("writes temp file and returns path", () => {
+    const path = writeTempFile("test_tool", "content here");
+    tempFiles.push(path);
+    expect(path).toContain("pi-ref-tools-test_tool");
+    expect(path).toContain(".txt");
+    expect(existsSync(path)).toBe(true);
+  });
 
-	it("sanitizes tool name", () => {
-		const path = writeTempFile("my-tool-123!@#", "content");
-		tempFiles.push(path);
-		expect(path).toContain("my-tool-123__");
-	});
+  it("sanitizes tool name", () => {
+    const path = writeTempFile("my-tool-123!@#", "content");
+    tempFiles.push(path);
+    expect(path).toContain("my-tool-123__");
+  });
 
-	it("writes correct content", () => {
-		const content = "test content\nwith multiple lines";
-		const path = writeTempFile("test", content);
-		tempFiles.push(path);
-		expect(readFileSync(path, "utf-8")).toBe(content);
-	});
+  it("writes correct content", () => {
+    const content = "test content\nwith multiple lines";
+    const path = writeTempFile("test", content);
+    tempFiles.push(path);
+    expect(readFileSync(path, "utf-8")).toBe(content);
+  });
 });

--- a/packages/pi-ref-tools/__tests__/index.test.ts
+++ b/packages/pi-ref-tools/__tests__/index.test.ts
@@ -3,225 +3,225 @@ import { describe, expect, it, vi } from "vitest";
 import refTools from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 describe("pi-ref-tools", () => {
-	it("registers tools", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers tools", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-		expect(toolNames).toEqual(expect.arrayContaining(["ref_search_documentation", "ref_read_url"]));
-	});
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toEqual(expect.arrayContaining(["ref_search_documentation", "ref_read_url"]));
+  });
 
-	it("registers flags", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers flags", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toEqual(
-			expect.arrayContaining([
-				"--ref-mcp-url",
-				"--ref-mcp-api-key",
-				"--ref-mcp-timeout-ms",
-				"--ref-mcp-protocol",
-				"--ref-mcp-config",
-				"--ref-mcp-max-bytes",
-				"--ref-mcp-max-lines",
-			]),
-		);
-	});
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toEqual(
+      expect.arrayContaining([
+        "--ref-mcp-url",
+        "--ref-mcp-api-key",
+        "--ref-mcp-timeout-ms",
+        "--ref-mcp-protocol",
+        "--ref-mcp-config",
+        "--ref-mcp-max-bytes",
+        "--ref-mcp-max-lines",
+      ]),
+    );
+  });
 
-	it("registers exactly 2 tools", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers exactly 2 tools", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-		expect(toolNames).toHaveLength(2);
-	});
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toHaveLength(2);
+  });
 
-	it("registers exactly 7 flags", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers exactly 7 flags", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toHaveLength(7);
-	});
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toHaveLength(7);
+  });
 
-	it("registers tool with correct parameters schema", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers tool with correct parameters schema", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const searchTool = tools.find((t) => t.name === "ref_search_documentation");
-		expect(searchTool).toBeDefined();
-		expect(searchTool?.parameters).toBeDefined();
-		expect(searchTool?.execute).toBeDefined();
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const searchTool = tools.find((t) => t.name === "ref_search_documentation");
+    expect(searchTool).toBeDefined();
+    expect(searchTool?.parameters).toBeDefined();
+    expect(searchTool?.execute).toBeDefined();
+  });
 
-	it("registers tool with description", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers tool with description", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const searchTool = tools.find((t) => t.name === "ref_search_documentation");
-		expect(searchTool?.description).toContain("Ref");
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const searchTool = tools.find((t) => t.name === "ref_search_documentation");
+    expect(searchTool?.description).toContain("Ref");
+  });
 
-	it("registers tool with label", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers tool with label", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const searchTool = tools.find((t) => t.name === "ref_search_documentation");
-		expect(searchTool?.label).toBe("Ref Doc Search");
-	});
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const searchTool = tools.find((t) => t.name === "ref_search_documentation");
+    expect(searchTool?.label).toBe("Ref Doc Search");
+  });
 
-	it("registers flags with string type", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers flags with string type", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
-		const urlFlag = flags.find((f) => f.name === "--ref-mcp-url");
-		expect(urlFlag?.type).toBe("string");
-	});
+    const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
+    const urlFlag = flags.find((f) => f.name === "--ref-mcp-url");
+    expect(urlFlag?.type).toBe("string");
+  });
 
-	it("registers flags with descriptions", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers flags with descriptions", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
-		flags.forEach((flag) => {
-			expect(flag.description).toBeDefined();
-			expect(typeof flag.description).toBe("string");
-		});
-	});
+    const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
+    flags.forEach((flag) => {
+      expect(flag.description).toBeDefined();
+      expect(typeof flag.description).toBe("string");
+    });
+  });
 
-	it("registers both search and read tools", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers both search and read tools", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const searchTool = tools.find((t) => t.name === "ref_search_documentation");
-		const readTool = tools.find((t) => t.name === "ref_read_url");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const searchTool = tools.find((t) => t.name === "ref_search_documentation");
+    const readTool = tools.find((t) => t.name === "ref_read_url");
 
-		expect(searchTool?.label).toBe("Ref Doc Search");
-		expect(readTool?.label).toBe("Ref Read URL");
-	});
+    expect(searchTool?.label).toBe("Ref Doc Search");
+    expect(readTool?.label).toBe("Ref Read URL");
+  });
 
-	it("registers all required flags", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers all required flags", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
 
-		expect(flagNames).toContain("--ref-mcp-url");
-		expect(flagNames).toContain("--ref-mcp-api-key");
-		expect(flagNames).toContain("--ref-mcp-timeout-ms");
-		expect(flagNames).toContain("--ref-mcp-protocol");
-		expect(flagNames).toContain("--ref-mcp-config");
-		expect(flagNames).toContain("--ref-mcp-max-bytes");
-		expect(flagNames).toContain("--ref-mcp-max-lines");
-	});
+    expect(flagNames).toContain("--ref-mcp-url");
+    expect(flagNames).toContain("--ref-mcp-api-key");
+    expect(flagNames).toContain("--ref-mcp-timeout-ms");
+    expect(flagNames).toContain("--ref-mcp-protocol");
+    expect(flagNames).toContain("--ref-mcp-config");
+    expect(flagNames).toContain("--ref-mcp-max-bytes");
+    expect(flagNames).toContain("--ref-mcp-max-lines");
+  });
 
-	it("can be initialized with config flag", () => {
-		const getFlagCalls: string[] = [];
-		const mockPi = {
-			registerFlag: vi.fn((name: string) => {
-				getFlagCalls.push(name);
-			}),
-			getFlag: vi.fn((flag: string) => {
-				if (flag === "--ref-mcp-config") return "/path/to/config.json";
-				return undefined;
-			}),
-			registerTool: vi.fn(),
-			on: vi.fn(),
-		};
+  it("can be initialized with config flag", () => {
+    const getFlagCalls: string[] = [];
+    const mockPi = {
+      registerFlag: vi.fn((name: string) => {
+        getFlagCalls.push(name);
+      }),
+      getFlag: vi.fn((flag: string) => {
+        if (flag === "--ref-mcp-config") return "/path/to/config.json";
+        return undefined;
+      }),
+      registerTool: vi.fn(),
+      on: vi.fn(),
+    };
 
-		refTools(mockPi as unknown as ExtensionAPI);
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		expect(getFlagCalls).toContain("--ref-mcp-config");
-	});
+    expect(getFlagCalls).toContain("--ref-mcp-config");
+  });
 
-	it("registers tools with unique execute functions", () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("registers tools with unique execute functions", () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const executeFunctions = tools.map((t) => t.execute);
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const executeFunctions = tools.map((t) => t.execute);
 
-		executeFunctions.forEach((fn) => {
-			expect(fn).toBeDefined();
-			expect(typeof fn).toBe("function");
-		});
-	});
+    executeFunctions.forEach((fn) => {
+      expect(fn).toBeDefined();
+      expect(typeof fn).toBe("function");
+    });
+  });
 
-	it("handles multiple extension instances", () => {
-		const mockPi1 = createMockPi();
-		const mockPi2 = createMockPi();
+  it("handles multiple extension instances", () => {
+    const mockPi1 = createMockPi();
+    const mockPi2 = createMockPi();
 
-		refTools(mockPi1 as unknown as ExtensionAPI);
-		refTools(mockPi2 as unknown as ExtensionAPI);
+    refTools(mockPi1 as unknown as ExtensionAPI);
+    refTools(mockPi2 as unknown as ExtensionAPI);
 
-		expect(mockPi1.registerTool).toHaveBeenCalledTimes(2);
-		expect(mockPi2.registerTool).toHaveBeenCalledTimes(2);
-	});
+    expect(mockPi1.registerTool).toHaveBeenCalledTimes(2);
+    expect(mockPi2.registerTool).toHaveBeenCalledTimes(2);
+  });
 
-	it("returns cancelled response when signal is aborted", async () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("returns cancelled response when signal is aborted", async () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const searchTool = tools.find((t) => t.name === "ref_search_documentation");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const searchTool = tools.find((t) => t.name === "ref_search_documentation");
 
-		const abortedSignal = { aborted: true } as AbortSignal;
-		const result = await searchTool?.execute("call-123", { query: "test" }, abortedSignal, undefined, undefined);
+    const abortedSignal = { aborted: true } as AbortSignal;
+    const result = await searchTool?.execute("call-123", { query: "test" }, abortedSignal, undefined, undefined);
 
-		expect(result.content[0].text).toContain("Cancelled");
-		expect(result.details.cancelled).toBe(true);
-	});
+    expect(result.content[0].text).toContain("Cancelled");
+    expect(result.details.cancelled).toBe(true);
+  });
 
-	it("returns cancelled for ref_read_url when signal is aborted", async () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("returns cancelled for ref_read_url when signal is aborted", async () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const readTool = tools.find((t) => t.name === "ref_read_url");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const readTool = tools.find((t) => t.name === "ref_read_url");
 
-		const abortedSignal = { aborted: true } as AbortSignal;
-		const result = await readTool?.execute(
-			"call-123",
-			{ url: "https://example.com" },
-			abortedSignal,
-			undefined,
-			undefined,
-		);
+    const abortedSignal = { aborted: true } as AbortSignal;
+    const result = await readTool?.execute(
+      "call-123",
+      { url: "https://example.com" },
+      abortedSignal,
+      undefined,
+      undefined,
+    );
 
-		expect(result.content[0].text).toContain("Cancelled");
-		expect(result.details.cancelled).toBe(true);
-	});
+    expect(result.content[0].text).toContain("Cancelled");
+    expect(result.details.cancelled).toBe(true);
+  });
 
-	it("calls onUpdate with pending status", async () => {
-		const mockPi = createMockPi();
-		refTools(mockPi as unknown as ExtensionAPI);
+  it("calls onUpdate with pending status", async () => {
+    const mockPi = createMockPi();
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-		const searchTool = tools.find((t) => t.name === "ref_search_documentation");
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    const searchTool = tools.find((t) => t.name === "ref_search_documentation");
 
-		const onUpdate = vi.fn();
-		const pendingSignal = { aborted: false } as AbortSignal;
+    const onUpdate = vi.fn();
+    const pendingSignal = { aborted: false } as AbortSignal;
 
-		try {
-			await searchTool?.execute("call-123", { query: "test" }, pendingSignal, onUpdate, undefined);
-		} catch {
-			// Expected to fail without real MCP server
-		}
+    try {
+      await searchTool?.execute("call-123", { query: "test" }, pendingSignal, onUpdate, undefined);
+    } catch {
+      // Expected to fail without real MCP server
+    }
 
-		expect(onUpdate).toHaveBeenCalled();
-	});
+    expect(onUpdate).toHaveBeenCalled();
+  });
 });

--- a/packages/pi-ref-tools/__tests__/runtime.test.ts
+++ b/packages/pi-ref-tools/__tests__/runtime.test.ts
@@ -6,148 +6,148 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import refTools from "../extensions/index.js";
 
 const createMockPi = (flags: Record<string, string | boolean | undefined> = {}) =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn<(name: string) => string | boolean | undefined>((name: string) => flags[name]),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn<(name: string) => string | boolean | undefined>((name: string) => flags[name]),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 const getRegisteredTool = (mockPi: ReturnType<typeof createMockPi>, name: string) => {
-	const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-	return tools.find((tool) => tool.name === name);
+  const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+  return tools.find((tool) => tool.name === name);
 };
 
 const getEventHandler = (mockPi: ReturnType<typeof createMockPi>, eventName: string) => {
-	const entry = mockPi.on.mock.calls.find(([event]) => event === eventName);
-	return entry?.[1];
+  const entry = mockPi.on.mock.calls.find(([event]) => event === eventName);
+  return entry?.[1];
 };
 
 describe("pi-ref-tools runtime", () => {
-	const originalFetch = global.fetch;
-	const originalApiKey = process.env.REF_API_KEY;
-	const originalUrl = process.env.REF_MCP_URL;
+  const originalFetch = global.fetch;
+  const originalApiKey = process.env.REF_API_KEY;
+  const originalUrl = process.env.REF_MCP_URL;
 
-	beforeEach(() => {
-		vi.restoreAllMocks();
-		delete process.env.REF_API_KEY;
-		delete process.env.REF_MCP_URL;
-	});
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.REF_API_KEY;
+    delete process.env.REF_MCP_URL;
+  });
 
-	afterEach(() => {
-		global.fetch = originalFetch;
-		if (originalApiKey === undefined) delete process.env.REF_API_KEY;
-		else process.env.REF_API_KEY = originalApiKey;
-		if (originalUrl === undefined) delete process.env.REF_MCP_URL;
-		else process.env.REF_MCP_URL = originalUrl;
-	});
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalApiKey === undefined) delete process.env.REF_API_KEY;
+    else process.env.REF_API_KEY = originalApiKey;
+    if (originalUrl === undefined) delete process.env.REF_MCP_URL;
+    else process.env.REF_MCP_URL = originalUrl;
+  });
 
-	it("logs connected session status from config", async () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-ref-runtime-"));
-		const configPath = join(base, "ref-tools.json");
-		writeFileSync(configPath, JSON.stringify({ url: "https://docs.example.test/mcp", apiKey: "config-key" }), "utf-8");
+  it("logs connected session status from config", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-ref-runtime-"));
+    const configPath = join(base, "ref-tools.json");
+    writeFileSync(configPath, JSON.stringify({ url: "https://docs.example.test/mcp", apiKey: "config-key" }), "utf-8");
 
-		const mockPi = createMockPi({ "--ref-mcp-config": configPath });
-		refTools(mockPi as unknown as ExtensionAPI);
+    const mockPi = createMockPi({ "--ref-mcp-config": configPath });
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const sessionStart = getEventHandler(mockPi, "session_start");
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		await sessionStart?.();
+    const sessionStart = getEventHandler(mockPi, "session_start");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await sessionStart?.();
 
-		expect(logSpy).toHaveBeenCalledWith(
-			"[ref-tools] Connected to https://docs.example.test/mcp (API key: config file)",
-		);
-	});
+    expect(logSpy).toHaveBeenCalledWith(
+      "[ref-tools] Connected to https://docs.example.test/mcp (API key: config file)",
+    );
+  });
 
-	it("executes ref_search_documentation successfully", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ jsonrpc: "2.0", id: "ref-mcp-1", result: {} }), {
-					status: 200,
-					headers: { "content-type": "application/json", "mcp-session-id": "session-123" },
-				}),
-			)
-			.mockResolvedValueOnce(new Response(null, { status: 202 }))
-			.mockResolvedValueOnce(
-				new Response(
-					JSON.stringify({
-						jsonrpc: "2.0",
-						id: "ref-mcp-2",
-						result: { content: [{ type: "text", text: "React documentation result" }] },
-					}),
-					{ status: 200, headers: { "content-type": "application/json" } },
-				),
-			);
-		global.fetch = fetchMock as typeof fetch;
+  it("executes ref_search_documentation successfully", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "ref-mcp-1", result: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json", "mcp-session-id": "session-123" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: "ref-mcp-2",
+            result: { content: [{ type: "text", text: "React documentation result" }] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    global.fetch = fetchMock as typeof fetch;
 
-		const mockPi = createMockPi({
-			"--ref-mcp-url": "https://docs.example.test/mcp",
-			"--ref-mcp-api-key": "flag-api-key",
-		});
-		refTools(mockPi as unknown as ExtensionAPI);
+    const mockPi = createMockPi({
+      "--ref-mcp-url": "https://docs.example.test/mcp",
+      "--ref-mcp-api-key": "flag-api-key",
+    });
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const searchTool = getRegisteredTool(mockPi, "ref_search_documentation");
-		const onUpdate = vi.fn();
-		const result = await searchTool?.execute(
-			"call-1",
-			{ query: "React hooks", piMaxBytes: 2000, piMaxLines: 100 },
-			new AbortController().signal,
-			onUpdate,
-			undefined,
-		);
+    const searchTool = getRegisteredTool(mockPi, "ref_search_documentation");
+    const onUpdate = vi.fn();
+    const result = await searchTool?.execute(
+      "call-1",
+      { query: "React hooks", piMaxBytes: 2000, piMaxLines: 100 },
+      new AbortController().signal,
+      onUpdate,
+      undefined,
+    );
 
-		expect(onUpdate).toHaveBeenCalledWith({
-			content: [{ type: "text", text: "Searching Ref documentation..." }],
-			details: { status: "pending" },
-		});
-		expect(fetchMock).toHaveBeenCalledTimes(3);
-		expect(fetchMock).toHaveBeenNthCalledWith(
-			3,
-			"https://docs.example.test/mcp",
-			expect.objectContaining({
-				method: "POST",
-				headers: expect.objectContaining({
-					"x-ref-api-key": "flag-api-key",
-					"mcp-session-id": "session-123",
-				}),
-			}),
-		);
-		expect(result.isError).toBe(false);
-		expect(result.content[0].text).toContain("React documentation result");
-		expect(result.details.endpoint).toBe("https://docs.example.test/mcp");
-	});
+    expect(onUpdate).toHaveBeenCalledWith({
+      content: [{ type: "text", text: "Searching Ref documentation..." }],
+      details: { status: "pending" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://docs.example.test/mcp",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-ref-api-key": "flag-api-key",
+          "mcp-session-id": "session-123",
+        }),
+      }),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain("React documentation result");
+    expect(result.details.endpoint).toBe("https://docs.example.test/mcp");
+  });
 
-	it("returns a formatted MCP error for ref_read_url failures", async () => {
-		global.fetch = vi
-			.fn()
-			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ jsonrpc: "2.0", id: "ref-mcp-1", result: {} }), {
-					status: 200,
-					headers: { "content-type": "application/json" },
-				}),
-			)
-			.mockResolvedValueOnce(new Response(null, { status: 202 }))
-			.mockResolvedValueOnce(new Response("boom", { status: 500, statusText: "Server Error" })) as typeof fetch;
+  it("returns a formatted MCP error for ref_read_url failures", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "ref-mcp-1", result: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockResolvedValueOnce(new Response("boom", { status: 500, statusText: "Server Error" })) as typeof fetch;
 
-		const mockPi = createMockPi({ "--ref-mcp-url": "https://docs.example.test/mcp" });
-		refTools(mockPi as unknown as ExtensionAPI);
+    const mockPi = createMockPi({ "--ref-mcp-url": "https://docs.example.test/mcp" });
+    refTools(mockPi as unknown as ExtensionAPI);
 
-		const readTool = getRegisteredTool(mockPi, "ref_read_url");
-		const result = await readTool?.execute(
-			"call-2",
-			{ url: "https://example.com/docs" },
-			new AbortController().signal,
-			undefined,
-			undefined,
-		);
+    const readTool = getRegisteredTool(mockPi, "ref_read_url");
+    const result = await readTool?.execute(
+      "call-2",
+      { url: "https://example.com/docs" },
+      new AbortController().signal,
+      undefined,
+      undefined,
+    );
 
-		expect(result.isError).toBe(true);
-		expect(result.content[0].text).toContain("Ref MCP error: MCP HTTP 500: boom");
-		expect(result.details).toEqual({
-			tool: "ref_read_url",
-			endpoint: "https://docs.example.test/mcp",
-			error: "MCP HTTP 500: boom",
-		});
-	});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Ref MCP error: MCP HTTP 500: boom");
+    expect(result.details).toEqual({
+      tool: "ref_read_url",
+      endpoint: "https://docs.example.test/mcp",
+      error: "MCP HTTP 500: boom",
+    });
+  });
 });

--- a/packages/pi-ref-tools/extensions/index.ts
+++ b/packages/pi-ref-tools/extensions/index.ts
@@ -44,17 +44,17 @@ const DEFAULT_ENDPOINT = "https://api.ref.tools/mcp";
 const DEFAULT_TIMEOUT_MS = 30000;
 const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
 const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
-	url: DEFAULT_ENDPOINT,
-	apiKey: null,
-	timeoutMs: DEFAULT_TIMEOUT_MS,
-	protocolVersion: DEFAULT_PROTOCOL_VERSION,
-	maxBytes: DEFAULT_MAX_BYTES,
-	maxLines: DEFAULT_MAX_LINES,
+  url: DEFAULT_ENDPOINT,
+  apiKey: null,
+  timeoutMs: DEFAULT_TIMEOUT_MS,
+  protocolVersion: DEFAULT_PROTOCOL_VERSION,
+  maxBytes: DEFAULT_MAX_BYTES,
+  maxLines: DEFAULT_MAX_LINES,
 };
 
 const CLIENT_INFO = {
-	name: "pi-ref-tools-extension",
-	version: "1.0.0",
+  name: "pi-ref-tools-extension",
+  version: "1.0.0",
 } as const;
 
 // =============================================================================
@@ -64,52 +64,52 @@ const CLIENT_INFO = {
 type JsonRpcId = string;
 
 interface JsonRpcError {
-	code: number;
-	message: string;
-	data?: unknown;
+  code: number;
+  message: string;
+  data?: unknown;
 }
 
 interface JsonRpcResponse {
-	jsonrpc: "2.0";
-	id?: JsonRpcId | number | null;
-	result?: unknown;
-	error?: JsonRpcError;
+  jsonrpc: "2.0";
+  id?: JsonRpcId | number | null;
+  result?: unknown;
+  error?: JsonRpcError;
 }
 
 interface McpToolResult {
-	content?: Array<Record<string, unknown>>;
-	isError?: boolean;
+  content?: Array<Record<string, unknown>>;
+  isError?: boolean;
 }
 
 interface McpToolDetails {
-	tool: string;
-	endpoint: string;
-	truncated: boolean;
-	truncation?: {
-		truncatedBy: "lines" | "bytes" | null;
-		totalLines: number;
-		totalBytes: number;
-		outputLines: number;
-		outputBytes: number;
-		maxLines: number;
-		maxBytes: number;
-	};
-	tempFile?: string;
+  tool: string;
+  endpoint: string;
+  truncated: boolean;
+  truncation?: {
+    truncatedBy: "lines" | "bytes" | null;
+    totalLines: number;
+    totalBytes: number;
+    outputLines: number;
+    outputBytes: number;
+    maxLines: number;
+    maxBytes: number;
+  };
+  tempFile?: string;
 }
 
 interface McpErrorDetails {
-	tool: string;
-	endpoint: string;
-	error: string;
+  tool: string;
+  endpoint: string;
+  error: string;
 }
 
 interface RefMcpConfig {
-	url?: string;
-	apiKey?: string;
-	timeoutMs?: number;
-	protocolVersion?: string;
-	maxBytes?: number;
-	maxLines?: number;
+  url?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  protocolVersion?: string;
+  maxBytes?: number;
+  maxLines?: number;
 }
 
 // =============================================================================
@@ -117,233 +117,233 @@ interface RefMcpConfig {
 // =============================================================================
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
-	return isRecord(value) && value.jsonrpc === "2.0";
+  return isRecord(value) && value.jsonrpc === "2.0";
 }
 
 function toJsonString(value: unknown): string {
-	if (typeof value === "string") {
-		return value;
-	}
-	try {
-		return JSON.stringify(value, null, 2);
-	} catch {
-		return String(value);
-	}
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function formatToolOutput(
-	toolName: string,
-	endpoint: string,
-	result: McpToolResult,
-	limits?: { maxBytes?: number; maxLines?: number },
+  toolName: string,
+  endpoint: string,
+  result: McpToolResult,
+  limits?: { maxBytes?: number; maxLines?: number },
 ): { text: string; details: McpToolDetails } {
-	const contentBlocks = Array.isArray(result.content) ? result.content : [];
-	const renderedBlocks =
-		contentBlocks.length > 0
-			? contentBlocks.map((block) => {
-					if (block.type === "text" && typeof block.text === "string") {
-						return block.text;
-					}
-					return toJsonString(block);
-				})
-			: [toJsonString(result)];
+  const contentBlocks = Array.isArray(result.content) ? result.content : [];
+  const renderedBlocks =
+    contentBlocks.length > 0
+      ? contentBlocks.map((block) => {
+          if (block.type === "text" && typeof block.text === "string") {
+            return block.text;
+          }
+          return toJsonString(block);
+        })
+      : [toJsonString(result)];
 
-	const rawText = renderedBlocks.join("\n");
-	const truncation = truncateHead(rawText, {
-		maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
-		maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
-	});
+  const rawText = renderedBlocks.join("\n");
+  const truncation = truncateHead(rawText, {
+    maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
+    maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
+  });
 
-	let text = truncation.content;
-	let tempFile: string | undefined;
+  let text = truncation.content;
+  let tempFile: string | undefined;
 
-	if (truncation.truncated) {
-		tempFile = writeTempFile(toolName, rawText);
-		text +=
-			`\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
-			`(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
-			`Full output saved to: ${tempFile}]`;
-	}
+  if (truncation.truncated) {
+    tempFile = writeTempFile(toolName, rawText);
+    text +=
+      `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
+      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
+      `Full output saved to: ${tempFile}]`;
+  }
 
-	if (truncation.firstLineExceedsLimit && rawText.length > 0) {
-		text =
-			`[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
-			text;
-	}
+  if (truncation.firstLineExceedsLimit && rawText.length > 0) {
+    text =
+      `[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
+      text;
+  }
 
-	return {
-		text,
-		details: {
-			tool: toolName,
-			endpoint,
-			truncated: truncation.truncated,
-			truncation: {
-				truncatedBy: truncation.truncatedBy,
-				totalLines: truncation.totalLines,
-				totalBytes: truncation.totalBytes,
-				outputLines: truncation.outputLines,
-				outputBytes: truncation.outputBytes,
-				maxLines: truncation.maxLines,
-				maxBytes: truncation.maxBytes,
-			},
-			tempFile,
-		},
-	};
+  return {
+    text,
+    details: {
+      tool: toolName,
+      endpoint,
+      truncated: truncation.truncated,
+      truncation: {
+        truncatedBy: truncation.truncatedBy,
+        totalLines: truncation.totalLines,
+        totalBytes: truncation.totalBytes,
+        outputLines: truncation.outputLines,
+        outputBytes: truncation.outputBytes,
+        maxLines: truncation.maxLines,
+        maxBytes: truncation.maxBytes,
+      },
+      tempFile,
+    },
+  };
 }
 
 function writeTempFile(toolName: string, content: string): string {
-	const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
-	const filename = `pi-ref-tools-${safeName}-${Date.now()}.txt`;
-	const filePath = join(tmpdir(), filename);
-	writeFileSync(filePath, content, "utf-8");
-	return filePath;
+  const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
+  const filename = `pi-ref-tools-${safeName}-${Date.now()}.txt`;
+  const filePath = join(tmpdir(), filename);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
 }
 
 function parseTimeoutMs(value: string | number | undefined, fallback: number): number {
-	if (!value) {
-		return fallback;
-	}
-	const parsed = typeof value === "number" ? value : Number(value);
-	if (!Number.isFinite(parsed) || parsed <= 0) {
-		return fallback;
-	}
-	return parsed;
+  if (!value) {
+    return fallback;
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
 }
 
 function normalizeString(value: unknown): string | undefined {
-	if (typeof value !== "string") {
-		return undefined;
-	}
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function normalizeNumber(value: unknown): number | undefined {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		return value;
-	}
-	if (typeof value === "string") {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed)) {
-			return parsed;
-		}
-	}
-	return undefined;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
 }
 
 function splitParams(params: Record<string, unknown>): {
-	mcpArgs: Record<string, unknown>;
-	requestedLimits: { maxBytes?: number; maxLines?: number };
+  mcpArgs: Record<string, unknown>;
+  requestedLimits: { maxBytes?: number; maxLines?: number };
 } {
-	const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
-		piMaxBytes?: unknown;
-		piMaxLines?: unknown;
-	};
-	return {
-		mcpArgs: rest,
-		requestedLimits: {
-			maxBytes: normalizeNumber(piMaxBytes),
-			maxLines: normalizeNumber(piMaxLines),
-		},
-	};
+  const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
+    piMaxBytes?: unknown;
+    piMaxLines?: unknown;
+  };
+  return {
+    mcpArgs: rest,
+    requestedLimits: {
+      maxBytes: normalizeNumber(piMaxBytes),
+      maxLines: normalizeNumber(piMaxLines),
+    },
+  };
 }
 
 function resolveEffectiveLimits(
-	requested: { maxBytes?: number; maxLines?: number },
-	maxAllowed: { maxBytes: number; maxLines: number },
+  requested: { maxBytes?: number; maxLines?: number },
+  maxAllowed: { maxBytes: number; maxLines: number },
 ): { maxBytes: number; maxLines: number } {
-	const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
-	const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
-	return {
-		maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
-		maxLines: Math.min(requestedLines, maxAllowed.maxLines),
-	};
+  const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
+  const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
+  return {
+    maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
+    maxLines: Math.min(requestedLines, maxAllowed.maxLines),
+  };
 }
 
 function resolveConfigPath(configPath: string): string {
-	const trimmed = configPath.trim();
-	if (trimmed.startsWith("~/")) {
-		return join(homedir(), trimmed.slice(2));
-	}
-	if (trimmed.startsWith("~")) {
-		return join(homedir(), trimmed.slice(1));
-	}
-	if (isAbsolute(trimmed)) {
-		return trimmed;
-	}
-	return resolve(process.cwd(), trimmed);
+  const trimmed = configPath.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(homedir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
 }
 
 function parseConfig(raw: unknown, pathHint: string): RefMcpConfig {
-	if (!isRecord(raw)) {
-		throw new Error(`Invalid Ref MCP config at ${pathHint}: expected an object.`);
-	}
-	return {
-		url: normalizeString(raw.url),
-		apiKey: normalizeString(raw.apiKey),
-		timeoutMs: normalizeNumber(raw.timeoutMs),
-		protocolVersion: normalizeString(raw.protocolVersion),
-		maxBytes: normalizeNumber(raw.maxBytes),
-		maxLines: normalizeNumber(raw.maxLines),
-	};
+  if (!isRecord(raw)) {
+    throw new Error(`Invalid Ref MCP config at ${pathHint}: expected an object.`);
+  }
+  return {
+    url: normalizeString(raw.url),
+    apiKey: normalizeString(raw.apiKey),
+    timeoutMs: normalizeNumber(raw.timeoutMs),
+    protocolVersion: normalizeString(raw.protocolVersion),
+    maxBytes: normalizeNumber(raw.maxBytes),
+    maxLines: normalizeNumber(raw.maxLines),
+  };
 }
 
 function loadConfig(configPath: string | undefined): RefMcpConfig | null {
-	const candidates: string[] = [];
-	const envConfig = process.env.REF_MCP_CONFIG;
-	if (configPath) {
-		candidates.push(resolveConfigPath(configPath));
-	} else if (envConfig) {
-		candidates.push(resolveConfigPath(envConfig));
-	} else {
-		const projectConfigPath = join(process.cwd(), ".pi", "extensions", "ref-tools.json");
-		const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "ref-tools.json");
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		candidates.push(projectConfigPath, globalConfigPath);
-	}
+  const candidates: string[] = [];
+  const envConfig = process.env.REF_MCP_CONFIG;
+  if (configPath) {
+    candidates.push(resolveConfigPath(configPath));
+  } else if (envConfig) {
+    candidates.push(resolveConfigPath(envConfig));
+  } else {
+    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "ref-tools.json");
+    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "ref-tools.json");
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    candidates.push(projectConfigPath, globalConfigPath);
+  }
 
-	for (const candidate of candidates) {
-		if (!existsSync(candidate)) {
-			continue;
-		}
-		try {
-			const raw = readFileSync(candidate, "utf-8");
-			const parsed = JSON.parse(raw);
-			return parseConfig(parsed, candidate);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			console.warn(`[pi-ref-tools] Failed to parse config ${candidate}: ${message}`);
-		}
-	}
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    try {
+      const raw = readFileSync(candidate, "utf-8");
+      const parsed = JSON.parse(raw);
+      return parseConfig(parsed, candidate);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[pi-ref-tools] Failed to parse config ${candidate}: ${message}`);
+    }
+  }
 
-	return null;
+  return null;
 }
 
 function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-	if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-		return;
-	}
-	try {
-		mkdirSync(dirname(globalConfigPath), { recursive: true });
-		writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		console.warn(`[pi-ref-tools] Failed to write ${globalConfigPath}: ${message}`);
-	}
+  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
+    return;
+  }
+  try {
+    mkdirSync(dirname(globalConfigPath), { recursive: true });
+    writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-ref-tools] Failed to write ${globalConfigPath}: ${message}`);
+  }
 }
 
 function redactApiKey(apiKey: string | undefined): string {
-	if (!apiKey) {
-		return "(none)";
-	}
-	if (apiKey.length <= 8) {
-		return "***";
-	}
-	return `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`;
+  if (!apiKey) {
+    return "(none)";
+  }
+  if (apiKey.length <= 8) {
+    return "***";
+  }
+  return `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`;
 }
 
 // =============================================================================
@@ -351,307 +351,307 @@ function redactApiKey(apiKey: string | undefined): string {
 // =============================================================================
 
 class RefMcpClient {
-	private requestCounter = 0;
-	private initialized = false;
-	private initializing: Promise<void> | null = null;
-	private lastEndpoint: string | null = null;
-	private lastApiKey: string | null = null;
-	private sessionId: string | null = null;
+  private requestCounter = 0;
+  private initialized = false;
+  private initializing: Promise<void> | null = null;
+  private lastEndpoint: string | null = null;
+  private lastApiKey: string | null = null;
+  private sessionId: string | null = null;
 
-	constructor(
-		private readonly resolveEndpoint: () => string,
-		private readonly resolveApiKey: () => string | undefined,
-		private readonly getTimeoutMs: () => number,
-		private readonly getProtocolVersion: () => string,
-	) {}
+  constructor(
+    private readonly resolveEndpoint: () => string,
+    private readonly resolveApiKey: () => string | undefined,
+    private readonly getTimeoutMs: () => number,
+    private readonly getProtocolVersion: () => string,
+  ) {}
 
-	currentEndpoint(): string {
-		return this.resolveEndpoint();
-	}
+  currentEndpoint(): string {
+    return this.resolveEndpoint();
+  }
 
-	async callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult> {
-		await this.ensureInitialized(signal);
-		const result = await this.sendRequest("tools/call", { name: toolName, arguments: args }, signal);
-		if (isRecord(result)) {
-			return result as McpToolResult;
-		}
-		return { content: [{ type: "text", text: toJsonString(result) }] };
-	}
+  async callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpToolResult> {
+    await this.ensureInitialized(signal);
+    const result = await this.sendRequest("tools/call", { name: toolName, arguments: args }, signal);
+    if (isRecord(result)) {
+      return result as McpToolResult;
+    }
+    return { content: [{ type: "text", text: toJsonString(result) }] };
+  }
 
-	private async ensureInitialized(signal?: AbortSignal): Promise<void> {
-		const endpoint = this.resolveEndpoint();
-		const apiKey = this.resolveApiKey();
-		if (this.lastEndpoint !== endpoint || this.lastApiKey !== apiKey) {
-			this.initialized = false;
-			this.initializing = null;
-			this.sessionId = null;
-			this.lastEndpoint = endpoint;
-			this.lastApiKey = apiKey ?? null;
-		}
+  private async ensureInitialized(signal?: AbortSignal): Promise<void> {
+    const endpoint = this.resolveEndpoint();
+    const apiKey = this.resolveApiKey();
+    if (this.lastEndpoint !== endpoint || this.lastApiKey !== apiKey) {
+      this.initialized = false;
+      this.initializing = null;
+      this.sessionId = null;
+      this.lastEndpoint = endpoint;
+      this.lastApiKey = apiKey ?? null;
+    }
 
-		if (this.initialized) {
-			return;
-		}
+    if (this.initialized) {
+      return;
+    }
 
-		if (!this.initializing) {
-			this.initializing = (async () => {
-				await this.initialize(signal);
-				this.initialized = true;
-			})()
-				.catch((error) => {
-					this.initialized = false;
-					throw error;
-				})
-				.finally(() => {
-					this.initializing = null;
-				});
-		}
+    if (!this.initializing) {
+      this.initializing = (async () => {
+        await this.initialize(signal);
+        this.initialized = true;
+      })()
+        .catch((error) => {
+          this.initialized = false;
+          throw error;
+        })
+        .finally(() => {
+          this.initializing = null;
+        });
+    }
 
-		await this.initializing;
-	}
+    await this.initializing;
+  }
 
-	private async initialize(signal?: AbortSignal): Promise<void> {
-		await this.sendRequest(
-			"initialize",
-			{
-				protocolVersion: this.getProtocolVersion(),
-				capabilities: {},
-				clientInfo: CLIENT_INFO,
-			},
-			signal,
-		);
-		await this.sendNotification("notifications/initialized", {}, signal);
-	}
+  private async initialize(signal?: AbortSignal): Promise<void> {
+    await this.sendRequest(
+      "initialize",
+      {
+        protocolVersion: this.getProtocolVersion(),
+        capabilities: {},
+        clientInfo: CLIENT_INFO,
+      },
+      signal,
+    );
+    await this.sendNotification("notifications/initialized", {}, signal);
+  }
 
-	private async sendRequest(method: string, params: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
-		const id = this.nextId();
-		const response = await this.sendJsonRpc(
-			{
-				jsonrpc: "2.0",
-				id,
-				method,
-				params,
-			},
-			signal,
-		);
+  private async sendRequest(method: string, params: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    const id = this.nextId();
+    const response = await this.sendJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id,
+        method,
+        params,
+      },
+      signal,
+    );
 
-		const json = extractJsonRpcResponse(response, id);
-		if (json.error) {
-			throw new Error(`MCP error ${json.error.code}: ${json.error.message}`);
-		}
-		return json.result;
-	}
+    const json = extractJsonRpcResponse(response, id);
+    if (json.error) {
+      throw new Error(`MCP error ${json.error.code}: ${json.error.message}`);
+    }
+    return json.result;
+  }
 
-	private async sendNotification(method: string, params: Record<string, unknown>, signal?: AbortSignal): Promise<void> {
-		await this.sendJsonRpc(
-			{
-				jsonrpc: "2.0",
-				method,
-				params,
-			},
-			signal,
-			true,
-		);
-	}
+  private async sendNotification(method: string, params: Record<string, unknown>, signal?: AbortSignal): Promise<void> {
+    await this.sendJsonRpc(
+      {
+        jsonrpc: "2.0",
+        method,
+        params,
+      },
+      signal,
+      true,
+    );
+  }
 
-	private async sendJsonRpc(
-		payload: Record<string, unknown>,
-		signal?: AbortSignal,
-		isNotification = false,
-	): Promise<unknown> {
-		const endpoint = this.resolveEndpoint();
-		const apiKey = this.resolveApiKey();
-		const { signal: mergedSignal, cleanup } = createMergedSignal(signal, this.getTimeoutMs());
+  private async sendJsonRpc(
+    payload: Record<string, unknown>,
+    signal?: AbortSignal,
+    isNotification = false,
+  ): Promise<unknown> {
+    const endpoint = this.resolveEndpoint();
+    const apiKey = this.resolveApiKey();
+    const { signal: mergedSignal, cleanup } = createMergedSignal(signal, this.getTimeoutMs());
 
-		const headers: Record<string, string> = {
-			"content-type": "application/json",
-			accept: "application/json, text/event-stream",
-		};
-		if (apiKey) {
-			headers["x-ref-api-key"] = apiKey;
-		}
-		if (this.sessionId) {
-			headers["mcp-session-id"] = this.sessionId;
-		}
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    };
+    if (apiKey) {
+      headers["x-ref-api-key"] = apiKey;
+    }
+    if (this.sessionId) {
+      headers["mcp-session-id"] = this.sessionId;
+    }
 
-		try {
-			const response = await fetch(endpoint, {
-				method: "POST",
-				headers,
-				body: JSON.stringify(payload),
-				signal: mergedSignal,
-			});
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        signal: mergedSignal,
+      });
 
-			// Capture session ID from server (set during initialize, persisted for all subsequent requests)
-			const returnedSessionId = response.headers.get("mcp-session-id");
-			if (returnedSessionId) {
-				this.sessionId = returnedSessionId;
-			}
+      // Capture session ID from server (set during initialize, persisted for all subsequent requests)
+      const returnedSessionId = response.headers.get("mcp-session-id");
+      if (returnedSessionId) {
+        this.sessionId = returnedSessionId;
+      }
 
-			if (response.status === 204 || response.status === 202) {
-				return undefined;
-			}
+      if (response.status === 204 || response.status === 202) {
+        return undefined;
+      }
 
-			if (!response.ok) {
-				const text = await response.text();
-				throw new Error(`MCP HTTP ${response.status}: ${text || response.statusText}`);
-			}
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`MCP HTTP ${response.status}: ${text || response.statusText}`);
+      }
 
-			if (isNotification) {
-				return undefined;
-			}
+      if (isNotification) {
+        return undefined;
+      }
 
-			const contentType = response.headers.get("content-type") ?? "";
-			if (contentType.includes("application/json")) {
-				const json: unknown = await response.json();
-				return json;
-			}
-			if (contentType.includes("text/event-stream")) {
-				return parseSseResponse(response, payload.id);
-			}
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("application/json")) {
+        const json: unknown = await response.json();
+        return json;
+      }
+      if (contentType.includes("text/event-stream")) {
+        return parseSseResponse(response, payload.id);
+      }
 
-			const text = await response.text();
-			throw new Error(`Unexpected MCP response content-type: ${contentType || "unknown"} (${text.slice(0, 200)})`);
-		} finally {
-			cleanup();
-		}
-	}
+      const text = await response.text();
+      throw new Error(`Unexpected MCP response content-type: ${contentType || "unknown"} (${text.slice(0, 200)})`);
+    } finally {
+      cleanup();
+    }
+  }
 
-	private nextId(): JsonRpcId {
-		this.requestCounter += 1;
-		return `ref-mcp-${this.requestCounter}`;
-	}
+  private nextId(): JsonRpcId {
+    this.requestCounter += 1;
+    return `ref-mcp-${this.requestCounter}`;
+  }
 }
 
 function extractJsonRpcResponse(response: unknown, requestId: unknown): JsonRpcResponse {
-	if (Array.isArray(response)) {
-		const match = response.find((item) => isJsonRpcResponse(item) && item.id === requestId);
-		if (match) {
-			return match;
-		}
-		throw new Error("MCP response did not include matching request id.");
-	}
+  if (Array.isArray(response)) {
+    const match = response.find((item) => isJsonRpcResponse(item) && item.id === requestId);
+    if (match) {
+      return match;
+    }
+    throw new Error("MCP response did not include matching request id.");
+  }
 
-	if (isJsonRpcResponse(response)) {
-		return response;
-	}
+  if (isJsonRpcResponse(response)) {
+    return response;
+  }
 
-	throw new Error("Invalid MCP response payload.");
+  throw new Error("Invalid MCP response payload.");
 }
 
 function extractSseData(line: string): string | undefined {
-	if (!line.startsWith("data:")) {
-		return undefined;
-	}
+  if (!line.startsWith("data:")) {
+    return undefined;
+  }
 
-	const data = line.slice(5).trim();
-	if (!data || data === "[DONE]") {
-		return undefined;
-	}
+  const data = line.slice(5).trim();
+  if (!data || data === "[DONE]") {
+    return undefined;
+  }
 
-	return data;
+  return data;
 }
 
 function parseMatchingSseMessage(data: string, requestId: unknown): unknown {
-	try {
-		const parsed: unknown = JSON.parse(data);
-		if (isRecord(parsed) && parsed.id === requestId) {
-			return parsed;
-		}
-	} catch {
-		// Ignore malformed SSE chunk.
-	}
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (isRecord(parsed) && parsed.id === requestId) {
+      return parsed;
+    }
+  } catch {
+    // Ignore malformed SSE chunk.
+  }
 
-	return undefined;
+  return undefined;
 }
 
 function extractMatchingSseResponse(buffer: string, requestId: unknown): { remainingBuffer: string; matched: unknown } {
-	let remainingBuffer = buffer;
-	let newlineIndex = remainingBuffer.indexOf("\n");
+  let remainingBuffer = buffer;
+  let newlineIndex = remainingBuffer.indexOf("\n");
 
-	while (newlineIndex >= 0) {
-		const line = remainingBuffer.slice(0, newlineIndex).trimEnd();
-		remainingBuffer = remainingBuffer.slice(newlineIndex + 1);
-		newlineIndex = remainingBuffer.indexOf("\n");
+  while (newlineIndex >= 0) {
+    const line = remainingBuffer.slice(0, newlineIndex).trimEnd();
+    remainingBuffer = remainingBuffer.slice(newlineIndex + 1);
+    newlineIndex = remainingBuffer.indexOf("\n");
 
-		const data = extractSseData(line);
-		if (!data) {
-			continue;
-		}
+    const data = extractSseData(line);
+    if (!data) {
+      continue;
+    }
 
-		const matched = parseMatchingSseMessage(data, requestId);
-		if (matched) {
-			return { remainingBuffer, matched };
-		}
-	}
+    const matched = parseMatchingSseMessage(data, requestId);
+    if (matched) {
+      return { remainingBuffer, matched };
+    }
+  }
 
-	return { remainingBuffer, matched: undefined };
+  return { remainingBuffer, matched: undefined };
 }
 
 async function parseSseResponse(response: Response, requestId: unknown): Promise<unknown> {
-	if (!response.body) {
-		throw new Error("MCP response stream missing body.");
-	}
+  if (!response.body) {
+    throw new Error("MCP response stream missing body.");
+  }
 
-	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
-	let buffer = "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
 
-	while (true) {
-		const { value, done } = await reader.read();
-		if (done) {
-			break;
-		}
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
 
-		buffer += decoder.decode(value, { stream: true });
-		const result = extractMatchingSseResponse(buffer, requestId);
-		buffer = result.remainingBuffer;
+    buffer += decoder.decode(value, { stream: true });
+    const result = extractMatchingSseResponse(buffer, requestId);
+    buffer = result.remainingBuffer;
 
-		if (result.matched) {
-			await reader.cancel();
-			return result.matched;
-		}
-	}
+    if (result.matched) {
+      await reader.cancel();
+      return result.matched;
+    }
+  }
 
-	throw new Error("MCP SSE response ended without a matching result.");
+  throw new Error("MCP SSE response ended without a matching result.");
 }
 
 function createMergedSignal(
-	parentSignal: AbortSignal | undefined,
-	timeoutMs: number,
+  parentSignal: AbortSignal | undefined,
+  timeoutMs: number,
 ): { signal: AbortSignal; cleanup: () => void } {
-	const controller = new AbortController();
-	let timeoutId: NodeJS.Timeout | undefined;
+  const controller = new AbortController();
+  let timeoutId: NodeJS.Timeout | undefined;
 
-	const handleAbort = () => {
-		controller.abort();
-	};
+  const handleAbort = () => {
+    controller.abort();
+  };
 
-	if (parentSignal) {
-		if (parentSignal.aborted) {
-			controller.abort();
-		} else {
-			parentSignal.addEventListener("abort", handleAbort, { once: true });
-		}
-	}
+  if (parentSignal) {
+    if (parentSignal.aborted) {
+      controller.abort();
+    } else {
+      parentSignal.addEventListener("abort", handleAbort, { once: true });
+    }
+  }
 
-	if (timeoutMs > 0) {
-		timeoutId = setTimeout(() => {
-			controller.abort();
-		}, timeoutMs);
-	}
+  if (timeoutMs > 0) {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+    }, timeoutMs);
+  }
 
-	return {
-		signal: controller.signal,
-		cleanup: () => {
-			if (timeoutId) {
-				clearTimeout(timeoutId);
-			}
-			if (parentSignal) {
-				parentSignal.removeEventListener("abort", handleAbort);
-			}
-		},
-	};
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (parentSignal) {
+        parentSignal.removeEventListener("abort", handleAbort);
+      }
+    },
+  };
 }
 
 // =============================================================================
@@ -659,23 +659,23 @@ function createMergedSignal(
 // =============================================================================
 
 const searchDocumentationParams = Type.Object(
-	{
-		query: Type.String({
-			description: "Your search query. Include programming language, framework, or library names for best results.",
-		}),
-		piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-		piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-	},
-	{ additionalProperties: true },
+  {
+    query: Type.String({
+      description: "Your search query. Include programming language, framework, or library names for best results.",
+    }),
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
 );
 
 const readUrlParams = Type.Object(
-	{
-		url: Type.String({ description: "The exact URL of the documentation page to read." }),
-		piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-		piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-	},
-	{ additionalProperties: true },
+  {
+    url: Type.String({ description: "The exact URL of the documentation page to read." }),
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
 );
 
 // =============================================================================
@@ -683,232 +683,232 @@ const readUrlParams = Type.Object(
 // =============================================================================
 
 function getConfigOverride(pi: ExtensionAPI): string | undefined {
-	const configFlag = pi.getFlag("--ref-mcp-config");
-	return typeof configFlag === "string" ? configFlag : undefined;
+  const configFlag = pi.getFlag("--ref-mcp-config");
+  return typeof configFlag === "string" ? configFlag : undefined;
 }
 
 type ApiKeySource = "CLI flag" | "REF_API_KEY env var" | "config file";
 
 interface RefRuntimeSettings {
-	config: RefMcpConfig | null;
-	endpoint: string;
-	apiKey?: string;
-	apiKeySource?: ApiKeySource;
-	maxBytes: number;
-	maxLines: number;
-	timeoutMs: number;
-	protocolVersion: string;
+  config: RefMcpConfig | null;
+  endpoint: string;
+  apiKey?: string;
+  apiKeySource?: ApiKeySource;
+  maxBytes: number;
+  maxLines: number;
+  timeoutMs: number;
+  protocolVersion: string;
 }
 
 function loadRuntimeConfig(pi: ExtensionAPI): RefMcpConfig | null {
-	return loadConfig(getConfigOverride(pi));
+  return loadConfig(getConfigOverride(pi));
 }
 
 function resolveRuntimeSettings(pi: ExtensionAPI): RefRuntimeSettings {
-	const config = loadRuntimeConfig(pi);
-	const urlFlag = normalizeString(pi.getFlag("--ref-mcp-url"));
-	const envUrl = normalizeString(process.env.REF_MCP_URL);
-	const configUrl = normalizeString(config?.url);
-	const endpoint = urlFlag ?? envUrl ?? configUrl ?? DEFAULT_ENDPOINT;
+  const config = loadRuntimeConfig(pi);
+  const urlFlag = normalizeString(pi.getFlag("--ref-mcp-url"));
+  const envUrl = normalizeString(process.env.REF_MCP_URL);
+  const configUrl = normalizeString(config?.url);
+  const endpoint = urlFlag ?? envUrl ?? configUrl ?? DEFAULT_ENDPOINT;
 
-	const apiKeyFlag = normalizeString(pi.getFlag("--ref-mcp-api-key"));
-	const envApiKey = normalizeString(process.env.REF_API_KEY);
-	const configApiKey = normalizeString(config?.apiKey);
-	const apiKey = apiKeyFlag ?? envApiKey ?? configApiKey;
-	const apiKeySource = apiKeyFlag
-		? "CLI flag"
-		: envApiKey
-			? "REF_API_KEY env var"
-			: configApiKey
-				? "config file"
-				: undefined;
+  const apiKeyFlag = normalizeString(pi.getFlag("--ref-mcp-api-key"));
+  const envApiKey = normalizeString(process.env.REF_API_KEY);
+  const configApiKey = normalizeString(config?.apiKey);
+  const apiKey = apiKeyFlag ?? envApiKey ?? configApiKey;
+  const apiKeySource = apiKeyFlag
+    ? "CLI flag"
+    : envApiKey
+      ? "REF_API_KEY env var"
+      : configApiKey
+        ? "config file"
+        : undefined;
 
-	const maxBytesFlag = normalizeNumber(pi.getFlag("--ref-mcp-max-bytes"));
-	const maxLinesFlag = normalizeNumber(pi.getFlag("--ref-mcp-max-lines"));
-	const maxBytes =
-		maxBytesFlag ?? normalizeNumber(process.env.REF_MCP_MAX_BYTES ?? config?.maxBytes) ?? DEFAULT_MAX_BYTES;
-	const maxLines =
-		maxLinesFlag ?? normalizeNumber(process.env.REF_MCP_MAX_LINES ?? config?.maxLines) ?? DEFAULT_MAX_LINES;
+  const maxBytesFlag = normalizeNumber(pi.getFlag("--ref-mcp-max-bytes"));
+  const maxLinesFlag = normalizeNumber(pi.getFlag("--ref-mcp-max-lines"));
+  const maxBytes =
+    maxBytesFlag ?? normalizeNumber(process.env.REF_MCP_MAX_BYTES ?? config?.maxBytes) ?? DEFAULT_MAX_BYTES;
+  const maxLines =
+    maxLinesFlag ?? normalizeNumber(process.env.REF_MCP_MAX_LINES ?? config?.maxLines) ?? DEFAULT_MAX_LINES;
 
-	const timeoutFlag = pi.getFlag("--ref-mcp-timeout-ms");
-	const timeoutValue =
-		typeof timeoutFlag === "string" ? timeoutFlag : (process.env.REF_MCP_TIMEOUT_MS ?? config?.timeoutMs);
-	const timeoutMs = parseTimeoutMs(timeoutValue, DEFAULT_TIMEOUT_MS);
+  const timeoutFlag = pi.getFlag("--ref-mcp-timeout-ms");
+  const timeoutValue =
+    typeof timeoutFlag === "string" ? timeoutFlag : (process.env.REF_MCP_TIMEOUT_MS ?? config?.timeoutMs);
+  const timeoutMs = parseTimeoutMs(timeoutValue, DEFAULT_TIMEOUT_MS);
 
-	const protocolFlag = normalizeString(pi.getFlag("--ref-mcp-protocol"));
-	const envProtocol = normalizeString(process.env.REF_MCP_PROTOCOL_VERSION);
-	const protocolVersion = protocolFlag ?? envProtocol ?? config?.protocolVersion ?? DEFAULT_PROTOCOL_VERSION;
+  const protocolFlag = normalizeString(pi.getFlag("--ref-mcp-protocol"));
+  const envProtocol = normalizeString(process.env.REF_MCP_PROTOCOL_VERSION);
+  const protocolVersion = protocolFlag ?? envProtocol ?? config?.protocolVersion ?? DEFAULT_PROTOCOL_VERSION;
 
-	return {
-		config,
-		endpoint,
-		apiKey,
-		apiKeySource,
-		maxBytes,
-		maxLines,
-		timeoutMs,
-		protocolVersion,
-	};
+  return {
+    config,
+    endpoint,
+    apiKey,
+    apiKeySource,
+    maxBytes,
+    maxLines,
+    timeoutMs,
+    protocolVersion,
+  };
 }
 
 function formatSessionStartMessage(settings: RefRuntimeSettings): string {
-	if (settings.apiKeySource) {
-		return `[ref-tools] Connected to ${settings.endpoint} (API key: ${settings.apiKeySource})`;
-	}
-	return `[ref-tools] No API key configured for ${settings.endpoint}. Set REF_API_KEY or use --ref-mcp-api-key.`;
+  if (settings.apiKeySource) {
+    return `[ref-tools] Connected to ${settings.endpoint} (API key: ${settings.apiKeySource})`;
+  }
+  return `[ref-tools] No API key configured for ${settings.endpoint}. Set REF_API_KEY or use --ref-mcp-api-key.`;
 }
 
 export {
-	DEFAULT_CONFIG_FILE,
-	ensureDefaultConfigFile,
-	extractMatchingSseResponse,
-	extractSseData,
-	formatSessionStartMessage,
-	formatToolOutput,
-	isJsonRpcResponse,
-	isRecord,
-	loadRuntimeConfig,
-	normalizeNumber,
-	normalizeString,
-	parseConfig,
-	parseMatchingSseMessage,
-	parseTimeoutMs,
-	redactApiKey,
-	resolveConfigPath,
-	resolveEffectiveLimits,
-	resolveRuntimeSettings,
-	splitParams,
-	toJsonString,
-	writeTempFile,
+  DEFAULT_CONFIG_FILE,
+  ensureDefaultConfigFile,
+  extractMatchingSseResponse,
+  extractSseData,
+  formatSessionStartMessage,
+  formatToolOutput,
+  isJsonRpcResponse,
+  isRecord,
+  loadRuntimeConfig,
+  normalizeNumber,
+  normalizeString,
+  parseConfig,
+  parseMatchingSseMessage,
+  parseTimeoutMs,
+  redactApiKey,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  resolveRuntimeSettings,
+  splitParams,
+  toJsonString,
+  writeTempFile,
 };
 
 export default function refTools(pi: ExtensionAPI) {
-	// SessionStart: check config and print status
-	pi.on("session_start", async () => {
-		console.log(formatSessionStartMessage(resolveRuntimeSettings(pi)));
-	});
+  // SessionStart: check config and print status
+  pi.on("session_start", async () => {
+    console.log(formatSessionStartMessage(resolveRuntimeSettings(pi)));
+  });
 
-	// Register CLI flags
-	pi.registerFlag("--ref-mcp-url", {
-		description: "Override the Ref MCP endpoint.",
-		type: "string",
-	});
-	pi.registerFlag("--ref-mcp-api-key", {
-		description: "Ref API key (sent as x-ref-api-key header).",
-		type: "string",
-	});
-	pi.registerFlag("--ref-mcp-timeout-ms", {
-		description: "HTTP timeout for MCP requests (milliseconds).",
-		type: "string",
-	});
-	pi.registerFlag("--ref-mcp-protocol", {
-		description: "MCP protocol version for initialize() (default: 2025-06-18).",
-		type: "string",
-	});
-	pi.registerFlag("--ref-mcp-config", {
-		description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/ref-tools.json).",
-		type: "string",
-	});
-	pi.registerFlag("--ref-mcp-max-bytes", {
-		description: "Max bytes to keep from tool output (default: 51200).",
-		type: "string",
-	});
-	pi.registerFlag("--ref-mcp-max-lines", {
-		description: "Max lines to keep from tool output (default: 2000).",
-		type: "string",
-	});
+  // Register CLI flags
+  pi.registerFlag("--ref-mcp-url", {
+    description: "Override the Ref MCP endpoint.",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-api-key", {
+    description: "Ref API key (sent as x-ref-api-key header).",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-timeout-ms", {
+    description: "HTTP timeout for MCP requests (milliseconds).",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-protocol", {
+    description: "MCP protocol version for initialize() (default: 2025-06-18).",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-config", {
+    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/ref-tools.json).",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-max-bytes", {
+    description: "Max bytes to keep from tool output (default: 51200).",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-max-lines", {
+    description: "Max lines to keep from tool output (default: 2000).",
+    type: "string",
+  });
 
-	const getRuntimeSettings = (): RefRuntimeSettings => resolveRuntimeSettings(pi);
-	const getBaseUrl = (): string => getRuntimeSettings().endpoint;
-	const getApiKey = (): string | undefined => getRuntimeSettings().apiKey;
-	const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
-		const { maxBytes, maxLines } = getRuntimeSettings();
-		return { maxBytes, maxLines };
-	};
+  const getRuntimeSettings = (): RefRuntimeSettings => resolveRuntimeSettings(pi);
+  const getBaseUrl = (): string => getRuntimeSettings().endpoint;
+  const getApiKey = (): string | undefined => getRuntimeSettings().apiKey;
+  const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
+    const { maxBytes, maxLines } = getRuntimeSettings();
+    return { maxBytes, maxLines };
+  };
 
-	const client = new RefMcpClient(
-		() => getBaseUrl(),
-		() => getApiKey(),
-		() => getRuntimeSettings().timeoutMs,
-		() => getRuntimeSettings().protocolVersion,
-	);
+  const client = new RefMcpClient(
+    () => getBaseUrl(),
+    () => getApiKey(),
+    () => getRuntimeSettings().timeoutMs,
+    () => getRuntimeSettings().protocolVersion,
+  );
 
-	// Register ref_search_documentation tool
-	pi.registerTool({
-		name: "ref_search_documentation",
-		label: "Ref Doc Search",
-		description:
-			"Search technical documentation via Ref.tools; best for API docs, library references, and framework guides. " +
-			"Include language/framework names in your query for best results. " +
-			"Client-side truncation; override with piMaxBytes/piMaxLines (clamped by config).",
-		parameters: searchDocumentationParams,
-		async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-			if (signal?.aborted) {
-				return { content: [{ type: "text", text: "Cancelled." }], details: { cancelled: true } };
-			}
-			onUpdate?.({
-				content: [{ type: "text", text: "Searching Ref documentation..." }],
-				details: { status: "pending" },
-			});
+  // Register ref_search_documentation tool
+  pi.registerTool({
+    name: "ref_search_documentation",
+    label: "Ref Doc Search",
+    description:
+      "Search technical documentation via Ref.tools; best for API docs, library references, and framework guides. " +
+      "Include language/framework names in your query for best results. " +
+      "Client-side truncation; override with piMaxBytes/piMaxLines (clamped by config).",
+    parameters: searchDocumentationParams,
+    async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+      if (signal?.aborted) {
+        return { content: [{ type: "text", text: "Cancelled." }], details: { cancelled: true } };
+      }
+      onUpdate?.({
+        content: [{ type: "text", text: "Searching Ref documentation..." }],
+        details: { status: "pending" },
+      });
 
-			try {
-				const endpoint = client.currentEndpoint();
-				const { mcpArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
-				const maxLimits = getMaxLimits();
-				const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-				const result = await client.callTool("ref_search_documentation", mcpArgs, signal);
-				const { text, details } = formatToolOutput("ref_search_documentation", endpoint, result, effectiveLimits);
-				return { content: [{ type: "text", text }], details, isError: result.isError === true };
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return {
-					content: [{ type: "text", text: `Ref MCP error: ${message}` }],
-					isError: true,
-					details: {
-						tool: "ref_search_documentation",
-						endpoint: client.currentEndpoint(),
-						error: message,
-					} satisfies McpErrorDetails,
-				};
-			}
-		},
-	});
+      try {
+        const endpoint = client.currentEndpoint();
+        const { mcpArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
+        const maxLimits = getMaxLimits();
+        const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
+        const result = await client.callTool("ref_search_documentation", mcpArgs, signal);
+        const { text, details } = formatToolOutput("ref_search_documentation", endpoint, result, effectiveLimits);
+        return { content: [{ type: "text", text }], details, isError: result.isError === true };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Ref MCP error: ${message}` }],
+          isError: true,
+          details: {
+            tool: "ref_search_documentation",
+            endpoint: client.currentEndpoint(),
+            error: message,
+          } satisfies McpErrorDetails,
+        };
+      }
+    },
+  });
 
-	// Register ref_read_url tool
-	pi.registerTool({
-		name: "ref_read_url",
-		label: "Ref Read URL",
-		description:
-			"Read a documentation URL via Ref.tools and return optimized markdown. " +
-			"Pass the exact URL from a ref_search_documentation result or any documentation page. " +
-			"Client-side truncation; override with piMaxBytes/piMaxLines (clamped by config).",
-		parameters: readUrlParams,
-		async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-			if (signal?.aborted) {
-				return { content: [{ type: "text", text: "Cancelled." }], details: { cancelled: true } };
-			}
-			onUpdate?.({ content: [{ type: "text", text: "Reading URL via Ref..." }], details: { status: "pending" } });
+  // Register ref_read_url tool
+  pi.registerTool({
+    name: "ref_read_url",
+    label: "Ref Read URL",
+    description:
+      "Read a documentation URL via Ref.tools and return optimized markdown. " +
+      "Pass the exact URL from a ref_search_documentation result or any documentation page. " +
+      "Client-side truncation; override with piMaxBytes/piMaxLines (clamped by config).",
+    parameters: readUrlParams,
+    async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+      if (signal?.aborted) {
+        return { content: [{ type: "text", text: "Cancelled." }], details: { cancelled: true } };
+      }
+      onUpdate?.({ content: [{ type: "text", text: "Reading URL via Ref..." }], details: { status: "pending" } });
 
-			try {
-				const endpoint = client.currentEndpoint();
-				const { mcpArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
-				const maxLimits = getMaxLimits();
-				const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-				const result = await client.callTool("ref_read_url", mcpArgs, signal);
-				const { text, details } = formatToolOutput("ref_read_url", endpoint, result, effectiveLimits);
-				return { content: [{ type: "text", text }], details, isError: result.isError === true };
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return {
-					content: [{ type: "text", text: `Ref MCP error: ${message}` }],
-					isError: true,
-					details: {
-						tool: "ref_read_url",
-						endpoint: client.currentEndpoint(),
-						error: message,
-					} satisfies McpErrorDetails,
-				};
-			}
-		},
-	});
+      try {
+        const endpoint = client.currentEndpoint();
+        const { mcpArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
+        const maxLimits = getMaxLimits();
+        const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
+        const result = await client.callTool("ref_read_url", mcpArgs, signal);
+        const { text, details } = formatToolOutput("ref_read_url", endpoint, result, effectiveLimits);
+        return { content: [{ type: "text", text }], details, isError: result.isError === true };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Ref MCP error: ${message}` }],
+          isError: true,
+          details: {
+            tool: "ref_read_url",
+            endpoint: client.currentEndpoint(),
+            error: message,
+          } satisfies McpErrorDetails,
+        };
+      }
+    },
+  });
 }

--- a/packages/pi-sequential-thinking/__tests__/analyzer.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/analyzer.test.ts
@@ -3,210 +3,210 @@ import { ThoughtAnalyzer } from "../extensions/analyzer.js";
 import { ThoughtStage } from "../extensions/types.js";
 
 describe("ThoughtAnalyzer", () => {
-	const analyzer = new ThoughtAnalyzer();
+  const analyzer = new ThoughtAnalyzer();
 
-	// Helper to create thought data
-	const createThought = (
-		overrides: Partial<{
-			id: string;
-			thought_number: number;
-			stage: ThoughtStage;
-			tags: string[];
-			total_thoughts: number;
-		}> = {},
-	) => ({
-		thought: "Test thought",
-		thought_number: 1,
-		total_thoughts: 5,
-		next_thought_needed: true,
-		stage: ThoughtStage.ANALYSIS,
-		tags: [],
-		axioms_used: [],
-		assumptions_challenged: [],
-		timestamp: "2024-01-01T00:00:00.000Z",
-		id: "default-id",
-		...overrides,
-	});
+  // Helper to create thought data
+  const createThought = (
+    overrides: Partial<{
+      id: string;
+      thought_number: number;
+      stage: ThoughtStage;
+      tags: string[];
+      total_thoughts: number;
+    }> = {},
+  ) => ({
+    thought: "Test thought",
+    thought_number: 1,
+    total_thoughts: 5,
+    next_thought_needed: true,
+    stage: ThoughtStage.ANALYSIS,
+    tags: [],
+    axioms_used: [],
+    assumptions_challenged: [],
+    timestamp: "2024-01-01T00:00:00.000Z",
+    id: "default-id",
+    ...overrides,
+  });
 
-	describe("findRelatedThoughts", () => {
-		it("finds thoughts in the same stage", () => {
-			const current = createThought({ id: "current", stage: ThoughtStage.ANALYSIS });
-			const related1 = createThought({ id: "related1", stage: ThoughtStage.ANALYSIS });
-			const related2 = createThought({ id: "related2", stage: ThoughtStage.ANALYSIS });
-			const other = createThought({ id: "other", stage: ThoughtStage.RESEARCH });
+  describe("findRelatedThoughts", () => {
+    it("finds thoughts in the same stage", () => {
+      const current = createThought({ id: "current", stage: ThoughtStage.ANALYSIS });
+      const related1 = createThought({ id: "related1", stage: ThoughtStage.ANALYSIS });
+      const related2 = createThought({ id: "related2", stage: ThoughtStage.ANALYSIS });
+      const other = createThought({ id: "other", stage: ThoughtStage.RESEARCH });
 
-			const allThoughts = [current, related1, related2, other];
-			const result = analyzer.findRelatedThoughts(current, allThoughts);
+      const allThoughts = [current, related1, related2, other];
+      const result = analyzer.findRelatedThoughts(current, allThoughts);
 
-			expect(result.map((t) => t.id)).toContain("related1");
-			expect(result.map((t) => t.id)).toContain("related2");
-			expect(result.map((t) => t.id)).not.toContain("other");
-		});
+      expect(result.map((t) => t.id)).toContain("related1");
+      expect(result.map((t) => t.id)).toContain("related2");
+      expect(result.map((t) => t.id)).not.toContain("other");
+    });
 
-		it("prioritizes same stage over tag matches", () => {
-			const current = createThought({
-				id: "current",
-				stage: ThoughtStage.RESEARCH,
-				tags: ["tag1"],
-			});
-			const sameStage = createThought({ id: "same-stage", stage: ThoughtStage.RESEARCH });
-			const tagMatch = createThought({
-				id: "tag-match",
-				stage: ThoughtStage.ANALYSIS,
-				tags: ["tag1"],
-			});
+    it("prioritizes same stage over tag matches", () => {
+      const current = createThought({
+        id: "current",
+        stage: ThoughtStage.RESEARCH,
+        tags: ["tag1"],
+      });
+      const sameStage = createThought({ id: "same-stage", stage: ThoughtStage.RESEARCH });
+      const tagMatch = createThought({
+        id: "tag-match",
+        stage: ThoughtStage.ANALYSIS,
+        tags: ["tag1"],
+      });
 
-			const allThoughts = [current, sameStage, tagMatch];
-			const result = analyzer.findRelatedThoughts(current, allThoughts, 1);
+      const allThoughts = [current, sameStage, tagMatch];
+      const result = analyzer.findRelatedThoughts(current, allThoughts, 1);
 
-			expect(result[0].id).toBe("same-stage");
-		});
+      expect(result[0].id).toBe("same-stage");
+    });
 
-		it("respects maxResults limit", () => {
-			const current = createThought({ id: "current", stage: ThoughtStage.ANALYSIS });
-			const related = [
-				createThought({ id: "r1", stage: ThoughtStage.ANALYSIS }),
-				createThought({ id: "r2", stage: ThoughtStage.ANALYSIS }),
-				createThought({ id: "r3", stage: ThoughtStage.ANALYSIS }),
-			];
+    it("respects maxResults limit", () => {
+      const current = createThought({ id: "current", stage: ThoughtStage.ANALYSIS });
+      const related = [
+        createThought({ id: "r1", stage: ThoughtStage.ANALYSIS }),
+        createThought({ id: "r2", stage: ThoughtStage.ANALYSIS }),
+        createThought({ id: "r3", stage: ThoughtStage.ANALYSIS }),
+      ];
 
-			const result = analyzer.findRelatedThoughts(current, [current, ...related], 2);
-			expect(result.length).toBe(2);
-		});
+      const result = analyzer.findRelatedThoughts(current, [current, ...related], 2);
+      expect(result.length).toBe(2);
+    });
 
-		it("finds tag-based related thoughts", () => {
-			const current = createThought({
-				id: "current",
-				stage: ThoughtStage.RESEARCH, // Different stage so tag matching is primary
-				tags: ["database", "performance"],
-			});
-			const match1 = createThought({ id: "match1", stage: ThoughtStage.ANALYSIS, tags: ["database"] });
-			const match2 = createThought({ id: "match2", stage: ThoughtStage.SYNTHESIS, tags: ["database", "performance"] });
+    it("finds tag-based related thoughts", () => {
+      const current = createThought({
+        id: "current",
+        stage: ThoughtStage.RESEARCH, // Different stage so tag matching is primary
+        tags: ["database", "performance"],
+      });
+      const match1 = createThought({ id: "match1", stage: ThoughtStage.ANALYSIS, tags: ["database"] });
+      const match2 = createThought({ id: "match2", stage: ThoughtStage.SYNTHESIS, tags: ["database", "performance"] });
 
-			const result = analyzer.findRelatedThoughts(current, [current, match1, match2], 2);
+      const result = analyzer.findRelatedThoughts(current, [current, match1, match2], 2);
 
-			// Should prefer match2 (more matching tags)
-			expect(result[0].id).toBe("match2");
-			expect(result[1].id).toBe("match1");
-		});
-	});
+      // Should prefer match2 (more matching tags)
+      expect(result[0].id).toBe("match2");
+      expect(result[1].id).toBe("match1");
+    });
+  });
 
-	describe("analyzeThought", () => {
-		it("analyzes a thought with context", () => {
-			const thought = createThought({
-				id: "thought1",
-				thought_number: 2,
-				total_thoughts: 5,
-				stage: ThoughtStage.SYNTHESIS,
-				tags: ["architecture"],
-			});
-			const allThoughts = [createThought({ id: "prev", thought_number: 1, stage: ThoughtStage.SYNTHESIS }), thought];
+  describe("analyzeThought", () => {
+    it("analyzes a thought with context", () => {
+      const thought = createThought({
+        id: "thought1",
+        thought_number: 2,
+        total_thoughts: 5,
+        stage: ThoughtStage.SYNTHESIS,
+        tags: ["architecture"],
+      });
+      const allThoughts = [createThought({ id: "prev", thought_number: 1, stage: ThoughtStage.SYNTHESIS }), thought];
 
-			const result = analyzer.analyzeThought(thought, allThoughts);
+      const result = analyzer.analyzeThought(thought, allThoughts);
 
-			expect(result.thoughtAnalysis.currentThought.thoughtNumber).toBe(2);
-			expect(result.thoughtAnalysis.currentThought.totalThoughts).toBe(5);
-			expect(result.thoughtAnalysis.currentThought.stage).toBe(ThoughtStage.SYNTHESIS);
-			expect(result.thoughtAnalysis.analysis.progress).toBe(40); // 2/5 * 100
-			expect(result.thoughtAnalysis.analysis.isFirstInStage).toBe(false);
-		});
+      expect(result.thoughtAnalysis.currentThought.thoughtNumber).toBe(2);
+      expect(result.thoughtAnalysis.currentThought.totalThoughts).toBe(5);
+      expect(result.thoughtAnalysis.currentThought.stage).toBe(ThoughtStage.SYNTHESIS);
+      expect(result.thoughtAnalysis.analysis.progress).toBe(40); // 2/5 * 100
+      expect(result.thoughtAnalysis.analysis.isFirstInStage).toBe(false);
+    });
 
-		it("detects first thought in stage", () => {
-			const thought = createThought({
-				id: "first",
-				thought_number: 1,
-				stage: ThoughtStage.CONCLUSION,
-			});
-			const allThoughts = [thought];
+    it("detects first thought in stage", () => {
+      const thought = createThought({
+        id: "first",
+        thought_number: 1,
+        stage: ThoughtStage.CONCLUSION,
+      });
+      const allThoughts = [thought];
 
-			const result = analyzer.analyzeThought(thought, allThoughts);
+      const result = analyzer.analyzeThought(thought, allThoughts);
 
-			expect(result.thoughtAnalysis.analysis.isFirstInStage).toBe(true);
-		});
-	});
+      expect(result.thoughtAnalysis.analysis.isFirstInStage).toBe(true);
+    });
+  });
 
-	describe("generateSummary", () => {
-		it("returns message for empty thoughts", () => {
-			const result = analyzer.generateSummary([]);
-			expect(result.summary).toBe("No thoughts recorded yet");
-		});
+  describe("generateSummary", () => {
+    it("returns message for empty thoughts", () => {
+      const result = analyzer.generateSummary([]);
+      expect(result.summary).toBe("No thoughts recorded yet");
+    });
 
-		it("generates summary with stage counts", () => {
-			const thoughts = [
-				createThought({ id: "1", thought_number: 1, stage: ThoughtStage.PROBLEM_DEFINITION }),
-				createThought({ id: "2", thought_number: 2, stage: ThoughtStage.RESEARCH }),
-				createThought({ id: "3", thought_number: 3, stage: ThoughtStage.RESEARCH }),
-				createThought({ id: "4", thought_number: 4, stage: ThoughtStage.ANALYSIS }),
-				createThought({ id: "5", thought_number: 5, stage: ThoughtStage.SYNTHESIS }),
-				createThought({ id: "6", thought_number: 6, stage: ThoughtStage.CONCLUSION, total_thoughts: 6 }),
-			];
+    it("generates summary with stage counts", () => {
+      const thoughts = [
+        createThought({ id: "1", thought_number: 1, stage: ThoughtStage.PROBLEM_DEFINITION }),
+        createThought({ id: "2", thought_number: 2, stage: ThoughtStage.RESEARCH }),
+        createThought({ id: "3", thought_number: 3, stage: ThoughtStage.RESEARCH }),
+        createThought({ id: "4", thought_number: 4, stage: ThoughtStage.ANALYSIS }),
+        createThought({ id: "5", thought_number: 5, stage: ThoughtStage.SYNTHESIS }),
+        createThought({ id: "6", thought_number: 6, stage: ThoughtStage.CONCLUSION, total_thoughts: 6 }),
+      ];
 
-			const result = analyzer.generateSummary(thoughts);
-			const summary = result.summary as { totalThoughts: number; stages: Record<string, number> };
+      const result = analyzer.generateSummary(thoughts);
+      const summary = result.summary as { totalThoughts: number; stages: Record<string, number> };
 
-			expect(summary.totalThoughts).toBe(6);
-			expect(summary.stages["Problem Definition"]).toBe(1);
-			expect(summary.stages.Research).toBe(2);
-			expect(summary.stages.Analysis).toBe(1);
-			expect(summary.stages.Synthesis).toBe(1);
-			expect(summary.stages.Conclusion).toBe(1);
-		});
+      expect(summary.totalThoughts).toBe(6);
+      expect(summary.stages["Problem Definition"]).toBe(1);
+      expect(summary.stages.Research).toBe(2);
+      expect(summary.stages.Analysis).toBe(1);
+      expect(summary.stages.Synthesis).toBe(1);
+      expect(summary.stages.Conclusion).toBe(1);
+    });
 
-		it("generates timeline", () => {
-			const thoughts = [
-				createThought({ id: "3", thought_number: 3 }),
-				createThought({ id: "1", thought_number: 1 }),
-				createThought({ id: "2", thought_number: 2 }),
-			];
+    it("generates timeline", () => {
+      const thoughts = [
+        createThought({ id: "3", thought_number: 3 }),
+        createThought({ id: "1", thought_number: 1 }),
+        createThought({ id: "2", thought_number: 2 }),
+      ];
 
-			const result = analyzer.generateSummary(thoughts);
-			const summary = result.summary as { timeline: Array<{ number: number; stage: string }> };
+      const result = analyzer.generateSummary(thoughts);
+      const summary = result.summary as { timeline: Array<{ number: number; stage: string }> };
 
-			expect(summary.timeline).toEqual([
-				{ number: 1, stage: ThoughtStage.ANALYSIS },
-				{ number: 2, stage: ThoughtStage.ANALYSIS },
-				{ number: 3, stage: ThoughtStage.ANALYSIS },
-			]);
-		});
+      expect(summary.timeline).toEqual([
+        { number: 1, stage: ThoughtStage.ANALYSIS },
+        { number: 2, stage: ThoughtStage.ANALYSIS },
+        { number: 3, stage: ThoughtStage.ANALYSIS },
+      ]);
+    });
 
-		it("counts top tags", () => {
-			const thoughts = [
-				createThought({ id: "1", tags: ["tag1", "tag2"] }),
-				createThought({ id: "2", tags: ["tag1", "tag3"] }),
-				createThought({ id: "3", tags: ["tag1"] }),
-				createThought({ id: "4", tags: ["tag2"] }),
-			];
+    it("counts top tags", () => {
+      const thoughts = [
+        createThought({ id: "1", tags: ["tag1", "tag2"] }),
+        createThought({ id: "2", tags: ["tag1", "tag3"] }),
+        createThought({ id: "3", tags: ["tag1"] }),
+        createThought({ id: "4", tags: ["tag2"] }),
+      ];
 
-			const result = analyzer.generateSummary(thoughts);
-			const summary = result.summary as { topTags: Array<{ tag: string; count: number }> };
+      const result = analyzer.generateSummary(thoughts);
+      const summary = result.summary as { topTags: Array<{ tag: string; count: number }> };
 
-			expect(summary.topTags[0]).toEqual({ tag: "tag1", count: 3 });
-			expect(summary.topTags[1]).toEqual({ tag: "tag2", count: 2 });
-			expect(summary.topTags[2]).toEqual({ tag: "tag3", count: 1 });
-		});
+      expect(summary.topTags[0]).toEqual({ tag: "tag1", count: 3 });
+      expect(summary.topTags[1]).toEqual({ tag: "tag2", count: 2 });
+      expect(summary.topTags[2]).toEqual({ tag: "tag3", count: 1 });
+    });
 
-		it("calculates completion percentage", () => {
-			const thoughts = [
-				createThought({ id: "1", thought_number: 1, total_thoughts: 10 }),
-				createThought({ id: "2", thought_number: 2, total_thoughts: 10 }),
-				createThought({ id: "3", thought_number: 3, total_thoughts: 10 }),
-			];
+    it("calculates completion percentage", () => {
+      const thoughts = [
+        createThought({ id: "1", thought_number: 1, total_thoughts: 10 }),
+        createThought({ id: "2", thought_number: 2, total_thoughts: 10 }),
+        createThought({ id: "3", thought_number: 3, total_thoughts: 10 }),
+      ];
 
-			const result = analyzer.generateSummary(thoughts);
-			const summary = result.summary as { completionStatus: { percentComplete: number } };
+      const result = analyzer.generateSummary(thoughts);
+      const summary = result.summary as { completionStatus: { percentComplete: number } };
 
-			expect(summary.completionStatus.percentComplete).toBe(30);
-		});
+      expect(summary.completionStatus.percentComplete).toBe(30);
+    });
 
-		it("detects all stages present", () => {
-			const thoughts = Object.values(ThoughtStage).map((stage, i) =>
-				createThought({ id: String(i), thought_number: i + 1, stage }),
-			);
+    it("detects all stages present", () => {
+      const thoughts = Object.values(ThoughtStage).map((stage, i) =>
+        createThought({ id: String(i), thought_number: i + 1, stage }),
+      );
 
-			const result = analyzer.generateSummary(thoughts);
-			const summary = result.summary as { completionStatus: { hasAllStages: boolean } };
+      const result = analyzer.generateSummary(thoughts);
+      const summary = result.summary as { completionStatus: { hasAllStages: boolean } };
 
-			expect(summary.completionStatus.hasAllStages).toBe(true);
-		});
-	});
+      expect(summary.completionStatus.hasAllStages).toBe(true);
+    });
+  });
 });

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -3,235 +3,235 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	DEFAULT_CONFIG_FILE,
-	ensureDefaultConfigFile,
-	formatToolOutput,
-	isRecord,
-	normalizeNumber,
-	normalizeString,
-	parseConfig,
-	resolveConfigPath,
-	resolveEffectiveLimits,
-	splitParams,
-	toJsonString,
-	writeTempFile,
+  DEFAULT_CONFIG_FILE,
+  ensureDefaultConfigFile,
+  formatToolOutput,
+  isRecord,
+  normalizeNumber,
+  normalizeString,
+  parseConfig,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  splitParams,
+  toJsonString,
+  writeTempFile,
 } from "../extensions/index.js";
 
 describe("pi-sequential-thinking helpers", () => {
-	it("splits params and clamps limits", () => {
-		const { toolArgs, requestedLimits } = splitParams({
-			piMaxBytes: "100",
-			piMaxLines: 5,
-			thought: "hello",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			stage: "Analysis",
-		});
-		expect(toolArgs).toEqual({
-			thought: "hello",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			stage: "Analysis",
-		});
-		expect(requestedLimits).toEqual({ maxBytes: 100, maxLines: 5 });
+  it("splits params and clamps limits", () => {
+    const { toolArgs, requestedLimits } = splitParams({
+      piMaxBytes: "100",
+      piMaxLines: 5,
+      thought: "hello",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: "Analysis",
+    });
+    expect(toolArgs).toEqual({
+      thought: "hello",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: "Analysis",
+    });
+    expect(requestedLimits).toEqual({ maxBytes: 100, maxLines: 5 });
 
-		const effective = resolveEffectiveLimits({ maxBytes: 200, maxLines: 2 }, { maxBytes: 120, maxLines: 10 });
-		expect(effective).toEqual({ maxBytes: 120, maxLines: 2 });
-	});
+    const effective = resolveEffectiveLimits({ maxBytes: 200, maxLines: 2 }, { maxBytes: 120, maxLines: 10 });
+    expect(effective).toEqual({ maxBytes: 120, maxLines: 2 });
+  });
 
-	it("resolves effective limits using defaults when not requested", () => {
-		const effective = resolveEffectiveLimits({}, { maxBytes: 51200, maxLines: 2000 });
-		expect(effective).toEqual({ maxBytes: 51200, maxLines: 2000 });
-	});
+  it("resolves effective limits using defaults when not requested", () => {
+    const effective = resolveEffectiveLimits({}, { maxBytes: 51200, maxLines: 2000 });
+    expect(effective).toEqual({ maxBytes: 51200, maxLines: 2000 });
+  });
 
-	it("normalizes numbers from strings and numbers", () => {
-		expect(normalizeNumber(42)).toBe(42);
-		expect(normalizeNumber("123")).toBe(123);
-		expect(normalizeNumber("abc")).toBeUndefined();
-		expect(normalizeNumber(null)).toBeUndefined();
-		expect(normalizeNumber(undefined)).toBeUndefined();
-		expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
-	});
+  it("normalizes numbers from strings and numbers", () => {
+    expect(normalizeNumber(42)).toBe(42);
+    expect(normalizeNumber("123")).toBe(123);
+    expect(normalizeNumber("abc")).toBeUndefined();
+    expect(normalizeNumber(null)).toBeUndefined();
+    expect(normalizeNumber(undefined)).toBeUndefined();
+    expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
 
-	it("writes default config when none exists", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-seq-think-config-"));
-		const projectConfigPath = join(base, "project", ".pi", "extensions", "sequential-thinking.json");
-		const globalConfigPath = join(base, "global", "extensions", "sequential-thinking.json");
+  it("writes default config when none exists", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-config-"));
+    const projectConfigPath = join(base, "project", ".pi", "extensions", "sequential-thinking.json");
+    const globalConfigPath = join(base, "global", "extensions", "sequential-thinking.json");
 
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
 
-		expect(existsSync(globalConfigPath)).toBe(true);
-		const raw = readFileSync(globalConfigPath, "utf-8");
-		expect(JSON.parse(raw)).toEqual(DEFAULT_CONFIG_FILE);
-	});
+    expect(existsSync(globalConfigPath)).toBe(true);
+    const raw = readFileSync(globalConfigPath, "utf-8");
+    expect(JSON.parse(raw)).toEqual(DEFAULT_CONFIG_FILE);
+  });
 
-	it("does not overwrite existing config", () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-seq-think-config-exists-"));
-		const projectConfigPath = join(base, "project", ".pi", "extensions", "sequential-thinking.json");
-		const globalConfigPath = join(base, "global", "extensions", "sequential-thinking.json");
+  it("does not overwrite existing config", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-config-exists-"));
+    const projectConfigPath = join(base, "project", ".pi", "extensions", "sequential-thinking.json");
+    const globalConfigPath = join(base, "global", "extensions", "sequential-thinking.json");
 
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		const firstContent = readFileSync(globalConfigPath, "utf-8");
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    const firstContent = readFileSync(globalConfigPath, "utf-8");
 
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		const secondContent = readFileSync(globalConfigPath, "utf-8");
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    const secondContent = readFileSync(globalConfigPath, "utf-8");
 
-		expect(firstContent).toBe(secondContent);
-	});
+    expect(firstContent).toBe(secondContent);
+  });
 });
 
 describe("pi-sequential-thinking type guards", () => {
-	it("isRecord returns true for plain objects", () => {
-		expect(isRecord({})).toBe(true);
-		expect(isRecord({ a: 1 })).toBe(true);
-	});
+  it("isRecord returns true for plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
 
-	it("isRecord returns false for non-objects", () => {
-		expect(isRecord(null)).toBe(false);
-		expect(isRecord(undefined)).toBe(false);
-		expect(isRecord("string")).toBe(false);
-		expect(isRecord(123)).toBe(false);
-		expect(isRecord([])).toBe(false);
-	});
+  it("isRecord returns false for non-objects", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord("string")).toBe(false);
+    expect(isRecord(123)).toBe(false);
+    expect(isRecord([])).toBe(false);
+  });
 });
 
 describe("pi-sequential-thinking toJsonString", () => {
-	it("returns strings as-is", () => {
-		expect(toJsonString("hello")).toBe("hello");
-		expect(toJsonString("")).toBe("");
-	});
+  it("returns strings as-is", () => {
+    expect(toJsonString("hello")).toBe("hello");
+    expect(toJsonString("")).toBe("");
+  });
 
-	it("stringifies objects", () => {
-		const result = toJsonString({ a: 1, b: 2 });
-		expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
-	});
+  it("stringifies objects", () => {
+    const result = toJsonString({ a: 1, b: 2 });
+    expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
+  });
 
-	it("converts primitives", () => {
-		expect(toJsonString(42)).toBe("42");
-		expect(toJsonString(true)).toBe("true");
-		expect(toJsonString(null)).toBe("null");
-	});
+  it("converts primitives", () => {
+    expect(toJsonString(42)).toBe("42");
+    expect(toJsonString(true)).toBe("true");
+    expect(toJsonString(null)).toBe("null");
+  });
 });
 
 describe("pi-sequential-thinking normalizeString", () => {
-	it("returns trimmed strings", () => {
-		expect(normalizeString("  hello  ")).toBe("hello");
-		expect(normalizeString("test")).toBe("test");
-	});
+  it("returns trimmed strings", () => {
+    expect(normalizeString("  hello  ")).toBe("hello");
+    expect(normalizeString("test")).toBe("test");
+  });
 
-	it("returns undefined for empty/whitespace strings", () => {
-		expect(normalizeString("")).toBeUndefined();
-		expect(normalizeString("   ")).toBeUndefined();
-	});
+  it("returns undefined for empty/whitespace strings", () => {
+    expect(normalizeString("")).toBeUndefined();
+    expect(normalizeString("   ")).toBeUndefined();
+  });
 
-	it("returns undefined for non-strings", () => {
-		expect(normalizeString(123)).toBeUndefined();
-		expect(normalizeString(null)).toBeUndefined();
-		expect(normalizeString(undefined)).toBeUndefined();
-	});
+  it("returns undefined for non-strings", () => {
+    expect(normalizeString(123)).toBeUndefined();
+    expect(normalizeString(null)).toBeUndefined();
+    expect(normalizeString(undefined)).toBeUndefined();
+  });
 });
 
 describe("pi-sequential-thinking resolveConfigPath", () => {
-	it("resolves paths starting with ~/", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(homedir());
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~/", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(homedir());
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("resolves paths starting with ~", () => {
-		const result = resolveConfigPath("~/.pi/config.json");
-		expect(result).toContain(".pi/config.json");
-	});
+  it("resolves paths starting with ~", () => {
+    const result = resolveConfigPath("~/.pi/config.json");
+    expect(result).toContain(".pi/config.json");
+  });
 
-	it("returns absolute paths as-is", () => {
-		const absolute = "/absolute/path/to/config.json";
-		expect(resolveConfigPath(absolute)).toBe(absolute);
-	});
+  it("returns absolute paths as-is", () => {
+    const absolute = "/absolute/path/to/config.json";
+    expect(resolveConfigPath(absolute)).toBe(absolute);
+  });
 
-	it("resolves relative paths from cwd", () => {
-		const result = resolveConfigPath("relative/path.json");
-		expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
-	});
+  it("resolves relative paths from cwd", () => {
+    const result = resolveConfigPath("relative/path.json");
+    expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
+  });
 });
 
 describe("pi-sequential-thinking parseConfig", () => {
-	it("parses valid config", () => {
-		const raw = {
-			storageDir: "/custom/storage",
-			maxBytes: 1024,
-			maxLines: 500,
-		};
-		const result = parseConfig(raw, "/path/to/config.json");
-		expect(result).toEqual({
-			storageDir: "/custom/storage",
-			maxBytes: 1024,
-			maxLines: 500,
-		});
-	});
+  it("parses valid config", () => {
+    const raw = {
+      storageDir: "/custom/storage",
+      maxBytes: 1024,
+      maxLines: 500,
+    };
+    const result = parseConfig(raw, "/path/to/config.json");
+    expect(result).toEqual({
+      storageDir: "/custom/storage",
+      maxBytes: 1024,
+      maxLines: 500,
+    });
+  });
 
-	it("normalizes string values", () => {
-		const raw = { storageDir: "  /custom/storage  " };
-		const result = parseConfig(raw, "/path");
-		expect(result.storageDir).toBe("/custom/storage");
-	});
+  it("normalizes string values", () => {
+    const raw = { storageDir: "  /custom/storage  " };
+    const result = parseConfig(raw, "/path");
+    expect(result.storageDir).toBe("/custom/storage");
+  });
 
-	it("ignores null/undefined values", () => {
-		const raw = { storageDir: null, maxBytes: undefined, maxLines: NaN };
-		const result = parseConfig(raw, "/path");
-		expect(result.storageDir).toBeUndefined();
-		expect(result.maxBytes).toBeUndefined();
-		expect(result.maxLines).toBeUndefined();
-	});
+  it("ignores null/undefined values", () => {
+    const raw = { storageDir: null, maxBytes: undefined, maxLines: NaN };
+    const result = parseConfig(raw, "/path");
+    expect(result.storageDir).toBeUndefined();
+    expect(result.maxBytes).toBeUndefined();
+    expect(result.maxLines).toBeUndefined();
+  });
 
-	it("throws for non-object config", () => {
-		expect(() => parseConfig(null, "/path")).toThrow("Invalid Sequential Thinking config");
-		expect(() => parseConfig("string", "/path")).toThrow("Invalid Sequential Thinking config");
-		expect(() => parseConfig(123, "/path")).toThrow("Invalid Sequential Thinking config");
-	});
+  it("throws for non-object config", () => {
+    expect(() => parseConfig(null, "/path")).toThrow("Invalid Sequential Thinking config");
+    expect(() => parseConfig("string", "/path")).toThrow("Invalid Sequential Thinking config");
+    expect(() => parseConfig(123, "/path")).toThrow("Invalid Sequential Thinking config");
+  });
 });
 
 describe("pi-sequential-thinking formatToolOutput", () => {
-	it("formats simple result", () => {
-		const result = formatToolOutput("test_tool", { message: "Hello" }, { maxBytes: 50000, maxLines: 2000 });
-		expect(result.text).toContain("Hello");
-		expect(result.details.truncated).toBe(false);
-	});
+  it("formats simple result", () => {
+    const result = formatToolOutput("test_tool", { message: "Hello" }, { maxBytes: 50000, maxLines: 2000 });
+    expect(result.text).toContain("Hello");
+    expect(result.details.truncated).toBe(false);
+  });
 
-	it("handles object result", () => {
-		const result = formatToolOutput("test_tool", { data: 123 }, {});
-		expect(result.text).toContain("data");
-		expect(result.text).toContain("123");
-	});
+  it("handles object result", () => {
+    const result = formatToolOutput("test_tool", { data: 123 }, {});
+    expect(result.text).toContain("data");
+    expect(result.text).toContain("123");
+  });
 });
 
 describe("pi-sequential-thinking writeTempFile", () => {
-	const tempFiles: string[] = [];
+  const tempFiles: string[] = [];
 
-	afterEach(() => {
-		import("node:fs").then(({ unlinkSync }) => {
-			tempFiles.forEach((f) => {
-				try {
-					unlinkSync(f);
-				} catch {
-					// ignore cleanup errors
-				}
-			});
-		});
-	});
+  afterEach(() => {
+    import("node:fs").then(({ unlinkSync }) => {
+      tempFiles.forEach((f) => {
+        try {
+          unlinkSync(f);
+        } catch {
+          // ignore cleanup errors
+        }
+      });
+    });
+  });
 
-	it("writes temp file and returns path", () => {
-		const path = writeTempFile("test_tool", "content here");
-		tempFiles.push(path);
-		expect(path).toContain("pi-seq-think-test_tool");
-		expect(path).toContain(".txt");
-		expect(existsSync(path)).toBe(true);
-	});
+  it("writes temp file and returns path", () => {
+    const path = writeTempFile("test_tool", "content here");
+    tempFiles.push(path);
+    expect(path).toContain("pi-seq-think-test_tool");
+    expect(path).toContain(".txt");
+    expect(existsSync(path)).toBe(true);
+  });
 
-	it("sanitizes tool name", () => {
-		const path = writeTempFile("my-tool!@#", "content");
-		tempFiles.push(path);
-		expect(path).toContain("my-tool__");
-	});
+  it("sanitizes tool name", () => {
+    const path = writeTempFile("my-tool!@#", "content");
+    tempFiles.push(path);
+    expect(path).toContain("my-tool__");
+  });
 });

--- a/packages/pi-sequential-thinking/__tests__/index.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/index.test.ts
@@ -3,51 +3,51 @@ import { describe, expect, it, vi } from "vitest";
 import sequentialThinking from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 describe("pi-sequential-thinking", () => {
-	it("registers tools", () => {
-		const mockPi = createMockPi();
-		sequentialThinking(mockPi as unknown as ExtensionAPI);
+  it("registers tools", () => {
+    const mockPi = createMockPi();
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
 
-		const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
-		expect(toolNames).toEqual(
-			expect.arrayContaining([
-				"process_thought",
-				"generate_summary",
-				"clear_history",
-				"export_session",
-				"import_session",
-			]),
-		);
-	});
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        "process_thought",
+        "generate_summary",
+        "clear_history",
+        "export_session",
+        "import_session",
+      ]),
+    );
+  });
 
-	it("registers flags", () => {
-		const mockPi = createMockPi();
-		sequentialThinking(mockPi as unknown as ExtensionAPI);
+  it("registers flags", () => {
+    const mockPi = createMockPi();
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).toEqual(
-			expect.arrayContaining([
-				"--seq-think-storage-dir",
-				"--seq-think-config",
-				"--seq-think-max-bytes",
-				"--seq-think-max-lines",
-			]),
-		);
-	});
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toEqual(
+      expect.arrayContaining([
+        "--seq-think-storage-dir",
+        "--seq-think-config",
+        "--seq-think-max-bytes",
+        "--seq-think-max-lines",
+      ]),
+    );
+  });
 
-	it("does not register command/args flags (native implementation)", () => {
-		const mockPi = createMockPi();
-		sequentialThinking(mockPi as unknown as ExtensionAPI);
+  it("does not register command/args flags (native implementation)", () => {
+    const mockPi = createMockPi();
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
 
-		const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-		expect(flagNames).not.toContain("--seq-think-command");
-		expect(flagNames).not.toContain("--seq-think-args");
-	});
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).not.toContain("--seq-think-command");
+    expect(flagNames).not.toContain("--seq-think-args");
+  });
 });

--- a/packages/pi-sequential-thinking/__tests__/runtime.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/runtime.test.ts
@@ -6,124 +6,124 @@ import { describe, expect, it, vi } from "vitest";
 import sequentialThinking from "../extensions/index.js";
 
 const createMockPi = (flags: Record<string, string | boolean | undefined> = {}) =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn<(name: string) => string | boolean | undefined>((name: string) => flags[name]),
-		registerTool: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn<(name: string) => string | boolean | undefined>((name: string) => flags[name]),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 const getRegisteredTool = (mockPi: ReturnType<typeof createMockPi>, name: string) => {
-	const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-	return tools.find((tool) => tool.name === name);
+  const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+  return tools.find((tool) => tool.name === name);
 };
 
 describe("pi-sequential-thinking runtime", () => {
-	it("processes thoughts, summarizes, clears, exports, imports, and runs sequential_think", async () => {
-		const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-"));
-		const exportPath = join(storageDir, "nested", "session.json");
-		const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
-		sequentialThinking(mockPi as unknown as ExtensionAPI);
+  it("processes thoughts, summarizes, clears, exports, imports, and runs sequential_think", async () => {
+    const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-"));
+    const exportPath = join(storageDir, "nested", "session.json");
+    const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
 
-		const processTool = getRegisteredTool(mockPi, "process_thought");
-		const summaryTool = getRegisteredTool(mockPi, "generate_summary");
-		const clearTool = getRegisteredTool(mockPi, "clear_history");
-		const exportTool = getRegisteredTool(mockPi, "export_session");
-		const importTool = getRegisteredTool(mockPi, "import_session");
-		const sequentialTool = getRegisteredTool(mockPi, "sequential_think");
+    const processTool = getRegisteredTool(mockPi, "process_thought");
+    const summaryTool = getRegisteredTool(mockPi, "generate_summary");
+    const clearTool = getRegisteredTool(mockPi, "clear_history");
+    const exportTool = getRegisteredTool(mockPi, "export_session");
+    const importTool = getRegisteredTool(mockPi, "import_session");
+    const sequentialTool = getRegisteredTool(mockPi, "sequential_think");
 
-		const onUpdate = vi.fn();
-		const processResult = await processTool?.execute(
-			"call-1",
-			{
-				thought: "We should use a feature flag for rollout",
-				thought_number: 1,
-				total_thoughts: 3,
-				next_thought_needed: true,
-				stage: "Analysis",
-				tags: ["rollout"],
-			},
-			undefined,
-			onUpdate,
-			undefined,
-		);
+    const onUpdate = vi.fn();
+    const processResult = await processTool?.execute(
+      "call-1",
+      {
+        thought: "We should use a feature flag for rollout",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+        stage: "Analysis",
+        tags: ["rollout"],
+      },
+      undefined,
+      onUpdate,
+      undefined,
+    );
 
-		expect(onUpdate).toHaveBeenCalledWith({
-			content: [{ type: "text", text: "Processing thought..." }],
-			details: { status: "pending" },
-		});
-		expect(processResult.isError).toBe(false);
-		expect(processResult.content[0].text).toContain("thoughtAnalysis");
+    expect(onUpdate).toHaveBeenCalledWith({
+      content: [{ type: "text", text: "Processing thought..." }],
+      details: { status: "pending" },
+    });
+    expect(processResult.isError).toBe(false);
+    expect(processResult.content[0].text).toContain("thoughtAnalysis");
 
-		const summaryResult = await summaryTool?.execute("call-2", {}, undefined, undefined, undefined);
-		expect(summaryResult.isError).toBe(false);
-		expect(summaryResult.content[0].text).toContain("summary");
+    const summaryResult = await summaryTool?.execute("call-2", {}, undefined, undefined, undefined);
+    expect(summaryResult.isError).toBe(false);
+    expect(summaryResult.content[0].text).toContain("summary");
 
-		const exportResult = await exportTool?.execute(
-			"call-3",
-			{ file_path: exportPath },
-			undefined,
-			undefined,
-			undefined,
-		);
-		expect(exportResult.content[0].text).toContain("Session exported");
-		expect(existsSync(exportPath)).toBe(true);
+    const exportResult = await exportTool?.execute(
+      "call-3",
+      { file_path: exportPath },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(exportResult.content[0].text).toContain("Session exported");
+    expect(existsSync(exportPath)).toBe(true);
 
-		const clearResult = await clearTool?.execute("call-4", {}, undefined, undefined, undefined);
-		expect(clearResult.content[0].text).toContain("Thought history cleared");
+    const clearResult = await clearTool?.execute("call-4", {}, undefined, undefined, undefined);
+    expect(clearResult.content[0].text).toContain("Thought history cleared");
 
-		const importResult = await importTool?.execute(
-			"call-5",
-			{ file_path: exportPath },
-			undefined,
-			undefined,
-			undefined,
-		);
-		expect(importResult.content[0].text).toContain("Session imported");
+    const importResult = await importTool?.execute(
+      "call-5",
+      { file_path: exportPath },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(importResult.content[0].text).toContain("Session imported");
 
-		const sequentialResult = await sequentialTool?.execute(
-			"call-6",
-			{ topic: "Database migration strategy", num_thoughts: 5 },
-			undefined,
-			undefined,
-			undefined,
-		);
-		expect(sequentialResult.isError).toBe(false);
-		expect(sequentialResult.content[0].text).toContain('"database"');
-	});
+    const sequentialResult = await sequentialTool?.execute(
+      "call-6",
+      { topic: "Database migration strategy", num_thoughts: 5 },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(sequentialResult.isError).toBe(false);
+    expect(sequentialResult.content[0].text).toContain('"database"');
+  });
 
-	it("returns validation errors for invalid runtime inputs", async () => {
-		const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-errors-"));
-		const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
-		sequentialThinking(mockPi as unknown as ExtensionAPI);
+  it("returns validation errors for invalid runtime inputs", async () => {
+    const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-errors-"));
+    const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
 
-		const processTool = getRegisteredTool(mockPi, "process_thought");
-		const importTool = getRegisteredTool(mockPi, "import_session");
+    const processTool = getRegisteredTool(mockPi, "process_thought");
+    const importTool = getRegisteredTool(mockPi, "import_session");
 
-		const invalidThought = await processTool?.execute(
-			"call-7",
-			{
-				thought: "   ",
-				thought_number: 1,
-				total_thoughts: 1,
-				next_thought_needed: false,
-				stage: "Analysis",
-			},
-			undefined,
-			undefined,
-			undefined,
-		);
-		expect(invalidThought.isError).toBe(true);
-		expect(invalidThought.content[0].text).toContain("Thought content cannot be empty");
+    const invalidThought = await processTool?.execute(
+      "call-7",
+      {
+        thought: "   ",
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+        stage: "Analysis",
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(invalidThought.isError).toBe(true);
+    expect(invalidThought.content[0].text).toContain("Thought content cannot be empty");
 
-		const missingImport = await importTool?.execute(
-			"call-8",
-			{ file_path: join(storageDir, "missing.json") },
-			undefined,
-			undefined,
-			undefined,
-		);
-		expect(missingImport.isError).toBe(true);
-		expect(missingImport.content[0].text).toContain("File not found");
-	});
+    const missingImport = await importTool?.execute(
+      "call-8",
+      { file_path: join(storageDir, "missing.json") },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(missingImport.isError).toBe(true);
+    expect(missingImport.content[0].text).toContain("File not found");
+  });
 });

--- a/packages/pi-sequential-thinking/__tests__/storage.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/storage.test.ts
@@ -7,273 +7,273 @@ import type { ThoughtData } from "../extensions/types.js";
 import { ThoughtStage } from "../extensions/types.js";
 
 const createThought = (overrides: Partial<ThoughtData> = {}): ThoughtData => ({
-	id: "test-id-1",
-	thought: "Test thought content",
-	thought_number: 1,
-	total_thoughts: 3,
-	next_thought_needed: true,
-	stage: ThoughtStage.ANALYSIS,
-	timestamp: new Date().toISOString(),
-	tags: [],
-	axioms_used: [],
-	assumptions_challenged: [],
-	...overrides,
+  id: "test-id-1",
+  thought: "Test thought content",
+  thought_number: 1,
+  total_thoughts: 3,
+  next_thought_needed: true,
+  stage: ThoughtStage.ANALYSIS,
+  timestamp: new Date().toISOString(),
+  tags: [],
+  axioms_used: [],
+  assumptions_challenged: [],
+  ...overrides,
 });
 
 describe("ThoughtStorage", () => {
-	let tempDir: string;
+  let tempDir: string;
 
-	beforeEach(() => {
-		tempDir = join(tmpdir(), `pi-storage-test-${Date.now()}`);
-		mkdirSync(tempDir, { recursive: true });
-	});
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `pi-storage-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
 
-	afterEach(() => {
-		try {
-			rmSync(tempDir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup errors
-		}
-	});
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
 
-	describe("constructor", () => {
-		it("creates storage with custom directory", () => {
-			const _storage = new ThoughtStorage(tempDir);
-			expect(existsSync(tempDir)).toBe(true);
-		});
+  describe("constructor", () => {
+    it("creates storage with custom directory", () => {
+      const _storage = new ThoughtStorage(tempDir);
+      expect(existsSync(tempDir)).toBe(true);
+    });
 
-		it("creates default directory when none specified", () => {
-			const storage = new ThoughtStorage();
-			// Should not throw and should create directory
-			expect(storage).toBeDefined();
-		});
-	});
+    it("creates default directory when none specified", () => {
+      const storage = new ThoughtStorage();
+      // Should not throw and should create directory
+      expect(storage).toBeDefined();
+    });
+  });
 
-	describe("addThought", () => {
-		it("adds a thought to storage", () => {
-			const storage = new ThoughtStorage(tempDir);
-			const thought = createThought();
+  describe("addThought", () => {
+    it("adds a thought to storage", () => {
+      const storage = new ThoughtStorage(tempDir);
+      const thought = createThought();
 
-			storage.addThought(thought);
+      storage.addThought(thought);
 
-			const thoughts = storage.getAllThoughts();
-			expect(thoughts).toHaveLength(1);
-			expect(thoughts[0].thought).toBe("Test thought content");
-		});
+      const thoughts = storage.getAllThoughts();
+      expect(thoughts).toHaveLength(1);
+      expect(thoughts[0].thought).toBe("Test thought content");
+    });
 
-		it("persists thought to disk", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought());
+    it("persists thought to disk", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought());
 
-			// Create new instance to verify persistence
-			const storage2 = new ThoughtStorage(tempDir);
-			const thoughts = storage2.getAllThoughts();
+      // Create new instance to verify persistence
+      const storage2 = new ThoughtStorage(tempDir);
+      const thoughts = storage2.getAllThoughts();
 
-			expect(thoughts).toHaveLength(1);
-		});
+      expect(thoughts).toHaveLength(1);
+    });
 
-		it("adds multiple thoughts", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought({ thought_number: 1 }));
-			storage.addThought(createThought({ thought_number: 2 }));
-			storage.addThought(createThought({ thought_number: 3 }));
+    it("adds multiple thoughts", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought_number: 1 }));
+      storage.addThought(createThought({ thought_number: 2 }));
+      storage.addThought(createThought({ thought_number: 3 }));
 
-			const thoughts = storage.getAllThoughts();
-			expect(thoughts).toHaveLength(3);
-		});
-	});
+      const thoughts = storage.getAllThoughts();
+      expect(thoughts).toHaveLength(3);
+    });
+  });
 
-	describe("getAllThoughts", () => {
-		it("returns empty array when no thoughts", () => {
-			const storage = new ThoughtStorage(tempDir);
-			expect(storage.getAllThoughts()).toEqual([]);
-		});
+  describe("getAllThoughts", () => {
+    it("returns empty array when no thoughts", () => {
+      const storage = new ThoughtStorage(tempDir);
+      expect(storage.getAllThoughts()).toEqual([]);
+    });
 
-		it("returns copy of thoughts array", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought());
+    it("returns copy of thoughts array", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought());
 
-			const thoughts1 = storage.getAllThoughts();
-			const thoughts2 = storage.getAllThoughts();
+      const thoughts1 = storage.getAllThoughts();
+      const thoughts2 = storage.getAllThoughts();
 
-			expect(thoughts1).not.toBe(thoughts2);
-			expect(thoughts1).toEqual(thoughts2);
-		});
+      expect(thoughts1).not.toBe(thoughts2);
+      expect(thoughts1).toEqual(thoughts2);
+    });
 
-		it("modifying returned array does not affect storage", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought());
+    it("modifying returned array does not affect storage", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought());
 
-			const thoughts = storage.getAllThoughts();
-			thoughts.push(createThought({ id: "modified" }));
+      const thoughts = storage.getAllThoughts();
+      thoughts.push(createThought({ id: "modified" }));
 
-			expect(storage.getAllThoughts()).toHaveLength(1);
-		});
-	});
+      expect(storage.getAllThoughts()).toHaveLength(1);
+    });
+  });
 
-	describe("clearHistory", () => {
-		it("clears all thoughts", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought());
-			storage.addThought(createThought());
+  describe("clearHistory", () => {
+    it("clears all thoughts", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought());
+      storage.addThought(createThought());
 
-			storage.clearHistory();
+      storage.clearHistory();
 
-			expect(storage.getAllThoughts()).toEqual([]);
-		});
+      expect(storage.getAllThoughts()).toEqual([]);
+    });
 
-		it("persists cleared state", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought());
-			storage.clearHistory();
+    it("persists cleared state", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought());
+      storage.clearHistory();
 
-			const storage2 = new ThoughtStorage(tempDir);
-			expect(storage2.getAllThoughts()).toEqual([]);
-		});
-	});
+      const storage2 = new ThoughtStorage(tempDir);
+      expect(storage2.getAllThoughts()).toEqual([]);
+    });
+  });
 
-	describe("exportSession", () => {
-		it("exports thoughts to file", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought({ thought: "First thought" }));
-			storage.addThought(createThought({ thought: "Second thought", thought_number: 2 }));
+  describe("exportSession", () => {
+    it("exports thoughts to file", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought: "First thought" }));
+      storage.addThought(createThought({ thought: "Second thought", thought_number: 2 }));
 
-			const exportPath = join(tempDir, "export.json");
-			storage.exportSession(exportPath);
+      const exportPath = join(tempDir, "export.json");
+      storage.exportSession(exportPath);
 
-			expect(existsSync(exportPath)).toBe(true);
+      expect(existsSync(exportPath)).toBe(true);
 
-			const exported = JSON.parse(readFileSync(exportPath, "utf-8"));
-			expect(exported.thoughts).toHaveLength(2);
-			expect(exported.metadata.totalThoughts).toBe(2);
-			expect(exported.metadata.stages).toBeDefined();
-		});
+      const exported = JSON.parse(readFileSync(exportPath, "utf-8"));
+      expect(exported.thoughts).toHaveLength(2);
+      expect(exported.metadata.totalThoughts).toBe(2);
+      expect(exported.metadata.stages).toBeDefined();
+    });
 
-		it("includes export timestamp", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.addThought(createThought());
+    it("includes export timestamp", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought());
 
-			const exportPath = join(tempDir, "export2.json");
-			storage.exportSession(exportPath);
+      const exportPath = join(tempDir, "export2.json");
+      storage.exportSession(exportPath);
 
-			const exported = JSON.parse(readFileSync(exportPath, "utf-8"));
-			expect(exported.exportedAt).toBeDefined();
-		});
-	});
+      const exported = JSON.parse(readFileSync(exportPath, "utf-8"));
+      expect(exported.exportedAt).toBeDefined();
+    });
+  });
 
-	describe("importSession", () => {
-		it("imports thoughts from file", () => {
-			// First, create an export file manually
-			const exportPath = join(tempDir, "import.json");
-			const exportData = {
-				thoughts: [
-					{
-						id: "imported-1",
-						thought: "Imported thought 1",
-						thought_number: 1,
-						total_thoughts: 2,
-						next_thought_needed: true,
-						stage: "Analysis",
-						timestamp: new Date().toISOString(),
-						tags: [],
-						axioms_used: [],
-						assumptions_challenged: [],
-					},
-					{
-						id: "imported-2",
-						thought: "Imported thought 2",
-						thought_number: 2,
-						total_thoughts: 2,
-						next_thought_needed: false,
-						stage: "Conclusion",
-						timestamp: new Date().toISOString(),
-						tags: [],
-						axioms_used: [],
-						assumptions_challenged: [],
-					},
-				],
-				lastUpdated: new Date().toISOString(),
-			};
-			writeFileSync(exportPath, JSON.stringify(exportData), "utf-8");
+  describe("importSession", () => {
+    it("imports thoughts from file", () => {
+      // First, create an export file manually
+      const exportPath = join(tempDir, "import.json");
+      const exportData = {
+        thoughts: [
+          {
+            id: "imported-1",
+            thought: "Imported thought 1",
+            thought_number: 1,
+            total_thoughts: 2,
+            next_thought_needed: true,
+            stage: "Analysis",
+            timestamp: new Date().toISOString(),
+            tags: [],
+            axioms_used: [],
+            assumptions_challenged: [],
+          },
+          {
+            id: "imported-2",
+            thought: "Imported thought 2",
+            thought_number: 2,
+            total_thoughts: 2,
+            next_thought_needed: false,
+            stage: "Conclusion",
+            timestamp: new Date().toISOString(),
+            tags: [],
+            axioms_used: [],
+            assumptions_challenged: [],
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      };
+      writeFileSync(exportPath, JSON.stringify(exportData), "utf-8");
 
-			// Import into new storage
-			const storage = new ThoughtStorage(tempDir);
-			storage.importSession(exportPath);
+      // Import into new storage
+      const storage = new ThoughtStorage(tempDir);
+      storage.importSession(exportPath);
 
-			const thoughts = storage.getAllThoughts();
-			expect(thoughts).toHaveLength(2);
-			expect(thoughts[0].thought).toBe("Imported thought 1");
-			expect(thoughts[1].thought).toBe("Imported thought 2");
-		});
+      const thoughts = storage.getAllThoughts();
+      expect(thoughts).toHaveLength(2);
+      expect(thoughts[0].thought).toBe("Imported thought 1");
+      expect(thoughts[1].thought).toBe("Imported thought 2");
+    });
 
-		it("handles legacy format (array directly)", () => {
-			const legacyPath = join(tempDir, "legacy.json");
-			const legacyData = [
-				{
-					id: "legacy-1",
-					thought: "Legacy thought",
-					thought_number: 1,
-					total_thoughts: 1,
-					next_thought_needed: false,
-					stage: "Conclusion",
-					timestamp: new Date().toISOString(),
-					tags: [],
-					axioms_used: [],
-					assumptions_challenged: [],
-				},
-			];
-			writeFileSync(legacyPath, JSON.stringify(legacyData), "utf-8");
+    it("handles legacy format (array directly)", () => {
+      const legacyPath = join(tempDir, "legacy.json");
+      const legacyData = [
+        {
+          id: "legacy-1",
+          thought: "Legacy thought",
+          thought_number: 1,
+          total_thoughts: 1,
+          next_thought_needed: false,
+          stage: "Conclusion",
+          timestamp: new Date().toISOString(),
+          tags: [],
+          axioms_used: [],
+          assumptions_challenged: [],
+        },
+      ];
+      writeFileSync(legacyPath, JSON.stringify(legacyData), "utf-8");
 
-			const storage = new ThoughtStorage(tempDir);
-			storage.importSession(legacyPath);
+      const storage = new ThoughtStorage(tempDir);
+      storage.importSession(legacyPath);
 
-			const thoughts = storage.getAllThoughts();
-			expect(thoughts).toHaveLength(1);
-			expect(thoughts[0].thought).toBe("Legacy thought");
-		});
+      const thoughts = storage.getAllThoughts();
+      expect(thoughts).toHaveLength(1);
+      expect(thoughts[0].thought).toBe("Legacy thought");
+    });
 
-		it("handles empty/invalid file", () => {
-			const emptyPath = join(tempDir, "empty.json");
-			writeFileSync(emptyPath, JSON.stringify({}), "utf-8");
+    it("handles empty/invalid file", () => {
+      const emptyPath = join(tempDir, "empty.json");
+      writeFileSync(emptyPath, JSON.stringify({}), "utf-8");
 
-			const storage = new ThoughtStorage(tempDir);
-			storage.importSession(emptyPath);
+      const storage = new ThoughtStorage(tempDir);
+      storage.importSession(emptyPath);
 
-			expect(storage.getAllThoughts()).toEqual([]);
-		});
+      expect(storage.getAllThoughts()).toEqual([]);
+    });
 
-		it("handles non-existent file", () => {
-			const storage = new ThoughtStorage(tempDir);
-			storage.importSession(join(tempDir, "nonexistent.json"));
+    it("handles non-existent file", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.importSession(join(tempDir, "nonexistent.json"));
 
-			expect(storage.getAllThoughts()).toEqual([]);
-		});
-	});
+      expect(storage.getAllThoughts()).toEqual([]);
+    });
+  });
 
-	describe("error handling", () => {
-		it("handles corrupted JSON file gracefully", () => {
-			const corruptedPath = join(tempDir, "corrupted.json");
-			writeFileSync(corruptedPath, "not valid json {{{", "utf-8");
+  describe("error handling", () => {
+    it("handles corrupted JSON file gracefully", () => {
+      const corruptedPath = join(tempDir, "corrupted.json");
+      writeFileSync(corruptedPath, "not valid json {{{", "utf-8");
 
-			// Should not throw
-			const storage = new ThoughtStorage(tempDir);
-			expect(storage.getAllThoughts()).toEqual([]);
-		});
+      // Should not throw
+      const storage = new ThoughtStorage(tempDir);
+      expect(storage.getAllThoughts()).toEqual([]);
+    });
 
-		it("handles invalid current_session.json", () => {
-			// Create a storage with the session file
-			const sessionFile = join(tempDir, "current_session.json");
-			writeFileSync(sessionFile, "not valid json {{{{json", "utf-8");
+    it("handles invalid current_session.json", () => {
+      // Create a storage with the session file
+      const sessionFile = join(tempDir, "current_session.json");
+      writeFileSync(sessionFile, "not valid json {{{{json", "utf-8");
 
-			// Create storage - should handle corrupted session gracefully
-			const storage = new ThoughtStorage(tempDir);
+      // Create storage - should handle corrupted session gracefully
+      const storage = new ThoughtStorage(tempDir);
 
-			// Should load empty and overwrite with valid data
-			expect(storage.getAllThoughts()).toEqual([]);
+      // Should load empty and overwrite with valid data
+      expect(storage.getAllThoughts()).toEqual([]);
 
-			// Save should work
-			storage.addThought(createThought());
-			expect(storage.getAllThoughts()).toHaveLength(1);
-		});
-	});
+      // Save should work
+      storage.addThought(createThought());
+      expect(storage.getAllThoughts()).toHaveLength(1);
+    });
+  });
 });

--- a/packages/pi-sequential-thinking/__tests__/types.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/types.test.ts
@@ -1,215 +1,215 @@
 import { describe, expect, it } from "vitest";
 import {
-	generateUuid,
-	isValidThoughtData,
-	parseThoughtStage,
-	ThoughtStage,
-	thoughtFromDict,
-	thoughtToDict,
-	validateThoughtData,
+  generateUuid,
+  isValidThoughtData,
+  parseThoughtStage,
+  ThoughtStage,
+  thoughtFromDict,
+  thoughtToDict,
+  validateThoughtData,
 } from "../extensions/types.js";
 
 describe("ThoughtStage", () => {
-	it("parses valid stages case-insensitively", () => {
-		expect(parseThoughtStage("Problem Definition")).toBe(ThoughtStage.PROBLEM_DEFINITION);
-		expect(parseThoughtStage("problem definition")).toBe(ThoughtStage.PROBLEM_DEFINITION);
-		expect(parseThoughtStage("PROBLEM DEFINITION")).toBe(ThoughtStage.PROBLEM_DEFINITION);
-		expect(parseThoughtStage("Research")).toBe(ThoughtStage.RESEARCH);
-		expect(parseThoughtStage("Analysis")).toBe(ThoughtStage.ANALYSIS);
-		expect(parseThoughtStage("Synthesis")).toBe(ThoughtStage.SYNTHESIS);
-		expect(parseThoughtStage("Conclusion")).toBe(ThoughtStage.CONCLUSION);
-	});
+  it("parses valid stages case-insensitively", () => {
+    expect(parseThoughtStage("Problem Definition")).toBe(ThoughtStage.PROBLEM_DEFINITION);
+    expect(parseThoughtStage("problem definition")).toBe(ThoughtStage.PROBLEM_DEFINITION);
+    expect(parseThoughtStage("PROBLEM DEFINITION")).toBe(ThoughtStage.PROBLEM_DEFINITION);
+    expect(parseThoughtStage("Research")).toBe(ThoughtStage.RESEARCH);
+    expect(parseThoughtStage("Analysis")).toBe(ThoughtStage.ANALYSIS);
+    expect(parseThoughtStage("Synthesis")).toBe(ThoughtStage.SYNTHESIS);
+    expect(parseThoughtStage("Conclusion")).toBe(ThoughtStage.CONCLUSION);
+  });
 
-	it("throws on invalid stage", () => {
-		expect(() => parseThoughtStage("Invalid Stage")).toThrow("Invalid thinking stage");
-	});
+  it("throws on invalid stage", () => {
+    expect(() => parseThoughtStage("Invalid Stage")).toThrow("Invalid thinking stage");
+  });
 });
 
 describe("validateThoughtData", () => {
-	it("returns no errors for valid data", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 1,
-			total_thoughts: 3,
-		};
-		expect(validateThoughtData(data)).toEqual([]);
-	});
+  it("returns no errors for valid data", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 1,
+      total_thoughts: 3,
+    };
+    expect(validateThoughtData(data)).toEqual([]);
+  });
 
-	it("returns error for empty thought", () => {
-		const data = {
-			thought: "",
-			thought_number: 1,
-			total_thoughts: 3,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought",
-			message: "Thought content cannot be empty",
-		});
-	});
+  it("returns error for empty thought", () => {
+    const data = {
+      thought: "",
+      thought_number: 1,
+      total_thoughts: 3,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought",
+      message: "Thought content cannot be empty",
+    });
+  });
 
-	it("returns error for whitespace-only thought", () => {
-		const data = {
-			thought: "   ",
-			thought_number: 1,
-			total_thoughts: 3,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought",
-			message: "Thought content cannot be empty",
-		});
-	});
+  it("returns error for whitespace-only thought", () => {
+    const data = {
+      thought: "   ",
+      thought_number: 1,
+      total_thoughts: 3,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought",
+      message: "Thought content cannot be empty",
+    });
+  });
 
-	it("returns error for non-positive thought_number", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 0,
-			total_thoughts: 3,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "thought_number",
-			message: "Thought number must be a positive integer",
-		});
-	});
+  it("returns error for non-positive thought_number", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 0,
+      total_thoughts: 3,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "thought_number",
+      message: "Thought number must be a positive integer",
+    });
+  });
 
-	it("returns error when total_thoughts < thought_number", () => {
-		const data = {
-			thought: "My thought",
-			thought_number: 5,
-			total_thoughts: 3,
-		};
-		expect(validateThoughtData(data)).toContainEqual({
-			field: "total_thoughts",
-			message: "Total thoughts must be greater or equal to current thought number",
-		});
-	});
+  it("returns error when total_thoughts < thought_number", () => {
+    const data = {
+      thought: "My thought",
+      thought_number: 5,
+      total_thoughts: 3,
+    };
+    expect(validateThoughtData(data)).toContainEqual({
+      field: "total_thoughts",
+      message: "Total thoughts must be greater or equal to current thought number",
+    });
+  });
 });
 
 describe("isValidThoughtData", () => {
-	it("returns true for valid data", () => {
-		expect(
-			isValidThoughtData({
-				thought: "My thought",
-				thought_number: 1,
-				total_thoughts: 3,
-			}),
-		).toBe(true);
-	});
+  it("returns true for valid data", () => {
+    expect(
+      isValidThoughtData({
+        thought: "My thought",
+        thought_number: 1,
+        total_thoughts: 3,
+      }),
+    ).toBe(true);
+  });
 
-	it("returns false for invalid data", () => {
-		expect(isValidThoughtData({ thought: "", thought_number: 0, total_thoughts: 0 })).toBe(false);
-	});
+  it("returns false for invalid data", () => {
+    expect(isValidThoughtData({ thought: "", thought_number: 0, total_thoughts: 0 })).toBe(false);
+  });
 });
 
 describe("thoughtToDict", () => {
-	it("converts thought to dict without id by default", () => {
-		const thought = {
-			thought: "Test thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			stage: ThoughtStage.RESEARCH,
-			tags: ["test"],
-			axioms_used: [],
-			assumptions_challenged: [],
-			timestamp: "2024-01-01T00:00:00.000Z",
-			id: "test-id",
-		};
-		const dict = thoughtToDict(thought);
-		expect(dict.thought).toBe("Test thought");
-		expect(dict.thoughtNumber).toBe(1);
-		expect(dict.totalThoughts).toBe(3);
-		expect(dict.nextThoughtNeeded).toBe(true);
-		expect(dict.stage).toBe(ThoughtStage.RESEARCH);
-		expect(dict.tags).toEqual(["test"]);
-		expect(dict.axiomsUsed).toEqual([]);
-		expect(dict.assumptionsChallenged).toEqual([]);
-		expect(dict.timestamp).toBe("2024-01-01T00:00:00.000Z");
-		expect(dict.id).toBeUndefined();
-	});
+  it("converts thought to dict without id by default", () => {
+    const thought = {
+      thought: "Test thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: ThoughtStage.RESEARCH,
+      tags: ["test"],
+      axioms_used: [],
+      assumptions_challenged: [],
+      timestamp: "2024-01-01T00:00:00.000Z",
+      id: "test-id",
+    };
+    const dict = thoughtToDict(thought);
+    expect(dict.thought).toBe("Test thought");
+    expect(dict.thoughtNumber).toBe(1);
+    expect(dict.totalThoughts).toBe(3);
+    expect(dict.nextThoughtNeeded).toBe(true);
+    expect(dict.stage).toBe(ThoughtStage.RESEARCH);
+    expect(dict.tags).toEqual(["test"]);
+    expect(dict.axiomsUsed).toEqual([]);
+    expect(dict.assumptionsChallenged).toEqual([]);
+    expect(dict.timestamp).toBe("2024-01-01T00:00:00.000Z");
+    expect(dict.id).toBeUndefined();
+  });
 
-	it("includes id when requested", () => {
-		const thought = {
-			thought: "Test thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			stage: ThoughtStage.ANALYSIS,
-			tags: [],
-			axioms_used: [],
-			assumptions_challenged: [],
-			timestamp: "2024-01-01T00:00:00.000Z",
-			id: "test-id",
-		};
-		const dict = thoughtToDict(thought, true);
-		expect(dict.id).toBe("test-id");
-	});
+  it("includes id when requested", () => {
+    const thought = {
+      thought: "Test thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: ThoughtStage.ANALYSIS,
+      tags: [],
+      axioms_used: [],
+      assumptions_challenged: [],
+      timestamp: "2024-01-01T00:00:00.000Z",
+      id: "test-id",
+    };
+    const dict = thoughtToDict(thought, true);
+    expect(dict.id).toBe("test-id");
+  });
 });
 
 describe("thoughtFromDict", () => {
-	it("parses dict with camelCase keys", () => {
-		const dict = {
-			thought: "Test thought",
-			thoughtNumber: 2,
-			totalThoughts: 5,
-			nextThoughtNeeded: false,
-			stage: "Synthesis",
-			tags: ["tag1", "tag2"],
-			axiomsUsed: ["axiom1"],
-			assumptionsChallenged: [],
-			timestamp: "2024-01-01T00:00:00.000Z",
-			id: "parsed-id",
-		};
-		const thought = thoughtFromDict(dict);
-		expect(thought.thought).toBe("Test thought");
-		expect(thought.thought_number).toBe(2);
-		expect(thought.total_thoughts).toBe(5);
-		expect(thought.next_thought_needed).toBe(false);
-		expect(thought.stage).toBe(ThoughtStage.SYNTHESIS);
-		expect(thought.tags).toEqual(["tag1", "tag2"]);
-		expect(thought.axioms_used).toEqual(["axiom1"]);
-		expect(thought.id).toBe("parsed-id");
-	});
+  it("parses dict with camelCase keys", () => {
+    const dict = {
+      thought: "Test thought",
+      thoughtNumber: 2,
+      totalThoughts: 5,
+      nextThoughtNeeded: false,
+      stage: "Synthesis",
+      tags: ["tag1", "tag2"],
+      axiomsUsed: ["axiom1"],
+      assumptionsChallenged: [],
+      timestamp: "2024-01-01T00:00:00.000Z",
+      id: "parsed-id",
+    };
+    const thought = thoughtFromDict(dict);
+    expect(thought.thought).toBe("Test thought");
+    expect(thought.thought_number).toBe(2);
+    expect(thought.total_thoughts).toBe(5);
+    expect(thought.next_thought_needed).toBe(false);
+    expect(thought.stage).toBe(ThoughtStage.SYNTHESIS);
+    expect(thought.tags).toEqual(["tag1", "tag2"]);
+    expect(thought.axioms_used).toEqual(["axiom1"]);
+    expect(thought.id).toBe("parsed-id");
+  });
 
-	it("parses dict with snake_case keys", () => {
-		const dict = {
-			thought: "Test thought",
-			thought_number: 1,
-			total_thoughts: 3,
-			next_thought_needed: true,
-			stage: "Conclusion",
-			tags: [],
-			axioms_used: [],
-			assumptions_challenged: [],
-			timestamp: "2024-01-01T00:00:00.000Z",
-			id: "snake-id",
-		};
-		const thought = thoughtFromDict(dict);
-		expect(thought.thought_number).toBe(1);
-		expect(thought.stage).toBe(ThoughtStage.CONCLUSION);
-	});
+  it("parses dict with snake_case keys", () => {
+    const dict = {
+      thought: "Test thought",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: "Conclusion",
+      tags: [],
+      axioms_used: [],
+      assumptions_challenged: [],
+      timestamp: "2024-01-01T00:00:00.000Z",
+      id: "snake-id",
+    };
+    const thought = thoughtFromDict(dict);
+    expect(thought.thought_number).toBe(1);
+    expect(thought.stage).toBe(ThoughtStage.CONCLUSION);
+  });
 
-	it("generates id when not provided", () => {
-		const dict = {
-			thought: "Test thought",
-			thoughtNumber: 1,
-			totalThoughts: 1,
-			nextThoughtNeeded: false,
-			stage: "Analysis",
-		};
-		const thought = thoughtFromDict(dict);
-		expect(thought.id).toBeDefined();
-		expect(thought.id).toMatch(/^[0-9a-f-]+$/);
-	});
+  it("generates id when not provided", () => {
+    const dict = {
+      thought: "Test thought",
+      thoughtNumber: 1,
+      totalThoughts: 1,
+      nextThoughtNeeded: false,
+      stage: "Analysis",
+    };
+    const thought = thoughtFromDict(dict);
+    expect(thought.id).toBeDefined();
+    expect(thought.id).toMatch(/^[0-9a-f-]+$/);
+  });
 });
 
 describe("generateUuid", () => {
-	it("generates valid UUID format", () => {
-		const uuid = generateUuid();
-		expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-	});
+  it("generates valid UUID format", () => {
+    const uuid = generateUuid();
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
 
-	it("generates unique IDs", () => {
-		const ids = new Set(Array.from({ length: 100 }, () => generateUuid()));
-		expect(ids.size).toBe(100);
-	});
+  it("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateUuid()));
+    expect(ids.size).toBe(100);
+  });
 });

--- a/packages/pi-sequential-thinking/extensions/analyzer.ts
+++ b/packages/pi-sequential-thinking/extensions/analyzer.ts
@@ -9,207 +9,207 @@ import type { ThoughtData } from "./types.js";
 // =============================================================================
 
 export class ThoughtAnalyzer {
-	private getSameStageThoughts(currentThought: ThoughtData, allThoughts: ThoughtData[]): ThoughtData[] {
-		return allThoughts.filter(
-			(thought) => this.isDifferentThought(thought, currentThought) && thought.stage === currentThought.stage,
-		);
-	}
+  private getSameStageThoughts(currentThought: ThoughtData, allThoughts: ThoughtData[]): ThoughtData[] {
+    return allThoughts.filter(
+      (thought) => this.isDifferentThought(thought, currentThought) && thought.stage === currentThought.stage,
+    );
+  }
 
-	private getTagRelatedThoughts(currentThought: ThoughtData, allThoughts: ThoughtData[]): ThoughtData[] {
-		if (currentThought.tags.length === 0) {
-			return [];
-		}
+  private getTagRelatedThoughts(currentThought: ThoughtData, allThoughts: ThoughtData[]): ThoughtData[] {
+    if (currentThought.tags.length === 0) {
+      return [];
+    }
 
-		return allThoughts
-			.map((thought) => ({
-				thought,
-				matchCount: this.countMatchingTags(currentThought, thought),
-			}))
-			.filter(({ thought, matchCount }) => this.isDifferentThought(thought, currentThought) && matchCount > 0)
-			.sort((a, b) => b.matchCount - a.matchCount)
-			.map(({ thought }) => thought);
-	}
+    return allThoughts
+      .map((thought) => ({
+        thought,
+        matchCount: this.countMatchingTags(currentThought, thought),
+      }))
+      .filter(({ thought, matchCount }) => this.isDifferentThought(thought, currentThought) && matchCount > 0)
+      .sort((a, b) => b.matchCount - a.matchCount)
+      .map(({ thought }) => thought);
+  }
 
-	private countMatchingTags(currentThought: ThoughtData, candidateThought: ThoughtData): number {
-		return currentThought.tags.filter((tag) => candidateThought.tags.includes(tag)).length;
-	}
+  private countMatchingTags(currentThought: ThoughtData, candidateThought: ThoughtData): number {
+    return currentThought.tags.filter((tag) => candidateThought.tags.includes(tag)).length;
+  }
 
-	private isDifferentThought(thought: ThoughtData, currentThought: ThoughtData): boolean {
-		return thought.id !== currentThought.id;
-	}
+  private isDifferentThought(thought: ThoughtData, currentThought: ThoughtData): boolean {
+    return thought.id !== currentThought.id;
+  }
 
-	private mergeThoughtsWithLimit(thoughtGroups: ThoughtData[][], maxResults: number): ThoughtData[] {
-		const combined: ThoughtData[] = [];
-		const seenIds = new Set<string>();
+  private mergeThoughtsWithLimit(thoughtGroups: ThoughtData[][], maxResults: number): ThoughtData[] {
+    const combined: ThoughtData[] = [];
+    const seenIds = new Set<string>();
 
-		for (const thoughts of thoughtGroups) {
-			for (const thought of thoughts) {
-				if (seenIds.has(thought.id)) {
-					continue;
-				}
+    for (const thoughts of thoughtGroups) {
+      for (const thought of thoughts) {
+        if (seenIds.has(thought.id)) {
+          continue;
+        }
 
-				combined.push(thought);
-				seenIds.add(thought.id);
+        combined.push(thought);
+        seenIds.add(thought.id);
 
-				if (combined.length >= maxResults) {
-					return combined;
-				}
-			}
-		}
+        if (combined.length >= maxResults) {
+          return combined;
+        }
+      }
+    }
 
-		return combined;
-	}
+    return combined;
+  }
 
-	/**
-	 * Find thoughts related to the current thought.
-	 * Related thoughts are those in the same stage or sharing similar tags.
-	 */
-	findRelatedThoughts(currentThought: ThoughtData, allThoughts: ThoughtData[], maxResults = 3): ThoughtData[] {
-		const sameStageThoughts = this.getSameStageThoughts(currentThought, allThoughts);
-		const tagRelatedThoughts = this.getTagRelatedThoughts(currentThought, allThoughts);
+  /**
+   * Find thoughts related to the current thought.
+   * Related thoughts are those in the same stage or sharing similar tags.
+   */
+  findRelatedThoughts(currentThought: ThoughtData, allThoughts: ThoughtData[], maxResults = 3): ThoughtData[] {
+    const sameStageThoughts = this.getSameStageThoughts(currentThought, allThoughts);
+    const tagRelatedThoughts = this.getTagRelatedThoughts(currentThought, allThoughts);
 
-		return this.mergeThoughtsWithLimit([sameStageThoughts, tagRelatedThoughts], maxResults);
-	}
+    return this.mergeThoughtsWithLimit([sameStageThoughts, tagRelatedThoughts], maxResults);
+  }
 
-	/**
-	 * Analyze a single thought in context of all thoughts.
-	 */
-	analyzeThought(
-		thought: ThoughtData,
-		allThoughts: ThoughtData[],
-	): {
-		thoughtAnalysis: {
-			currentThought: {
-				thoughtNumber: number;
-				totalThoughts: number;
-				nextThoughtNeeded: boolean;
-				stage: string;
-				tags: string[];
-				timestamp: string;
-			};
-			analysis: {
-				relatedThoughtsCount: number;
-				relatedThoughtSummaries: Array<{
-					thoughtNumber: number;
-					stage: string;
-					snippet: string;
-				}>;
-				progress: number;
-				isFirstInStage: boolean;
-			};
-			context: {
-				thoughtHistoryLength: number;
-				currentStage: string;
-			};
-		};
-	} {
-		// Find related thoughts
-		const relatedThoughts = this.findRelatedThoughts(thought, allThoughts);
+  /**
+   * Analyze a single thought in context of all thoughts.
+   */
+  analyzeThought(
+    thought: ThoughtData,
+    allThoughts: ThoughtData[],
+  ): {
+    thoughtAnalysis: {
+      currentThought: {
+        thoughtNumber: number;
+        totalThoughts: number;
+        nextThoughtNeeded: boolean;
+        stage: string;
+        tags: string[];
+        timestamp: string;
+      };
+      analysis: {
+        relatedThoughtsCount: number;
+        relatedThoughtSummaries: Array<{
+          thoughtNumber: number;
+          stage: string;
+          snippet: string;
+        }>;
+        progress: number;
+        isFirstInStage: boolean;
+      };
+      context: {
+        thoughtHistoryLength: number;
+        currentStage: string;
+      };
+    };
+  } {
+    // Find related thoughts
+    const relatedThoughts = this.findRelatedThoughts(thought, allThoughts);
 
-		// Check if this is the first thought in its stage
-		const sameStageThoughts = allThoughts.filter((t) => t.stage === thought.stage);
-		const isFirstInStage = sameStageThoughts.every((t) => t.thought_number >= thought.thought_number);
+    // Check if this is the first thought in its stage
+    const sameStageThoughts = allThoughts.filter((t) => t.stage === thought.stage);
+    const isFirstInStage = sameStageThoughts.every((t) => t.thought_number >= thought.thought_number);
 
-		// Calculate progress
-		const progress = (thought.thought_number / thought.total_thoughts) * 100;
+    // Calculate progress
+    const progress = (thought.thought_number / thought.total_thoughts) * 100;
 
-		return {
-			thoughtAnalysis: {
-				currentThought: {
-					thoughtNumber: thought.thought_number,
-					totalThoughts: thought.total_thoughts,
-					nextThoughtNeeded: thought.next_thought_needed,
-					stage: thought.stage,
-					tags: thought.tags,
-					timestamp: thought.timestamp,
-				},
-				analysis: {
-					relatedThoughtsCount: relatedThoughts.length,
-					relatedThoughtSummaries: relatedThoughts.map((t) => ({
-						thoughtNumber: t.thought_number,
-						stage: t.stage,
-						snippet: t.thought.length > 100 ? `${t.thought.slice(0, 100)}...` : t.thought,
-					})),
-					progress,
-					isFirstInStage,
-				},
-				context: {
-					thoughtHistoryLength: allThoughts.length,
-					currentStage: thought.stage,
-				},
-			},
-		};
-	}
+    return {
+      thoughtAnalysis: {
+        currentThought: {
+          thoughtNumber: thought.thought_number,
+          totalThoughts: thought.total_thoughts,
+          nextThoughtNeeded: thought.next_thought_needed,
+          stage: thought.stage,
+          tags: thought.tags,
+          timestamp: thought.timestamp,
+        },
+        analysis: {
+          relatedThoughtsCount: relatedThoughts.length,
+          relatedThoughtSummaries: relatedThoughts.map((t) => ({
+            thoughtNumber: t.thought_number,
+            stage: t.stage,
+            snippet: t.thought.length > 100 ? `${t.thought.slice(0, 100)}...` : t.thought,
+          })),
+          progress,
+          isFirstInStage,
+        },
+        context: {
+          thoughtHistoryLength: allThoughts.length,
+          currentStage: thought.stage,
+        },
+      },
+    };
+  }
 
-	/**
-	 * Generate a summary of the entire thinking process.
-	 */
-	generateSummary(thoughts: ThoughtData[]): { summary: SummaryData | string } {
-		if (thoughts.length === 0) {
-			return { summary: "No thoughts recorded yet" };
-		}
+  /**
+   * Generate a summary of the entire thinking process.
+   */
+  generateSummary(thoughts: ThoughtData[]): { summary: SummaryData | string } {
+    if (thoughts.length === 0) {
+      return { summary: "No thoughts recorded yet" };
+    }
 
-		// Group thoughts by stage
-		const stages: Record<string, ThoughtData[]> = {};
-		for (const thought of thoughts) {
-			if (!stages[thought.stage]) {
-				stages[thought.stage] = [];
-			}
-			stages[thought.stage].push(thought);
-		}
+    // Group thoughts by stage
+    const stages: Record<string, ThoughtData[]> = {};
+    for (const thought of thoughts) {
+      if (!stages[thought.stage]) {
+        stages[thought.stage] = [];
+      }
+      stages[thought.stage].push(thought);
+    }
 
-		// Count tags
-		const tagCounts = new Map<string, number>();
-		for (const thought of thoughts) {
-			for (const tag of thought.tags) {
-				tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
-			}
-		}
+    // Count tags
+    const tagCounts = new Map<string, number>();
+    for (const thought of thoughts) {
+      for (const tag of thought.tags) {
+        tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+      }
+    }
 
-		// Get top 5 tags
-		const topTags = Array.from(tagCounts.entries())
-			.sort((a, b) => b[1] - a[1])
-			.slice(0, 5)
-			.map(([tag, count]) => ({ tag, count }));
+    // Get top 5 tags
+    const topTags = Array.from(tagCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([tag, count]) => ({ tag, count }));
 
-		// Calculate completion status
-		const maxTotal = Math.max(...thoughts.map((t) => t.total_thoughts), 0);
-		const percentComplete = maxTotal > 0 ? (thoughts.length / maxTotal) * 100 : 0;
+    // Calculate completion status
+    const maxTotal = Math.max(...thoughts.map((t) => t.total_thoughts), 0);
+    const percentComplete = maxTotal > 0 ? (thoughts.length / maxTotal) * 100 : 0;
 
-		// Check if all stages are represented
-		const allStagesPresent = Object.keys(stages).length === 5;
+    // Check if all stages are represented
+    const allStagesPresent = Object.keys(stages).length === 5;
 
-		// Create timeline
-		const sortedThoughts = [...thoughts].sort((a, b) => a.thought_number - b.thought_number);
-		const timeline = sortedThoughts.map((t) => ({
-			number: t.thought_number,
-			stage: t.stage,
-		}));
+    // Create timeline
+    const sortedThoughts = [...thoughts].sort((a, b) => a.thought_number - b.thought_number);
+    const timeline = sortedThoughts.map((t) => ({
+      number: t.thought_number,
+      stage: t.stage,
+    }));
 
-		const summary: SummaryData = {
-			totalThoughts: thoughts.length,
-			stages: Object.fromEntries(
-				Object.entries(stages).map(([stage, thoughtsList]) => [stage, thoughtsList.length]),
-			) as Record<string, number>,
-			timeline,
-			topTags,
-			completionStatus: {
-				hasAllStages: allStagesPresent,
-				percentComplete,
-			},
-		};
+    const summary: SummaryData = {
+      totalThoughts: thoughts.length,
+      stages: Object.fromEntries(
+        Object.entries(stages).map(([stage, thoughtsList]) => [stage, thoughtsList.length]),
+      ) as Record<string, number>,
+      timeline,
+      topTags,
+      completionStatus: {
+        hasAllStages: allStagesPresent,
+        percentComplete,
+      },
+    };
 
-		return { summary };
-	}
+    return { summary };
+  }
 }
 
 export interface SummaryData {
-	totalThoughts: number;
-	stages: Record<string, number>;
-	timeline: Array<{ number: number; stage: string }>;
-	topTags: Array<{ tag: string; count: number }>;
-	completionStatus: {
-		hasAllStages: boolean;
-		percentComplete: number;
-	};
+  totalThoughts: number;
+  stages: Record<string, number>;
+  timeline: Array<{ number: number; stage: string }>;
+  topTags: Array<{ tag: string; count: number }>;
+  completionStatus: {
+    hasAllStages: boolean;
+    percentComplete: number;
+  };
 }

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -32,7 +32,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { AgentToolUpdateCallback, ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { ThoughtAnalyzer } from "./analyzer.js";
@@ -44,9 +44,9 @@ import { generateUuid, parseThoughtStage, type ThoughtData, ThoughtStage } from 
 // =============================================================================
 
 const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
-	storageDir: null,
-	maxBytes: DEFAULT_MAX_BYTES,
-	maxLines: DEFAULT_MAX_LINES,
+  storageDir: null,
+  maxBytes: DEFAULT_MAX_BYTES,
+  maxLines: DEFAULT_MAX_LINES,
 };
 
 // =============================================================================
@@ -54,9 +54,9 @@ const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
 // =============================================================================
 
 interface SeqThinkConfig {
-	storageDir?: string;
-	maxBytes?: number;
-	maxLines?: number;
+  storageDir?: string;
+  maxBytes?: number;
+  maxLines?: number;
 }
 
 // =============================================================================
@@ -64,202 +64,202 @@ interface SeqThinkConfig {
 // =============================================================================
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toJsonString(value: unknown): string {
-	if (typeof value === "string") {
-		return value;
-	}
-	try {
-		return JSON.stringify(value, null, 2);
-	} catch {
-		return String(value);
-	}
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function formatToolOutput(
-	toolName: string,
-	result: unknown,
-	limits: { maxBytes?: number; maxLines?: number },
+  toolName: string,
+  result: unknown,
+  limits: { maxBytes?: number; maxLines?: number },
 ): { text: string; details: McpToolDetails } {
-	const rawText = toJsonString(result);
-	const truncation = truncateHead(rawText, {
-		maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
-		maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
-	});
+  const rawText = toJsonString(result);
+  const truncation = truncateHead(rawText, {
+    maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
+    maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
+  });
 
-	let text = truncation.content;
-	let tempFile: string | undefined;
+  let text = truncation.content;
+  let tempFile: string | undefined;
 
-	if (truncation.truncated) {
-		tempFile = writeTempFile(toolName, rawText);
-		text +=
-			`\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
-			`(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
-			`Full output saved to: ${tempFile}]`;
-	}
+  if (truncation.truncated) {
+    tempFile = writeTempFile(toolName, rawText);
+    text +=
+      `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
+      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
+      `Full output saved to: ${tempFile}]`;
+  }
 
-	if (truncation.firstLineExceedsLimit && rawText.length > 0) {
-		text =
-			`[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
-			text;
-	}
+  if (truncation.firstLineExceedsLimit && rawText.length > 0) {
+    text =
+      `[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
+      text;
+  }
 
-	return {
-		text,
-		details: {
-			tool: toolName,
-			truncated: truncation.truncated,
-			truncation: {
-				truncatedBy: truncation.truncatedBy,
-				totalLines: truncation.totalLines,
-				totalBytes: truncation.totalBytes,
-				outputLines: truncation.outputLines,
-				outputBytes: truncation.outputBytes,
-				maxLines: truncation.maxLines,
-				maxBytes: truncation.maxBytes,
-			},
-			tempFile,
-		},
-	};
+  return {
+    text,
+    details: {
+      tool: toolName,
+      truncated: truncation.truncated,
+      truncation: {
+        truncatedBy: truncation.truncatedBy,
+        totalLines: truncation.totalLines,
+        totalBytes: truncation.totalBytes,
+        outputLines: truncation.outputLines,
+        outputBytes: truncation.outputBytes,
+        maxLines: truncation.maxLines,
+        maxBytes: truncation.maxBytes,
+      },
+      tempFile,
+    },
+  };
 }
 
 function writeTempFile(toolName: string, content: string): string {
-	const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
-	const filename = `pi-seq-think-${safeName}-${Date.now()}.txt`;
-	const filePath = join(tmpdir(), filename);
-	writeFileSync(filePath, content, "utf-8");
-	return filePath;
+  const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
+  const filename = `pi-seq-think-${safeName}-${Date.now()}.txt`;
+  const filePath = join(tmpdir(), filename);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
 }
 
 function normalizeString(value: unknown): string | undefined {
-	if (typeof value !== "string") {
-		return undefined;
-	}
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function normalizeNumber(value: unknown): number | undefined {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		return value;
-	}
-	if (typeof value === "string") {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed)) {
-			return parsed;
-		}
-	}
-	return undefined;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
 }
 
 function splitParams(params: Record<string, unknown>): {
-	toolArgs: Record<string, unknown>;
-	requestedLimits: { maxBytes?: number; maxLines?: number };
+  toolArgs: Record<string, unknown>;
+  requestedLimits: { maxBytes?: number; maxLines?: number };
 } {
-	const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
-		piMaxBytes?: unknown;
-		piMaxLines?: unknown;
-	};
-	return {
-		toolArgs: rest,
-		requestedLimits: {
-			maxBytes: normalizeNumber(piMaxBytes),
-			maxLines: normalizeNumber(piMaxLines),
-		},
-	};
+  const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
+    piMaxBytes?: unknown;
+    piMaxLines?: unknown;
+  };
+  return {
+    toolArgs: rest,
+    requestedLimits: {
+      maxBytes: normalizeNumber(piMaxBytes),
+      maxLines: normalizeNumber(piMaxLines),
+    },
+  };
 }
 
 function resolveEffectiveLimits(
-	requested: { maxBytes?: number; maxLines?: number },
-	maxAllowed: { maxBytes: number; maxLines: number },
+  requested: { maxBytes?: number; maxLines?: number },
+  maxAllowed: { maxBytes: number; maxLines: number },
 ): { maxBytes: number; maxLines: number } {
-	const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
-	const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
-	return {
-		maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
-		maxLines: Math.min(requestedLines, maxAllowed.maxLines),
-	};
+  const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
+  const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
+  return {
+    maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
+    maxLines: Math.min(requestedLines, maxAllowed.maxLines),
+  };
 }
 
 function resolveConfigPath(configPath: string): string {
-	const trimmed = configPath.trim();
-	if (trimmed.startsWith("~/")) {
-		return join(homedir(), trimmed.slice(2));
-	}
-	if (trimmed.startsWith("~")) {
-		return join(homedir(), trimmed.slice(1));
-	}
-	if (isAbsolute(trimmed)) {
-		return trimmed;
-	}
-	return resolve(process.cwd(), trimmed);
+  const trimmed = configPath.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(homedir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
 }
 
 function parseConfig(raw: unknown, pathHint: string): SeqThinkConfig {
-	if (!isRecord(raw)) {
-		throw new Error(`Invalid Sequential Thinking config at ${pathHint}: expected an object.`);
-	}
-	return {
-		storageDir: normalizeString(raw.storageDir),
-		maxBytes: normalizeNumber(raw.maxBytes),
-		maxLines: normalizeNumber(raw.maxLines),
-	};
+  if (!isRecord(raw)) {
+    throw new Error(`Invalid Sequential Thinking config at ${pathHint}: expected an object.`);
+  }
+  return {
+    storageDir: normalizeString(raw.storageDir),
+    maxBytes: normalizeNumber(raw.maxBytes),
+    maxLines: normalizeNumber(raw.maxLines),
+  };
 }
 
 function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
-	const candidates: string[] = [];
-	const envConfig = process.env.SEQ_THINK_CONFIG;
-	if (configPath) {
-		candidates.push(resolveConfigPath(configPath));
-	} else if (envConfig) {
-		candidates.push(resolveConfigPath(envConfig));
-	} else {
-		const projectConfigPath = join(process.cwd(), ".pi", "extensions", "sequential-thinking.json");
-		const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "sequential-thinking.json");
-		ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-		candidates.push(projectConfigPath, globalConfigPath);
-	}
+  const candidates: string[] = [];
+  const envConfig = process.env.SEQ_THINK_CONFIG;
+  if (configPath) {
+    candidates.push(resolveConfigPath(configPath));
+  } else if (envConfig) {
+    candidates.push(resolveConfigPath(envConfig));
+  } else {
+    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "sequential-thinking.json");
+    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "sequential-thinking.json");
+    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    candidates.push(projectConfigPath, globalConfigPath);
+  }
 
-	for (const candidate of candidates) {
-		if (!existsSync(candidate)) {
-			continue;
-		}
-		const raw = readFileSync(candidate, "utf-8");
-		const parsed = JSON.parse(raw);
-		return parseConfig(parsed, candidate);
-	}
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    const raw = readFileSync(candidate, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parseConfig(parsed, candidate);
+  }
 
-	return null;
+  return null;
 }
 
 function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-	if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-		return;
-	}
-	try {
-		mkdirSync(dirname(globalConfigPath), { recursive: true });
-		writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		console.warn(`[pi-sequential-thinking] Failed to write ${globalConfigPath}: ${message}`);
-	}
+  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
+    return;
+  }
+  try {
+    mkdirSync(dirname(globalConfigPath), { recursive: true });
+    writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-sequential-thinking] Failed to write ${globalConfigPath}: ${message}`);
+  }
 }
 
 interface McpToolDetails {
-	tool: string;
-	truncated: boolean;
-	truncation?: {
-		truncatedBy: "lines" | "bytes" | null;
-		totalLines: number;
-		totalBytes: number;
-		outputLines: number;
-		outputBytes: number;
-		maxLines: number;
-		maxBytes: number;
-	};
-	tempFile?: string;
+  tool: string;
+  truncated: boolean;
+  truncation?: {
+    truncatedBy: "lines" | "bytes" | null;
+    totalLines: number;
+    totalBytes: number;
+    outputLines: number;
+    outputBytes: number;
+    maxLines: number;
+    maxBytes: number;
+  };
+  tempFile?: string;
 }
 
 // =============================================================================
@@ -267,73 +267,73 @@ interface McpToolDetails {
 // =============================================================================
 
 const processThoughtParams = Type.Object(
-	{
-		thought: Type.String({ description: "The content of your thought." }),
-		thought_number: Type.Integer({
-			minimum: 1,
-			description: "Position in your sequence (e.g., 1 for first thought).",
-		}),
-		total_thoughts: Type.Integer({ minimum: 1, description: "Expected total thoughts in the sequence." }),
-		next_thought_needed: Type.Boolean({ description: "Whether more thoughts are needed after this one." }),
-		stage: Type.Union(
-			[
-				Type.Literal("Problem Definition"),
-				Type.Literal("Research"),
-				Type.Literal("Analysis"),
-				Type.Literal("Synthesis"),
-				Type.Literal("Conclusion"),
-			],
-			{ description: "The thinking stage." },
-		),
-		tags: Type.Optional(Type.Array(Type.String(), { description: "Keywords or categories for your thought." })),
-		axioms_used: Type.Optional(
-			Type.Array(Type.String(), { description: "Principles or axioms applied in your thought." }),
-		),
-		assumptions_challenged: Type.Optional(
-			Type.Array(Type.String(), {
-				description: "Assumptions your thought questions or challenges.",
-			}),
-		),
-		piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-		piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-	},
-	{ additionalProperties: true },
+  {
+    thought: Type.String({ description: "The content of your thought." }),
+    thought_number: Type.Integer({
+      minimum: 1,
+      description: "Position in your sequence (e.g., 1 for first thought).",
+    }),
+    total_thoughts: Type.Integer({ minimum: 1, description: "Expected total thoughts in the sequence." }),
+    next_thought_needed: Type.Boolean({ description: "Whether more thoughts are needed after this one." }),
+    stage: Type.Union(
+      [
+        Type.Literal("Problem Definition"),
+        Type.Literal("Research"),
+        Type.Literal("Analysis"),
+        Type.Literal("Synthesis"),
+        Type.Literal("Conclusion"),
+      ],
+      { description: "The thinking stage." },
+    ),
+    tags: Type.Optional(Type.Array(Type.String(), { description: "Keywords or categories for your thought." })),
+    axioms_used: Type.Optional(
+      Type.Array(Type.String(), { description: "Principles or axioms applied in your thought." }),
+    ),
+    assumptions_challenged: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Assumptions your thought questions or challenges.",
+      }),
+    ),
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
 );
 
 const generateSummaryParams = Type.Object(
-	{
-		piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-		piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-	},
-	{ additionalProperties: true },
+  {
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
 );
 
 const clearHistoryParams = Type.Object({}, { additionalProperties: true });
 
 const exportSessionParams = Type.Object(
-	{
-		file_path: Type.String({ description: "Path to save the exported session JSON file." }),
-	},
-	{ additionalProperties: true },
+  {
+    file_path: Type.String({ description: "Path to save the exported session JSON file." }),
+  },
+  { additionalProperties: true },
 );
 
 const importSessionParams = Type.Object(
-	{
-		file_path: Type.String({ description: "Path to the JSON file to import." }),
-	},
-	{ additionalProperties: true },
+  {
+    file_path: Type.String({ description: "Path to the JSON file to import." }),
+  },
+  { additionalProperties: true },
 );
 
 const sequentialThinkParams = Type.Object(
-	{
-		topic: Type.String({ description: "The topic or question to think through." }),
-		num_thoughts: Type.Optional(
-			Type.Integer({ minimum: 3, maximum: 10, description: "Number of thoughts to generate (default: 5)." }),
-		),
-		piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-		piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-	},
-	{ additionalProperties: true },
+  {
+    topic: Type.String({ description: "The topic or question to think through." }),
+    num_thoughts: Type.Optional(
+      Type.Integer({ minimum: 3, maximum: 10, description: "Number of thoughts to generate (default: 5)." }),
+    ),
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
 );
 
 // =============================================================================
@@ -343,365 +343,364 @@ const sequentialThinkParams = Type.Object(
 export { ThoughtStorage } from "./storage.js";
 
 export default function sequentialThinking(pi: ExtensionAPI) {
-	// Register CLI flags
-	pi.registerFlag("--seq-think-storage-dir", {
-		description: "Storage directory for thought sessions.",
-		type: "string",
-	});
-	pi.registerFlag("--seq-think-config", {
-		description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/sequential-thinking.json).",
-		type: "string",
-	});
-	pi.registerFlag("--seq-think-max-bytes", {
-		description: "Max bytes to keep from tool output (default: 51200).",
-		type: "string",
-	});
-	pi.registerFlag("--seq-think-max-lines", {
-		description: "Max lines to keep from tool output (default: 2000).",
-		type: "string",
-	});
+  // Register CLI flags
+  pi.registerFlag("--seq-think-storage-dir", {
+    description: "Storage directory for thought sessions.",
+    type: "string",
+  });
+  pi.registerFlag("--seq-think-config", {
+    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/sequential-thinking.json).",
+    type: "string",
+  });
+  pi.registerFlag("--seq-think-max-bytes", {
+    description: "Max bytes to keep from tool output (default: 51200).",
+    type: "string",
+  });
+  pi.registerFlag("--seq-think-max-lines", {
+    description: "Max lines to keep from tool output (default: 2000).",
+    type: "string",
+  });
 
-	const getStorageDir = (): string | undefined => {
-		const storageDirFlag = pi.getFlag("--seq-think-storage-dir");
-		if (typeof storageDirFlag === "string" && storageDirFlag.trim().length > 0) {
-			return resolveConfigPath(storageDirFlag);
-		}
+  const getStorageDir = (): string | undefined => {
+    const storageDirFlag = pi.getFlag("--seq-think-storage-dir");
+    if (typeof storageDirFlag === "string" && storageDirFlag.trim().length > 0) {
+      return resolveConfigPath(storageDirFlag);
+    }
 
-		const configFlag = pi.getFlag("--seq-think-config");
-		const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
-		const envStorageDir = normalizeString(process.env.MCP_STORAGE_DIR);
-		if (envStorageDir) {
-			return resolveConfigPath(envStorageDir);
-		}
-		if (config?.storageDir) {
-			return resolveConfigPath(config.storageDir);
-		}
-		return undefined;
-	};
+    const configFlag = pi.getFlag("--seq-think-config");
+    const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+    const envStorageDir = normalizeString(process.env.MCP_STORAGE_DIR);
+    if (envStorageDir) {
+      return resolveConfigPath(envStorageDir);
+    }
+    if (config?.storageDir) {
+      return resolveConfigPath(config.storageDir);
+    }
+    return undefined;
+  };
 
-	// Create singleton storage and analyzer
-	const storage = new ThoughtStorage(getStorageDir());
-	const analyzer = new ThoughtAnalyzer();
+  // Create singleton storage and analyzer
+  const storage = new ThoughtStorage(getStorageDir());
+  const analyzer = new ThoughtAnalyzer();
 
-	const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
-		const maxBytesFlag = pi.getFlag("--seq-think-max-bytes");
-		const maxLinesFlag = pi.getFlag("--seq-think-max-lines");
-		const configFlag = pi.getFlag("--seq-think-config");
-		const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+  const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
+    const maxBytesFlag = pi.getFlag("--seq-think-max-bytes");
+    const maxLinesFlag = pi.getFlag("--seq-think-max-lines");
+    const configFlag = pi.getFlag("--seq-think-config");
+    const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
 
-		const maxBytes =
-			typeof maxBytesFlag === "string"
-				? normalizeNumber(maxBytesFlag)
-				: normalizeNumber(process.env.SEQ_THINK_MAX_BYTES ?? config?.maxBytes);
-		const maxLines =
-			typeof maxLinesFlag === "string"
-				? normalizeNumber(maxLinesFlag)
-				: normalizeNumber(process.env.SEQ_THINK_MAX_LINES ?? config?.maxLines);
+    const maxBytes =
+      typeof maxBytesFlag === "string"
+        ? normalizeNumber(maxBytesFlag)
+        : normalizeNumber(process.env.SEQ_THINK_MAX_BYTES ?? config?.maxBytes);
+    const maxLines =
+      typeof maxLinesFlag === "string"
+        ? normalizeNumber(maxLinesFlag)
+        : normalizeNumber(process.env.SEQ_THINK_MAX_LINES ?? config?.maxLines);
 
-		return {
-			maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
-			maxLines: maxLines ?? DEFAULT_MAX_LINES,
-		};
-	};
+    return {
+      maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
+      maxLines: maxLines ?? DEFAULT_MAX_LINES,
+    };
+  };
 
-	// Helper to execute a tool
-	const executeTool = (
-		toolName: string,
-		pendingMessage: string,
-		executeFn: () => unknown,
-		// biome-ignore lint/suspicious/noExplicitAny: pi's AgentToolUpdateCallback type varies by tool
-		onUpdate: ((partialResult: any) => void) | undefined,
-		params: Record<string, unknown>,
-	) => {
-		onUpdate?.({
-			content: [{ type: "text" as const, text: pendingMessage }],
-			details: { status: "pending" },
-		});
+  // Helper to execute a tool
+  const executeTool = (
+    toolName: string,
+    pendingMessage: string,
+    executeFn: () => unknown,
+    onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+    params: Record<string, unknown>,
+  ) => {
+    onUpdate?.({
+      content: [{ type: "text" as const, text: pendingMessage }],
+      details: { status: "pending" },
+    });
 
-		try {
-			const { requestedLimits } = splitParams(params);
-			const maxLimits = getMaxLimits();
-			const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-			const result = executeFn();
-			const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
-			return { content: [{ type: "text" as const, text }], details, isError: false };
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			return {
-				content: [{ type: "text" as const, text: `Sequential Thinking error: ${message}` }],
-				isError: true,
-				details: { tool: toolName, error: message },
-			};
-		}
-	};
+    try {
+      const { requestedLimits } = splitParams(params);
+      const maxLimits = getMaxLimits();
+      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
+      const result = executeFn();
+      const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
+      return { content: [{ type: "text" as const, text }], details, isError: false };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text" as const, text: `Sequential Thinking error: ${message}` }],
+        isError: true,
+        details: { tool: toolName, error: message },
+      };
+    }
+  };
 
-	// =============================================================================
-	// Tool Implementations
-	// =============================================================================
+  // =============================================================================
+  // Tool Implementations
+  // =============================================================================
 
-	function processThought(args: Record<string, unknown>): { thoughtAnalysis: unknown } {
-		const thought = args.thought as string;
-		const thoughtNumber = args.thought_number as number;
-		const totalThoughts = args.total_thoughts as number;
-		const nextThoughtNeeded = args.next_thought_needed as boolean;
-		const stageStr = args.stage as string;
-		const tags = (args.tags as string[]) ?? [];
-		const axiomsUsed = (args.axioms_used as string[]) ?? [];
-		const assumptionsChallenged = (args.assumptions_challenged as string[]) ?? [];
+  function processThought(args: Record<string, unknown>): { thoughtAnalysis: unknown } {
+    const thought = args.thought as string;
+    const thoughtNumber = args.thought_number as number;
+    const totalThoughts = args.total_thoughts as number;
+    const nextThoughtNeeded = args.next_thought_needed as boolean;
+    const stageStr = args.stage as string;
+    const tags = (args.tags as string[]) ?? [];
+    const axiomsUsed = (args.axioms_used as string[]) ?? [];
+    const assumptionsChallenged = (args.assumptions_challenged as string[]) ?? [];
 
-		// Parse stage
-		const stage: ThoughtStage = parseThoughtStage(stageStr);
+    // Parse stage
+    const stage: ThoughtStage = parseThoughtStage(stageStr);
 
-		// Create thought data
-		const thoughtData: ThoughtData = {
-			thought,
-			thought_number: thoughtNumber,
-			total_thoughts: totalThoughts,
-			next_thought_needed: nextThoughtNeeded,
-			stage,
-			tags,
-			axioms_used: axiomsUsed,
-			assumptions_challenged: assumptionsChallenged,
-			timestamp: new Date().toISOString(),
-			id: generateUuid(),
-		};
+    // Create thought data
+    const thoughtData: ThoughtData = {
+      thought,
+      thought_number: thoughtNumber,
+      total_thoughts: totalThoughts,
+      next_thought_needed: nextThoughtNeeded,
+      stage,
+      tags,
+      axioms_used: axiomsUsed,
+      assumptions_challenged: assumptionsChallenged,
+      timestamp: new Date().toISOString(),
+      id: generateUuid(),
+    };
 
-		// Validate
-		if (!thought.trim()) {
-			throw new Error("Thought content cannot be empty");
-		}
-		if (thoughtNumber < 1) {
-			throw new Error("Thought number must be a positive integer");
-		}
-		if (totalThoughts < thoughtNumber) {
-			throw new Error("Total thoughts must be greater or equal to current thought number");
-		}
+    // Validate
+    if (!thought.trim()) {
+      throw new Error("Thought content cannot be empty");
+    }
+    if (thoughtNumber < 1) {
+      throw new Error("Thought number must be a positive integer");
+    }
+    if (totalThoughts < thoughtNumber) {
+      throw new Error("Total thoughts must be greater or equal to current thought number");
+    }
 
-		// Store and analyze
-		storage.addThought(thoughtData);
-		const allThoughts = storage.getAllThoughts();
-		const analysis = analyzer.analyzeThought(thoughtData, allThoughts);
+    // Store and analyze
+    storage.addThought(thoughtData);
+    const allThoughts = storage.getAllThoughts();
+    const analysis = analyzer.analyzeThought(thoughtData, allThoughts);
 
-		return analysis;
-	}
+    return analysis;
+  }
 
-	function generateSummary(): { summary: unknown } {
-		const thoughts = storage.getAllThoughts();
-		return analyzer.generateSummary(thoughts);
-	}
+  function generateSummary(): { summary: unknown } {
+    const thoughts = storage.getAllThoughts();
+    return analyzer.generateSummary(thoughts);
+  }
 
-	function clearHistory(): { status: string; message: string } {
-		storage.clearHistory();
-		return { status: "success", message: "Thought history cleared" };
-	}
+  function clearHistory(): { status: string; message: string } {
+    storage.clearHistory();
+    return { status: "success", message: "Thought history cleared" };
+  }
 
-	function exportSession(args: Record<string, unknown>): { status: string; message: string } {
-		const filePath = args.file_path as string;
-		if (!filePath) {
-			throw new Error("file_path is required");
-		}
-		storage.exportSession(filePath);
-		return { status: "success", message: `Session exported to ${filePath}` };
-	}
+  function exportSession(args: Record<string, unknown>): { status: string; message: string } {
+    const filePath = args.file_path as string;
+    if (!filePath) {
+      throw new Error("file_path is required");
+    }
+    storage.exportSession(filePath);
+    return { status: "success", message: `Session exported to ${filePath}` };
+  }
 
-	function importSession(args: Record<string, unknown>): { status: string; message: string } {
-		const filePath = args.file_path as string;
-		if (!filePath) {
-			throw new Error("file_path is required");
-		}
-		if (!existsSync(filePath)) {
-			throw new Error(`File not found: ${filePath}`);
-		}
-		storage.importSession(filePath);
-		return { status: "success", message: `Session imported from ${filePath}` };
-	}
+  function importSession(args: Record<string, unknown>): { status: string; message: string } {
+    const filePath = args.file_path as string;
+    if (!filePath) {
+      throw new Error("file_path is required");
+    }
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+    storage.importSession(filePath);
+    return { status: "success", message: `Session imported from ${filePath}` };
+  }
 
-	// =============================================================================
-	// Register Tools
-	// =============================================================================
+  // =============================================================================
+  // Register Tools
+  // =============================================================================
 
-	pi.registerTool({
-		name: "process_thought",
-		label: "Process Thought",
-		description:
-			"Record and analyze a sequential thought with metadata. Use this to break down complex problems " +
-			"into structured steps through stages: Problem Definition, Research, Analysis, Synthesis, Conclusion. " +
-			"Each thought is tracked with its position in the sequence, stage, tags, and related analysis.",
-		parameters: processThoughtParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			const { toolArgs } = splitParams(params as Record<string, unknown>);
-			return executeTool(
-				"process_thought",
-				"Processing thought...",
-				() => processThought(toolArgs),
-				onUpdate,
-				params as Record<string, unknown>,
-			);
-		},
-	});
+  pi.registerTool({
+    name: "process_thought",
+    label: "Process Thought",
+    description:
+      "Record and analyze a sequential thought with metadata. Use this to break down complex problems " +
+      "into structured steps through stages: Problem Definition, Research, Analysis, Synthesis, Conclusion. " +
+      "Each thought is tracked with its position in the sequence, stage, tags, and related analysis.",
+    parameters: processThoughtParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      return executeTool(
+        "process_thought",
+        "Processing thought...",
+        () => processThought(toolArgs),
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
 
-	pi.registerTool({
-		name: "generate_summary",
-		label: "Generate Thinking Summary",
-		description:
-			"Generate a summary of the entire sequential thinking process. Returns stage counts, " +
-			"timeline, top tags, and completion status. Use after processing multiple thoughts.",
-		parameters: generateSummaryParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			return executeTool(
-				"generate_summary",
-				"Generating summary...",
-				generateSummary,
-				onUpdate,
-				params as Record<string, unknown>,
-			);
-		},
-	});
+  pi.registerTool({
+    name: "generate_summary",
+    label: "Generate Thinking Summary",
+    description:
+      "Generate a summary of the entire sequential thinking process. Returns stage counts, " +
+      "timeline, top tags, and completion status. Use after processing multiple thoughts.",
+    parameters: generateSummaryParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      return executeTool(
+        "generate_summary",
+        "Generating summary...",
+        generateSummary,
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
 
-	pi.registerTool({
-		name: "clear_history",
-		label: "Clear Thought History",
-		description: "Reset the sequential thinking process by clearing all recorded thoughts.",
-		parameters: clearHistoryParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			return executeTool(
-				"clear_history",
-				"Clearing history...",
-				clearHistory,
-				onUpdate,
-				params as Record<string, unknown>,
-			);
-		},
-	});
+  pi.registerTool({
+    name: "clear_history",
+    label: "Clear Thought History",
+    description: "Reset the sequential thinking process by clearing all recorded thoughts.",
+    parameters: clearHistoryParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      return executeTool(
+        "clear_history",
+        "Clearing history...",
+        clearHistory,
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
 
-	pi.registerTool({
-		name: "export_session",
-		label: "Export Thinking Session",
-		description:
-			"Export the current thinking session to a JSON file for sharing or backup. " +
-			"Parent directories are created automatically.",
-		parameters: exportSessionParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			const { toolArgs } = splitParams(params as Record<string, unknown>);
-			return executeTool(
-				"export_session",
-				"Exporting session...",
-				() => exportSession(toolArgs),
-				onUpdate,
-				params as Record<string, unknown>,
-			);
-		},
-	});
+  pi.registerTool({
+    name: "export_session",
+    label: "Export Thinking Session",
+    description:
+      "Export the current thinking session to a JSON file for sharing or backup. " +
+      "Parent directories are created automatically.",
+    parameters: exportSessionParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      return executeTool(
+        "export_session",
+        "Exporting session...",
+        () => exportSession(toolArgs),
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
 
-	pi.registerTool({
-		name: "import_session",
-		label: "Import Thinking Session",
-		description: "Import a previously exported thinking session from a JSON file.",
-		parameters: importSessionParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			const { toolArgs } = splitParams(params as Record<string, unknown>);
-			return executeTool(
-				"import_session",
-				"Importing session...",
-				() => importSession(toolArgs),
-				onUpdate,
-				params as Record<string, unknown>,
-			);
-		},
-	});
+  pi.registerTool({
+    name: "import_session",
+    label: "Import Thinking Session",
+    description: "Import a previously exported thinking session from a JSON file.",
+    parameters: importSessionParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      return executeTool(
+        "import_session",
+        "Importing session...",
+        () => importSession(toolArgs),
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
 
-	pi.registerTool({
-		name: "sequential_think",
-		label: "Sequential Thinking",
-		description:
-			"Think through a topic systematically using structured cognitive stages. " +
-			"Call this when user asks to 'think through', 'analyze', or 'decide' something. " +
-			"Processes through Problem Definition → Research → Analysis → Synthesis → Conclusion. " +
-			"Returns a structured summary with recommendations.",
-		parameters: sequentialThinkParams,
-		async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-			const { toolArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
-			const maxLimits = getMaxLimits();
-			const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
+  pi.registerTool({
+    name: "sequential_think",
+    label: "Sequential Thinking",
+    description:
+      "Think through a topic systematically using structured cognitive stages. " +
+      "Call this when user asks to 'think through', 'analyze', or 'decide' something. " +
+      "Processes through Problem Definition → Research → Analysis → Synthesis → Conclusion. " +
+      "Returns a structured summary with recommendations.",
+    parameters: sequentialThinkParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
+      const maxLimits = getMaxLimits();
+      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
 
-			onUpdate?.({
-				content: [{ type: "text" as const, text: "Starting structured thinking process..." }],
-				details: { status: "pending" },
-			});
+      onUpdate?.({
+        content: [{ type: "text" as const, text: "Starting structured thinking process..." }],
+        details: { status: "pending" },
+      });
 
-			try {
-				const topic = toolArgs.topic as string;
-				const numThoughts = (toolArgs.num_thoughts as number) || 5;
+      try {
+        const topic = toolArgs.topic as string;
+        const numThoughts = (toolArgs.num_thoughts as number) || 5;
 
-				// Generate thoughts for each stage
-				const stages: ThoughtStage[] = [
-					ThoughtStage.PROBLEM_DEFINITION,
-					ThoughtStage.RESEARCH,
-					ThoughtStage.ANALYSIS,
-					ThoughtStage.SYNTHESIS,
-					ThoughtStage.CONCLUSION,
-				];
+        // Generate thoughts for each stage
+        const stages: ThoughtStage[] = [
+          ThoughtStage.PROBLEM_DEFINITION,
+          ThoughtStage.RESEARCH,
+          ThoughtStage.ANALYSIS,
+          ThoughtStage.SYNTHESIS,
+          ThoughtStage.CONCLUSION,
+        ];
 
-				const stagePrompts: Record<ThoughtStage, string> = {
-					[ThoughtStage.PROBLEM_DEFINITION]: `Define the problem: What exactly needs to be decided or solved regarding "${topic}"? What are the constraints and success criteria?`,
-					[ThoughtStage.RESEARCH]: `Research options for "${topic}": What are the available choices? What are their tradeoffs? What does the evidence say?`,
-					[ThoughtStage.ANALYSIS]: `Analyze "${topic}": Examine each option in detail. What are the pros and cons? What are the risks?`,
-					[ThoughtStage.SYNTHESIS]: `Synthesize insights about "${topic}": How do the pieces fit together? What is the overall assessment?`,
-					[ThoughtStage.CONCLUSION]: `Draw a conclusion about "${topic}": What is the recommendation? What is the final verdict?`,
-				};
+        const stagePrompts: Record<ThoughtStage, string> = {
+          [ThoughtStage.PROBLEM_DEFINITION]: `Define the problem: What exactly needs to be decided or solved regarding "${topic}"? What are the constraints and success criteria?`,
+          [ThoughtStage.RESEARCH]: `Research options for "${topic}": What are the available choices? What are their tradeoffs? What does the evidence say?`,
+          [ThoughtStage.ANALYSIS]: `Analyze "${topic}": Examine each option in detail. What are the pros and cons? What are the risks?`,
+          [ThoughtStage.SYNTHESIS]: `Synthesize insights about "${topic}": How do the pieces fit together? What is the overall assessment?`,
+          [ThoughtStage.CONCLUSION]: `Draw a conclusion about "${topic}": What is the recommendation? What is the final verdict?`,
+        };
 
-				// Process thoughts for each stage
-				for (let i = 0; i < Math.min(numThoughts, stages.length); i++) {
-					const stage = stages[i];
-					const thoughtData: ThoughtData = {
-						thought: stagePrompts[stage],
-						thought_number: i + 1,
-						total_thoughts: Math.min(numThoughts, stages.length),
-						next_thought_needed: i < Math.min(numThoughts, stages.length) - 1,
-						stage,
-						tags: [topic.toLowerCase().split(/\s+/)[0]], // First word of topic as tag
-						axioms_used: [],
-						assumptions_challenged: [],
-						timestamp: new Date().toISOString(),
-						id: generateUuid(),
-					};
+        // Process thoughts for each stage
+        for (let i = 0; i < Math.min(numThoughts, stages.length); i++) {
+          const stage = stages[i];
+          const thoughtData: ThoughtData = {
+            thought: stagePrompts[stage],
+            thought_number: i + 1,
+            total_thoughts: Math.min(numThoughts, stages.length),
+            next_thought_needed: i < Math.min(numThoughts, stages.length) - 1,
+            stage,
+            tags: [topic.toLowerCase().split(/\s+/)[0]], // First word of topic as tag
+            axioms_used: [],
+            assumptions_challenged: [],
+            timestamp: new Date().toISOString(),
+            id: generateUuid(),
+          };
 
-					storage.addThought(thoughtData);
-				}
+          storage.addThought(thoughtData);
+        }
 
-				// Generate summary
-				const summary = analyzer.generateSummary(storage.getAllThoughts());
-				const { text, details } = formatToolOutput("sequential_think", summary, effectiveLimits);
+        // Generate summary
+        const summary = analyzer.generateSummary(storage.getAllThoughts());
+        const { text, details } = formatToolOutput("sequential_think", summary, effectiveLimits);
 
-				return {
-					content: [{ type: "text" as const, text }],
-					details,
-					isError: false,
-				};
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return {
-					content: [{ type: "text" as const, text: `Sequential Thinking error: ${message}` }],
-					isError: true,
-					details: { tool: "sequential_think", error: message },
-				};
-			}
-		},
-	});
+        return {
+          content: [{ type: "text" as const, text }],
+          details,
+          isError: false,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Sequential Thinking error: ${message}` }],
+          isError: true,
+          details: { tool: "sequential_think", error: message },
+        };
+      }
+    },
+  });
 }
 
 // Export utilities for testing
 export {
-	DEFAULT_CONFIG_FILE,
-	ensureDefaultConfigFile,
-	formatToolOutput,
-	isRecord,
-	normalizeNumber,
-	normalizeString,
-	parseConfig,
-	resolveConfigPath,
-	resolveEffectiveLimits,
-	splitParams,
-	toJsonString,
-	writeTempFile,
+  DEFAULT_CONFIG_FILE,
+  ensureDefaultConfigFile,
+  formatToolOutput,
+  isRecord,
+  normalizeNumber,
+  normalizeString,
+  parseConfig,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  splitParams,
+  toJsonString,
+  writeTempFile,
 };

--- a/packages/pi-sequential-thinking/extensions/storage.ts
+++ b/packages/pi-sequential-thinking/extensions/storage.ts
@@ -12,157 +12,157 @@ import { type ThoughtData, thoughtFromDict, thoughtToDict } from "./types.js";
 // =============================================================================
 
 export class ThoughtStorage {
-	private thoughts: ThoughtData[] = [];
-	private readonly storageDir: string;
-	private readonly currentSessionFile: string;
+  private thoughts: ThoughtData[] = [];
+  private readonly storageDir: string;
+  private readonly currentSessionFile: string;
 
-	constructor(storageDir?: string) {
-		if (storageDir) {
-			this.storageDir = storageDir;
-		} else {
-			this.storageDir = join(homedir(), ".mcp_sequential_thinking");
-		}
+  constructor(storageDir?: string) {
+    if (storageDir) {
+      this.storageDir = storageDir;
+    } else {
+      this.storageDir = join(homedir(), ".mcp_sequential_thinking");
+    }
 
-		// Ensure storage directory exists
-		mkdirSync(this.storageDir, { recursive: true });
+    // Ensure storage directory exists
+    mkdirSync(this.storageDir, { recursive: true });
 
-		this.currentSessionFile = join(this.storageDir, "current_session.json");
+    this.currentSessionFile = join(this.storageDir, "current_session.json");
 
-		// Load existing session
-		this.loadSession();
-	}
+    // Load existing session
+    this.loadSession();
+  }
 
-	// =============================================================================
-	// Public API
-	// =============================================================================
+  // =============================================================================
+  // Public API
+  // =============================================================================
 
-	addThought(thought: ThoughtData): void {
-		this.thoughts.push(thought);
-		this.saveSession();
-	}
+  addThought(thought: ThoughtData): void {
+    this.thoughts.push(thought);
+    this.saveSession();
+  }
 
-	getAllThoughts(): ThoughtData[] {
-		// Return a copy to prevent external modification
-		return [...this.thoughts];
-	}
+  getAllThoughts(): ThoughtData[] {
+    // Return a copy to prevent external modification
+    return [...this.thoughts];
+  }
 
-	clearHistory(): void {
-		this.thoughts = [];
-		this.saveSession();
-	}
+  clearHistory(): void {
+    this.thoughts = [];
+    this.saveSession();
+  }
 
-	exportSession(filePath: string): void {
-		const exportData = {
-			thoughts: this.thoughts.map((t) => thoughtToDict(t, true)),
-			lastUpdated: new Date().toISOString(),
-			exportedAt: new Date().toISOString(),
-			metadata: {
-				totalThoughts: this.thoughts.length,
-				stages: this.getStageCounts(),
-			},
-		};
+  exportSession(filePath: string): void {
+    const exportData = {
+      thoughts: this.thoughts.map((t) => thoughtToDict(t, true)),
+      lastUpdated: new Date().toISOString(),
+      exportedAt: new Date().toISOString(),
+      metadata: {
+        totalThoughts: this.thoughts.length,
+        stages: this.getStageCounts(),
+      },
+    };
 
-		this.saveToFile(filePath, exportData);
-	}
+    this.saveToFile(filePath, exportData);
+  }
 
-	importSession(filePath: string): void {
-		const loadedThoughts = this.loadFromFile(filePath);
-		this.thoughts = loadedThoughts;
-		this.saveSession();
-	}
+  importSession(filePath: string): void {
+    const loadedThoughts = this.loadFromFile(filePath);
+    this.thoughts = loadedThoughts;
+    this.saveSession();
+  }
 
-	// =============================================================================
-	// Private Methods
-	// =============================================================================
+  // =============================================================================
+  // Private Methods
+  // =============================================================================
 
-	private loadSession(): void {
-		this.thoughts = this.loadFromFile(this.currentSessionFile);
-	}
+  private loadSession(): void {
+    this.thoughts = this.loadFromFile(this.currentSessionFile);
+  }
 
-	private saveSession(): void {
-		const data = {
-			thoughts: this.thoughts.map((t) => thoughtToDict(t, true)),
-			lastUpdated: new Date().toISOString(),
-		};
+  private saveSession(): void {
+    const data = {
+      thoughts: this.thoughts.map((t) => thoughtToDict(t, true)),
+      lastUpdated: new Date().toISOString(),
+    };
 
-		this.saveToFile(this.currentSessionFile, data);
-	}
+    this.saveToFile(this.currentSessionFile, data);
+  }
 
-	private loadFromFile(filePath: string): ThoughtData[] {
-		if (!existsSync(filePath)) {
-			return [];
-		}
+  private loadFromFile(filePath: string): ThoughtData[] {
+    if (!existsSync(filePath)) {
+      return [];
+    }
 
-		try {
-			const content = readFileSync(filePath, "utf-8");
-			const data = JSON.parse(content);
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      const data = JSON.parse(content);
 
-			if (!data || !Array.isArray(data.thoughts)) {
-				// Handle legacy format (array directly)
-				if (Array.isArray(data)) {
-					return data.map((item) => thoughtFromDict(item as Record<string, unknown>));
-				}
-				return [];
-			}
+      if (!data || !Array.isArray(data.thoughts)) {
+        // Handle legacy format (array directly)
+        if (Array.isArray(data)) {
+          return data.map((item) => thoughtFromDict(item as Record<string, unknown>));
+        }
+        return [];
+      }
 
-			return data.thoughts.map((item: Record<string, unknown>) => thoughtFromDict(item));
-		} catch (error) {
-			// Handle corrupted file - create backup and return empty
-			console.warn(`[pi-sequential-thinking] Error loading ${filePath}: ${error}`);
-			this.backupCorruptedFile(filePath);
-			return [];
-		}
-	}
+      return data.thoughts.map((item: Record<string, unknown>) => thoughtFromDict(item));
+    } catch (error) {
+      // Handle corrupted file - create backup and return empty
+      console.warn(`[pi-sequential-thinking] Error loading ${filePath}: ${error}`);
+      this.backupCorruptedFile(filePath);
+      return [];
+    }
+  }
 
-	private saveToFile(filePath: string, data: Record<string, unknown>): void {
-		// Ensure parent directory exists
-		mkdirSync(dirname(filePath), { recursive: true });
+  private saveToFile(filePath: string, data: Record<string, unknown>): void {
+    // Ensure parent directory exists
+    mkdirSync(dirname(filePath), { recursive: true });
 
-		const lockPath = `${filePath}.lock`;
+    const lockPath = `${filePath}.lock`;
 
-		// Simple file locking simulation using atomic write
-		// In production, you'd use a proper file locking library
-		this.acquireLock(lockPath);
-		try {
-			const tempPath = `${filePath}.tmp.${Date.now()}`;
-			writeFileSync(tempPath, JSON.stringify(data, null, 2), "utf-8");
-			// Atomic rename
-			renameSync(tempPath, filePath);
-		} finally {
-			this.releaseLock(lockPath);
-		}
-	}
+    // Simple file locking simulation using atomic write
+    // In production, you'd use a proper file locking library
+    this.acquireLock(lockPath);
+    try {
+      const tempPath = `${filePath}.tmp.${Date.now()}`;
+      writeFileSync(tempPath, JSON.stringify(data, null, 2), "utf-8");
+      // Atomic rename
+      renameSync(tempPath, filePath);
+    } finally {
+      this.releaseLock(lockPath);
+    }
+  }
 
-	private acquireLock(_lockPath: string): void {
-		// Simplified locking - in production use proper file locking
-		// The atomic rename pattern above provides reasonable safety
-	}
+  private acquireLock(_lockPath: string): void {
+    // Simplified locking - in production use proper file locking
+    // The atomic rename pattern above provides reasonable safety
+  }
 
-	private releaseLock(_lockPath: string): void {
-		// Simplified locking release
-	}
+  private releaseLock(_lockPath: string): void {
+    // Simplified locking release
+  }
 
-	private backupCorruptedFile(filePath: string): void {
-		if (!existsSync(filePath)) {
-			return;
-		}
+  private backupCorruptedFile(filePath: string): void {
+    if (!existsSync(filePath)) {
+      return;
+    }
 
-		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-		const backupPath = `${filePath}.bak.${timestamp}`;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const backupPath = `${filePath}.bak.${timestamp}`;
 
-		try {
-			renameSync(filePath, backupPath);
-			console.log(`[pi-sequential-thinking] Backed up corrupted file to ${backupPath}`);
-		} catch {
-			console.warn(`[pi-sequential-thinking] Could not backup corrupted file ${filePath}`);
-		}
-	}
+    try {
+      renameSync(filePath, backupPath);
+      console.log(`[pi-sequential-thinking] Backed up corrupted file to ${backupPath}`);
+    } catch {
+      console.warn(`[pi-sequential-thinking] Could not backup corrupted file ${filePath}`);
+    }
+  }
 
-	private getStageCounts(): Record<string, number> {
-		const counts: Record<string, number> = {};
-		for (const thought of this.thoughts) {
-			counts[thought.stage] = (counts[thought.stage] || 0) + 1;
-		}
-		return counts;
-	}
+  private getStageCounts(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const thought of this.thoughts) {
+      counts[thought.stage] = (counts[thought.stage] || 0) + 1;
+    }
+    return counts;
+  }
 }

--- a/packages/pi-sequential-thinking/extensions/types.ts
+++ b/packages/pi-sequential-thinking/extensions/types.ts
@@ -7,24 +7,24 @@
 // =============================================================================
 
 export enum ThoughtStage {
-	PROBLEM_DEFINITION = "Problem Definition",
-	RESEARCH = "Research",
-	ANALYSIS = "Analysis",
-	SYNTHESIS = "Synthesis",
-	CONCLUSION = "Conclusion",
+  PROBLEM_DEFINITION = "Problem Definition",
+  RESEARCH = "Research",
+  ANALYSIS = "Analysis",
+  SYNTHESIS = "Synthesis",
+  CONCLUSION = "Conclusion",
 }
 
 const THOUGHT_STAGE_VALUES = Object.values(ThoughtStage);
 
 export function parseThoughtStage(value: string): ThoughtStage {
-	const normalized = value.toLowerCase().trim();
-	for (const stage of THOUGHT_STAGE_VALUES) {
-		if (stage.toLowerCase() === normalized) {
-			return stage;
-		}
-	}
-	const validStages = THOUGHT_STAGE_VALUES.join(", ");
-	throw new Error(`Invalid thinking stage: '${value}'. Valid stages are: ${validStages}`);
+  const normalized = value.toLowerCase().trim();
+  for (const stage of THOUGHT_STAGE_VALUES) {
+    if (stage.toLowerCase() === normalized) {
+      return stage;
+    }
+  }
+  const validStages = THOUGHT_STAGE_VALUES.join(", ");
+  throw new Error(`Invalid thinking stage: '${value}'. Valid stages are: ${validStages}`);
 }
 
 // =============================================================================
@@ -32,16 +32,16 @@ export function parseThoughtStage(value: string): ThoughtStage {
 // =============================================================================
 
 export interface ThoughtData {
-	thought: string;
-	thought_number: number;
-	total_thoughts: number;
-	next_thought_needed: boolean;
-	stage: ThoughtStage;
-	tags: string[];
-	axioms_used: string[];
-	assumptions_challenged: string[];
-	timestamp: string;
-	id: string;
+  thought: string;
+  thought_number: number;
+  total_thoughts: number;
+  next_thought_needed: boolean;
+  stage: ThoughtStage;
+  tags: string[];
+  axioms_used: string[];
+  assumptions_challenged: string[];
+  timestamp: string;
+  id: string;
 }
 
 // =============================================================================
@@ -49,41 +49,41 @@ export interface ThoughtData {
 // =============================================================================
 
 export interface ValidationError {
-	field: string;
-	message: string;
+  field: string;
+  message: string;
 }
 
 export function validateThoughtData(data: Partial<ThoughtData>): ValidationError[] {
-	const errors: ValidationError[] = [];
+  const errors: ValidationError[] = [];
 
-	// thought: non-empty
-	if (!data.thought?.trim()) {
-		errors.push({ field: "thought", message: "Thought content cannot be empty" });
-	}
+  // thought: non-empty
+  if (!data.thought?.trim()) {
+    errors.push({ field: "thought", message: "Thought content cannot be empty" });
+  }
 
-	// thought_number: positive integer
-	if (data.thought_number === undefined || data.thought_number < 1) {
-		errors.push({
-			field: "thought_number",
-			message: "Thought number must be a positive integer",
-		});
-	}
+  // thought_number: positive integer
+  if (data.thought_number === undefined || data.thought_number < 1) {
+    errors.push({
+      field: "thought_number",
+      message: "Thought number must be a positive integer",
+    });
+  }
 
-	// total_thoughts: >= thought_number
-	if (data.total_thoughts !== undefined && data.thought_number !== undefined) {
-		if (data.total_thoughts < data.thought_number) {
-			errors.push({
-				field: "total_thoughts",
-				message: "Total thoughts must be greater or equal to current thought number",
-			});
-		}
-	}
+  // total_thoughts: >= thought_number
+  if (data.total_thoughts !== undefined && data.thought_number !== undefined) {
+    if (data.total_thoughts < data.thought_number) {
+      errors.push({
+        field: "total_thoughts",
+        message: "Total thoughts must be greater or equal to current thought number",
+      });
+    }
+  }
 
-	return errors;
+  return errors;
 }
 
 export function isValidThoughtData(data: Partial<ThoughtData>): boolean {
-	return validateThoughtData(data).length === 0;
+  return validateThoughtData(data).length === 0;
 }
 
 // =============================================================================
@@ -91,54 +91,54 @@ export function isValidThoughtData(data: Partial<ThoughtData>): boolean {
 // =============================================================================
 
 export interface ThoughtDataSerialized extends Omit<ThoughtData, "stage"> {
-	stage: string;
+  stage: string;
 }
 
 export function thoughtToDict(data: ThoughtData, includeId = false): Record<string, unknown> {
-	const result: Record<string, unknown> = {
-		thought: data.thought,
-		thoughtNumber: data.thought_number,
-		totalThoughts: data.total_thoughts,
-		nextThoughtNeeded: data.next_thought_needed,
-		stage: data.stage,
-		tags: data.tags,
-		axiomsUsed: data.axioms_used,
-		assumptionsChallenged: data.assumptions_challenged,
-		timestamp: data.timestamp,
-	};
+  const result: Record<string, unknown> = {
+    thought: data.thought,
+    thoughtNumber: data.thought_number,
+    totalThoughts: data.total_thoughts,
+    nextThoughtNeeded: data.next_thought_needed,
+    stage: data.stage,
+    tags: data.tags,
+    axiomsUsed: data.axioms_used,
+    assumptionsChallenged: data.assumptions_challenged,
+    timestamp: data.timestamp,
+  };
 
-	if (includeId) {
-		result.id = data.id;
-	}
+  if (includeId) {
+    result.id = data.id;
+  }
 
-	return result;
+  return result;
 }
 
 export function thoughtFromDict(dict: Record<string, unknown>): ThoughtData {
-	const stageValue = typeof dict.stage === "string" ? parseThoughtStage(dict.stage) : ThoughtStage.ANALYSIS;
+  const stageValue = typeof dict.stage === "string" ? parseThoughtStage(dict.stage) : ThoughtStage.ANALYSIS;
 
-	const id = typeof dict.id === "string" ? dict.id : generateUuid();
+  const id = typeof dict.id === "string" ? dict.id : generateUuid();
 
-	return {
-		thought: typeof dict.thought === "string" ? dict.thought : "",
-		thought_number: typeof dict.thoughtNumber === "number" ? dict.thoughtNumber : 1,
-		total_thoughts: typeof dict.totalThoughts === "number" ? dict.totalThoughts : 1,
-		next_thought_needed: typeof dict.nextThoughtNeeded === "boolean" ? dict.nextThoughtNeeded : false,
-		stage: stageValue,
-		tags: Array.isArray(dict.tags) ? dict.tags.filter((t): t is string => typeof t === "string") : [],
-		axioms_used: Array.isArray(dict.axiomsUsed)
-			? dict.axiomsUsed.filter((a): a is string => typeof a === "string")
-			: Array.isArray(dict.axioms_used)
-				? dict.axioms_used.filter((a): a is string => typeof a === "string")
-				: [],
-		assumptions_challenged: Array.isArray(dict.assumptionsChallenged)
-			? dict.assumptionsChallenged.filter((a): a is string => typeof a === "string")
-			: Array.isArray(dict.assumptions_challenged)
-				? dict.assumptions_challenged.filter((a): a is string => typeof a === "string")
-				: [],
-		timestamp: typeof dict.timestamp === "string" ? dict.timestamp : new Date().toISOString(),
-		id,
-	};
+  return {
+    thought: typeof dict.thought === "string" ? dict.thought : "",
+    thought_number: typeof dict.thoughtNumber === "number" ? dict.thoughtNumber : 1,
+    total_thoughts: typeof dict.totalThoughts === "number" ? dict.totalThoughts : 1,
+    next_thought_needed: typeof dict.nextThoughtNeeded === "boolean" ? dict.nextThoughtNeeded : false,
+    stage: stageValue,
+    tags: Array.isArray(dict.tags) ? dict.tags.filter((t): t is string => typeof t === "string") : [],
+    axioms_used: Array.isArray(dict.axiomsUsed)
+      ? dict.axiomsUsed.filter((a): a is string => typeof a === "string")
+      : Array.isArray(dict.axioms_used)
+        ? dict.axioms_used.filter((a): a is string => typeof a === "string")
+        : [],
+    assumptions_challenged: Array.isArray(dict.assumptionsChallenged)
+      ? dict.assumptionsChallenged.filter((a): a is string => typeof a === "string")
+      : Array.isArray(dict.assumptions_challenged)
+        ? dict.assumptions_challenged.filter((a): a is string => typeof a === "string")
+        : [],
+    timestamp: typeof dict.timestamp === "string" ? dict.timestamp : new Date().toISOString(),
+    id,
+  };
 }
 
 // =============================================================================
@@ -146,9 +146,9 @@ export function thoughtFromDict(dict: Record<string, unknown>): ThoughtData {
 // =============================================================================
 
 export function generateUuid(): string {
-	return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
-		const r = (Math.random() * 16) | 0;
-		const v = c === "x" ? r : (r & 0x3) | 0x8;
-		return v.toString(16);
-	});
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }

--- a/packages/pi-specdocs/__tests__/index.test.ts
+++ b/packages/pi-specdocs/__tests__/index.test.ts
@@ -3,47 +3,47 @@ import { describe, expect, it, vi } from "vitest";
 import specdocs from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		registerCommand: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 describe("pi-specdocs", () => {
-	it("registers session_start handler", () => {
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
+  it("registers session_start handler", () => {
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
 
-		const events = mockPi.on.mock.calls.map(([event]) => event);
-		expect(events).toContain("session_start");
-	});
+    const events = mockPi.on.mock.calls.map(([event]) => event);
+    expect(events).toContain("session_start");
+  });
 
-	it("registers tool_result handler", () => {
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
+  it("registers tool_result handler", () => {
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
 
-		const events = mockPi.on.mock.calls.map(([event]) => event);
-		expect(events).toContain("tool_result");
-	});
+    const events = mockPi.on.mock.calls.map(([event]) => event);
+    expect(events).toContain("tool_result");
+  });
 
-	it("registers specdocs-validate command", () => {
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
+  it("registers specdocs-validate command", () => {
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
 
-		expect(mockPi.registerCommand).toHaveBeenCalledWith(
-			"specdocs-validate",
-			expect.objectContaining({
-				description: expect.stringContaining("specdocs"),
-			}),
-		);
-	});
+    expect(mockPi.registerCommand).toHaveBeenCalledWith(
+      "specdocs-validate",
+      expect.objectContaining({
+        description: expect.stringContaining("specdocs"),
+      }),
+    );
+  });
 
-	it("does not register any tools", () => {
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
+  it("does not register any tools", () => {
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
 
-		expect(mockPi.registerTool).not.toHaveBeenCalled();
-	});
+    expect(mockPi.registerTool).not.toHaveBeenCalled();
+  });
 });

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -6,100 +6,100 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import specdocs from "../extensions/index.js";
 
 const createMockPi = () =>
-	({
-		registerFlag: vi.fn(),
-		getFlag: vi.fn(() => undefined),
-		registerTool: vi.fn(),
-		registerCommand: vi.fn(),
-		on: vi.fn(),
-	}) satisfies Partial<ExtensionAPI>;
+  ({
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => undefined),
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+    on: vi.fn(),
+  }) satisfies Partial<ExtensionAPI>;
 
 const getEventHandler = (mockPi: ReturnType<typeof createMockPi>, eventName: string) => {
-	const entry = mockPi.on.mock.calls.find(([event]) => event === eventName);
-	return entry?.[1];
+  const entry = mockPi.on.mock.calls.find(([event]) => event === eventName);
+  return entry?.[1];
 };
 
 const getCommandHandler = (mockPi: ReturnType<typeof createMockPi>, commandName: string) => {
-	const entry = mockPi.registerCommand.mock.calls.find(([name]) => name === commandName);
-	return entry?.[1]?.handler;
+  const entry = mockPi.registerCommand.mock.calls.find(([name]) => name === commandName);
+  return entry?.[1]?.handler;
 };
 
 describe("pi-specdocs runtime", () => {
-	const originalCwd = process.cwd();
+  const originalCwd = process.cwd();
 
-	afterEach(() => {
-		process.chdir(originalCwd);
-		vi.restoreAllMocks();
-	});
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+  });
 
-	it("logs workspace summary during session_start", async () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-specdocs-runtime-"));
-		mkdirSync(join(base, ".claude"), { recursive: true });
-		mkdirSync(join(base, "docs", "prd"), { recursive: true });
-		mkdirSync(join(base, "docs", "adr"), { recursive: true });
-		writeFileSync(join(base, ".claude", "tracker.md"), "---\ntracker: github\n---\n");
-		writeFileSync(join(base, "docs", "prd", "PRD-001-auth.md"), '---\ntitle: "Auth"\nstatus: Draft\n---\n');
-		writeFileSync(join(base, "docs", "adr", "ADR-0001-db.md"), '---\ntitle: "DB"\nstatus: Proposed\n---\n');
+  it("logs workspace summary during session_start", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-runtime-"));
+    mkdirSync(join(base, ".claude"), { recursive: true });
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    mkdirSync(join(base, "docs", "adr"), { recursive: true });
+    writeFileSync(join(base, ".claude", "tracker.md"), "---\ntracker: github\n---\n");
+    writeFileSync(join(base, "docs", "prd", "PRD-001-auth.md"), '---\ntitle: "Auth"\nstatus: Draft\n---\n');
+    writeFileSync(join(base, "docs", "adr", "ADR-0001-db.md"), '---\ntitle: "DB"\nstatus: Proposed\n---\n');
 
-		process.chdir(base);
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
-		const sessionStart = getEventHandler(mockPi, "session_start");
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    process.chdir(base);
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const sessionStart = getEventHandler(mockPi, "session_start");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		await sessionStart?.();
+    await sessionStart?.();
 
-		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[specdocs] Tracker: github"));
-		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Workspace: 1 PRDs, 1 ADRs"));
-	});
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[specdocs] Tracker: github"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Workspace: 1 PRDs, 1 ADRs"));
+  });
 
-	it("warns on invalid frontmatter after write/edit tool results", async () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-specdocs-lint-"));
-		const filePath = join(base, "docs", "prd", "PRD-001-bad.md");
-		mkdirSync(join(base, "docs", "prd"), { recursive: true });
-		writeFileSync(filePath, '---\ntitle: "Broken"\n---\n');
+  it("warns on invalid frontmatter after write/edit tool results", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-lint-"));
+    const filePath = join(base, "docs", "prd", "PRD-001-bad.md");
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    writeFileSync(filePath, '---\ntitle: "Broken"\n---\n');
 
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
-		const toolResult = getEventHandler(mockPi, "tool_result");
-		const notify = vi.fn();
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const toolResult = getEventHandler(mockPi, "tool_result");
+    const notify = vi.fn();
 
-		await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { ui: { notify } });
+    await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { ui: { notify } });
 
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Frontmatter warnings"), "warning");
-	});
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Frontmatter warnings"), "warning");
+  });
 
-	it("runs specdocs-validate and reports errors/warnings", async () => {
-		const base = mkdtempSync(join(tmpdir(), "pi-specdocs-validate-"));
-		mkdirSync(join(base, "docs", "prd"), { recursive: true });
-		mkdirSync(join(base, "docs", "adr"), { recursive: true });
-		mkdirSync(join(base, "docs", "architecture"), { recursive: true });
+  it("runs specdocs-validate and reports errors/warnings", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-validate-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    mkdirSync(join(base, "docs", "adr"), { recursive: true });
+    mkdirSync(join(base, "docs", "architecture"), { recursive: true });
 
-		writeFileSync(
-			join(base, "docs", "prd", "PRD-001-good.md"),
-			'---\nprd: PRD-001\ntitle: "Good"\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n',
-		);
-		writeFileSync(
-			join(base, "docs", "prd", "PRD-003-gap.md"),
-			'---\nprd: PRD-003\ntitle: "Gap"\nstatus: Draft\nowner: Bob\ndate: 2025-01-01\nissue: 2\nversion: 1\n---\n',
-		);
-		writeFileSync(join(base, "docs", "prd", "bad-name.md"), "# invalid filename\n");
-		writeFileSync(
-			join(base, "docs", "adr", "ADR-0002-gap.md"),
-			'---\nadr: ADR-0002\ntitle: "Gap ADR"\nstatus: Proposed\ndate: 2025-01-01\nprd: PRD-001\n---\n',
-		);
+    writeFileSync(
+      join(base, "docs", "prd", "PRD-001-good.md"),
+      '---\nprd: PRD-001\ntitle: "Good"\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n',
+    );
+    writeFileSync(
+      join(base, "docs", "prd", "PRD-003-gap.md"),
+      '---\nprd: PRD-003\ntitle: "Gap"\nstatus: Draft\nowner: Bob\ndate: 2025-01-01\nissue: 2\nversion: 1\n---\n',
+    );
+    writeFileSync(join(base, "docs", "prd", "bad-name.md"), "# invalid filename\n");
+    writeFileSync(
+      join(base, "docs", "adr", "ADR-0002-gap.md"),
+      '---\nadr: ADR-0002\ntitle: "Gap ADR"\nstatus: Proposed\ndate: 2025-01-01\nprd: PRD-001\n---\n',
+    );
 
-		const mockPi = createMockPi();
-		specdocs(mockPi as unknown as ExtensionAPI);
-		const handler = getCommandHandler(mockPi, "specdocs-validate");
-		const notify = vi.fn();
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-validate");
+    const notify = vi.fn();
 
-		await handler?.({}, { cwd: base, ui: { notify } });
+    await handler?.({}, { cwd: base, ui: { notify } });
 
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Numbering gap: PRD-002 is missing"), "error");
-		expect(notify).toHaveBeenCalledWith(
-			expect.stringContaining("filename doesn't match PRD-NNN-*.md pattern"),
-			"error",
-		);
-	});
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Numbering gap: PRD-002 is missing"), "error");
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("filename doesn't match PRD-NNN-*.md pattern"),
+      "error",
+    );
+  });
 });

--- a/packages/pi-specdocs/__tests__/scanner.test.ts
+++ b/packages/pi-specdocs/__tests__/scanner.test.ts
@@ -5,27 +5,27 @@ import { describe, expect, it } from "vitest";
 import { extractFrontmatterField, formatSummary, listMatchingFiles, scanWorkspace } from "../extensions/index.js";
 
 describe("scanner", () => {
-	it("returns empty for non-existent directory", () => {
-		const files = listMatchingFiles("/tmp/does-not-exist-specdocs", /^PRD-\d{3}-.*\.md$/);
-		expect(files).toEqual([]);
-	});
+  it("returns empty for non-existent directory", () => {
+    const files = listMatchingFiles("/tmp/does-not-exist-specdocs", /^PRD-\d{3}-.*\.md$/);
+    expect(files).toEqual([]);
+  });
 
-	it("lists matching files sorted", () => {
-		const base = mkdtempSync(join(tmpdir(), "specdocs-test-"));
-		writeFileSync(join(base, "PRD-002-second.md"), "");
-		writeFileSync(join(base, "PRD-001-first.md"), "");
-		writeFileSync(join(base, "README.md"), "");
+  it("lists matching files sorted", () => {
+    const base = mkdtempSync(join(tmpdir(), "specdocs-test-"));
+    writeFileSync(join(base, "PRD-002-second.md"), "");
+    writeFileSync(join(base, "PRD-001-first.md"), "");
+    writeFileSync(join(base, "README.md"), "");
 
-		const files = listMatchingFiles(base, /^PRD-\d{3}-.*\.md$/);
-		expect(files).toEqual(["PRD-001-first.md", "PRD-002-second.md"]);
-	});
+    const files = listMatchingFiles(base, /^PRD-\d{3}-.*\.md$/);
+    expect(files).toEqual(["PRD-001-first.md", "PRD-002-second.md"]);
+  });
 
-	it("extracts frontmatter fields", () => {
-		const base = mkdtempSync(join(tmpdir(), "specdocs-fm-"));
-		const filepath = join(base, "test.md");
-		writeFileSync(
-			filepath,
-			`---
+  it("extracts frontmatter fields", () => {
+    const base = mkdtempSync(join(tmpdir(), "specdocs-fm-"));
+    const filepath = join(base, "test.md");
+    writeFileSync(
+      filepath,
+      `---
 title: "My Feature"
 status: Draft
 owner: "Alice"
@@ -33,75 +33,75 @@ owner: "Alice"
 
 # Content here
 `,
-		);
+    );
 
-		expect(extractFrontmatterField(filepath, "title")).toBe("My Feature");
-		expect(extractFrontmatterField(filepath, "status")).toBe("Draft");
-		expect(extractFrontmatterField(filepath, "owner")).toBe("Alice");
-		expect(extractFrontmatterField(filepath, "missing")).toBe("");
-	});
+    expect(extractFrontmatterField(filepath, "title")).toBe("My Feature");
+    expect(extractFrontmatterField(filepath, "status")).toBe("Draft");
+    expect(extractFrontmatterField(filepath, "owner")).toBe("Alice");
+    expect(extractFrontmatterField(filepath, "missing")).toBe("");
+  });
 
-	it("returns empty string for files without frontmatter", () => {
-		const base = mkdtempSync(join(tmpdir(), "specdocs-nofm-"));
-		const filepath = join(base, "test.md");
-		writeFileSync(filepath, "# Just a heading\n\nNo frontmatter here.\n");
+  it("returns empty string for files without frontmatter", () => {
+    const base = mkdtempSync(join(tmpdir(), "specdocs-nofm-"));
+    const filepath = join(base, "test.md");
+    writeFileSync(filepath, "# Just a heading\n\nNo frontmatter here.\n");
 
-		expect(extractFrontmatterField(filepath, "title")).toBe("");
-	});
+    expect(extractFrontmatterField(filepath, "title")).toBe("");
+  });
 
-	it("scans workspace and identifies drafts and proposed", () => {
-		const base = mkdtempSync(join(tmpdir(), "specdocs-scan-"));
-		const prdDir = join(base, "docs", "prd");
-		const adrDir = join(base, "docs", "adr");
-		const planDir = join(base, "docs", "architecture");
-		mkdirSync(prdDir, { recursive: true });
-		mkdirSync(adrDir, { recursive: true });
-		mkdirSync(planDir, { recursive: true });
+  it("scans workspace and identifies drafts and proposed", () => {
+    const base = mkdtempSync(join(tmpdir(), "specdocs-scan-"));
+    const prdDir = join(base, "docs", "prd");
+    const adrDir = join(base, "docs", "adr");
+    const planDir = join(base, "docs", "architecture");
+    mkdirSync(prdDir, { recursive: true });
+    mkdirSync(adrDir, { recursive: true });
+    mkdirSync(planDir, { recursive: true });
 
-		writeFileSync(join(prdDir, "PRD-001-auth.md"), '---\ntitle: "Auth Feature"\nstatus: Draft\n---\n# Auth\n');
-		writeFileSync(join(prdDir, "PRD-002-cache.md"), '---\ntitle: "Cache Layer"\nstatus: Approved\n---\n# Cache\n');
-		writeFileSync(
-			join(adrDir, "ADR-0001-db-choice.md"),
-			'---\ntitle: "PostgreSQL vs DynamoDB"\nstatus: Proposed\n---\n# DB\n',
-		);
-		writeFileSync(
-			join(adrDir, "ADR-0002-api-style.md"),
-			'---\ntitle: "REST vs GraphQL"\nstatus: Accepted\n---\n# API\n',
-		);
-		writeFileSync(join(planDir, "plan-auth.md"), "# Auth Plan\n");
+    writeFileSync(join(prdDir, "PRD-001-auth.md"), '---\ntitle: "Auth Feature"\nstatus: Draft\n---\n# Auth\n');
+    writeFileSync(join(prdDir, "PRD-002-cache.md"), '---\ntitle: "Cache Layer"\nstatus: Approved\n---\n# Cache\n');
+    writeFileSync(
+      join(adrDir, "ADR-0001-db-choice.md"),
+      '---\ntitle: "PostgreSQL vs DynamoDB"\nstatus: Proposed\n---\n# DB\n',
+    );
+    writeFileSync(
+      join(adrDir, "ADR-0002-api-style.md"),
+      '---\ntitle: "REST vs GraphQL"\nstatus: Accepted\n---\n# API\n',
+    );
+    writeFileSync(join(planDir, "plan-auth.md"), "# Auth Plan\n");
 
-		const result = scanWorkspace(base);
-		expect(result.prdFiles).toHaveLength(2);
-		expect(result.adrFiles).toHaveLength(2);
-		expect(result.planFiles).toHaveLength(1);
-		expect(result.draftPrds).toEqual(["Auth Feature"]);
-		expect(result.proposedAdrs).toEqual(["PostgreSQL vs DynamoDB"]);
-	});
+    const result = scanWorkspace(base);
+    expect(result.prdFiles).toHaveLength(2);
+    expect(result.adrFiles).toHaveLength(2);
+    expect(result.planFiles).toHaveLength(1);
+    expect(result.draftPrds).toEqual(["Auth Feature"]);
+    expect(result.proposedAdrs).toEqual(["PostgreSQL vs DynamoDB"]);
+  });
 
-	it("formats summary correctly", () => {
-		const summary = formatSummary({
-			prdFiles: ["PRD-001-auth.md", "PRD-002-cache.md"],
-			adrFiles: ["ADR-0001-db.md"],
-			planFiles: ["plan-auth.md"],
-			proposedAdrs: ["PostgreSQL vs DynamoDB"],
-			draftPrds: ["Auth Feature"],
-		});
+  it("formats summary correctly", () => {
+    const summary = formatSummary({
+      prdFiles: ["PRD-001-auth.md", "PRD-002-cache.md"],
+      adrFiles: ["ADR-0001-db.md"],
+      planFiles: ["plan-auth.md"],
+      proposedAdrs: ["PostgreSQL vs DynamoDB"],
+      draftPrds: ["Auth Feature"],
+    });
 
-		expect(summary).toContain("[specdocs] Workspace: 2 PRDs, 1 ADRs, 1 plans");
-		expect(summary).toContain("[specdocs] Proposed ADRs needing review:");
-		expect(summary).toContain("  - PostgreSQL vs DynamoDB");
-		expect(summary).toContain("[specdocs] Draft PRDs:");
-		expect(summary).toContain("  - Auth Feature");
-	});
+    expect(summary).toContain("[specdocs] Workspace: 2 PRDs, 1 ADRs, 1 plans");
+    expect(summary).toContain("[specdocs] Proposed ADRs needing review:");
+    expect(summary).toContain("  - PostgreSQL vs DynamoDB");
+    expect(summary).toContain("[specdocs] Draft PRDs:");
+    expect(summary).toContain("  - Auth Feature");
+  });
 
-	it("returns null when no docs exist", () => {
-		const summary = formatSummary({
-			prdFiles: [],
-			adrFiles: [],
-			planFiles: [],
-			proposedAdrs: [],
-			draftPrds: [],
-		});
-		expect(summary).toBeNull();
-	});
+  it("returns null when no docs exist", () => {
+    const summary = formatSummary({
+      prdFiles: [],
+      adrFiles: [],
+      planFiles: [],
+      proposedAdrs: [],
+      draftPrds: [],
+    });
+    expect(summary).toBeNull();
+  });
 });

--- a/packages/pi-specdocs/__tests__/spec-validation.test.ts
+++ b/packages/pi-specdocs/__tests__/spec-validation.test.ts
@@ -33,216 +33,216 @@ prd: "PRD-001-test"
 `;
 
 function writeTempDoc(directory: string, filename: string, content: string): string {
-	const filepath = join(directory, filename);
-	mkdirSync(join(filepath, ".."), { recursive: true });
-	writeFileSync(filepath, content);
-	return filepath;
+  const filepath = join(directory, filename);
+  mkdirSync(join(filepath, ".."), { recursive: true });
+  writeFileSync(filepath, content);
+  return filepath;
 }
 
 // --- Frontmatter parsing ---
 
 describe("parseFrontmatter", () => {
-	it("parses valid frontmatter", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = join(dir, "test.md");
-			writeFileSync(path, VALID_PRD);
-			const fields = parseFrontmatter(path);
-			expect(fields).not.toBeNull();
-			expect(fields?.title).toBe("Test PRD");
-			expect(fields?.prd).toBe("PRD-001");
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("parses valid frontmatter", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = join(dir, "test.md");
+      writeFileSync(path, VALID_PRD);
+      const fields = parseFrontmatter(path);
+      expect(fields).not.toBeNull();
+      expect(fields?.title).toBe("Test PRD");
+      expect(fields?.prd).toBe("PRD-001");
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("strips quotes from values", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = join(dir, "test.md");
-			writeFileSync(path, '---\ntitle: "Quoted Title"\nprd: PRD-001\n---\n');
-			const fields = parseFrontmatter(path);
-			expect(fields?.title).toBe("Quoted Title");
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("strips quotes from values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = join(dir, "test.md");
+      writeFileSync(path, '---\ntitle: "Quoted Title"\nprd: PRD-001\n---\n');
+      const fields = parseFrontmatter(path);
+      expect(fields?.title).toBe("Quoted Title");
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("returns null for files without frontmatter", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = join(dir, "test.md");
-			writeFileSync(path, "# Just a heading\n");
-			expect(parseFrontmatter(path)).toBeNull();
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("returns null for files without frontmatter", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = join(dir, "test.md");
+      writeFileSync(path, "# Just a heading\n");
+      expect(parseFrontmatter(path)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("returns null for nonexistent file", () => {
-		expect(parseFrontmatter("/nonexistent/file.md")).toBeNull();
-	});
+  it("returns null for nonexistent file", () => {
+    expect(parseFrontmatter("/nonexistent/file.md")).toBeNull();
+  });
 });
 
 // --- Path detection ---
 
 describe("path detection", () => {
-	it("detects relative PRD path", () => {
-		expect(isPrd("docs/prd/PRD-001-test.md")).toBe(true);
-	});
+  it("detects relative PRD path", () => {
+    expect(isPrd("docs/prd/PRD-001-test.md")).toBe(true);
+  });
 
-	it("detects absolute PRD path", () => {
-		expect(isPrd("/Users/foo/docs/prd/PRD-001-test.md")).toBe(true);
-	});
+  it("detects absolute PRD path", () => {
+    expect(isPrd("/Users/foo/docs/prd/PRD-001-test.md")).toBe(true);
+  });
 
-	it("detects relative ADR path", () => {
-		expect(isAdr("docs/adr/ADR-0001-test.md")).toBe(true);
-	});
+  it("detects relative ADR path", () => {
+    expect(isAdr("docs/adr/ADR-0001-test.md")).toBe(true);
+  });
 
-	it("detects absolute ADR path", () => {
-		expect(isAdr("/Users/foo/docs/adr/ADR-0001-test.md")).toBe(true);
-	});
+  it("detects absolute ADR path", () => {
+    expect(isAdr("/Users/foo/docs/adr/ADR-0001-test.md")).toBe(true);
+  });
 
-	it("returns false for non-spec paths", () => {
-		expect(isPrd("src/main.py")).toBe(false);
-		expect(isAdr("src/main.py")).toBe(false);
-	});
+  it("returns false for non-spec paths", () => {
+    expect(isPrd("src/main.py")).toBe(false);
+    expect(isAdr("src/main.py")).toBe(false);
+  });
 });
 
 // --- PRD validation ---
 
 describe("validate PRD", () => {
-	it("returns no warnings for valid PRD", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", VALID_PRD);
-			expect(validateFrontmatter(path)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("returns no warnings for valid PRD", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", VALID_PRD);
+      expect(validateFrontmatter(path)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports missing required fields", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const content =
-				'---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\ndate: 2026-04-14\nissue: N/A\nversion: "1.0"\n---\n';
-			const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", content);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("owner"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports missing required fields", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content =
+        '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\ndate: 2026-04-14\nissue: N/A\nversion: "1.0"\n---\n';
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("owner"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports invalid number format", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const content = VALID_PRD.replace("PRD-001", "PRD-1");
-			const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-1-test.md", content);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("PRD-NNN"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports invalid number format", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_PRD.replace("PRD-001", "PRD-1");
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-1-test.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("PRD-NNN"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports filename mismatch", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-002-test.md", VALID_PRD);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.toLowerCase().includes("filename"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports filename mismatch", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-002-test.md", VALID_PRD);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.toLowerCase().includes("filename"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports invalid status", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const content = VALID_PRD.replace("status: Draft", "status: Banana");
-			const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", content);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("Banana"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports invalid status", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_PRD.replace("status: Draft", "status: Banana");
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Banana"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports missing frontmatter", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", "# No frontmatter\n");
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("No YAML frontmatter"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports missing frontmatter", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", "# No frontmatter\n");
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("No YAML frontmatter"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });
 
 // --- ADR validation ---
 
 describe("validate ADR", () => {
-	it("returns no warnings for valid ADR", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", VALID_ADR);
-			expect(validateFrontmatter(path)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("returns no warnings for valid ADR", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", VALID_ADR);
+      expect(validateFrontmatter(path)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports missing prd field", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const content = '---\ntitle: "Test"\nadr: ADR-0001\nstatus: Proposed\ndate: 2026-04-14\n---\n';
-			const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", content);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("prd"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports missing prd field", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = '---\ntitle: "Test"\nadr: ADR-0001\nstatus: Proposed\ndate: 2026-04-14\n---\n';
+      const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("prd"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports invalid ADR number", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const content = VALID_ADR.replace("ADR-0001", "ADR-01");
-			const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-01-test.md", content);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("ADR-NNNN"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports invalid ADR number", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_ADR.replace("ADR-0001", "ADR-01");
+      const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-01-test.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("ADR-NNNN"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 
-	it("reports invalid ADR status", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const content = VALID_ADR.replace("status: Proposed", "status: Active");
-			const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", content);
-			const warnings = validateFrontmatter(path);
-			expect(warnings.some((w) => w.includes("Active"))).toBe(true);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("reports invalid ADR status", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_ADR.replace("status: Proposed", "status: Active");
+      const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Active"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });
 
 // --- Non-spec files ---
 
 describe("non-spec files", () => {
-	it("returns empty warnings for non-spec files", () => {
-		const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
-		try {
-			const path = join(dir, "README.md");
-			writeFileSync(path, "# README\n");
-			expect(validateFrontmatter(path)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true });
-		}
-	});
+  it("returns empty warnings for non-spec files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = join(dir, "README.md");
+      writeFileSync(path, "# README\n");
+      expect(validateFrontmatter(path)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });

--- a/packages/pi-specdocs/extensions/index.ts
+++ b/packages/pi-specdocs/extensions/index.ts
@@ -32,134 +32,134 @@ const ADR_FILENAME_PATTERN = /^ADR-\d{4}-.*\.md$/;
 // =============================================================================
 
 function parseFrontmatter(filepath: string): Record<string, string> | null {
-	if (!existsSync(filepath)) return null;
+  if (!existsSync(filepath)) return null;
 
-	let content: string;
-	try {
-		content = readFileSync(filepath, "utf-8");
-	} catch {
-		return null;
-	}
+  let content: string;
+  try {
+    content = readFileSync(filepath, "utf-8");
+  } catch {
+    return null;
+  }
 
-	const lines = content.split("\n");
-	if (!lines.length || lines[0].trim() !== "---") return null;
+  const lines = content.split("\n");
+  if (!lines.length || lines[0].trim() !== "---") return null;
 
-	const fields: Record<string, string> = {};
-	for (let i = 1; i < lines.length; i++) {
-		if (lines[i].trim() === "---") break;
-		const colonIdx = lines[i].indexOf(":");
-		if (colonIdx === -1) continue;
-		const key = lines[i].slice(0, colonIdx).trim();
-		const value = lines[i]
-			.slice(colonIdx + 1)
-			.trim()
-			.replace(/^["']|["']$/g, "");
-		fields[key] = value;
-	}
+  const fields: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") break;
+    const colonIdx = lines[i].indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = lines[i].slice(0, colonIdx).trim();
+    const value = lines[i]
+      .slice(colonIdx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    fields[key] = value;
+  }
 
-	return Object.keys(fields).length ? fields : null;
+  return Object.keys(fields).length ? fields : null;
 }
 
 function isPrd(path: string): boolean {
-	return path.includes("docs/prd/PRD-");
+  return path.includes("docs/prd/PRD-");
 }
 
 function isAdr(path: string): boolean {
-	return path.includes("docs/adr/ADR-");
+  return path.includes("docs/adr/ADR-");
 }
 
 interface DocValidationConfig {
-	docType: "PRD" | "ADR";
-	requiredFields: readonly string[];
-	validStatuses: readonly string[];
-	numberPattern: RegExp;
-	numberField: "prd" | "adr";
-	expectedNumberFormat: string;
+  docType: "PRD" | "ADR";
+  requiredFields: readonly string[];
+  validStatuses: readonly string[];
+  numberPattern: RegExp;
+  numberField: "prd" | "adr";
+  expectedNumberFormat: string;
 }
 
 function getDocValidationConfig(filepath: string): DocValidationConfig | null {
-	if (isPrd(filepath)) {
-		return {
-			docType: "PRD",
-			requiredFields: PRD_REQUIRED_FIELDS,
-			validStatuses: PRD_VALID_STATUSES,
-			numberPattern: /^PRD-\d{3}$/,
-			numberField: "prd",
-			expectedNumberFormat: "PRD-NNN (3-digit zero-padded)",
-		};
-	}
+  if (isPrd(filepath)) {
+    return {
+      docType: "PRD",
+      requiredFields: PRD_REQUIRED_FIELDS,
+      validStatuses: PRD_VALID_STATUSES,
+      numberPattern: /^PRD-\d{3}$/,
+      numberField: "prd",
+      expectedNumberFormat: "PRD-NNN (3-digit zero-padded)",
+    };
+  }
 
-	if (isAdr(filepath)) {
-		return {
-			docType: "ADR",
-			requiredFields: ADR_REQUIRED_FIELDS,
-			validStatuses: ADR_VALID_STATUSES,
-			numberPattern: /^ADR-\d{4}$/,
-			numberField: "adr",
-			expectedNumberFormat: "ADR-NNNN (4-digit zero-padded)",
-		};
-	}
+  if (isAdr(filepath)) {
+    return {
+      docType: "ADR",
+      requiredFields: ADR_REQUIRED_FIELDS,
+      validStatuses: ADR_VALID_STATUSES,
+      numberPattern: /^ADR-\d{4}$/,
+      numberField: "adr",
+      expectedNumberFormat: "ADR-NNNN (4-digit zero-padded)",
+    };
+  }
 
-	return null;
+  return null;
 }
 
 function collectMissingFieldWarnings(
-	fields: Record<string, string>,
-	config: DocValidationConfig,
-	warnings: string[],
+  fields: Record<string, string>,
+  config: DocValidationConfig,
+  warnings: string[],
 ): void {
-	for (const field of config.requiredFields) {
-		if (!fields[field]) {
-			warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
-		}
-	}
+  for (const field of config.requiredFields) {
+    if (!fields[field]) {
+      warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
+    }
+  }
 }
 
 function collectNumberWarnings(
-	fields: Record<string, string>,
-	config: DocValidationConfig,
-	filename: string,
-	warnings: string[],
+  fields: Record<string, string>,
+  config: DocValidationConfig,
+  filename: string,
+  warnings: string[],
 ): void {
-	const numberValue = fields[config.numberField] ?? "";
-	if (!numberValue) {
-		return;
-	}
+  const numberValue = fields[config.numberField] ?? "";
+  if (!numberValue) {
+    return;
+  }
 
-	if (!config.numberPattern.test(numberValue)) {
-		warnings.push(
-			`⚠ ${config.docType}: Number '${numberValue}' doesn't match expected format ${config.expectedNumberFormat}.`,
-		);
-	}
+  if (!config.numberPattern.test(numberValue)) {
+    warnings.push(
+      `⚠ ${config.docType}: Number '${numberValue}' doesn't match expected format ${config.expectedNumberFormat}.`,
+    );
+  }
 
-	if (!filename.startsWith(numberValue)) {
-		warnings.push(`⚠ ${config.docType}: Frontmatter says '${numberValue}' but filename is '${filename}'.`);
-	}
+  if (!filename.startsWith(numberValue)) {
+    warnings.push(`⚠ ${config.docType}: Frontmatter says '${numberValue}' but filename is '${filename}'.`);
+  }
 }
 
 function collectStatusWarnings(fields: Record<string, string>, config: DocValidationConfig, warnings: string[]): void {
-	const status = fields.status ?? "";
-	if (status && !config.validStatuses.includes(status)) {
-		warnings.push(`⚠ ${config.docType}: Unknown status '${status}'. Expected: ${config.validStatuses.join(", ")}.`);
-	}
+  const status = fields.status ?? "";
+  if (status && !config.validStatuses.includes(status)) {
+    warnings.push(`⚠ ${config.docType}: Unknown status '${status}'. Expected: ${config.validStatuses.join(", ")}.`);
+  }
 }
 
 function validateFrontmatter(filepath: string): string[] {
-	const config = getDocValidationConfig(filepath);
-	if (!config) {
-		return [];
-	}
+  const config = getDocValidationConfig(filepath);
+  if (!config) {
+    return [];
+  }
 
-	const fields = parseFrontmatter(filepath);
-	if (fields === null) {
-		return [`⚠ ${config.docType}: No YAML frontmatter found.`];
-	}
+  const fields = parseFrontmatter(filepath);
+  if (fields === null) {
+    return [`⚠ ${config.docType}: No YAML frontmatter found.`];
+  }
 
-	const warnings: string[] = [];
-	collectMissingFieldWarnings(fields, config, warnings);
-	collectNumberWarnings(fields, config, basename(filepath), warnings);
-	collectStatusWarnings(fields, config, warnings);
-	return warnings;
+  const warnings: string[] = [];
+  collectMissingFieldWarnings(fields, config, warnings);
+  collectNumberWarnings(fields, config, basename(filepath), warnings);
+  collectStatusWarnings(fields, config, warnings);
+  return warnings;
 }
 
 // =============================================================================
@@ -180,215 +180,215 @@ const SCAN_PLAN_PATTERN = /^plan-.*\.md$/;
 // =============================================================================
 
 interface TrackerConfig {
-	[key: string]: string;
+  [key: string]: string;
 }
 
 function readConfig(cwd: string): TrackerConfig {
-	const configPath = join(cwd, CONFIG_PATH);
-	if (!existsSync(configPath)) {
-		return {};
-	}
-	try {
-		const content = readFileSync(configPath, "utf-8");
-		const lines = content.split("\n");
+  const configPath = join(cwd, CONFIG_PATH);
+  if (!existsSync(configPath)) {
+    return {};
+  }
+  try {
+    const content = readFileSync(configPath, "utf-8");
+    const lines = content.split("\n");
 
-		if (lines.length === 0 || lines[0].trim() !== "---") {
-			return {};
-		}
+    if (lines.length === 0 || lines[0].trim() !== "---") {
+      return {};
+    }
 
-		const config: TrackerConfig = {};
-		for (let i = 1; i < lines.length; i++) {
-			if (lines[i].trim() === "---") {
-				break;
-			}
-			if (lines[i].includes(":")) {
-				const colonIdx = lines[i].indexOf(":");
-				const key = lines[i].slice(0, colonIdx).trim();
-				const value = lines[i]
-					.slice(colonIdx + 1)
-					.trim()
-					.replace(/^["']|["']$/g, "");
-				config[key] = value;
-			}
-		}
-		return config;
-	} catch {
-		return {};
-	}
+    const config: TrackerConfig = {};
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trim() === "---") {
+        break;
+      }
+      if (lines[i].includes(":")) {
+        const colonIdx = lines[i].indexOf(":");
+        const key = lines[i].slice(0, colonIdx).trim();
+        const value = lines[i]
+          .slice(colonIdx + 1)
+          .trim()
+          .replace(/^["']|["']$/g, "");
+        config[key] = value;
+      }
+    }
+    return config;
+  } catch {
+    return {};
+  }
 }
 
 function resolveTracker(config: TrackerConfig): { tracker: "github" | "linear"; warning?: string } {
-	const tracker = config.tracker || "github";
-	if (tracker === "github" || tracker === "linear") {
-		return { tracker };
-	}
+  const tracker = config.tracker || "github";
+  if (tracker === "github" || tracker === "linear") {
+    return { tracker };
+  }
 
-	return {
-		tracker: "github",
-		warning: `[specdocs] WARNING: unknown tracker '${tracker}' in ${CONFIG_PATH} — defaulting to github`,
-	};
+  return {
+    tracker: "github",
+    warning: `[specdocs] WARNING: unknown tracker '${tracker}' in ${CONFIG_PATH} — defaulting to github`,
+  };
 }
 
 function formatTrackerInfo(tracker: "github" | "linear", config: TrackerConfig): { info: string; warnings: string[] } {
-	const warnings: string[] = [];
-	let info = `Tracker: ${tracker}`;
+  const warnings: string[] = [];
+  let info = `Tracker: ${tracker}`;
 
-	if (tracker === "linear") {
-		const team = config["linear-team"] || "";
-		if (team) {
-			info += ` (team: ${team})`;
-		} else {
-			warnings.push(`[specdocs] WARNING: tracker=linear but linear-team is not set in ${CONFIG_PATH}`);
-		}
-	} else if (Object.keys(config).length === 0) {
-		info += " (default)";
-	}
+  if (tracker === "linear") {
+    const team = config["linear-team"] || "";
+    if (team) {
+      info += ` (team: ${team})`;
+    } else {
+      warnings.push(`[specdocs] WARNING: tracker=linear but linear-team is not set in ${CONFIG_PATH}`);
+    }
+  } else if (Object.keys(config).length === 0) {
+    info += " (default)";
+  }
 
-	return { info, warnings };
+  return { info, warnings };
 }
 
 function getNotionConfigInfo(config: TrackerConfig): { info: string; warnings: string[] } {
-	const notionSync = (config["notion-sync"] || "false").toLowerCase() === "true";
-	const warnings: string[] = [];
+  const notionSync = (config["notion-sync"] || "false").toLowerCase() === "true";
+  const warnings: string[] = [];
 
-	if (notionSync && !config["notion-prd-database"]) {
-		warnings.push(`[specdocs] WARNING: notion-sync=true but notion-prd-database is not set in ${CONFIG_PATH}`);
-	}
+  if (notionSync && !config["notion-prd-database"]) {
+    warnings.push(`[specdocs] WARNING: notion-sync=true but notion-prd-database is not set in ${CONFIG_PATH}`);
+  }
 
-	if (notionSync && !config["notion-adr-database"]) {
-		warnings.push(`[specdocs] WARNING: notion-sync=true but notion-adr-database is not set in ${CONFIG_PATH}`);
-	}
+  if (notionSync && !config["notion-adr-database"]) {
+    warnings.push(`[specdocs] WARNING: notion-sync=true but notion-adr-database is not set in ${CONFIG_PATH}`);
+  }
 
-	return {
-		info: notionSync ? "Notion sync: enabled" : "Notion sync: disabled",
-		warnings,
-	};
+  return {
+    info: notionSync ? "Notion sync: enabled" : "Notion sync: disabled",
+    warnings,
+  };
 }
 
 function formatConfig(config: TrackerConfig): string {
-	const lines: string[] = [];
-	const hasConfig = Object.keys(config).length > 0;
-	const { tracker, warning: trackerWarning } = resolveTracker(config);
-	const trackerInfo = formatTrackerInfo(tracker, config);
-	const notionInfo = getNotionConfigInfo(config);
+  const lines: string[] = [];
+  const hasConfig = Object.keys(config).length > 0;
+  const { tracker, warning: trackerWarning } = resolveTracker(config);
+  const trackerInfo = formatTrackerInfo(tracker, config);
+  const notionInfo = getNotionConfigInfo(config);
 
-	if (trackerWarning) {
-		lines.push(trackerWarning);
-	}
-	lines.push(...trackerInfo.warnings, ...notionInfo.warnings);
-	lines.push(`[specdocs] ${trackerInfo.info} | ${notionInfo.info}`);
+  if (trackerWarning) {
+    lines.push(trackerWarning);
+  }
+  lines.push(...trackerInfo.warnings, ...notionInfo.warnings);
+  lines.push(`[specdocs] ${trackerInfo.info} | ${notionInfo.info}`);
 
-	if (!hasConfig) {
-		lines.push("[specdocs] No config found. Any tracker-aware skill or command will prompt for setup on first use.");
-	}
+  if (!hasConfig) {
+    lines.push("[specdocs] No config found. Any tracker-aware skill or command will prompt for setup on first use.");
+  }
 
-	return lines.join("\n");
+  return lines.join("\n");
 }
 
 function listMatchingFiles(directory: string, pattern: RegExp): string[] {
-	if (!existsSync(directory)) {
-		return [];
-	}
-	try {
-		return readdirSync(directory)
-			.filter((f) => pattern.test(f))
-			.sort();
-	} catch {
-		return [];
-	}
+  if (!existsSync(directory)) {
+    return [];
+  }
+  try {
+    return readdirSync(directory)
+      .filter((f) => pattern.test(f))
+      .sort();
+  } catch {
+    return [];
+  }
 }
 
 function extractFrontmatterField(filepath: string, field: string): string {
-	try {
-		const content = readFileSync(filepath, "utf-8");
-		const lines = content.split("\n");
+  try {
+    const content = readFileSync(filepath, "utf-8");
+    const lines = content.split("\n");
 
-		if (lines.length === 0 || lines[0].trim() !== "---") {
-			return "";
-		}
+    if (lines.length === 0 || lines[0].trim() !== "---") {
+      return "";
+    }
 
-		for (let i = 1; i < lines.length; i++) {
-			if (lines[i].trim() === "---") {
-				break;
-			}
-			if (lines[i].startsWith(`${field}:`)) {
-				return lines[i]
-					.split(":", 2)[1]
-					.trim()
-					.replace(/^["']|["']$/g, "");
-			}
-		}
-	} catch {
-		// Ignore read errors
-	}
-	return "";
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trim() === "---") {
+        break;
+      }
+      if (lines[i].startsWith(`${field}:`)) {
+        return lines[i]
+          .split(":", 2)[1]
+          .trim()
+          .replace(/^["']|["']$/g, "");
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return "";
 }
 
 interface ScanResult {
-	prdFiles: string[];
-	adrFiles: string[];
-	planFiles: string[];
-	proposedAdrs: string[];
-	draftPrds: string[];
+  prdFiles: string[];
+  adrFiles: string[];
+  planFiles: string[];
+  proposedAdrs: string[];
+  draftPrds: string[];
 }
 
 function scanWorkspace(cwd: string): ScanResult {
-	const prdDir = join(cwd, PRD_DIR);
-	const adrDir = join(cwd, ADR_DIR);
-	const planDir = join(cwd, PLAN_DIR);
+  const prdDir = join(cwd, PRD_DIR);
+  const adrDir = join(cwd, ADR_DIR);
+  const planDir = join(cwd, PLAN_DIR);
 
-	const prdFiles = listMatchingFiles(prdDir, SCAN_PRD_PATTERN);
-	const adrFiles = listMatchingFiles(adrDir, SCAN_ADR_PATTERN);
-	const planFiles = listMatchingFiles(planDir, SCAN_PLAN_PATTERN);
+  const prdFiles = listMatchingFiles(prdDir, SCAN_PRD_PATTERN);
+  const adrFiles = listMatchingFiles(adrDir, SCAN_ADR_PATTERN);
+  const planFiles = listMatchingFiles(planDir, SCAN_PLAN_PATTERN);
 
-	const proposedAdrs: string[] = [];
-	for (const filename of adrFiles) {
-		const filepath = join(adrDir, filename);
-		const status = extractFrontmatterField(filepath, "status");
-		if (status === "Proposed") {
-			const title = extractFrontmatterField(filepath, "title") || filename;
-			proposedAdrs.push(title);
-		}
-	}
+  const proposedAdrs: string[] = [];
+  for (const filename of adrFiles) {
+    const filepath = join(adrDir, filename);
+    const status = extractFrontmatterField(filepath, "status");
+    if (status === "Proposed") {
+      const title = extractFrontmatterField(filepath, "title") || filename;
+      proposedAdrs.push(title);
+    }
+  }
 
-	const draftPrds: string[] = [];
-	for (const filename of prdFiles) {
-		const filepath = join(prdDir, filename);
-		const status = extractFrontmatterField(filepath, "status");
-		if (status === "Draft") {
-			const title = extractFrontmatterField(filepath, "title") || filename;
-			draftPrds.push(title);
-		}
-	}
+  const draftPrds: string[] = [];
+  for (const filename of prdFiles) {
+    const filepath = join(prdDir, filename);
+    const status = extractFrontmatterField(filepath, "status");
+    if (status === "Draft") {
+      const title = extractFrontmatterField(filepath, "title") || filename;
+      draftPrds.push(title);
+    }
+  }
 
-	return { prdFiles, adrFiles, planFiles, proposedAdrs, draftPrds };
+  return { prdFiles, adrFiles, planFiles, proposedAdrs, draftPrds };
 }
 
 function formatSummary(result: ScanResult): string | null {
-	const { prdFiles, adrFiles, planFiles, proposedAdrs, draftPrds } = result;
+  const { prdFiles, adrFiles, planFiles, proposedAdrs, draftPrds } = result;
 
-	if (prdFiles.length === 0 && adrFiles.length === 0 && planFiles.length === 0) {
-		return null;
-	}
+  if (prdFiles.length === 0 && adrFiles.length === 0 && planFiles.length === 0) {
+    return null;
+  }
 
-	const lines: string[] = [];
-	lines.push(`[specdocs] Workspace: ${prdFiles.length} PRDs, ${adrFiles.length} ADRs, ${planFiles.length} plans`);
+  const lines: string[] = [];
+  lines.push(`[specdocs] Workspace: ${prdFiles.length} PRDs, ${adrFiles.length} ADRs, ${planFiles.length} plans`);
 
-	if (proposedAdrs.length > 0) {
-		lines.push("[specdocs] Proposed ADRs needing review:");
-		for (const title of proposedAdrs) {
-			lines.push(`  - ${title}`);
-		}
-	}
+  if (proposedAdrs.length > 0) {
+    lines.push("[specdocs] Proposed ADRs needing review:");
+    for (const title of proposedAdrs) {
+      lines.push(`  - ${title}`);
+    }
+  }
 
-	if (draftPrds.length > 0) {
-		lines.push("[specdocs] Draft PRDs:");
-		for (const title of draftPrds) {
-			lines.push(`  - ${title}`);
-		}
-	}
+  if (draftPrds.length > 0) {
+    lines.push("[specdocs] Draft PRDs:");
+    for (const title of draftPrds) {
+      lines.push(`  - ${title}`);
+    }
+  }
 
-	return lines.join("\n");
+  return lines.join("\n");
 }
 
 // =============================================================================
@@ -396,31 +396,31 @@ function formatSummary(result: ScanResult): string | null {
 // =============================================================================
 
 function extractFilePath(input: Record<string, unknown> | undefined): string {
-	if (!input) return "";
-	return (input.file_path as string) || (input.path as string) || "";
+  if (!input) return "";
+  return (input.file_path as string) || (input.path as string) || "";
 }
 
 async function handleDocLint(event: { toolName: string; input?: Record<string, unknown> }, ctx: ExtensionContext) {
-	if (event.toolName !== "write" && event.toolName !== "edit") {
-		return;
-	}
+  if (event.toolName !== "write" && event.toolName !== "edit") {
+    return;
+  }
 
-	const filePath = extractFilePath(event.input);
-	if (!filePath) return;
+  const filePath = extractFilePath(event.input);
+  if (!filePath) return;
 
-	if (!isPrd(filePath) && !isAdr(filePath)) {
-		return;
-	}
+  if (!isPrd(filePath) && !isAdr(filePath)) {
+    return;
+  }
 
-	if (!existsSync(filePath)) {
-		return;
-	}
+  if (!existsSync(filePath)) {
+    return;
+  }
 
-	const warnings = validateFrontmatter(filePath);
-	if (warnings.length > 0) {
-		const message = `[specdocs] Frontmatter warnings:\n${warnings.join("\n")}`;
-		ctx.ui.notify(message, "warning");
-	}
+  const warnings = validateFrontmatter(filePath);
+  if (warnings.length > 0) {
+    const message = `[specdocs] Frontmatter warnings:\n${warnings.join("\n")}`;
+    ctx.ui.notify(message, "warning");
+  }
 }
 
 // =============================================================================
@@ -428,141 +428,141 @@ async function handleDocLint(event: { toolName: string; input?: Record<string, u
 // =============================================================================
 
 interface ValidationIssue {
-	type: "error" | "warning";
-	message: string;
+  type: "error" | "warning";
+  message: string;
 }
 
 interface ValidationFiles {
-	prdDir: string;
-	adrDir: string;
-	prdFiles: string[];
-	adrFiles: string[];
+  prdDir: string;
+  adrDir: string;
+  prdFiles: string[];
+  adrFiles: string[];
 }
 
 function getValidationFiles(cwd: string): ValidationFiles {
-	const prdDir = join(cwd, PRD_DIR);
-	const adrDir = join(cwd, ADR_DIR);
-	const planDir = join(cwd, PLAN_DIR);
-	void listMatchingFiles(planDir, SCAN_PLAN_PATTERN);
+  const prdDir = join(cwd, PRD_DIR);
+  const adrDir = join(cwd, ADR_DIR);
+  const planDir = join(cwd, PLAN_DIR);
+  void listMatchingFiles(planDir, SCAN_PLAN_PATTERN);
 
-	return {
-		prdDir,
-		adrDir,
-		prdFiles: listMatchingFiles(prdDir, PRD_FILENAME_PATTERN),
-		adrFiles: listMatchingFiles(adrDir, ADR_FILENAME_PATTERN),
-	};
+  return {
+    prdDir,
+    adrDir,
+    prdFiles: listMatchingFiles(prdDir, PRD_FILENAME_PATTERN),
+    adrFiles: listMatchingFiles(adrDir, ADR_FILENAME_PATTERN),
+  };
 }
 
 function toWarningIssues(messages: string[]): ValidationIssue[] {
-	return messages.map((message) => ({ type: "warning", message }));
+  return messages.map((message) => ({ type: "warning", message }));
 }
 
 function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
-	const issues: ValidationIssue[] = [];
+  const issues: ValidationIssue[] = [];
 
-	for (const filename of files.prdFiles) {
-		issues.push(...toWarningIssues(validateFrontmatter(join(files.prdDir, filename))));
-	}
+  for (const filename of files.prdFiles) {
+    issues.push(...toWarningIssues(validateFrontmatter(join(files.prdDir, filename))));
+  }
 
-	for (const filename of files.adrFiles) {
-		issues.push(...toWarningIssues(validateFrontmatter(join(files.adrDir, filename))));
-	}
+  for (const filename of files.adrFiles) {
+    issues.push(...toWarningIssues(validateFrontmatter(join(files.adrDir, filename))));
+  }
 
-	return issues;
+  return issues;
 }
 
 function listMarkdownFiles(directory: string): string[] {
-	if (!existsSync(directory)) {
-		return [];
-	}
+  if (!existsSync(directory)) {
+    return [];
+  }
 
-	try {
-		return readdirSync(directory).filter((filename) => filename.endsWith(".md"));
-	} catch {
-		return [];
-	}
+  try {
+    return readdirSync(directory).filter((filename) => filename.endsWith(".md"));
+  } catch {
+    return [];
+  }
 }
 
 function collectFilenameIssues(
-	directory: string,
-	displayDir: string,
-	pattern: RegExp,
-	expected: string,
+  directory: string,
+  displayDir: string,
+  pattern: RegExp,
+  expected: string,
 ): ValidationIssue[] {
-	return listMarkdownFiles(directory)
-		.filter((filename) => !pattern.test(filename))
-		.map((filename) => ({
-			type: "error" as const,
-			message: `✗ ${displayDir}/${filename}: filename doesn't match ${expected} pattern`,
-		}));
+  return listMarkdownFiles(directory)
+    .filter((filename) => !pattern.test(filename))
+    .map((filename) => ({
+      type: "error" as const,
+      message: `✗ ${displayDir}/${filename}: filename doesn't match ${expected} pattern`,
+    }));
 }
 
 function extractDocumentNumbers(files: string[], pattern: RegExp): number[] {
-	return files
-		.map((filename) => {
-			const match = filename.match(pattern);
-			return match ? parseInt(match[1], 10) : null;
-		})
-		.filter((value): value is number => value !== null)
-		.sort((a, b) => a - b);
+  return files
+    .map((filename) => {
+      const match = filename.match(pattern);
+      return match ? parseInt(match[1], 10) : null;
+    })
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b);
 }
 
 function collectNumberingGapIssues(files: string[], pattern: RegExp, prefix: string, width: number): ValidationIssue[] {
-	const issues: ValidationIssue[] = [];
-	const numbers = extractDocumentNumbers(files, pattern);
+  const issues: ValidationIssue[] = [];
+  const numbers = extractDocumentNumbers(files, pattern);
 
-	for (let i = 0; i < numbers.length - 1; i++) {
-		for (let gap = numbers[i] + 1; gap < numbers[i + 1]; gap++) {
-			issues.push({
-				type: "warning",
-				message: `⚠ Numbering gap: ${prefix}-${String(gap).padStart(width, "0")} is missing`,
-			});
-		}
-	}
+  for (let i = 0; i < numbers.length - 1; i++) {
+    for (let gap = numbers[i] + 1; gap < numbers[i + 1]; gap++) {
+      issues.push({
+        type: "warning",
+        message: `⚠ Numbering gap: ${prefix}-${String(gap).padStart(width, "0")} is missing`,
+      });
+    }
+  }
 
-	return issues;
+  return issues;
 }
 
 function formatValidationIssues(issues: ValidationIssue[]): { message: string; level: "error" | "warning" | "info" } {
-	if (issues.length === 0) {
-		return { message: "[specdocs] Validation passed: no issues found.", level: "info" };
-	}
+  if (issues.length === 0) {
+    return { message: "[specdocs] Validation passed: no issues found.", level: "info" };
+  }
 
-	const errors = issues.filter((issue) => issue.type === "error");
-	const warnings = issues.filter((issue) => issue.type === "warning");
-	const lines: string[] = [];
+  const errors = issues.filter((issue) => issue.type === "error");
+  const warnings = issues.filter((issue) => issue.type === "warning");
+  const lines: string[] = [];
 
-	if (errors.length > 0) {
-		lines.push(`Errors (${errors.length}):`);
-		for (const error of errors) {
-			lines.push(`  ${error.message}`);
-		}
-	}
+  if (errors.length > 0) {
+    lines.push(`Errors (${errors.length}):`);
+    for (const error of errors) {
+      lines.push(`  ${error.message}`);
+    }
+  }
 
-	if (warnings.length > 0) {
-		lines.push(`Warnings (${warnings.length}):`);
-		for (const warning of warnings) {
-			lines.push(`  ${warning.message}`);
-		}
-	}
+  if (warnings.length > 0) {
+    lines.push(`Warnings (${warnings.length}):`);
+    for (const warning of warnings) {
+      lines.push(`  ${warning.message}`);
+    }
+  }
 
-	return {
-		message: `[specdocs] Validation:\n${lines.join("\n")}`,
-		level: errors.length > 0 ? "error" : "warning",
-	};
+  return {
+    message: `[specdocs] Validation:\n${lines.join("\n")}`,
+    level: errors.length > 0 ? "error" : "warning",
+  };
 }
 
 async function runValidation(ctx: { cwd: string } & ExtensionContext) {
-	const files = getValidationFiles(ctx.cwd);
-	const issues = [
-		...collectFrontmatterIssues(files),
-		...collectFilenameIssues(files.prdDir, PRD_DIR, PRD_FILENAME_PATTERN, "PRD-NNN-*.md"),
-		...collectFilenameIssues(files.adrDir, ADR_DIR, ADR_FILENAME_PATTERN, "ADR-NNNN-*.md"),
-		...collectNumberingGapIssues(files.prdFiles, /^PRD-(\d{3})-.*\.md$/, "PRD", 3),
-		...collectNumberingGapIssues(files.adrFiles, /^ADR-(\d{4})-.*\.md$/, "ADR", 4),
-	];
-	const result = formatValidationIssues(issues);
-	ctx.ui.notify(result.message, result.level);
+  const files = getValidationFiles(ctx.cwd);
+  const issues = [
+    ...collectFrontmatterIssues(files),
+    ...collectFilenameIssues(files.prdDir, PRD_DIR, PRD_FILENAME_PATTERN, "PRD-NNN-*.md"),
+    ...collectFilenameIssues(files.adrDir, ADR_DIR, ADR_FILENAME_PATTERN, "ADR-NNNN-*.md"),
+    ...collectNumberingGapIssues(files.prdFiles, /^PRD-(\d{3})-.*\.md$/, "PRD", 3),
+    ...collectNumberingGapIssues(files.adrFiles, /^ADR-(\d{4})-.*\.md$/, "ADR", 4),
+  ];
+  const result = formatValidationIssues(issues);
+  ctx.ui.notify(result.message, result.level);
 }
 
 // =============================================================================
@@ -570,16 +570,16 @@ async function runValidation(ctx: { cwd: string } & ExtensionContext) {
 // =============================================================================
 
 export {
-	extractFrontmatterField,
-	formatConfig,
-	formatSummary,
-	isAdr,
-	isPrd,
-	listMatchingFiles,
-	parseFrontmatter,
-	readConfig,
-	scanWorkspace,
-	validateFrontmatter,
+  extractFrontmatterField,
+  formatConfig,
+  formatSummary,
+  isAdr,
+  isPrd,
+  listMatchingFiles,
+  parseFrontmatter,
+  readConfig,
+  scanWorkspace,
+  validateFrontmatter,
 };
 
 // =============================================================================
@@ -587,28 +587,28 @@ export {
 // =============================================================================
 
 export default function specdocs(pi: ExtensionAPI) {
-	pi.on("session_start", async () => {
-		const cwd = process.cwd();
+  pi.on("session_start", async () => {
+    const cwd = process.cwd();
 
-		const config = readConfig(cwd);
-		console.log(formatConfig(config));
+    const config = readConfig(cwd);
+    console.log(formatConfig(config));
 
-		const result = scanWorkspace(cwd);
-		const summary = formatSummary(result);
-		if (summary) {
-			console.log(summary);
-		}
-	});
+    const result = scanWorkspace(cwd);
+    const summary = formatSummary(result);
+    if (summary) {
+      console.log(summary);
+    }
+  });
 
-	pi.on("tool_result", async (event, ctx) => {
-		await handleDocLint(event, ctx);
-	});
+  pi.on("tool_result", async (event, ctx) => {
+    await handleDocLint(event, ctx);
+  });
 
-	pi.registerCommand("specdocs-validate", {
-		description:
-			"(specdocs plugin) Validate all spec documents for frontmatter completeness, naming conventions, and cross-references",
-		handler: async (_args, ctx) => {
-			await runValidation(ctx);
-		},
-	});
+  pi.registerCommand("specdocs-validate", {
+    description:
+      "(specdocs plugin) Validate all spec documents for frontmatter completeness, naming conventions, and cross-references",
+    handler: async (_args, ctx) => {
+      await runValidation(ctx);
+    },
+  });
 }

--- a/packages/pi-statusline/__tests__/format.test.ts
+++ b/packages/pi-statusline/__tests__/format.test.ts
@@ -2,36 +2,36 @@ import { describe, expect, it } from "vitest";
 import { buildStatusLines, formatCompactNumber, formatModelLabel, formatTokenPair } from "../extensions/format.js";
 
 describe("pi-statusline format helpers", () => {
-	it("formats compact numbers", () => {
-		expect(formatCompactNumber(999)).toBe("999");
-		expect(formatCompactNumber(1_200)).toBe("1.2k");
-		expect(formatCompactNumber(1_000_000)).toBe("1.0M");
-	});
+  it("formats compact numbers", () => {
+    expect(formatCompactNumber(999)).toBe("999");
+    expect(formatCompactNumber(1_200)).toBe("1.2k");
+    expect(formatCompactNumber(1_000_000)).toBe("1.0M");
+  });
 
-	it("formats token pairs", () => {
-		expect(formatTokenPair(18_200, 14_200)).toBe("↑18.2k/↓14.2k");
-	});
+  it("formats token pairs", () => {
+    expect(formatTokenPair(18_200, 14_200)).toBe("↑18.2k/↓14.2k");
+  });
 
-	it("formats model labels with context window", () => {
-		expect(formatModelLabel({ name: "Opus 4.6", contextWindow: 1_000_000 })).toBe("Model: Opus 4.6 (1.0M context)");
-	});
+  it("formats model labels with context window", () => {
+    expect(formatModelLabel({ name: "Opus 4.6", contextWindow: 1_000_000 })).toBe("Model: Opus 4.6 (1.0M context)");
+  });
 
-	it("builds two status lines", () => {
-		const lines = buildStatusLines({
-			modelLabel: "Model: Opus 4.6",
-			thinkingLabel: "Thinking: medium",
-			contextLabel: "Ctx: 11.0%",
-			branchLabel: "⎇ main",
-			dirtyLabel: "dirty: +0",
-			tokenLabel: "↑18.2k/↓14.2k",
-			repoLabel: "evie-platform",
-			cwdLabel: "cwd: /tmp/repo",
-			worktreeLabel: "𖠰 none",
-			skillLabel: "Skill: release",
-		});
+  it("builds two status lines", () => {
+    const lines = buildStatusLines({
+      modelLabel: "Model: Opus 4.6",
+      thinkingLabel: "Thinking: medium",
+      contextLabel: "Ctx: 11.0%",
+      branchLabel: "⎇ main",
+      dirtyLabel: "dirty: +0",
+      tokenLabel: "↑18.2k/↓14.2k",
+      repoLabel: "evie-platform",
+      cwdLabel: "cwd: /tmp/repo",
+      worktreeLabel: "𖠰 none",
+      skillLabel: "Skill: release",
+    });
 
-		expect(lines).toHaveLength(2);
-		expect(lines[0]).toContain("Thinking: medium");
-		expect(lines[1]).toContain("Skill: release");
-	});
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("Thinking: medium");
+    expect(lines[1]).toContain("Skill: release");
+  });
 });

--- a/packages/pi-statusline/__tests__/git.test.ts
+++ b/packages/pi-statusline/__tests__/git.test.ts
@@ -1,56 +1,56 @@
 import { describe, expect, it } from "vitest";
 import {
-	getWorktreeLabelForPath,
-	isLinkedWorktreeGitDir,
-	parseDirtyCountFromPorcelain,
-	parseWorktreeListPorcelain,
+  getWorktreeLabelForPath,
+  isLinkedWorktreeGitDir,
+  parseDirtyCountFromPorcelain,
+  parseWorktreeListPorcelain,
 } from "../extensions/git.js";
 
 describe("pi-statusline git helpers", () => {
-	it("counts dirty paths from porcelain output", () => {
-		const output = " M file-a.ts\n?? file-b.ts\nA  file-c.ts\n";
-		expect(parseDirtyCountFromPorcelain(output)).toBe(3);
-	});
+  it("counts dirty paths from porcelain output", () => {
+    const output = " M file-a.ts\n?? file-b.ts\nA  file-c.ts\n";
+    expect(parseDirtyCountFromPorcelain(output)).toBe(3);
+  });
 
-	it("parses porcelain worktree output", () => {
-		const output = [
-			"worktree /repo",
-			"HEAD abcdef",
-			"branch refs/heads/main",
-			"",
-			"worktree /repo-feature",
-			"HEAD 123456",
-			"branch refs/heads/feature/test",
-			"",
-		].join("\n");
+  it("parses porcelain worktree output", () => {
+    const output = [
+      "worktree /repo",
+      "HEAD abcdef",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo-feature",
+      "HEAD 123456",
+      "branch refs/heads/feature/test",
+      "",
+    ].join("\n");
 
-		expect(parseWorktreeListPorcelain(output)).toEqual([
-			{ path: "/repo", branch: "refs/heads/main" },
-			{ path: "/repo-feature", branch: "refs/heads/feature/test" },
-		]);
-	});
+    expect(parseWorktreeListPorcelain(output)).toEqual([
+      { path: "/repo", branch: "refs/heads/main" },
+      { path: "/repo-feature", branch: "refs/heads/feature/test" },
+    ]);
+  });
 
-	it("detects linked worktree git dirs", () => {
-		expect(isLinkedWorktreeGitDir(".git/worktrees/feature")).toBe(true);
-		expect(isLinkedWorktreeGitDir("/tmp/repo/.git/worktrees/feature")).toBe(true);
-		expect(isLinkedWorktreeGitDir(".git")).toBe(false);
-	});
+  it("detects linked worktree git dirs", () => {
+    expect(isLinkedWorktreeGitDir(".git/worktrees/feature")).toBe(true);
+    expect(isLinkedWorktreeGitDir("/tmp/repo/.git/worktrees/feature")).toBe(true);
+    expect(isLinkedWorktreeGitDir(".git")).toBe(false);
+  });
 
-	it("returns branch basename for linked worktree paths", () => {
-		const label = getWorktreeLabelForPath(
-			[
-				{ path: "/repo", branch: "refs/heads/main" },
-				{ path: "/repo-feature", branch: "refs/heads/feature/test" },
-			],
-			"/repo-feature",
-			".git/worktrees/repo-feature",
-		);
+  it("returns branch basename for linked worktree paths", () => {
+    const label = getWorktreeLabelForPath(
+      [
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: "/repo-feature", branch: "refs/heads/feature/test" },
+      ],
+      "/repo-feature",
+      ".git/worktrees/repo-feature",
+    );
 
-		expect(label).toBe("test");
-	});
+    expect(label).toBe("test");
+  });
 
-	it('returns "main" for the main worktree', () => {
-		const label = getWorktreeLabelForPath([{ path: "/repo", branch: "refs/heads/main" }], "/repo", ".git");
-		expect(label).toBe("main");
-	});
+  it('returns "main" for the main worktree', () => {
+    const label = getWorktreeLabelForPath([{ path: "/repo", branch: "refs/heads/main" }], "/repo", ".git");
+    expect(label).toBe("main");
+  });
 });

--- a/packages/pi-statusline/__tests__/index.runtime.test.ts
+++ b/packages/pi-statusline/__tests__/index.runtime.test.ts
@@ -1,0 +1,138 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import statuslineExtension, {
+  buildLines,
+  createInitialGitSnapshot,
+  createInitialState,
+  extractSkillName,
+  getBranchLabel,
+  getDirtyLabel,
+  getWorktreeLabel,
+} from "../extensions/index.js";
+
+function createMockPi() {
+  return {
+    on: vi.fn(),
+    getThinkingLevel: vi.fn(() => "medium"),
+    exec: vi.fn(async (_cmd: string, args: string[]) => {
+      const joined = args.join(" ");
+      if (joined.includes("rev-parse --is-inside-work-tree")) return { code: 0, stdout: "true", stderr: "", killed: false };
+      if (joined.includes("rev-parse --show-toplevel")) return { code: 0, stdout: "/tmp/project", stderr: "", killed: false };
+      if (joined.includes("rev-parse --git-dir")) return { code: 0, stdout: ".git", stderr: "", killed: false };
+      if (joined.includes("branch --show-current")) return { code: 0, stdout: "main", stderr: "", killed: false };
+      if (joined.includes("status --porcelain")) return { code: 0, stdout: " M file.ts\n", stderr: "", killed: false };
+      if (joined.includes("worktree list --porcelain")) {
+        return { code: 0, stdout: "worktree /tmp/project\nHEAD abc\nbranch refs/heads/main\n", stderr: "", killed: false };
+      }
+      return { code: 1, stdout: "", stderr: "", killed: false };
+    }),
+    getCommands: vi.fn(() => [{ name: "release", source: "skill" }]),
+    registerTool: vi.fn(),
+  };
+}
+
+describe("pi-statusline runtime helpers", () => {
+  it("builds initial snapshots and labels", () => {
+    expect(createInitialGitSnapshot()).toEqual({ repoName: null, branch: null, dirtyCount: 0, worktreeLabel: "no git" });
+    expect(createInitialState().modelLabel).toBe("Model: none");
+    expect(getBranchLabel("main")).toBe("⎇ main");
+    expect(getBranchLabel(null)).toBe("⎇ no git");
+    expect(getWorktreeLabel("feature")).toBe("𖠰 feature");
+    expect(getDirtyLabel(2)).toBe("dirty: +2");
+  });
+
+  it("builds and truncates status lines", () => {
+    const lines = buildLines(
+      "/tmp/project",
+      {
+        ...createInitialState(),
+        modelLabel: "Model: opus",
+        thinkingLabel: "Thinking: medium",
+        contextLabel: "Ctx: 10.0%",
+        tokenLabel: "↑1.0k/↓2.0k",
+        gitSnapshot: { repoName: "project", branch: "main", dirtyCount: 3, worktreeLabel: "main" },
+        lastSkill: "release",
+      },
+      "main",
+      30,
+    );
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.length).toBeLessThanOrEqual(30);
+    expect(lines[1]?.length).toBeLessThanOrEqual(30);
+  });
+
+  it("extracts and ignores skill commands", () => {
+    expect(extractSkillName("/release now", [{ name: "release", source: "skill" }])).toBe("release");
+    expect(extractSkillName("plain text", [])).toBeNull();
+    expect(extractSkillName("/skill:", [])).toBeNull();
+  });
+});
+
+describe("pi-statusline extension runtime", () => {
+  it("emits status lines on non-UI session start and updates footer in UI mode", async () => {
+    const mockPi = createMockPi();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    const setFooter = vi.fn();
+
+    await sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/project",
+        hasUI: false,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [{ type: "message", message: { role: "assistant", usage: { input: 10, output: 20 } } }] },
+        getContextUsage: () => ({ percent: 12 }),
+        ui: { setFooter },
+      },
+    );
+
+    expect(logSpy).toHaveBeenCalled();
+
+    await sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/project",
+        hasUI: true,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 12 }),
+        ui: { setFooter },
+      },
+    );
+
+    expect(setFooter).toHaveBeenCalledTimes(1);
+    logSpy.mockRestore();
+  });
+
+  it("captures skill usage from input and tool execution events", async () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const inputHandler = mockPi.on.mock.calls.find(([name]) => name === "input")?.[1];
+    const toolHandler = mockPi.on.mock.calls.find(([name]) => name === "tool_execution_start")?.[1];
+    const toolDef = mockPi.registerTool.mock.calls[0]?.[0];
+
+    await inputHandler?.({ text: "/release" });
+    await toolHandler?.({ toolName: "Skill", args: { skill: "coverage" } });
+
+    const result = await toolDef.execute(
+      "tool-id",
+      {},
+      new AbortController().signal,
+      undefined,
+      {
+        cwd: "/tmp/project",
+        hasUI: false,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 12 }),
+      },
+    );
+
+    expect(result.content[0]?.text).toContain("Skill: coverage");
+  });
+});

--- a/packages/pi-statusline/__tests__/index.runtime.test.ts
+++ b/packages/pi-statusline/__tests__/index.runtime.test.ts
@@ -16,13 +16,20 @@ function createMockPi() {
     getThinkingLevel: vi.fn(() => "medium"),
     exec: vi.fn(async (_cmd: string, args: string[]) => {
       const joined = args.join(" ");
-      if (joined.includes("rev-parse --is-inside-work-tree")) return { code: 0, stdout: "true", stderr: "", killed: false };
-      if (joined.includes("rev-parse --show-toplevel")) return { code: 0, stdout: "/tmp/project", stderr: "", killed: false };
+      if (joined.includes("rev-parse --is-inside-work-tree"))
+        return { code: 0, stdout: "true", stderr: "", killed: false };
+      if (joined.includes("rev-parse --show-toplevel"))
+        return { code: 0, stdout: "/tmp/project", stderr: "", killed: false };
       if (joined.includes("rev-parse --git-dir")) return { code: 0, stdout: ".git", stderr: "", killed: false };
       if (joined.includes("branch --show-current")) return { code: 0, stdout: "main", stderr: "", killed: false };
       if (joined.includes("status --porcelain")) return { code: 0, stdout: " M file.ts\n", stderr: "", killed: false };
       if (joined.includes("worktree list --porcelain")) {
-        return { code: 0, stdout: "worktree /tmp/project\nHEAD abc\nbranch refs/heads/main\n", stderr: "", killed: false };
+        return {
+          code: 0,
+          stdout: "worktree /tmp/project\nHEAD abc\nbranch refs/heads/main\n",
+          stderr: "",
+          killed: false,
+        };
       }
       return { code: 1, stdout: "", stderr: "", killed: false };
     }),
@@ -33,7 +40,12 @@ function createMockPi() {
 
 describe("pi-statusline runtime helpers", () => {
   it("builds initial snapshots and labels", () => {
-    expect(createInitialGitSnapshot()).toEqual({ repoName: null, branch: null, dirtyCount: 0, worktreeLabel: "no git" });
+    expect(createInitialGitSnapshot()).toEqual({
+      repoName: null,
+      branch: null,
+      dirtyCount: 0,
+      worktreeLabel: "no git",
+    });
     expect(createInitialState().modelLabel).toBe("Model: none");
     expect(getBranchLabel("main")).toBe("⎇ main");
     expect(getBranchLabel(null)).toBe("⎇ no git");
@@ -84,7 +96,9 @@ describe("pi-statusline extension runtime", () => {
         cwd: "/tmp/project",
         hasUI: false,
         model: { id: "opus", contextWindow: 1000000 },
-        sessionManager: { getBranch: () => [{ type: "message", message: { role: "assistant", usage: { input: 10, output: 20 } } }] },
+        sessionManager: {
+          getBranch: () => [{ type: "message", message: { role: "assistant", usage: { input: 10, output: 20 } } }],
+        },
         getContextUsage: () => ({ percent: 12 }),
         ui: { setFooter },
       },
@@ -119,19 +133,13 @@ describe("pi-statusline extension runtime", () => {
     await inputHandler?.({ text: "/release" });
     await toolHandler?.({ toolName: "Skill", args: { skill: "coverage" } });
 
-    const result = await toolDef.execute(
-      "tool-id",
-      {},
-      new AbortController().signal,
-      undefined,
-      {
-        cwd: "/tmp/project",
-        hasUI: false,
-        model: { id: "opus", contextWindow: 1000000 },
-        sessionManager: { getBranch: () => [] },
-        getContextUsage: () => ({ percent: 12 }),
-      },
-    );
+    const result = await toolDef.execute("tool-id", {}, new AbortController().signal, undefined, {
+      cwd: "/tmp/project",
+      hasUI: false,
+      model: { id: "opus", contextWindow: 1000000 },
+      sessionManager: { getBranch: () => [] },
+      getContextUsage: () => ({ percent: 12 }),
+    });
 
     expect(result.content[0]?.text).toContain("Skill: coverage");
   });

--- a/packages/pi-statusline/__tests__/index.test.ts
+++ b/packages/pi-statusline/__tests__/index.test.ts
@@ -3,67 +3,67 @@ import { describe, expect, it, vi } from "vitest";
 import statuslineExtension, { extractSkillName } from "../extensions/index.js";
 
 const createMockPi = () => ({
-	on: vi.fn(),
-	getThinkingLevel: vi.fn(() => "medium"),
-	exec: vi.fn(async () => ({ code: 1, stdout: "", stderr: "", killed: false })),
-	getCommands: vi.fn(() => [{ name: "release", source: "skill" }]),
-	registerTool: vi.fn(),
+  on: vi.fn(),
+  getThinkingLevel: vi.fn(() => "medium"),
+  exec: vi.fn(async () => ({ code: 1, stdout: "", stderr: "", killed: false })),
+  getCommands: vi.fn(() => [{ name: "release", source: "skill" }]),
+  registerTool: vi.fn(),
 });
 
 describe("pi-statusline extension", () => {
-	it("registers expected event handlers", () => {
-		const mockPi = createMockPi();
-		statuslineExtension(mockPi as unknown as ExtensionAPI);
+  it("registers expected event handlers", () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
 
-		const eventNames = mockPi.on.mock.calls.map(([name]) => name);
-		expect(eventNames).toEqual(
-			expect.arrayContaining(["session_start", "model_select", "agent_end", "input", "tool_execution_start"]),
-		);
-	});
+    const eventNames = mockPi.on.mock.calls.map(([name]) => name);
+    expect(eventNames).toEqual(
+      expect.arrayContaining(["session_start", "model_select", "agent_end", "input", "tool_execution_start"]),
+    );
+  });
 
-	it("registers /statusline tool", () => {
-		const mockPi = createMockPi();
-		statuslineExtension(mockPi as unknown as ExtensionAPI);
+  it("registers /statusline tool", () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
 
-		expect(mockPi.registerTool).toHaveBeenCalledTimes(1);
-		expect(mockPi.registerTool).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: "statusline",
-				parameters: expect.any(Object),
-			}),
-		);
-	});
+    expect(mockPi.registerTool).toHaveBeenCalledTimes(1);
+    expect(mockPi.registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "statusline",
+        parameters: expect.any(Object),
+      }),
+    );
+  });
 
-	it("extracts skill names from explicit skill commands", () => {
-		expect(extractSkillName("/skill:release", [])).toBe("release");
-	});
+  it("extracts skill names from explicit skill commands", () => {
+    expect(extractSkillName("/skill:release", [])).toBe("release");
+  });
 
-	it("extracts skill names from registered skill commands", () => {
-		expect(extractSkillName("/release", [{ name: "release", source: "skill" }])).toBe("release");
-	});
+  it("extracts skill names from registered skill commands", () => {
+    expect(extractSkillName("/release", [{ name: "release", source: "skill" }])).toBe("release");
+  });
 
-	it("ignores non-skill slash commands", () => {
-		expect(extractSkillName("/model", [{ name: "release", source: "skill" }])).toBeNull();
-	});
+  it("ignores non-skill slash commands", () => {
+    expect(extractSkillName("/model", [{ name: "release", source: "skill" }])).toBeNull();
+  });
 
-	it("registers a custom footer on session_start", async () => {
-		const mockPi = createMockPi();
-		statuslineExtension(mockPi as unknown as ExtensionAPI);
+  it("registers a custom footer on session_start", async () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
 
-		const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
-		const setFooter = vi.fn();
-		await sessionStartHandler?.(
-			{},
-			{
-				cwd: "/tmp/project",
-				hasUI: true,
-				model: { id: "opus", contextWindow: 1_000_000 },
-				sessionManager: { getBranch: () => [] },
-				getContextUsage: () => ({ percent: 11 }),
-				ui: { setFooter },
-			},
-		);
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    const setFooter = vi.fn();
+    await sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/project",
+        hasUI: true,
+        model: { id: "opus", contextWindow: 1_000_000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 11 }),
+        ui: { setFooter },
+      },
+    );
 
-		expect(setFooter).toHaveBeenCalledTimes(1);
-	});
+    expect(setFooter).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/pi-statusline/__tests__/session.test.ts
+++ b/packages/pi-statusline/__tests__/session.test.ts
@@ -2,33 +2,33 @@ import { describe, expect, it } from "vitest";
 import { getContextLabel, getThinkingLabel, getTokenLabel, getTokenTotals } from "../extensions/session.js";
 
 describe("pi-statusline session helpers", () => {
-	it("sums assistant token usage", () => {
-		const totals = getTokenTotals([
-			{ type: "message", message: { role: "assistant", usage: { input: 1200, output: 300 } } },
-			{ type: "message", message: { role: "user" } },
-			{ type: "message", message: { role: "assistant", usage: { input: 800, output: 500 } } },
-		]);
+  it("sums assistant token usage", () => {
+    const totals = getTokenTotals([
+      { type: "message", message: { role: "assistant", usage: { input: 1200, output: 300 } } },
+      { type: "message", message: { role: "user" } },
+      { type: "message", message: { role: "assistant", usage: { input: 800, output: 500 } } },
+    ]);
 
-		expect(totals).toEqual({ input: 2000, output: 800 });
-	});
+    expect(totals).toEqual({ input: 2000, output: 800 });
+  });
 
-	it("formats token label from session entries", () => {
-		const label = getTokenLabel([
-			{ type: "message", message: { role: "assistant", usage: { input: 18000, output: 4200 } } },
-		]);
-		expect(label).toBe("↑18.0k/↓4.2k");
-	});
+  it("formats token label from session entries", () => {
+    const label = getTokenLabel([
+      { type: "message", message: { role: "assistant", usage: { input: 18000, output: 4200 } } },
+    ]);
+    expect(label).toBe("↑18.0k/↓4.2k");
+  });
 
-	it("formats context label from explicit percent", () => {
-		expect(getContextLabel({ percent: 11 }, { contextWindow: 1_000_000 })).toBe("Ctx: 11.0%");
-	});
+  it("formats context label from explicit percent", () => {
+    expect(getContextLabel({ percent: 11 }, { contextWindow: 1_000_000 })).toBe("Ctx: 11.0%");
+  });
 
-	it("computes context label from tokens and context window", () => {
-		expect(getContextLabel({ tokens: 110_000 }, { contextWindow: 1_000_000 })).toBe("Ctx: 11.0%");
-	});
+  it("computes context label from tokens and context window", () => {
+    expect(getContextLabel({ tokens: 110_000 }, { contextWindow: 1_000_000 })).toBe("Ctx: 11.0%");
+  });
 
-	it("formats thinking label", () => {
-		expect(getThinkingLabel("medium")).toBe("Thinking: medium");
-		expect(getThinkingLabel()).toBe("Thinking: off");
-	});
+  it("formats thinking label", () => {
+    expect(getThinkingLabel("medium")).toBe("Thinking: medium");
+    expect(getThinkingLabel()).toBe("Thinking: off");
+  });
 });

--- a/packages/pi-statusline/extensions/format.ts
+++ b/packages/pi-statusline/extensions/format.ts
@@ -1,65 +1,65 @@
 import type { MinimalModel, StatuslineLinesInput } from "./types.js";
 
 export function formatCompactNumber(value: number): string {
-	const absValue = Math.abs(value);
-	if (absValue >= 1_000_000) {
-		return `${(value / 1_000_000).toFixed(1)}M`;
-	}
-	if (absValue >= 1_000) {
-		return `${(value / 1_000).toFixed(1)}k`;
-	}
-	return String(value);
+  const absValue = Math.abs(value);
+  if (absValue >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (absValue >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}k`;
+  }
+  return String(value);
 }
 
 export function formatTokenPair(input: number, output: number): string {
-	return `↑${formatCompactNumber(input)}/↓${formatCompactNumber(output)}`;
+  return `↑${formatCompactNumber(input)}/↓${formatCompactNumber(output)}`;
 }
 
 export function formatContextWindow(contextWindow?: number): string | null {
-	if (!contextWindow || contextWindow <= 0) {
-		return null;
-	}
-	return `${formatCompactNumber(contextWindow)} context`;
+  if (!contextWindow || contextWindow <= 0) {
+    return null;
+  }
+  return `${formatCompactNumber(contextWindow)} context`;
 }
 
 export function formatModelLabel(model?: MinimalModel): string {
-	if (!model) {
-		return "Model: none";
-	}
+  if (!model) {
+    return "Model: none";
+  }
 
-	const baseName = model.name?.trim() || model.id?.trim() || "none";
-	const contextSuffix = formatContextWindow(model.contextWindow);
-	return contextSuffix ? `Model: ${baseName} (${contextSuffix})` : `Model: ${baseName}`;
+  const baseName = model.name?.trim() || model.id?.trim() || "none";
+  const contextSuffix = formatContextWindow(model.contextWindow);
+  return contextSuffix ? `Model: ${baseName} (${contextSuffix})` : `Model: ${baseName}`;
 }
 
 export function joinSegments(segments: string[]): string {
-	return segments.join(" | ");
+  return segments.join(" | ");
 }
 
 export function truncateLine(line: string, width: number): string {
-	if (width <= 0 || line.length <= width) {
-		return line;
-	}
-	if (width <= 3) {
-		return ".".repeat(width);
-	}
-	return `${line.slice(0, width - 3)}...`;
+  if (width <= 0 || line.length <= width) {
+    return line;
+  }
+  if (width <= 3) {
+    return ".".repeat(width);
+  }
+  return `${line.slice(0, width - 3)}...`;
 }
 
 export function buildStatusLines(input: StatuslineLinesInput, width?: number): string[] {
-	const line1 = joinSegments([
-		input.modelLabel,
-		input.thinkingLabel,
-		input.contextLabel,
-		input.branchLabel,
-		input.dirtyLabel,
-		input.tokenLabel,
-	]);
-	const line2 = joinSegments([input.repoLabel, input.cwdLabel, input.worktreeLabel, input.skillLabel]);
+  const line1 = joinSegments([
+    input.modelLabel,
+    input.thinkingLabel,
+    input.contextLabel,
+    input.branchLabel,
+    input.dirtyLabel,
+    input.tokenLabel,
+  ]);
+  const line2 = joinSegments([input.repoLabel, input.cwdLabel, input.worktreeLabel, input.skillLabel]);
 
-	if (width === undefined) {
-		return [line1, line2];
-	}
+  if (width === undefined) {
+    return [line1, line2];
+  }
 
-	return [truncateLine(line1, width), truncateLine(line2, width)];
+  return [truncateLine(line1, width), truncateLine(line2, width)];
 }

--- a/packages/pi-statusline/extensions/git.ts
+++ b/packages/pi-statusline/extensions/git.ts
@@ -5,119 +5,119 @@ import type { GitSnapshot, WorktreeEntry } from "./types.js";
 const GIT_TIMEOUT_MS = 3_000;
 
 export function parseDirtyCountFromPorcelain(stdout: string): number {
-	return stdout
-		.split(/\r?\n/)
-		.map((line) => line.trimEnd())
-		.filter((line) => line.length > 0).length;
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0).length;
 }
 
 export function parseWorktreeListPorcelain(stdout: string): WorktreeEntry[] {
-	const records = stdout
-		.trim()
-		.split(/\r?\n\r?\n/)
-		.filter((record) => record.trim().length > 0);
-	const entries: WorktreeEntry[] = [];
+  const records = stdout
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .filter((record) => record.trim().length > 0);
+  const entries: WorktreeEntry[] = [];
 
-	for (const record of records) {
-		let path: string | null = null;
-		let branch: string | null = null;
+  for (const record of records) {
+    let path: string | null = null;
+    let branch: string | null = null;
 
-		for (const line of record.split(/\r?\n/)) {
-			if (line.startsWith("worktree ")) {
-				path = line.slice("worktree ".length).trim();
-			} else if (line.startsWith("branch ")) {
-				branch = line.slice("branch ".length).trim();
-			}
-		}
+    for (const line of record.split(/\r?\n/)) {
+      if (line.startsWith("worktree ")) {
+        path = line.slice("worktree ".length).trim();
+      } else if (line.startsWith("branch ")) {
+        branch = line.slice("branch ".length).trim();
+      }
+    }
 
-		if (path) {
-			entries.push({ path, branch });
-		}
-	}
+    if (path) {
+      entries.push({ path, branch });
+    }
+  }
 
-	return entries;
+  return entries;
 }
 
 export function isLinkedWorktreeGitDir(gitDir: string): boolean {
-	const normalized = gitDir.replace(/\\/g, "/");
-	return normalized.includes("/worktrees/") || normalized.startsWith(".git/worktrees/");
+  const normalized = gitDir.replace(/\\/g, "/");
+  return normalized.includes("/worktrees/") || normalized.startsWith(".git/worktrees/");
 }
 
 export function normalizeBranchName(branchRef: string | null): string | null {
-	if (!branchRef) {
-		return null;
-	}
-	if (branchRef.startsWith("refs/heads/")) {
-		return branchRef.slice("refs/heads/".length);
-	}
-	return branchRef;
+  if (!branchRef) {
+    return null;
+  }
+  if (branchRef.startsWith("refs/heads/")) {
+    return branchRef.slice("refs/heads/".length);
+  }
+  return branchRef;
 }
 
 export function getWorktreeLabelForPath(
-	entries: ReadonlyArray<WorktreeEntry>,
-	currentTopLevel: string,
-	gitDir: string,
+  entries: ReadonlyArray<WorktreeEntry>,
+  currentTopLevel: string,
+  gitDir: string,
 ): string {
-	if (!isLinkedWorktreeGitDir(gitDir)) {
-		return "main";
-	}
+  if (!isLinkedWorktreeGitDir(gitDir)) {
+    return "main";
+  }
 
-	const normalizedTopLevel = normalize(currentTopLevel);
-	const match = entries.find((entry) => normalize(entry.path) === normalizedTopLevel);
-	if (!match) {
-		return "none";
-	}
+  const normalizedTopLevel = normalize(currentTopLevel);
+  const match = entries.find((entry) => normalize(entry.path) === normalizedTopLevel);
+  if (!match) {
+    return "none";
+  }
 
-	const branchName = normalizeBranchName(match.branch);
-	if (branchName) {
-		return basename(branchName);
-	}
+  const branchName = normalizeBranchName(match.branch);
+  if (branchName) {
+    return basename(branchName);
+  }
 
-	return basename(match.path) || "none";
+  return basename(match.path) || "none";
 }
 
 async function runGit(pi: ExtensionAPI, cwd: string, args: string[]): Promise<string | null> {
-	try {
-		const result = await pi.exec("git", args, {
-			cwd,
-			timeout: GIT_TIMEOUT_MS,
-		});
-		if (result.code !== 0) {
-			return null;
-		}
-		const stdout = result.stdout.trim();
-		return stdout.length > 0 ? stdout : "";
-	} catch {
-		return null;
-	}
+  try {
+    const result = await pi.exec("git", args, {
+      cwd,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    if (result.code !== 0) {
+      return null;
+    }
+    const stdout = result.stdout.trim();
+    return stdout.length > 0 ? stdout : "";
+  } catch {
+    return null;
+  }
 }
 
 export async function getGitSnapshot(pi: ExtensionAPI, cwd: string): Promise<GitSnapshot> {
-	const insideWorkTree = await runGit(pi, cwd, ["rev-parse", "--is-inside-work-tree"]);
-	if (insideWorkTree !== "true") {
-		return {
-			repoName: null,
-			branch: null,
-			dirtyCount: 0,
-			worktreeLabel: "no git",
-		};
-	}
+  const insideWorkTree = await runGit(pi, cwd, ["rev-parse", "--is-inside-work-tree"]);
+  if (insideWorkTree !== "true") {
+    return {
+      repoName: null,
+      branch: null,
+      dirtyCount: 0,
+      worktreeLabel: "no git",
+    };
+  }
 
-	const topLevel = await runGit(pi, cwd, ["rev-parse", "--show-toplevel"]);
-	const gitDir = await runGit(pi, cwd, ["rev-parse", "--git-dir"]);
-	const branch = await runGit(pi, cwd, ["branch", "--show-current"]);
-	const dirtyOutput = await runGit(pi, cwd, ["--no-optional-locks", "status", "--porcelain"]);
-	const worktreeOutput = await runGit(pi, cwd, ["worktree", "list", "--porcelain"]);
+  const topLevel = await runGit(pi, cwd, ["rev-parse", "--show-toplevel"]);
+  const gitDir = await runGit(pi, cwd, ["rev-parse", "--git-dir"]);
+  const branch = await runGit(pi, cwd, ["branch", "--show-current"]);
+  const dirtyOutput = await runGit(pi, cwd, ["--no-optional-locks", "status", "--porcelain"]);
+  const worktreeOutput = await runGit(pi, cwd, ["worktree", "list", "--porcelain"]);
 
-	const repoName = topLevel ? basename(topLevel) : null;
-	const dirtyCount = dirtyOutput === null ? 0 : parseDirtyCountFromPorcelain(dirtyOutput);
-	const worktreeEntries = worktreeOutput ? parseWorktreeListPorcelain(worktreeOutput) : [];
-	const worktreeLabel = topLevel && gitDir ? getWorktreeLabelForPath(worktreeEntries, topLevel, gitDir) : "no git";
+  const repoName = topLevel ? basename(topLevel) : null;
+  const dirtyCount = dirtyOutput === null ? 0 : parseDirtyCountFromPorcelain(dirtyOutput);
+  const worktreeEntries = worktreeOutput ? parseWorktreeListPorcelain(worktreeOutput) : [];
+  const worktreeLabel = topLevel && gitDir ? getWorktreeLabelForPath(worktreeEntries, topLevel, gitDir) : "no git";
 
-	return {
-		repoName,
-		branch: branch || null,
-		dirtyCount,
-		worktreeLabel,
-	};
+  return {
+    repoName,
+    branch: branch || null,
+    dirtyCount,
+    worktreeLabel,
+  };
 }

--- a/packages/pi-statusline/extensions/index.ts
+++ b/packages/pi-statusline/extensions/index.ts
@@ -3,210 +3,210 @@ import { Type } from "@sinclair/typebox";
 import { buildStatusLines } from "./format.js";
 import { getGitSnapshot } from "./git.js";
 import {
-	getContextLabel,
-	getCwdLabel,
-	getModelLabel,
-	getRepoFallbackLabel,
-	getThinkingLabel,
-	getTokenLabel,
+  getContextLabel,
+  getCwdLabel,
+  getModelLabel,
+  getRepoFallbackLabel,
+  getThinkingLabel,
+  getTokenLabel,
 } from "./session.js";
 import type { CommandLike, GitSnapshot, StatuslineState } from "./types.js";
 
-function createInitialGitSnapshot(): GitSnapshot {
-	return {
-		repoName: null,
-		branch: null,
-		dirtyCount: 0,
-		worktreeLabel: "no git",
-	};
+export function createInitialGitSnapshot(): GitSnapshot {
+  return {
+    repoName: null,
+    branch: null,
+    dirtyCount: 0,
+    worktreeLabel: "no git",
+  };
 }
 
-function createInitialState(): StatuslineState {
-	return {
-		modelLabel: "Model: none",
-		thinkingLabel: "Thinking: off",
-		contextLabel: "Ctx: n/a",
-		tokenLabel: "↑0/↓0",
-		gitSnapshot: createInitialGitSnapshot(),
-		lastSkill: null,
-	};
+export function createInitialState(): StatuslineState {
+  return {
+    modelLabel: "Model: none",
+    thinkingLabel: "Thinking: off",
+    contextLabel: "Ctx: n/a",
+    tokenLabel: "↑0/↓0",
+    gitSnapshot: createInitialGitSnapshot(),
+    lastSkill: null,
+  };
 }
 
 type StatuslineInput = {
-	modelLabel: string;
-	thinkingLabel: string;
-	contextLabel: string;
-	branchLabel: string;
-	dirtyLabel: string;
-	tokenLabel: string;
-	repoLabel: string;
-	cwdLabel: string;
-	worktreeLabel: string;
-	skillLabel: string;
+  modelLabel: string;
+  thinkingLabel: string;
+  contextLabel: string;
+  branchLabel: string;
+  dirtyLabel: string;
+  tokenLabel: string;
+  repoLabel: string;
+  cwdLabel: string;
+  worktreeLabel: string;
+  skillLabel: string;
 };
 
 export function extractSkillName(text: string, commands: ReadonlyArray<CommandLike>): string | null {
-	const trimmed = text.trim();
-	if (!trimmed.startsWith("/")) {
-		return null;
-	}
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) {
+    return null;
+  }
 
-	const firstToken = trimmed.split(/\s+/, 1)[0]?.slice(1);
-	if (!firstToken) {
-		return null;
-	}
+  const firstToken = trimmed.split(/\s+/, 1)[0]?.slice(1);
+  if (!firstToken) {
+    return null;
+  }
 
-	if (firstToken.startsWith("skill:")) {
-		const name = firstToken.slice("skill:".length).trim();
-		return name.length > 0 ? name : null;
-	}
+  if (firstToken.startsWith("skill:")) {
+    const name = firstToken.slice("skill:".length).trim();
+    return name.length > 0 ? name : null;
+  }
 
-	const matchingSkill = commands.find((command) => command.source === "skill" && command.name === firstToken);
-	if (!matchingSkill) {
-		return null;
-	}
+  const matchingSkill = commands.find((command) => command.source === "skill" && command.name === firstToken);
+  if (!matchingSkill) {
+    return null;
+  }
 
-	return matchingSkill.name.replace(/^skill:/, "");
+  return matchingSkill.name.replace(/^skill:/, "");
 }
 
-function getBranchLabel(branch: string | null | undefined): string {
-	return `⎇ ${branch || "no git"}`;
+export function getBranchLabel(branch: string | null | undefined): string {
+  return `⎇ ${branch || "no git"}`;
 }
 
-function getWorktreeLabel(worktreeLabel: string): string {
-	return `𖠰 ${worktreeLabel || "no git"}`;
+export function getWorktreeLabel(worktreeLabel: string): string {
+  return `𖠰 ${worktreeLabel || "no git"}`;
 }
 
-function getDirtyLabel(dirtyCount: number): string {
-	return `dirty: +${dirtyCount}`;
+export function getDirtyLabel(dirtyCount: number): string {
+  return `dirty: +${dirtyCount}`;
 }
 
-function buildLines(cwd: string, state: StatuslineState, branchLabel: string | null, width?: number): string[] {
-	const input: StatuslineInput = {
-		modelLabel: state.modelLabel,
-		thinkingLabel: state.thinkingLabel,
-		contextLabel: state.contextLabel,
-		branchLabel: getBranchLabel(branchLabel),
-		dirtyLabel: getDirtyLabel(state.gitSnapshot.dirtyCount),
-		tokenLabel: state.tokenLabel,
-		repoLabel: state.gitSnapshot.repoName || getRepoFallbackLabel(cwd),
-		cwdLabel: getCwdLabel(cwd),
-		worktreeLabel: getWorktreeLabel(state.gitSnapshot.worktreeLabel),
-		skillLabel: `Skill: ${state.lastSkill || "none"}`,
-	};
+export function buildLines(cwd: string, state: StatuslineState, branchLabel: string | null, width?: number): string[] {
+  const input: StatuslineInput = {
+    modelLabel: state.modelLabel,
+    thinkingLabel: state.thinkingLabel,
+    contextLabel: state.contextLabel,
+    branchLabel: getBranchLabel(branchLabel),
+    dirtyLabel: getDirtyLabel(state.gitSnapshot.dirtyCount),
+    tokenLabel: state.tokenLabel,
+    repoLabel: state.gitSnapshot.repoName || getRepoFallbackLabel(cwd),
+    cwdLabel: getCwdLabel(cwd),
+    worktreeLabel: getWorktreeLabel(state.gitSnapshot.worktreeLabel),
+    skillLabel: `Skill: ${state.lastSkill || "none"}`,
+  };
 
-	return buildStatusLines(input, width);
+  return buildStatusLines(input, width);
 }
 
 export default function statuslineExtension(pi: ExtensionAPI) {
-	let state = createInitialState();
-	let footerRegistered = false;
+  let state = createInitialState();
+  let footerRegistered = false;
 
-	const refreshDynamicState = (ctx: Pick<ExtensionContext, "model" | "sessionManager" | "getContextUsage">) => {
-		state = {
-			...state,
-			modelLabel: getModelLabel(ctx.model),
-			thinkingLabel: getThinkingLabel(pi.getThinkingLevel()),
-			contextLabel: getContextLabel(ctx.getContextUsage(), ctx.model),
-			tokenLabel: getTokenLabel(ctx.sessionManager.getBranch()),
-		};
-	};
+  const refreshDynamicState = (ctx: Pick<ExtensionContext, "model" | "sessionManager" | "getContextUsage">) => {
+    state = {
+      ...state,
+      modelLabel: getModelLabel(ctx.model),
+      thinkingLabel: getThinkingLabel(pi.getThinkingLevel()),
+      contextLabel: getContextLabel(ctx.getContextUsage(), ctx.model),
+      tokenLabel: getTokenLabel(ctx.sessionManager.getBranch()),
+    };
+  };
 
-	const refreshGitState = async (cwd: string) => {
-		state = {
-			...state,
-			gitSnapshot: await getGitSnapshot(pi, cwd),
-		};
-	};
+  const refreshGitState = async (cwd: string) => {
+    state = {
+      ...state,
+      gitSnapshot: await getGitSnapshot(pi, cwd),
+    };
+  };
 
-	const setSkill = (skillName: string | null | undefined) => {
-		if (!skillName) {
-			return;
-		}
-		state = {
-			...state,
-			lastSkill: skillName,
-		};
-	};
+  const setSkill = (skillName: string | null | undefined) => {
+    if (!skillName) {
+      return;
+    }
+    state = {
+      ...state,
+      lastSkill: skillName,
+    };
+  };
 
-	const emitStatusLines = (ctx: Pick<ExtensionContext, "cwd">) => {
-		const lines = buildLines(ctx.cwd, state, state.gitSnapshot.branch);
-		for (const line of lines) {
-			console.log(line);
-		}
-	};
+  const emitStatusLines = (ctx: Pick<ExtensionContext, "cwd">) => {
+    const lines = buildLines(ctx.cwd, state, state.gitSnapshot.branch);
+    for (const line of lines) {
+      console.log(line);
+    }
+  };
 
-	const updateAndLog = async (ctx: ExtensionContext, emit = true) => {
-		refreshDynamicState(ctx);
-		await refreshGitState(ctx.cwd);
-		if (!ctx.hasUI && emit) {
-			emitStatusLines(ctx);
-		}
-	};
+  const updateAndLog = async (ctx: ExtensionContext, emit = true) => {
+    refreshDynamicState(ctx);
+    await refreshGitState(ctx.cwd);
+    if (!ctx.hasUI && emit) {
+      emitStatusLines(ctx);
+    }
+  };
 
-	pi.on("session_start", async (_event, ctx) => {
-		state = createInitialState();
-		await updateAndLog(ctx);
+  pi.on("session_start", async (_event, ctx) => {
+    state = createInitialState();
+    await updateAndLog(ctx);
 
-		if (!ctx.hasUI || footerRegistered) {
-			return;
-		}
+    if (!ctx.hasUI || footerRegistered) {
+      return;
+    }
 
-		footerRegistered = true;
-		ctx.ui.setFooter((tui, _theme, footerData) => ({
-			dispose: footerData.onBranchChange(() => {
-				void refreshGitState(ctx.cwd).then(() => tui.requestRender());
-			}),
-			invalidate() {},
-			render(width: number): string[] {
-				refreshDynamicState(ctx);
-				return buildLines(ctx.cwd, state, footerData.getGitBranch(), width);
-			},
-		}));
-	});
+    footerRegistered = true;
+    ctx.ui.setFooter((tui, _theme, footerData) => ({
+      dispose: footerData.onBranchChange(() => {
+        void refreshGitState(ctx.cwd).then(() => tui.requestRender());
+      }),
+      invalidate() {},
+      render(width: number): string[] {
+        refreshDynamicState(ctx);
+        return buildLines(ctx.cwd, state, footerData.getGitBranch(), width);
+      },
+    }));
+  });
 
-	pi.on("agent_end", async (_event, ctx) => {
-		await updateAndLog(ctx);
-	});
+  pi.on("agent_end", async (_event, ctx) => {
+    await updateAndLog(ctx);
+  });
 
-	pi.on("model_select", async (_event, ctx) => {
-		await updateAndLog(ctx);
-	});
+  pi.on("model_select", async (_event, ctx) => {
+    await updateAndLog(ctx);
+  });
 
-	pi.on("input", async (event) => {
-		const skillName = extractSkillName(event.text, pi.getCommands() as CommandLike[]);
-		if (!skillName) {
-			return { action: "continue" };
-		}
+  pi.on("input", async (event) => {
+    const skillName = extractSkillName(event.text, pi.getCommands() as CommandLike[]);
+    if (!skillName) {
+      return { action: "continue" };
+    }
 
-		setSkill(skillName);
-		return { action: "continue" };
-	});
+    setSkill(skillName);
+    return { action: "continue" };
+  });
 
-	pi.on("tool_execution_start", async (event) => {
-		if (event.toolName !== "Skill" && event.toolName !== "skill") {
-			return;
-		}
+  pi.on("tool_execution_start", async (event) => {
+    if (event.toolName !== "Skill" && event.toolName !== "skill") {
+      return;
+    }
 
-		const args = (event as { args?: { skill?: string }; tool_input?: { skill?: string } }).args;
-		const toolInput = args ?? (event as { tool_input?: { skill?: string } }).tool_input;
-		if (typeof toolInput?.skill === "string" && toolInput.skill.length > 0) {
-			setSkill(toolInput.skill);
-		}
-	});
+    const args = (event as { args?: { skill?: string }; tool_input?: { skill?: string } }).args;
+    const toolInput = args ?? (event as { tool_input?: { skill?: string } }).tool_input;
+    if (typeof toolInput?.skill === "string" && toolInput.skill.length > 0) {
+      setSkill(toolInput.skill);
+    }
+  });
 
-	pi.registerTool({
-		name: "statusline",
-		label: "Statusline",
-		description: "Show the current status line with model, thinking effort, context, git info, and token counts",
-		parameters: Type.Object({}),
-		async execute(_toolCallId, _params, _signal, _onUpdate, ctx: ExtensionContext) {
-			await updateAndLog(ctx, false);
-			const text = buildLines(ctx.cwd, state, state.gitSnapshot.branch).join("\n");
-			return {
-				content: [{ type: "text", text }],
-				details: {},
-			};
-		},
-	});
+  pi.registerTool({
+    name: "statusline",
+    label: "Statusline",
+    description: "Show the current status line with model, thinking effort, context, git info, and token counts",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx: ExtensionContext) {
+      await updateAndLog(ctx, false);
+      const text = buildLines(ctx.cwd, state, state.gitSnapshot.branch).join("\n");
+      return {
+        content: [{ type: "text", text }],
+        details: {},
+      };
+    },
+  });
 }

--- a/packages/pi-statusline/extensions/session.ts
+++ b/packages/pi-statusline/extensions/session.ts
@@ -2,63 +2,63 @@ import { formatCompactNumber, formatModelLabel, formatTokenPair } from "./format
 import type { ContextUsageLike, MinimalModel, SessionEntryLike, TokenTotals } from "./types.js";
 
 export function getTokenTotals(entries: ReadonlyArray<SessionEntryLike>): TokenTotals {
-	let input = 0;
-	let output = 0;
+  let input = 0;
+  let output = 0;
 
-	for (const entry of entries) {
-		if (entry.type !== "message" || entry.message?.role !== "assistant") {
-			continue;
-		}
+  for (const entry of entries) {
+    if (entry.type !== "message" || entry.message?.role !== "assistant") {
+      continue;
+    }
 
-		input += entry.message.usage?.input ?? 0;
-		output += entry.message.usage?.output ?? 0;
-	}
+    input += entry.message.usage?.input ?? 0;
+    output += entry.message.usage?.output ?? 0;
+  }
 
-	return { input, output };
+  return { input, output };
 }
 
 export function getTokenLabel(entries: ReadonlyArray<SessionEntryLike>): string {
-	const totals = getTokenTotals(entries);
-	return formatTokenPair(totals.input, totals.output);
+  const totals = getTokenTotals(entries);
+  return formatTokenPair(totals.input, totals.output);
 }
 
 export function getThinkingLabel(thinkingLevel?: string): string {
-	return `Thinking: ${thinkingLevel || "off"}`;
+  return `Thinking: ${thinkingLevel || "off"}`;
 }
 
 export function getContextLabel(contextUsage: ContextUsageLike | undefined, model?: MinimalModel): string {
-	const percent = contextUsage?.percent;
-	if (typeof percent === "number" && Number.isFinite(percent)) {
-		return `Ctx: ${percent.toFixed(1)}%`;
-	}
+  const percent = contextUsage?.percent;
+  if (typeof percent === "number" && Number.isFinite(percent)) {
+    return `Ctx: ${percent.toFixed(1)}%`;
+  }
 
-	const tokens = contextUsage?.tokens;
-	const contextWindow = contextUsage?.contextWindow ?? model?.contextWindow;
-	if (typeof tokens === "number" && Number.isFinite(tokens) && contextWindow && contextWindow > 0) {
-		const computedPercent = (tokens / contextWindow) * 100;
-		return `Ctx: ${computedPercent.toFixed(1)}%`;
-	}
+  const tokens = contextUsage?.tokens;
+  const contextWindow = contextUsage?.contextWindow ?? model?.contextWindow;
+  if (typeof tokens === "number" && Number.isFinite(tokens) && contextWindow && contextWindow > 0) {
+    const computedPercent = (tokens / contextWindow) * 100;
+    return `Ctx: ${computedPercent.toFixed(1)}%`;
+  }
 
-	return "Ctx: n/a";
+  return "Ctx: n/a";
 }
 
 export function getModelLabel(model?: MinimalModel): string {
-	return formatModelLabel(model);
+  return formatModelLabel(model);
 }
 
 export function getRepoFallbackLabel(cwd: string): string {
-	const parts = cwd.split(/[\\/]/).filter((part) => part.length > 0);
-	return parts.at(-1) || cwd || "cwd";
+  const parts = cwd.split(/[\\/]/).filter((part) => part.length > 0);
+  return parts.at(-1) || cwd || "cwd";
 }
 
 export function getCwdLabel(cwd: string): string {
-	return `cwd: ${cwd || "n/a"}`;
+  return `cwd: ${cwd || "n/a"}`;
 }
 
 export function formatContextWindowSummary(model?: MinimalModel): string {
-	const contextWindow = model?.contextWindow;
-	if (!contextWindow || contextWindow <= 0) {
-		return "none";
-	}
-	return formatCompactNumber(contextWindow);
+  const contextWindow = model?.contextWindow;
+  if (!contextWindow || contextWindow <= 0) {
+    return "none";
+  }
+  return formatCompactNumber(contextWindow);
 }

--- a/packages/pi-statusline/extensions/types.ts
+++ b/packages/pi-statusline/extensions/types.ts
@@ -1,68 +1,68 @@
 export interface TokenTotals {
-	input: number;
-	output: number;
+  input: number;
+  output: number;
 }
 
 export interface GitSnapshot {
-	repoName: string | null;
-	branch: string | null;
-	dirtyCount: number;
-	worktreeLabel: string;
+  repoName: string | null;
+  branch: string | null;
+  dirtyCount: number;
+  worktreeLabel: string;
 }
 
 export interface StatuslineState {
-	modelLabel: string;
-	thinkingLabel: string;
-	contextLabel: string;
-	tokenLabel: string;
-	gitSnapshot: GitSnapshot;
-	lastSkill: string | null;
+  modelLabel: string;
+  thinkingLabel: string;
+  contextLabel: string;
+  tokenLabel: string;
+  gitSnapshot: GitSnapshot;
+  lastSkill: string | null;
 }
 
 export interface StatuslineLinesInput {
-	modelLabel: string;
-	thinkingLabel: string;
-	contextLabel: string;
-	branchLabel: string;
-	dirtyLabel: string;
-	tokenLabel: string;
-	repoLabel: string;
-	cwdLabel: string;
-	worktreeLabel: string;
-	skillLabel: string;
+  modelLabel: string;
+  thinkingLabel: string;
+  contextLabel: string;
+  branchLabel: string;
+  dirtyLabel: string;
+  tokenLabel: string;
+  repoLabel: string;
+  cwdLabel: string;
+  worktreeLabel: string;
+  skillLabel: string;
 }
 
 export interface MinimalModel {
-	id?: string;
-	name?: string;
-	contextWindow?: number;
+  id?: string;
+  name?: string;
+  contextWindow?: number;
 }
 
 export interface ContextUsageLike {
-	tokens?: number | null;
-	percent?: number | null;
-	contextWindow?: number | null;
+  tokens?: number | null;
+  percent?: number | null;
+  contextWindow?: number | null;
 }
 
 export interface AssistantUsageLike {
-	input?: number;
-	output?: number;
+  input?: number;
+  output?: number;
 }
 
 export interface SessionEntryLike {
-	type?: string;
-	message?: {
-		role?: string;
-		usage?: AssistantUsageLike;
-	};
+  type?: string;
+  message?: {
+    role?: string;
+    usage?: AssistantUsageLike;
+  };
 }
 
 export interface WorktreeEntry {
-	path: string;
-	branch: string | null;
+  path: string;
+  branch: string | null;
 }
 
 export interface CommandLike {
-	name: string;
-	source: string;
+  name: string;
+  source: string;
 }

--- a/scripts/write-coverage-summary.mjs
+++ b/scripts/write-coverage-summary.mjs
@@ -1,0 +1,24 @@
+import { appendFileSync, readFileSync } from "node:fs";
+
+const [summaryPath, packageName] = process.argv.slice(2);
+
+if (!summaryPath || !packageName) {
+  console.error("Usage: node scripts/write-coverage-summary.mjs <summary-path> <package-name>");
+  process.exit(1);
+}
+
+const summary = JSON.parse(readFileSync(summaryPath, "utf-8"));
+const total = summary.total;
+const output = [
+  `## Coverage: ${packageName}`,
+  "",
+  "| Metric | Covered | Total | Pct |",
+  "| --- | ---: | ---: | ---: |",
+  `| Lines | ${total.lines.covered} | ${total.lines.total} | ${total.lines.pct}% |`,
+  `| Statements | ${total.statements.covered} | ${total.statements.total} | ${total.statements.pct}% |`,
+  `| Functions | ${total.functions.covered} | ${total.functions.total} | ${total.functions.pct}% |`,
+  `| Branches | ${total.branches.covered} | ${total.branches.total} | ${total.branches.pct}% |`,
+  "",
+].join("\n");
+
+appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${output}\n`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
-	"compilerOptions": {
-		"target": "ES2022",
-		"module": "Node16",
-		"moduleResolution": "Node16",
-		"lib": ["ES2022", "DOM"],
-		"types": ["node", "portfinder"],
-		"strict": true,
-		"noEmit": true,
-		"skipLibCheck": true
-	},
-	"include": ["packages/*/extensions/**/*.ts", "packages/*/__tests__/**/*.ts"]
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "portfinder"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["packages/*/extensions/**/*.ts", "packages/*/__tests__/**/*.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	test: {
-		environment: "node",
-		include: ["packages/*/__tests__/**/*.test.ts"],
-	},
+  test: {
+    environment: "node",
+    include: ["packages/*/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text-summary", "json-summary", "html"],
+      reportsDirectory: "coverage",
+      include: ["packages/*/extensions/**/*.ts"],
+      thresholds: {
+        lines: 70,
+        statements: 70,
+        functions: 70,
+        branches: 60,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- update shared workspace tooling, formatting, and package-scoped CI configuration
- enforce the same per-package coverage thresholds in CI for every extension
- add runtime coverage for `pi-notion` and `pi-statusline` so the new gates pass consistently

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [x] Refactor

## Test plan
- run `npm run typecheck`
- run `npm run test`
- run package coverage for `pi-notion` with `70/70/70/60` thresholds
- run package coverage for `pi-statusline` with `70/70/70/60` thresholds