### PR TITLE
refactor: standardize extension settings and secret handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6450,7 +6450,7 @@
     },
     "packages/pi-code-reasoning": {
       "name": "@feniix/pi-code-reasoning",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-ai": "*",
@@ -6483,7 +6483,7 @@
     },
     "packages/pi-exa": {
       "name": "@feniix/pi-exa",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "exa-js": "^2.8.0"
@@ -6496,7 +6496,7 @@
     },
     "packages/pi-notion": {
       "name": "@feniix/pi-notion",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.1",
@@ -6514,7 +6514,7 @@
     },
     "packages/pi-ref-tools": {
       "name": "@feniix/pi-ref-tools",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-ai": "*",
@@ -6524,7 +6524,7 @@
     },
     "packages/pi-sequential-thinking": {
       "name": "@feniix/pi-sequential-thinking",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-ai": "*",

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -111,14 +111,21 @@ export CODE_REASONING_MAX_BYTES=102400
 export CODE_REASONING_MAX_LINES=5000
 ```
 
-### JSON Config
+### Settings File
 
-Create `~/.pi/agent/extensions/code-reasoning.json`:
+Use pi's standard settings locations:
+
+- project: `.pi/settings.json`
+- global: `~/.pi/agent/settings.json`
+
+Under the `pi-code-reasoning` key:
 
 ```json
 {
-  "maxBytes": 51200,
-  "maxLines": 2000
+  "pi-code-reasoning": {
+    "maxBytes": 51200,
+    "maxLines": 2000
+  }
 }
 ```
 
@@ -126,7 +133,7 @@ Create `~/.pi/agent/extensions/code-reasoning.json`:
 
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
-| `--code-reasoning-config` | `CODE_REASONING_CONFIG` | — | Custom config file path |
+| `--code-reasoning-config` | `CODE_REASONING_CONFIG` | — | Custom JSON config file path (overrides settings.json lookup) |
 | `--code-reasoning-max-bytes` | `CODE_REASONING_MAX_BYTES` | `51200` | Max output bytes |
 | `--code-reasoning-max-lines` | `CODE_REASONING_MAX_LINES` | `2000` | Max output lines |
 

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -130,13 +130,15 @@ Under the `pi-code-reasoning` key:
 ```
 
 > Best practice: use `settings.json` for non-secret defaults only.
-> If you need a separate private override file, use `--code-reasoning-config` or `CODE_REASONING_CONFIG` to point to a custom JSON config file.
+> If you need a separate private override file, use `--code-reasoning-config-file` or `CODE_REASONING_CONFIG_FILE` to point to a custom JSON config file.
+> Legacy aliases `--code-reasoning-config` and `CODE_REASONING_CONFIG` are still accepted but deprecated.
 
 ## CLI Flags
 
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
-| `--code-reasoning-config` | `CODE_REASONING_CONFIG` | — | Custom JSON config file path (overrides settings.json lookup) |
+| `--code-reasoning-config-file` | `CODE_REASONING_CONFIG_FILE` | — | Custom JSON config file path (overrides settings.json lookup) |
+| `--code-reasoning-config` | `CODE_REASONING_CONFIG` | — | Deprecated alias for the config file path |
 | `--code-reasoning-max-bytes` | `CODE_REASONING_MAX_BYTES` | `51200` | Max output bytes |
 | `--code-reasoning-max-lines` | `CODE_REASONING_MAX_LINES` | `2000` | Max output lines |
 

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -113,7 +113,7 @@ export CODE_REASONING_MAX_LINES=5000
 
 ### Settings File
 
-Use pi's standard settings locations:
+Use pi's standard settings locations for non-secret configuration:
 
 - project: `.pi/settings.json`
 - global: `~/.pi/agent/settings.json`
@@ -128,6 +128,9 @@ Under the `pi-code-reasoning` key:
   }
 }
 ```
+
+> Best practice: use `settings.json` for non-secret defaults only.
+> If you need a separate private override file, use `--code-reasoning-config` or `CODE_REASONING_CONFIG` to point to a custom JSON config file.
 
 ## CLI Flags
 

--- a/packages/pi-code-reasoning/__tests__/index.test.ts
+++ b/packages/pi-code-reasoning/__tests__/index.test.ts
@@ -27,7 +27,12 @@ describe("pi-code-reasoning", () => {
 
     const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
     expect(flagNames).toEqual(
-      expect.arrayContaining(["--code-reasoning-config", "--code-reasoning-max-bytes", "--code-reasoning-max-lines"]),
+      expect.arrayContaining([
+        "--code-reasoning-config-file",
+        "--code-reasoning-config",
+        "--code-reasoning-max-bytes",
+        "--code-reasoning-max-lines",
+      ]),
     );
   });
 
@@ -39,12 +44,12 @@ describe("pi-code-reasoning", () => {
     expect(toolNames).toHaveLength(3);
   });
 
-  it("registers exactly 3 flags", () => {
+  it("registers exactly 4 flags", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
     const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-    expect(flagNames).toHaveLength(3);
+    expect(flagNames).toHaveLength(4);
   });
 
   it("registers tools with execute functions", () => {

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -14,9 +14,9 @@
  *   "Process a thought about the database schema design"
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { AgentToolUpdateCallback, ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
@@ -78,6 +78,10 @@ interface McpToolDetails {
 // =============================================================================
 // Utility Functions
 // =============================================================================
+
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -194,10 +198,10 @@ function resolveEffectiveLimits(
 function resolveConfigPath(configPath: string): string {
   const trimmed = configPath.trim();
   if (trimmed.startsWith("~/")) {
-    return join(homedir(), trimmed.slice(2));
+    return join(getHomeDir(), trimmed.slice(2));
   }
   if (trimmed.startsWith("~")) {
-    return join(homedir(), trimmed.slice(1));
+    return join(getHomeDir(), trimmed.slice(1));
   }
   if (isAbsolute(trimmed)) {
     return trimmed;
@@ -215,43 +219,67 @@ function parseConfig(raw: unknown, pathHint: string): CodeReasoningConfig {
   };
 }
 
-function loadConfig(configPath: string | undefined): CodeReasoningConfig | null {
-  const candidates: string[] = [];
-  const envConfig = process.env.CODE_REASONING_CONFIG;
-  if (configPath) {
-    candidates.push(resolveConfigPath(configPath));
-  } else if (envConfig) {
-    candidates.push(resolveConfigPath(envConfig));
-  } else {
-    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "code-reasoning.json");
-    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "code-reasoning.json");
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    candidates.push(projectConfigPath, globalConfigPath);
+function loadConfigFile(path: string): CodeReasoningConfig | null {
+  if (!existsSync(path)) {
+    return null;
   }
 
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) {
-      continue;
-    }
-    const raw = readFileSync(candidate, "utf-8");
-    const parsed = JSON.parse(raw);
-    return parseConfig(parsed, candidate);
-  }
-
-  return null;
-}
-
-function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-    return;
-  }
   try {
-    mkdirSync(dirname(globalConfigPath), { recursive: true });
-    writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parseConfig(parsed, path);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-code-reasoning] Failed to write ${globalConfigPath}: ${message}`);
+    console.warn(`[pi-code-reasoning] Failed to parse config ${path}: ${message}`);
+    return null;
   }
+}
+
+function loadSettingsConfig(path: string): CodeReasoningConfig | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const config = parsed["pi-code-reasoning"];
+    if (!isRecord(config)) {
+      return null;
+    }
+    return parseConfig(config, path);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-code-reasoning] Failed to parse settings ${path}: ${message}`);
+    return null;
+  }
+}
+
+function loadConfig(configPath: string | undefined): CodeReasoningConfig | null {
+  const envConfig = process.env.CODE_REASONING_CONFIG;
+  if (configPath) {
+    return loadConfigFile(resolveConfigPath(configPath));
+  }
+  if (envConfig) {
+    return loadConfigFile(resolveConfigPath(envConfig));
+  }
+
+  const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
+  const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
+  const legacyProjectConfigPath = join(process.cwd(), ".pi", "extensions", "code-reasoning.json");
+  const legacyGlobalConfigPath = join(getHomeDir(), ".pi", "agent", "extensions", "code-reasoning.json");
+
+  const globalConfig = loadSettingsConfig(globalSettingsPath) ?? loadConfigFile(legacyGlobalConfigPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath) ?? loadConfigFile(legacyProjectConfigPath);
+
+  if (!globalConfig && !projectConfig) {
+    return null;
+  }
+
+  return {
+    maxBytes: projectConfig?.maxBytes ?? globalConfig?.maxBytes,
+    maxLines: projectConfig?.maxLines ?? globalConfig?.maxLines,
+  };
 }
 
 // =============================================================================
@@ -447,7 +475,8 @@ export {
 export default function codeReasoning(pi: ExtensionAPI) {
   // Register CLI flags
   pi.registerFlag("--code-reasoning-config", {
-    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/code-reasoning.json).",
+    description:
+      "Path to JSON config file (defaults to .pi/settings.json or ~/.pi/agent/settings.json under pi-code-reasoning).",
     type: "string",
   });
   pi.registerFlag("--code-reasoning-max-bytes", {

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -7,7 +7,7 @@
  * Setup:
  * 1. Install: pi install npm:@feniix/pi-code-reasoning
  * 2. Or pass flags:
- *    --code-reasoning-config, --code-reasoning-max-bytes, --code-reasoning-max-lines
+ *    --code-reasoning-config-file, --code-reasoning-max-bytes, --code-reasoning-max-lines
  *
  * Usage:
  *   "Use code reasoning to think through this architecture decision"
@@ -255,14 +255,36 @@ function loadSettingsConfig(path: string): CodeReasoningConfig | null {
   }
 }
 
+function warnIgnoredLegacyConfigFiles(): void {
+  const legacyPaths = [
+    join(process.cwd(), ".pi", "extensions", "code-reasoning.json"),
+    join(getHomeDir(), ".pi", "agent", "extensions", "code-reasoning.json"),
+  ];
+
+  for (const legacyPath of legacyPaths) {
+    if (existsSync(legacyPath)) {
+      console.warn(
+        `[pi-code-reasoning] Ignoring legacy config file ${legacyPath}. Migrate non-secret settings to .pi/settings.json or ~/.pi/agent/settings.json under "pi-code-reasoning", or pass --code-reasoning-config-file / CODE_REASONING_CONFIG_FILE explicitly.`,
+      );
+    }
+  }
+}
+
 function loadConfig(configPath: string | undefined): CodeReasoningConfig | null {
-  const envConfig = process.env.CODE_REASONING_CONFIG;
+  const envConfigFile = process.env.CODE_REASONING_CONFIG_FILE;
+  const legacyEnvConfig = process.env.CODE_REASONING_CONFIG;
   if (configPath) {
     return loadConfigFile(resolveConfigPath(configPath));
   }
-  if (envConfig) {
-    return loadConfigFile(resolveConfigPath(envConfig));
+  if (envConfigFile) {
+    return loadConfigFile(resolveConfigPath(envConfigFile));
   }
+  if (legacyEnvConfig) {
+    console.warn("[pi-code-reasoning] CODE_REASONING_CONFIG is deprecated; use CODE_REASONING_CONFIG_FILE.");
+    return loadConfigFile(resolveConfigPath(legacyEnvConfig));
+  }
+
+  warnIgnoredLegacyConfigFiles();
 
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
@@ -472,9 +494,13 @@ export {
 
 export default function codeReasoning(pi: ExtensionAPI) {
   // Register CLI flags
-  pi.registerFlag("--code-reasoning-config", {
+  pi.registerFlag("--code-reasoning-config-file", {
     description:
-      "Path to JSON config file (defaults to .pi/settings.json or ~/.pi/agent/settings.json under pi-code-reasoning).",
+      "Path to JSON config file (overrides .pi/settings.json or ~/.pi/agent/settings.json under pi-code-reasoning).",
+    type: "string",
+  });
+  pi.registerFlag("--code-reasoning-config", {
+    description: "Deprecated alias for --code-reasoning-config-file.",
     type: "string",
   });
   pi.registerFlag("--code-reasoning-max-bytes", {
@@ -491,8 +517,18 @@ export default function codeReasoning(pi: ExtensionAPI) {
   const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
     const maxBytesFlag = pi.getFlag("--code-reasoning-max-bytes");
     const maxLinesFlag = pi.getFlag("--code-reasoning-max-lines");
-    const configFlag = pi.getFlag("--code-reasoning-config");
-    const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+    const configFileFlag = pi.getFlag("--code-reasoning-config-file");
+    const legacyConfigFlag = pi.getFlag("--code-reasoning-config");
+    const configFlag =
+      typeof configFileFlag === "string"
+        ? configFileFlag
+        : typeof legacyConfigFlag === "string"
+          ? legacyConfigFlag
+          : undefined;
+    if (typeof configFileFlag !== "string" && typeof legacyConfigFlag === "string") {
+      console.warn("[pi-code-reasoning] --code-reasoning-config is deprecated; use --code-reasoning-config-file.");
+    }
+    const config = loadConfig(configFlag);
 
     const maxBytes =
       typeof maxBytesFlag === "string"

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -266,11 +266,9 @@ function loadConfig(configPath: string | undefined): CodeReasoningConfig | null 
 
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
-  const legacyProjectConfigPath = join(process.cwd(), ".pi", "extensions", "code-reasoning.json");
-  const legacyGlobalConfigPath = join(getHomeDir(), ".pi", "agent", "extensions", "code-reasoning.json");
 
-  const globalConfig = loadSettingsConfig(globalSettingsPath) ?? loadConfigFile(legacyGlobalConfigPath);
-  const projectConfig = loadSettingsConfig(projectSettingsPath) ?? loadConfigFile(legacyProjectConfigPath);
+  const globalConfig = loadSettingsConfig(globalSettingsPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath);
 
   if (!globalConfig && !projectConfig) {
     return null;

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-code-reasoning",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Code Reasoning extension for pi — reflective problem-solving through sequential thinking with branching and revision support",
   "keywords": [
     "pi",

--- a/packages/pi-conductor/__tests__/worktrees.test.ts
+++ b/packages/pi-conductor/__tests__/worktrees.test.ts
@@ -38,11 +38,11 @@ describe("worktree helpers", () => {
     expect(getCurrentBranch(tempDir)).toBe("main");
   });
 
-  it("plans a worktree path outside the repo root", () => {
+  it("plans a worktree path under the managed worktree root", () => {
     const path = planWorktreePath(tempDir, "backend");
     expect(path).toContain(`${basename(tempDir)}.worktrees`);
     expect(path).toContain("backend");
-    expect(path.startsWith(tempDir)).toBe(false);
+    expect(dirname(path)).toContain(`${basename(tempDir)}.worktrees`);
   });
 
   it("creates a managed worktree on a conductor branch", () => {

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -31,17 +31,26 @@ You need an Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.a
 export EXA_API_KEY="your_key"
 ```
 
-### Option 2: JSON Config File
+### Option 2: Settings File
 
-Create `~/.pi/agent/extensions/exa.json` (auto-created on first run):
+Use pi's standard settings locations for non-secret configuration:
+
+- project: `.pi/settings.json`
+- global: `~/.pi/agent/settings.json`
+
+Under the `pi-exa` key:
 
 ```json
 {
-  "apiKey": "your_key",
-  "enabledTools": ["web_search_exa", "web_fetch_exa"],
-  "advancedEnabled": false
+  "pi-exa": {
+    "enabledTools": ["web_search_exa", "web_fetch_exa"],
+    "advancedEnabled": false
+  }
 }
 ```
+
+> Best practice: keep `EXA_API_KEY` in an environment variable, not in `settings.json`.
+> If you need a persisted private file, use `--exa-config` or `EXA_CONFIG` to point to a custom JSON config outside your project.
 
 ### Option 3: CLI Flags
 

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -49,8 +49,8 @@ Under the `pi-exa` key:
 }
 ```
 
-> Best practice: keep `EXA_API_KEY` in an environment variable, not in `settings.json`.
-> If you need a persisted private file, use `--exa-config` or `EXA_CONFIG` to point to a custom JSON config outside your project.
+> Best practice: use `settings.json` for non-secret defaults only.
+> Keep `EXA_API_KEY` in an environment variable, or use `--exa-config` / `EXA_CONFIG` to point to a custom private JSON config file when you need to persist secrets outside your project.
 
 ### Option 3: CLI Flags
 

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -50,7 +50,8 @@ Under the `pi-exa` key:
 ```
 
 > Best practice: use `settings.json` for non-secret defaults only.
-> Keep `EXA_API_KEY` in an environment variable, or use `--exa-config` / `EXA_CONFIG` to point to a custom private JSON config file when you need to persist secrets outside your project.
+> Keep `EXA_API_KEY` in an environment variable, or use `--exa-config-file` / `EXA_CONFIG_FILE` to point to a custom private JSON config file when you need to persist secrets outside your project.
+> Legacy aliases `--exa-config` and `EXA_CONFIG` are still accepted but deprecated.
 
 ### Option 3: CLI Flags
 

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -53,15 +53,16 @@ describe("pi-exa extension", () => {
     const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
     expect(flagNames).toContain("--exa-api-key");
     expect(flagNames).toContain("--exa-enable-advanced");
+    expect(flagNames).toContain("--exa-config-file");
     expect(flagNames).toContain("--exa-config");
   });
 
-  it("registers exactly 3 flags", () => {
+  it("registers exactly 4 flags", () => {
     const mockPi = createMockPi();
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-    expect(flagNames).toHaveLength(3);
+    expect(flagNames).toHaveLength(4);
   });
 
   it("registers web_search_exa by default", () => {
@@ -93,7 +94,7 @@ describe("pi-exa extension", () => {
       apiKey: "config-api-key",
       enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
     });
-    const mockPi = createMockPi({ "--exa-config": configPath });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
@@ -313,7 +314,7 @@ describe("pi-exa extension", () => {
     const configPath = writeTempConfig({
       enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
     });
-    const mockPi = createMockPi({ "--exa-config": configPath });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
@@ -328,7 +329,7 @@ describe("pi-exa extension", () => {
       apiKey: "config-api-key",
       enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
     });
-    const mockPi = createMockPi({ "--exa-config": configPath });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
@@ -351,7 +352,7 @@ describe("pi-exa extension", () => {
       apiKey: "config-api-key",
       enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
     });
-    const mockPi = createMockPi({ "--exa-config": configPath });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
@@ -408,7 +409,7 @@ describe("pi-exa extension", () => {
       apiKey: "config-api-key",
       enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
     });
-    const mockPi = createMockPi({ "--exa-config": configPath });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");

--- a/packages/pi-exa/__tests__/helpers.test.ts
+++ b/packages/pi-exa/__tests__/helpers.test.ts
@@ -1,11 +1,10 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_MAX_CHARACTERS,
   DEFAULT_NUM_RESULTS,
-  ensureDefaultConfigFile,
   formatCrawlResults,
   formatSearchResults,
   getAuthStatusMessage,
@@ -233,38 +232,44 @@ describe("pi-exa constants", () => {
   });
 });
 
-describe("pi-exa ensureDefaultConfigFile", () => {
-  it("writes default config when none exists", () => {
-    const base = mkdtempSync(join(tmpdir(), "pi-exa-config-"));
-    const projectConfigPath = join(base, "project", ".pi", "extensions", "exa.json");
-    const globalConfigPath = join(base, "global", "extensions", "exa.json");
+describe("pi-exa settings config", () => {
+  it("loads settings from standard pi settings files", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-settings-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-settings-project-"));
 
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    mkdirSync(join(tempProject, ".pi"), { recursive: true });
 
-    expect(existsSync(globalConfigPath)).toBe(true);
-    const raw = readFileSync(globalConfigPath, "utf-8");
-    const parsed = JSON.parse(raw);
-    expect(parsed).toHaveProperty("apiKey");
-    expect(parsed).toHaveProperty("enabledTools");
-  });
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({ "pi-exa": { enabledTools: ["web_search_exa"] } }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(tempProject, ".pi", "settings.json"),
+      JSON.stringify({ "pi-exa": { advancedEnabled: true } }),
+      "utf-8",
+    );
 
-  it("does not overwrite existing config", () => {
-    const base = mkdtempSync(join(tmpdir(), "pi-exa-config-exists-"));
-    const projectConfigPath = join(base, "project", ".pi", "extensions", "exa.json");
-    const globalConfigPath = join(base, "global", "extensions", "exa.json");
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
 
-    // First call creates the file
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    const firstContent = readFileSync(globalConfigPath, "utf-8");
-
-    // Second call should not overwrite
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    const secondContent = readFileSync(globalConfigPath, "utf-8");
-
-    expect(firstContent).toBe(secondContent);
+    try {
+      const mod = await import("../extensions/index.js");
+      const result = mod.loadConfig(undefined);
+      expect(result?.apiKey).toBeUndefined();
+      expect(result?.enabledTools).toEqual(["web_search_exa"]);
+      expect(result?.advancedEnabled).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
   });
 });
-
 describe("pi-exa auth helpers", () => {
   it("prefers CLI flag over config and environment", () => {
     const pi = {
@@ -367,11 +372,23 @@ describe("pi-exa loadConfig", () => {
     expect(result?.apiKey).toBe("env-api-key");
   });
 
-  it("returns default config for empty config path", () => {
-    const result = loadConfig(undefined);
-    // Creates default config and returns it
-    expect(result).not.toBeNull();
-    expect(result).toHaveProperty("enabledTools");
-    expect(result?.enabledTools).toContain("web_search_exa");
+  it("returns null when no settings or legacy config exist", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-empty-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-empty-project-"));
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadConfig(undefined)).toBeNull();
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
   });
 });

--- a/packages/pi-exa/__tests__/helpers.test.ts
+++ b/packages/pi-exa/__tests__/helpers.test.ts
@@ -292,7 +292,7 @@ describe("pi-exa auth helpers", () => {
 
     const pi = {
       getFlag(flag: string) {
-        if (flag === "--exa-config") {
+        if (flag === "--exa-config-file") {
           return configPath;
         }
         return undefined;
@@ -370,6 +370,36 @@ describe("pi-exa loadConfig", () => {
 
     const result = loadConfig(configPath);
     expect(result?.apiKey).toBe("env-api-key");
+  });
+
+  it("warns when a legacy config file exists but is ignored", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-legacy-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-legacy-project-"));
+
+    mkdirSync(join(tempHome, ".pi", "agent", "extensions"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "extensions", "exa.json"),
+      JSON.stringify({ apiKey: "legacy-key" }),
+      "utf-8",
+    );
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadConfig(undefined)).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Ignoring legacy config file"));
+    } finally {
+      warnSpy.mockRestore();
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
   });
 
   it("returns null when no settings or legacy config exist", async () => {

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -153,13 +153,34 @@ function loadSettingsConfig(path: string): ExaConfig | null {
   }
 }
 
+function warnIgnoredLegacyConfigFiles(): void {
+  const legacyPaths = [
+    join(process.cwd(), ".pi", "extensions", "exa.json"),
+    join(getHomeDir(), ".pi", "agent", "extensions", "exa.json"),
+  ];
+
+  for (const legacyPath of legacyPaths) {
+    if (existsSync(legacyPath)) {
+      console.warn(
+        `[pi-exa] Ignoring legacy config file ${legacyPath}. Migrate non-secret settings to .pi/settings.json or ~/.pi/agent/settings.json under "pi-exa". Keep secrets in EXA_API_KEY or an explicit custom config via --exa-config-file / EXA_CONFIG_FILE.`,
+      );
+    }
+  }
+}
+
 function loadConfig(configPath?: string): ExaConfig | null {
   if (configPath) {
     return loadConfigFile(resolveConfigPath(configPath));
   }
+  if (process.env.EXA_CONFIG_FILE) {
+    return loadConfigFile(resolveConfigPath(process.env.EXA_CONFIG_FILE));
+  }
   if (process.env.EXA_CONFIG) {
+    console.warn("[pi-exa] EXA_CONFIG is deprecated; use EXA_CONFIG_FILE.");
     return loadConfigFile(resolveConfigPath(process.env.EXA_CONFIG));
   }
+
+  warnIgnoredLegacyConfigFiles();
 
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
@@ -179,7 +200,18 @@ function loadConfig(configPath?: string): ExaConfig | null {
 }
 
 function getConfigOverrideFlag(pi: ExtensionAPI): string | undefined {
-  return normalizeString(pi.getFlag("--exa-config"));
+  const configFileFlag = normalizeString(pi.getFlag("--exa-config-file"));
+  if (configFileFlag) {
+    return configFileFlag;
+  }
+
+  const legacyConfigFlag = normalizeString(pi.getFlag("--exa-config"));
+  if (legacyConfigFlag) {
+    console.warn("[pi-exa] --exa-config is deprecated; use --exa-config-file.");
+    return legacyConfigFlag;
+  }
+
+  return undefined;
 }
 
 function getResolvedConfig(pi: ExtensionAPI): ExaConfig | null {
@@ -494,8 +526,12 @@ export default function exaExtension(pi: ExtensionAPI) {
     description: "Enable web_search_advanced_exa tool",
     type: "boolean",
   });
-  pi.registerFlag("--exa-config", {
+  pi.registerFlag("--exa-config-file", {
     description: "Path to custom JSON config file for private overrides such as API keys.",
+    type: "string",
+  });
+  pi.registerFlag("--exa-config", {
+    description: "Deprecated alias for --exa-config-file.",
     type: "string",
   });
 

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -23,9 +23,9 @@
  *   - web_search_advanced_exa: Full-featured search (disabled by default)
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { Exa } from "exa-js";
@@ -74,6 +74,10 @@ interface ExaSearchResponse {
   searchTime?: number;
 }
 
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
+
 // =============================================================================
 // Config Loading
 // =============================================================================
@@ -81,10 +85,10 @@ interface ExaSearchResponse {
 function resolveConfigPath(configPath: string): string {
   const trimmed = configPath.trim();
   if (trimmed.startsWith("~/")) {
-    return join(homedir(), trimmed.slice(2));
+    return join(getHomeDir(), trimmed.slice(2));
   }
   if (trimmed.startsWith("~")) {
-    return join(homedir(), trimmed.slice(1));
+    return join(getHomeDir(), trimmed.slice(1));
   }
   if (isAbsolute(trimmed)) {
     return trimmed;
@@ -109,55 +113,71 @@ function parseConfig(raw: unknown): ExaConfig {
   };
 }
 
-function loadConfig(configPath?: string): ExaConfig | null {
-  const candidates: string[] = [];
-
-  if (configPath) {
-    candidates.push(resolveConfigPath(configPath));
-  } else if (process.env.EXA_CONFIG) {
-    candidates.push(resolveConfigPath(process.env.EXA_CONFIG));
-  } else {
-    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "exa.json");
-    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "exa.json");
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    candidates.push(projectConfigPath, globalConfigPath);
+function loadConfigFile(path: string): ExaConfig | null {
+  if (!existsSync(path)) {
+    return null;
   }
-
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) {
-      continue;
-    }
-    try {
-      const raw = readFileSync(candidate, "utf-8");
-      const parsed = JSON.parse(raw);
-      return parseConfig(parsed);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[pi-exa] Failed to parse config ${candidate}: ${message}`);
-    }
-  }
-
-  return null;
-}
-
-function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-    return;
-  }
-
-  const defaultConfig = {
-    apiKey: null,
-    enabledTools: ["web_search_exa", "web_fetch_exa"],
-    advancedEnabled: false,
-  };
 
   try {
-    mkdirSync(dirname(globalConfigPath), { recursive: true });
-    writeFileSync(globalConfigPath, `${JSON.stringify(defaultConfig, null, 2)}\n`, "utf-8");
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parseConfig(parsed);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-exa] Failed to write ${globalConfigPath}: ${message}`);
+    console.warn(`[pi-exa] Failed to parse config ${path}: ${message}`);
+    return null;
   }
+}
+
+function loadSettingsConfig(path: string): ExaConfig | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const config = parsed["pi-exa"];
+    if (typeof config !== "object" || config === null) {
+      return null;
+    }
+    const parsedConfig = parseConfig(config);
+    return {
+      enabledTools: parsedConfig.enabledTools,
+      advancedEnabled: parsedConfig.advancedEnabled,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-exa] Failed to parse settings ${path}: ${message}`);
+    return null;
+  }
+}
+
+function loadConfig(configPath?: string): ExaConfig | null {
+  if (configPath) {
+    return loadConfigFile(resolveConfigPath(configPath));
+  }
+  if (process.env.EXA_CONFIG) {
+    return loadConfigFile(resolveConfigPath(process.env.EXA_CONFIG));
+  }
+
+  const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
+  const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
+  const legacyGlobalConfigPath = join(getHomeDir(), ".pi", "agent", "extensions", "exa.json");
+  const legacyProjectConfigPath = join(process.cwd(), ".pi", "extensions", "exa.json");
+
+  const globalConfig = loadSettingsConfig(globalSettingsPath) ?? loadConfigFile(legacyGlobalConfigPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath) ?? loadConfigFile(legacyProjectConfigPath);
+
+  if (!globalConfig && !projectConfig) {
+    return null;
+  }
+
+  return {
+    apiKey: projectConfig?.apiKey ?? globalConfig?.apiKey,
+    enabledTools: projectConfig?.enabledTools ?? globalConfig?.enabledTools,
+    advancedEnabled: projectConfig?.advancedEnabled ?? globalConfig?.advancedEnabled,
+  };
 }
 
 function getConfigOverrideFlag(pi: ExtensionAPI): string | undefined {
@@ -447,7 +467,6 @@ async function performAdvancedSearch(
 export {
   DEFAULT_MAX_CHARACTERS,
   DEFAULT_NUM_RESULTS,
-  ensureDefaultConfigFile,
   formatCrawlResults,
   formatSearchResults,
   getAuthStatusMessage,
@@ -478,7 +497,7 @@ export default function exaExtension(pi: ExtensionAPI) {
     type: "boolean",
   });
   pi.registerFlag("--exa-config", {
-    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/exa.json)",
+    description: "Path to custom JSON config file for private overrides such as API keys.",
     type: "string",
   });
 

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -9,7 +9,7 @@
  * 2. Get API key from: https://dashboard.exa.ai/api-keys
  * 3. Configure via:
  *    - Environment variable: EXA_API_KEY
- *    - JSON config: ~/.pi/agent/extensions/exa.json
+ *    - Settings file for non-secret config: .pi/settings.json or ~/.pi/agent/settings.json under pi-exa
  *    - CLI flag: --exa-api-key
  *
  * Usage:
@@ -163,11 +163,9 @@ function loadConfig(configPath?: string): ExaConfig | null {
 
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
-  const legacyGlobalConfigPath = join(getHomeDir(), ".pi", "agent", "extensions", "exa.json");
-  const legacyProjectConfigPath = join(process.cwd(), ".pi", "extensions", "exa.json");
 
-  const globalConfig = loadSettingsConfig(globalSettingsPath) ?? loadConfigFile(legacyGlobalConfigPath);
-  const projectConfig = loadSettingsConfig(projectSettingsPath) ?? loadConfigFile(legacyProjectConfigPath);
+  const globalConfig = loadSettingsConfig(globalSettingsPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath);
 
   if (!globalConfig && !projectConfig) {
     return null;

--- a/packages/pi-exa/package.json
+++ b/packages/pi-exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-exa",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Exa MCP extension for pi — web search, content fetching, and advanced search via Exa AI",
   "keywords": [
     "pi",

--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -70,11 +70,12 @@ This package requires MCP OAuth (`/notion` or `notion_mcp_connect`) for tool con
 
 Session-start status checks for:
 
-1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp.json`)
+1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp-auth.json`, or `NOTION_MCP_AUTH_FILE` if explicitly set)
 2. Legacy OAuth token files under `~/.pi/agent/extensions/`
 3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`) and warns that MCP OAuth is still required.
 
-Best practice: keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` or in environment variables. Do not store tokens or client secrets in `settings.json`.
+Best practice: use `settings.json` for non-secret defaults only.
+Keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` (for example `notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` to a custom file path. Do not store tokens or client secrets in `settings.json`.
 
 ## Requirements
 

--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -70,12 +70,12 @@ This package requires MCP OAuth (`/notion` or `notion_mcp_connect`) for tool con
 
 Session-start status checks for:
 
-1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp-auth.json`, or `NOTION_MCP_AUTH_FILE` if explicitly set)
+1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp-auth.json`, or `NOTION_MCP_AUTH_FILE` / `--notion-mcp-auth-file` if explicitly set)
 2. Legacy OAuth token files under `~/.pi/agent/extensions/`
 3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`) and warns that MCP OAuth is still required.
 
 Best practice: use `settings.json` for non-secret defaults only.
-Keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` (for example `notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` to a custom file path. Do not store tokens or client secrets in `settings.json`.
+Keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` (for example `notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` or pass `--notion-mcp-auth-file` with a custom file path. Legacy aliases `NOTION_MCP_AUTH` and `--notion-mcp-auth` are still accepted but deprecated. Do not store tokens or client secrets in `settings.json`.
 
 ## Requirements
 

--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -75,7 +75,11 @@ Session-start status checks for:
 3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`) and warns that MCP OAuth is still required.
 
 Best practice: use `settings.json` for non-secret defaults only.
-Keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` (for example `notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` or pass `--notion-mcp-auth-file` with a custom file path. Legacy aliases `NOTION_MCP_AUTH` and `--notion-mcp-auth` are still accepted but deprecated. Do not store tokens or client secrets in `settings.json`.
+Keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` (for example `notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` or pass `--notion-mcp-auth-file` with a custom file path. Legacy aliases `NOTION_MCP_AUTH` and `--notion-mcp-auth` are still accepted but deprecated.
+
+For the legacy direct-token compatibility config path, prefer `NOTION_CONFIG_FILE` / `--notion-config-file`. Legacy aliases `NOTION_CONFIG` and `--notion-config` are still accepted but deprecated.
+
+Do not store tokens or client secrets in `settings.json`.
 
 ## Requirements
 

--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -72,7 +72,7 @@ Session-start status checks for:
 
 1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp.json`)
 2. Legacy OAuth token files under `~/.pi/agent/extensions/`
-3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`, `.pi/extensions/notion.json`, `~/.pi/agent/extensions/notion.json`) and warns that MCP OAuth is still required.
+3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`) and warns that MCP OAuth is still required.
 
 Best practice: keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` or in environment variables. Do not store tokens or client secrets in `settings.json`.
 

--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -72,7 +72,9 @@ Session-start status checks for:
 
 1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp.json`)
 2. Legacy OAuth token files under `~/.pi/agent/extensions/`
-3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`, `.pi/extensions/notion.json`) and warns that MCP OAuth is still required.
+3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`, `.pi/extensions/notion.json`, `~/.pi/agent/extensions/notion.json`) and warns that MCP OAuth is still required.
+
+Best practice: keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` or in environment variables. Do not store tokens or client secrets in `settings.json`.
 
 ## Requirements
 

--- a/packages/pi-notion/__tests__/extension.runtime.test.ts
+++ b/packages/pi-notion/__tests__/extension.runtime.test.ts
@@ -16,6 +16,35 @@ const getEventHandler = (mockPi: ReturnType<typeof createMockPi>, eventName: str
 };
 
 describe("pi-notion extension runtime", () => {
+  it("registers config-file flags", () => {
+    const mockPi = createMockPi();
+    notion(mockPi as unknown as ExtensionAPI);
+
+    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flagNames).toContain("--notion-config-file");
+    expect(flagNames).toContain("--notion-config");
+  });
+
+  it("supports deprecated notion config flag alias with warning", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const original = process.env.NOTION_CONFIG_FILE;
+    const mockPi = {
+      registerFlag: vi.fn(),
+      getFlag: vi.fn((flag: string) => (flag === "--notion-config" ? "~/legacy-notion-config.json" : undefined)),
+      registerTool: vi.fn(),
+      on: vi.fn(),
+    } satisfies Partial<ExtensionAPI>;
+
+    try {
+      notion(mockPi as unknown as ExtensionAPI);
+      expect(process.env.NOTION_CONFIG_FILE).toBe("~/legacy-notion-config.json");
+      expect(warnSpy).toHaveBeenCalledWith("[pi-notion] --notion-config is deprecated; use --notion-config-file.");
+    } finally {
+      warnSpy.mockRestore();
+      if (original) process.env.NOTION_CONFIG_FILE = original;
+      else delete process.env.NOTION_CONFIG_FILE;
+    }
+  });
   it("warns for incorrect notion-search inputs", async () => {
     const mockPi = createMockPi();
     notion(mockPi as unknown as ExtensionAPI);

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -273,6 +273,43 @@ describe("pi-notion loadConfig", () => {
     expect(result).toBeNull();
   });
 
+  it("loads from NOTION_CONFIG_FILE when set", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-notion-load-env-file-"));
+    const configPath = join(base, "notion-config.json");
+    const original = process.env.NOTION_CONFIG_FILE;
+    writeFileSync(configPath, JSON.stringify({ token: "env-file-token" }), "utf-8");
+    process.env.NOTION_CONFIG_FILE = configPath;
+
+    try {
+      expect(loadConfig(undefined)).toEqual({ token: "env-file-token" });
+    } finally {
+      if (original) process.env.NOTION_CONFIG_FILE = original;
+      else delete process.env.NOTION_CONFIG_FILE;
+    }
+  });
+
+  it("supports deprecated NOTION_CONFIG with warning", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-notion-load-env-legacy-"));
+    const configPath = join(base, "notion-config.json");
+    const original = process.env.NOTION_CONFIG;
+    const originalFile = process.env.NOTION_CONFIG_FILE;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    writeFileSync(configPath, JSON.stringify({ token: "legacy-env-token" }), "utf-8");
+    delete process.env.NOTION_CONFIG_FILE;
+    process.env.NOTION_CONFIG = configPath;
+
+    try {
+      expect(loadConfig(undefined)).toEqual({ token: "legacy-env-token" });
+      expect(warnSpy).toHaveBeenCalledWith("[pi-notion] NOTION_CONFIG is deprecated; use NOTION_CONFIG_FILE.");
+    } finally {
+      warnSpy.mockRestore();
+      if (original) process.env.NOTION_CONFIG = original;
+      else delete process.env.NOTION_CONFIG;
+      if (originalFile) process.env.NOTION_CONFIG_FILE = originalFile;
+      else delete process.env.NOTION_CONFIG_FILE;
+    }
+  });
+
   it("returns null when no custom config path is provided", () => {
     const result = loadConfig(undefined);
     expect(result).toBeNull();

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -313,6 +313,37 @@ describe("pi-notion checkNotionAuth", () => {
     const result = await importCheckNotionAuthInIsolatedEnv();
     expect(result.authenticated).toBe(false);
     expect(result.message).toContain("Not authenticated");
+  });
+
+  it("migrates legacy MCP auth file to the new filename", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-migrate-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-migrate-project-"));
+    const configDir = join(tempHome, ".pi", "agent", "extensions");
+
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, "notion-mcp.json"),
+      JSON.stringify({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" }),
+      "utf-8",
+    );
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+
+    try {
+      const mod = await import("../extensions/index.js");
+      const result = mod.checkNotionAuth();
+      expect(result.authenticated).toBe(true);
+      expect(existsSync(join(configDir, "notion-mcp.json"))).toBe(false);
+      expect(existsSync(join(configDir, "notion-mcp-auth.json"))).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
   });
 
   it("detects NOTION_API_KEY but still requires MCP auth", async () => {

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -273,29 +273,9 @@ describe("pi-notion loadConfig", () => {
     expect(result).toBeNull();
   });
 
-  it("loads from legacy private token files in an isolated environment", () => {
-    const originalHome = process.env.HOME;
-    const originalCwd = process.cwd();
-    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-load-default-home-"));
-    const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-load-default-project-"));
-    const globalConfigDir = join(tempHome, ".pi", "agent", "extensions");
-    const projectConfigDir = join(tempProject, ".pi", "extensions");
-
-    mkdirSync(globalConfigDir, { recursive: true });
-    mkdirSync(projectConfigDir, { recursive: true });
-    writeFileSync(join(globalConfigDir, "notion.json"), JSON.stringify({ token: null }), "utf-8");
-    writeFileSync(join(projectConfigDir, "notion.json"), JSON.stringify({ token: "project-token" }), "utf-8");
-    process.env.HOME = tempHome;
-    process.chdir(tempProject);
-
-    try {
-      const result = loadConfig(undefined);
-      expect(result).toEqual({ token: "project-token" });
-    } finally {
-      process.chdir(originalCwd);
-      if (originalHome) process.env.HOME = originalHome;
-      else delete process.env.HOME;
-    }
+  it("returns null when no custom config path is provided", () => {
+    const result = loadConfig(undefined);
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -273,22 +273,24 @@ describe("pi-notion loadConfig", () => {
     expect(result).toBeNull();
   });
 
-  it("returns default config when a default config file exists in an isolated environment", () => {
+  it("loads from legacy private token files in an isolated environment", () => {
     const originalHome = process.env.HOME;
     const originalCwd = process.cwd();
     const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-load-default-home-"));
     const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-load-default-project-"));
-    const configDir = join(tempHome, ".pi", "agent", "extensions");
-    const configPath = join(configDir, "notion.json");
+    const globalConfigDir = join(tempHome, ".pi", "agent", "extensions");
+    const projectConfigDir = join(tempProject, ".pi", "extensions");
 
-    mkdirSync(configDir, { recursive: true });
-    writeFileSync(configPath, JSON.stringify({ token: null }), "utf-8");
+    mkdirSync(globalConfigDir, { recursive: true });
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(globalConfigDir, "notion.json"), JSON.stringify({ token: null }), "utf-8");
+    writeFileSync(join(projectConfigDir, "notion.json"), JSON.stringify({ token: "project-token" }), "utf-8");
     process.env.HOME = tempHome;
     process.chdir(tempProject);
 
     try {
       const result = loadConfig(undefined);
-      expect(result).toEqual({ token: null });
+      expect(result).toEqual({ token: "project-token" });
     } finally {
       process.chdir(originalCwd);
       if (originalHome) process.env.HOME = originalHome;
@@ -305,8 +307,8 @@ describe("pi-notion checkNotionAuth", () => {
     const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-auth-home-"));
     const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-auth-project-"));
 
-    mkdirSync(join(tempHome, ".pi", "agent", "extensions"), { recursive: true });
-    mkdirSync(join(tempProject, ".pi", "extensions"), { recursive: true });
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    mkdirSync(join(tempProject, ".pi"), { recursive: true });
 
     process.env.HOME = tempHome;
     process.chdir(tempProject);

--- a/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
@@ -322,7 +322,11 @@ describe("pi-notion mcp client runtime helpers", () => {
   it("falls back to console logging when ui notifications fail", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     const notify = createUiNotifier({
-      events: { emit: vi.fn(() => { throw new Error("no ui"); }) },
+      events: {
+        emit: vi.fn(() => {
+          throw new Error("no ui");
+        }),
+      },
     } as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI);
 
     notify("fallback message", "error");
@@ -408,9 +412,7 @@ describe("pi-notion mcp client runtime helpers", () => {
     try {
       notionMCPClientExtension(mockPi as never);
       expect(process.env.NOTION_MCP_AUTH_FILE).toBe("~/legacy-auth.json");
-      expect(warnSpy).toHaveBeenCalledWith(
-        "[pi-notion] --notion-mcp-auth is deprecated; use --notion-mcp-auth-file.",
-      );
+      expect(warnSpy).toHaveBeenCalledWith("[pi-notion] --notion-mcp-auth is deprecated; use --notion-mcp-auth-file.");
     } finally {
       warnSpy.mockRestore();
       if (original) process.env.NOTION_MCP_AUTH_FILE = original;
@@ -429,7 +431,9 @@ describe("pi-notion mcp client runtime helpers", () => {
     };
 
     notionMCPClientExtension(mockPi as never);
-    const statusTool = mockPi.registerTool.mock.calls.map(([tool]) => tool).find((tool) => tool.name === "notion_mcp_status");
+    const statusTool = mockPi.registerTool.mock.calls
+      .map(([tool]) => tool)
+      .find((tool) => tool.name === "notion_mcp_status");
     const result = await statusTool.execute("id", {}, new AbortController().signal, undefined, undefined);
     expect(result.content[0].text).toContain("Connected: No");
   });

--- a/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
@@ -16,6 +16,7 @@ import {
   finalizeConnection,
   getConnectedStatusMessage,
   getConnectionStatusText,
+  getDefaultAuthFilePath,
   NotionMCPClient,
   resolveAccessToken,
   resolveCallbackResult,
@@ -251,13 +252,25 @@ describe("pi-notion mcp client runtime helpers", () => {
     expect(success.content[0]?.text).toBe("done");
   });
 
+  it("resolves auth file path from environment when configured", () => {
+    const original = process.env.NOTION_MCP_AUTH_FILE;
+    process.env.NOTION_MCP_AUTH_FILE = "~/custom-notion-auth.json";
+
+    try {
+      expect(getDefaultAuthFilePath()).toContain("custom-notion-auth.json");
+    } finally {
+      if (original) process.env.NOTION_MCP_AUTH_FILE = original;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+    }
+  });
+
   it("saves and clears config files with file token storage", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-notion-mcp-storage-"));
     const tokenStorage = new FileTokenStorage();
-    (tokenStorage as unknown as { path: string }).path = join(dir, "notion-mcp.json");
+    (tokenStorage as unknown as { path: string }).path = join(dir, "notion-mcp-auth.json");
 
     await tokenStorage.save({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" });
-    expect(existsSync(join(dir, "notion-mcp.json"))).toBe(true);
+    expect(existsSync(join(dir, "notion-mcp-auth.json"))).toBe(true);
     expect(await tokenStorage.load()).toMatchObject({ accessToken: "token-123" });
     await tokenStorage.clear();
     expect(await tokenStorage.load()).toBeNull();

--- a/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
+import notionMCPClientExtension, {
   buildAuthorizationUrl,
   buildHtmlResponse,
   coerceNumericProperties,
@@ -61,6 +61,9 @@ describe("pi-notion mcp client runtime helpers", () => {
 
     const code = resolveCallbackResult(new URLSearchParams("state=expected&code=code-123"), "expected");
     expect(code.result.code).toBe("code-123");
+
+    const missing = resolveCallbackResult(new URLSearchParams("state=expected"), "expected");
+    expect(missing.result.error).toBe("No code or token in callback");
   });
 
   it("creates a PKCE challenge pair and authorization URL", () => {
@@ -264,6 +267,25 @@ describe("pi-notion mcp client runtime helpers", () => {
     }
   });
 
+  it("supports deprecated auth file environment alias with warning", () => {
+    const original = process.env.NOTION_MCP_AUTH;
+    const originalFile = process.env.NOTION_MCP_AUTH_FILE;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    delete process.env.NOTION_MCP_AUTH_FILE;
+    process.env.NOTION_MCP_AUTH = "~/legacy-notion-auth.json";
+
+    try {
+      expect(getDefaultAuthFilePath()).toContain("legacy-notion-auth.json");
+      expect(warnSpy).toHaveBeenCalledWith("[pi-notion] NOTION_MCP_AUTH is deprecated; use NOTION_MCP_AUTH_FILE.");
+    } finally {
+      warnSpy.mockRestore();
+      if (original) process.env.NOTION_MCP_AUTH = original;
+      else delete process.env.NOTION_MCP_AUTH;
+      if (originalFile) process.env.NOTION_MCP_AUTH_FILE = originalFile;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+    }
+  });
+
   it("saves and clears config files with file token storage", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-notion-mcp-storage-"));
     const tokenStorage = new FileTokenStorage();
@@ -297,6 +319,32 @@ describe("pi-notion mcp client runtime helpers", () => {
     expect(clearSpy).toHaveBeenCalled();
   });
 
+  it("falls back to console logging when ui notifications fail", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const notify = createUiNotifier({
+      events: { emit: vi.fn(() => { throw new Error("no ui"); }) },
+    } as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI);
+
+    notify("fallback message", "error");
+    expect(logSpy).toHaveBeenCalledWith("[pi-notion] fallback message");
+    logSpy.mockRestore();
+  });
+
+  it("returns false when saved config is missing or invalid", async () => {
+    vi.spyOn(storage, "load").mockResolvedValueOnce(null);
+    expect(await connectWithSavedConfig(new NotionMCPClient(), vi.fn())).toBe(false);
+
+    const notify = vi.fn();
+    const client = new NotionMCPClient();
+    vi.spyOn(storage, "load").mockResolvedValueOnce({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token" });
+    vi.spyOn(client, "connect").mockRejectedValueOnce(new Error("bad auth"));
+    const clearSpy = vi.spyOn(storage, "clear").mockResolvedValueOnce();
+
+    expect(await connectWithSavedConfig(client, notify)).toBe(false);
+    expect(notify).toHaveBeenCalledWith("Connection failed: bad auth", "error");
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
   it("finalizes and ensures connections", async () => {
     const client = new NotionMCPClient();
     vi.spyOn(client, "connect").mockResolvedValue();
@@ -320,6 +368,70 @@ describe("pi-notion mcp client runtime helpers", () => {
     const reused = await ensureConnected(reuseClient, vi.fn(), vi.fn());
     expect(reused).toEqual({ reusedSavedConfig: true });
     expect(savedSpy).toHaveBeenCalled();
+  });
+
+  it("registers extension flags and management tools", () => {
+    const mockPi = {
+      registerFlag: vi.fn(),
+      getFlag: vi.fn(() => undefined),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      getAllTools: vi.fn(() => []),
+      events: { emit: vi.fn() },
+    };
+
+    notionMCPClientExtension(mockPi as never);
+
+    const flags = mockPi.registerFlag.mock.calls.map(([name]) => name);
+    expect(flags).toContain("--notion-mcp-auth-file");
+    expect(flags).toContain("--notion-mcp-auth");
+
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(tools).toEqual(expect.arrayContaining(["notion_mcp_connect", "notion_mcp_disconnect", "notion_mcp_status"]));
+    expect(mockPi.registerCommand).toHaveBeenCalledWith("notion", expect.any(Object));
+  });
+
+  it("uses deprecated auth file flag alias with a warning", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const original = process.env.NOTION_MCP_AUTH_FILE;
+    delete process.env.NOTION_MCP_AUTH_FILE;
+
+    const mockPi = {
+      registerFlag: vi.fn(),
+      getFlag: vi.fn((flag: string) => (flag === "--notion-mcp-auth" ? "~/legacy-auth.json" : undefined)),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      getAllTools: vi.fn(() => []),
+      events: { emit: vi.fn() },
+    };
+
+    try {
+      notionMCPClientExtension(mockPi as never);
+      expect(process.env.NOTION_MCP_AUTH_FILE).toBe("~/legacy-auth.json");
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[pi-notion] --notion-mcp-auth is deprecated; use --notion-mcp-auth-file.",
+      );
+    } finally {
+      warnSpy.mockRestore();
+      if (original) process.env.NOTION_MCP_AUTH_FILE = original;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+    }
+  });
+
+  it("reports disconnected MCP status through the registered tool", async () => {
+    const mockPi = {
+      registerFlag: vi.fn(),
+      getFlag: vi.fn(() => undefined),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      getAllTools: vi.fn(() => []),
+      events: { emit: vi.fn() },
+    };
+
+    notionMCPClientExtension(mockPi as never);
+    const statusTool = mockPi.registerTool.mock.calls.map(([tool]) => tool).find((tool) => tool.name === "notion_mcp_status");
+    const result = await statusTool.execute("id", {}, new AbortController().signal, undefined, undefined);
+    expect(result.content[0].text).toContain("Connected: No");
   });
 
   it("runs an OAuth callback server and resolves callback results", async () => {

--- a/packages/pi-notion/__tests__/notion-client.test.ts
+++ b/packages/pi-notion/__tests__/notion-client.test.ts
@@ -30,6 +30,7 @@ describe("pi-notion Extension File Structure", () => {
     expect(content).toContain("resolveConfigPath");
     expect(content).toContain("loadConfig");
     expect(content).toContain("homedir");
+    expect(content).toContain("NOTION_CONFIG_FILE");
     expect(content).toContain("NOTION_CONFIG");
   });
 

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -6,7 +6,7 @@
  * - Tool call guardrails: advisory warnings for common Notion mistakes
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
@@ -15,10 +15,29 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 // Config Paths
 // =============================================================================
 
-const CONFIG_DIR = join(homedir(), ".pi", "agent", "extensions");
-const MCP_CONFIG_FILE = join(CONFIG_DIR, "notion-mcp.json");
-const TOKEN_FILE = join(CONFIG_DIR, "notion-tokens.json");
-const LEGACY_TOKEN_FILE = join(process.cwd(), ".pi", "extensions", "notion.json");
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
+
+function getConfigDir(): string {
+  return join(getHomeDir(), ".pi", "agent", "extensions");
+}
+
+function getMcpConfigFile(): string {
+  return join(getConfigDir(), "notion-mcp.json");
+}
+
+function getTokenFile(): string {
+  return join(getConfigDir(), "notion-tokens.json");
+}
+
+function getLegacyGlobalTokenFile(): string {
+  return join(getConfigDir(), "notion.json");
+}
+
+function getLegacyProjectTokenFile(): string {
+  return join(process.cwd(), ".pi", "extensions", "notion.json");
+}
 
 // =============================================================================
 // Token Types
@@ -60,7 +79,7 @@ function readJsonIfExists<T>(path: string): T | null {
 }
 
 function getMcpConfigAuthStatus(): AuthStatus | null {
-  const config = readJsonIfExists<{ accessToken?: string; mcpUrl?: string }>(MCP_CONFIG_FILE);
+  const config = readJsonIfExists<{ accessToken?: string; mcpUrl?: string }>(getMcpConfigFile());
   if (typeof config?.accessToken !== "string" || config.accessToken.trim().length === 0) return null;
 
   return {
@@ -70,10 +89,11 @@ function getMcpConfigAuthStatus(): AuthStatus | null {
 }
 
 function getOAuthTokenAuthStatus(): AuthStatus | null {
-  const tokens = readJsonIfExists<OAuthTokens>(TOKEN_FILE);
+  const tokenFile = getTokenFile();
+  const tokens = readJsonIfExists<OAuthTokens>(tokenFile);
   if (!tokens?.accessToken || tokens.expiresAt <= Date.now()) return null;
 
-  const userInfoPath = TOKEN_FILE.replace("-tokens.json", "-user.json");
+  const userInfoPath = tokenFile.replace("-tokens.json", "-user.json");
   const userInfo = readJsonIfExists<NotionUserInfo>(userInfoPath);
   if (!userInfo) {
     return {
@@ -102,12 +122,12 @@ function getLegacyEnvAuthStatus(): AuthStatus | null {
 }
 
 function getLegacyConfigAuthStatus(): AuthStatus | null {
-  const config = readJsonIfExists<{ token?: string }>(LEGACY_TOKEN_FILE);
+  const config = loadConfig();
   if (!config?.token) return null;
 
   return {
     authenticated: false,
-    message: "[notion] Legacy notion.json token detected. MCP OAuth is still required: run /notion.",
+    message: "[notion] Legacy direct token config detected. MCP OAuth is still required: run /notion.",
   };
 }
 
@@ -220,16 +240,6 @@ export { checkNotionAuth, extractShortName, toolChecks };
 export default function notion(pi: ExtensionAPI) {
   // SessionStart: check auth and print status
   pi.on("session_start", async () => {
-    // Ensure config directory exists
-    if (!existsSync(CONFIG_DIR)) {
-      try {
-        mkdirSync(CONFIG_DIR, { recursive: true });
-        writeFileSync(join(CONFIG_DIR, "notion-mcp.json"), JSON.stringify({}), "utf-8");
-      } catch {
-        // Ignore if can't create
-      }
-    }
-
     const auth = checkNotionAuth();
     console.log(auth.message);
   });
@@ -250,28 +260,37 @@ interface NotionConfig {
 
 function resolveConfigPath(configPath: string): string {
   const trimmed = configPath.trim();
-  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-  if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
+  if (trimmed.startsWith("~/")) return join(getHomeDir(), trimmed.slice(2));
+  if (trimmed.startsWith("~")) return join(getHomeDir(), trimmed.slice(1));
   return resolve(process.cwd(), trimmed);
 }
 
+function loadConfigFile(path: string): NotionConfig | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as NotionConfig;
+  } catch {
+    return null;
+  }
+}
+
 function loadConfig(configPath?: string): NotionConfig | null {
-  const candidates: string[] = [];
-  if (configPath) candidates.push(resolveConfigPath(configPath));
-  else if (process.env.NOTION_CONFIG) candidates.push(resolveConfigPath(process.env.NOTION_CONFIG));
-  else {
-    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "notion.json");
-    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "notion.json");
-    candidates.push(projectConfigPath, globalConfigPath);
+  if (configPath) return loadConfigFile(resolveConfigPath(configPath));
+  if (process.env.NOTION_CONFIG) return loadConfigFile(resolveConfigPath(process.env.NOTION_CONFIG));
+
+  const globalConfig = loadConfigFile(getLegacyGlobalTokenFile());
+  const projectConfig = loadConfigFile(getLegacyProjectTokenFile());
+
+  if (!globalConfig && !projectConfig) {
+    return null;
   }
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      try {
-        return JSON.parse(readFileSync(candidate, "utf-8"));
-      } catch {}
-    }
-  }
-  return null;
+
+  return {
+    token: projectConfig?.token ?? globalConfig?.token,
+  };
 }
 
 interface TitleProp {

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -31,14 +31,6 @@ function getTokenFile(): string {
   return join(getConfigDir(), "notion-tokens.json");
 }
 
-function getLegacyGlobalTokenFile(): string {
-  return join(getConfigDir(), "notion.json");
-}
-
-function getLegacyProjectTokenFile(): string {
-  return join(process.cwd(), ".pi", "extensions", "notion.json");
-}
-
 // =============================================================================
 // Token Types
 // =============================================================================
@@ -121,22 +113,11 @@ function getLegacyEnvAuthStatus(): AuthStatus | null {
   };
 }
 
-function getLegacyConfigAuthStatus(): AuthStatus | null {
-  const config = loadConfig();
-  if (!config?.token) return null;
-
-  return {
-    authenticated: false,
-    message: "[notion] Legacy direct token config detected. MCP OAuth is still required: run /notion.",
-  };
-}
-
 function checkNotionAuth(): AuthStatus {
   return (
     getMcpConfigAuthStatus() ??
     getOAuthTokenAuthStatus() ??
-    getLegacyEnvAuthStatus() ??
-    getLegacyConfigAuthStatus() ?? {
+    getLegacyEnvAuthStatus() ?? {
       authenticated: false,
       message: "[notion] Not authenticated. Use /notion to connect your Notion workspace.",
     }
@@ -280,17 +261,7 @@ function loadConfigFile(path: string): NotionConfig | null {
 function loadConfig(configPath?: string): NotionConfig | null {
   if (configPath) return loadConfigFile(resolveConfigPath(configPath));
   if (process.env.NOTION_CONFIG) return loadConfigFile(resolveConfigPath(process.env.NOTION_CONFIG));
-
-  const globalConfig = loadConfigFile(getLegacyGlobalTokenFile());
-  const projectConfig = loadConfigFile(getLegacyProjectTokenFile());
-
-  if (!globalConfig && !projectConfig) {
-    return null;
-  }
-
-  return {
-    token: projectConfig?.token ?? globalConfig?.token,
-  };
+  return null;
 }
 
 interface TitleProp {

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -266,6 +266,24 @@ export { checkNotionAuth, extractShortName, toolChecks };
 // =============================================================================
 
 export default function notion(pi: ExtensionAPI) {
+  pi.registerFlag("--notion-config-file", {
+    description: "Path to a custom JSON config file for direct-token compatibility overrides.",
+    type: "string",
+  });
+  pi.registerFlag("--notion-config", {
+    description: "Deprecated alias for --notion-config-file.",
+    type: "string",
+  });
+
+  const configFileFlag = pi.getFlag("--notion-config-file");
+  const legacyConfigFlag = pi.getFlag("--notion-config");
+  if (typeof configFileFlag === "string" && configFileFlag.trim().length > 0) {
+    process.env.NOTION_CONFIG_FILE = configFileFlag;
+  } else if (typeof legacyConfigFlag === "string" && legacyConfigFlag.trim().length > 0) {
+    console.warn("[pi-notion] --notion-config is deprecated; use --notion-config-file.");
+    process.env.NOTION_CONFIG_FILE = legacyConfigFlag;
+  }
+
   // SessionStart: check auth and print status
   pi.on("session_start", async () => {
     const auth = checkNotionAuth();
@@ -307,7 +325,11 @@ function loadConfigFile(path: string): NotionConfig | null {
 
 function loadConfig(configPath?: string): NotionConfig | null {
   if (configPath) return loadConfigFile(resolveConfigPath(configPath));
-  if (process.env.NOTION_CONFIG) return loadConfigFile(resolveConfigPath(process.env.NOTION_CONFIG));
+  if (process.env.NOTION_CONFIG_FILE) return loadConfigFile(resolveConfigPath(process.env.NOTION_CONFIG_FILE));
+  if (process.env.NOTION_CONFIG) {
+    console.warn("[pi-notion] NOTION_CONFIG is deprecated; use NOTION_CONFIG_FILE.");
+    return loadConfigFile(resolveConfigPath(process.env.NOTION_CONFIG));
+  }
   return null;
 }
 

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -6,7 +6,7 @@
  * - Tool call guardrails: advisory warnings for common Notion mistakes
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
@@ -37,12 +37,41 @@ function resolveOptionalPath(path: string): string {
   return resolve(process.cwd(), trimmed);
 }
 
-function getMcpConfigFile(): string {
+function getLegacyMcpConfigFile(): string {
+  return join(getConfigDir(), "notion-mcp.json");
+}
+
+function migrateLegacyMcpConfigFile(): string {
   const configuredPath = process.env.NOTION_MCP_AUTH_FILE;
   if (typeof configuredPath === "string" && configuredPath.trim().length > 0) {
     return resolveOptionalPath(configuredPath);
   }
-  return join(getConfigDir(), "notion-mcp-auth.json");
+
+  const legacyConfiguredPath = process.env.NOTION_MCP_AUTH;
+  if (typeof legacyConfiguredPath === "string" && legacyConfiguredPath.trim().length > 0) {
+    console.warn("[pi-notion] NOTION_MCP_AUTH is deprecated; use NOTION_MCP_AUTH_FILE.");
+    return resolveOptionalPath(legacyConfiguredPath);
+  }
+
+  const nextPath = join(getConfigDir(), "notion-mcp-auth.json");
+  const legacyPath = getLegacyMcpConfigFile();
+
+  if (!existsSync(nextPath) && existsSync(legacyPath)) {
+    try {
+      mkdirSync(getConfigDir(), { recursive: true });
+      renameSync(legacyPath, nextPath);
+      console.warn(`[pi-notion] Migrated legacy MCP auth file from ${legacyPath} to ${nextPath}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[pi-notion] Failed to migrate legacy MCP auth file ${legacyPath}: ${message}`);
+    }
+  }
+
+  return nextPath;
+}
+
+function getMcpConfigFile(): string {
+  return migrateLegacyMcpConfigFile();
 }
 
 function getTokenFile(): string {

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 
 // =============================================================================
@@ -23,8 +23,26 @@ function getConfigDir(): string {
   return join(getHomeDir(), ".pi", "agent", "extensions");
 }
 
+function resolveOptionalPath(path: string): string {
+  const trimmed = path.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(getHomeDir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(getHomeDir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
+}
+
 function getMcpConfigFile(): string {
-  return join(getConfigDir(), "notion-mcp.json");
+  const configuredPath = process.env.NOTION_MCP_AUTH_FILE;
+  if (typeof configuredPath === "string" && configuredPath.trim().length > 0) {
+    return resolveOptionalPath(configuredPath);
+  }
+  return join(getConfigDir(), "notion-mcp-auth.json");
 }
 
 function getTokenFile(): string {

--- a/packages/pi-notion/extensions/mcp-client.ts
+++ b/packages/pi-notion/extensions/mcp-client.ts
@@ -13,7 +13,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { getPort as lookupPort } from "portfinder";
@@ -25,6 +25,7 @@ import { getPort as lookupPort } from "portfinder";
 const NOTION_MCP_URL = "https://mcp.notion.com/mcp";
 const HTTP_REQUEST_COMPLETE_MARKER = "\r\n\r\n";
 const CALLBACK_PATH_PREFIX = "GET /callback?";
+const NOTION_MCP_AUTH_FILE_ENV = "NOTION_MCP_AUTH_FILE";
 
 type NotifyLevel = "info" | "error";
 type NotifyFn = (message: string, type?: NotifyLevel) => void;
@@ -533,12 +534,34 @@ interface StoredConfig {
   clientSecret?: string;
 }
 
+function resolveAuthFilePath(path: string): string {
+  const trimmed = path.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(homedir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
+}
+
+function getDefaultAuthFilePath(): string {
+  const configuredPath = process.env[NOTION_MCP_AUTH_FILE_ENV];
+  if (typeof configuredPath === "string" && configuredPath.trim().length > 0) {
+    return resolveAuthFilePath(configuredPath);
+  }
+  const configDir = join(homedir(), ".pi", "agent", "extensions");
+  return join(configDir, "notion-mcp-auth.json");
+}
+
 class FileTokenStorage {
   private path: string;
 
   constructor() {
-    const configDir = join(homedir(), ".pi", "agent", "extensions");
-    this.path = join(configDir, "notion-mcp.json");
+    this.path = getDefaultAuthFilePath();
   }
 
   async save(config: StoredConfig): Promise<void> {
@@ -754,6 +777,7 @@ export {
   finalizeConnection,
   getConnectedStatusMessage,
   getConnectionStatusText,
+  getDefaultAuthFilePath,
   isNumericString,
   isRecord,
   NotionMCPClient,

--- a/packages/pi-notion/extensions/mcp-client.ts
+++ b/packages/pi-notion/extensions/mcp-client.ts
@@ -10,7 +10,7 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
@@ -26,6 +26,11 @@ const NOTION_MCP_URL = "https://mcp.notion.com/mcp";
 const HTTP_REQUEST_COMPLETE_MARKER = "\r\n\r\n";
 const CALLBACK_PATH_PREFIX = "GET /callback?";
 const NOTION_MCP_AUTH_FILE_ENV = "NOTION_MCP_AUTH_FILE";
+const NOTION_MCP_AUTH_FILE_LEGACY_ENV = "NOTION_MCP_AUTH";
+
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
 
 type NotifyLevel = "info" | "error";
 type NotifyFn = (message: string, type?: NotifyLevel) => void;
@@ -537,10 +542,10 @@ interface StoredConfig {
 function resolveAuthFilePath(path: string): string {
   const trimmed = path.trim();
   if (trimmed.startsWith("~/")) {
-    return join(homedir(), trimmed.slice(2));
+    return join(getHomeDir(), trimmed.slice(2));
   }
   if (trimmed.startsWith("~")) {
-    return join(homedir(), trimmed.slice(1));
+    return join(getHomeDir(), trimmed.slice(1));
   }
   if (isAbsolute(trimmed)) {
     return trimmed;
@@ -548,13 +553,39 @@ function resolveAuthFilePath(path: string): string {
   return resolve(process.cwd(), trimmed);
 }
 
+function getLegacyAuthFilePath(): string {
+  const configDir = join(getHomeDir(), ".pi", "agent", "extensions");
+  return join(configDir, "notion-mcp.json");
+}
+
 function getDefaultAuthFilePath(): string {
   const configuredPath = process.env[NOTION_MCP_AUTH_FILE_ENV];
   if (typeof configuredPath === "string" && configuredPath.trim().length > 0) {
     return resolveAuthFilePath(configuredPath);
   }
-  const configDir = join(homedir(), ".pi", "agent", "extensions");
-  return join(configDir, "notion-mcp-auth.json");
+
+  const legacyConfiguredPath = process.env[NOTION_MCP_AUTH_FILE_LEGACY_ENV];
+  if (typeof legacyConfiguredPath === "string" && legacyConfiguredPath.trim().length > 0) {
+    console.warn("[pi-notion] NOTION_MCP_AUTH is deprecated; use NOTION_MCP_AUTH_FILE.");
+    return resolveAuthFilePath(legacyConfiguredPath);
+  }
+
+  const configDir = join(getHomeDir(), ".pi", "agent", "extensions");
+  const nextPath = join(configDir, "notion-mcp-auth.json");
+  const legacyPath = getLegacyAuthFilePath();
+
+  if (!existsSync(nextPath) && existsSync(legacyPath)) {
+    try {
+      mkdirSync(configDir, { recursive: true });
+      renameSync(legacyPath, nextPath);
+      console.warn(`[pi-notion] Migrated legacy MCP auth file from ${legacyPath} to ${nextPath}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[pi-notion] Failed to migrate legacy MCP auth file ${legacyPath}: ${message}`);
+    }
+  }
+
+  return nextPath;
 }
 
 class FileTokenStorage {
@@ -790,6 +821,24 @@ export {
 };
 
 export default function notionMCPClientExtension(pi: ExtensionAPI) {
+  pi.registerFlag("--notion-mcp-auth-file", {
+    description: "Path to the persisted Notion MCP auth file.",
+    type: "string",
+  });
+  pi.registerFlag("--notion-mcp-auth", {
+    description: "Deprecated alias for --notion-mcp-auth-file.",
+    type: "string",
+  });
+
+  const authFileFlag = pi.getFlag("--notion-mcp-auth-file");
+  const legacyAuthFileFlag = pi.getFlag("--notion-mcp-auth");
+  if (typeof authFileFlag === "string" && authFileFlag.trim().length > 0) {
+    process.env.NOTION_MCP_AUTH_FILE = authFileFlag;
+  } else if (typeof legacyAuthFileFlag === "string" && legacyAuthFileFlag.trim().length > 0) {
+    console.warn("[pi-notion] --notion-mcp-auth is deprecated; use --notion-mcp-auth-file.");
+    process.env.NOTION_MCP_AUTH_FILE = legacyAuthFileFlag;
+  }
+
   mcpClient = new NotionMCPClient();
   const notify = createUiNotifier(pi);
 

--- a/packages/pi-notion/package.json
+++ b/packages/pi-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-notion",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Notion API extension for pi — read, search, and manage Notion pages, databases, and content",
   "keywords": [
     "pi",

--- a/packages/pi-ref-tools/README.md
+++ b/packages/pi-ref-tools/README.md
@@ -32,20 +32,29 @@ You need a Ref API key from [ref.tools/keys](https://ref.tools/keys).
 export REF_API_KEY="your_key"
 ```
 
-### Option 2: JSON Config File
+### Option 2: Settings File
 
-Create `~/.pi/agent/extensions/ref-tools.json` (auto-created on first run):
+Use pi's standard settings locations for non-secret configuration:
+
+- project: `.pi/settings.json`
+- global: `~/.pi/agent/settings.json`
+
+Under the `pi-ref-tools` key:
 
 ```json
 {
-  "url": "https://api.ref.tools/mcp",
-  "apiKey": "your_key",
-  "timeoutMs": 30000,
-  "protocolVersion": "2025-06-18",
-  "maxBytes": 51200,
-  "maxLines": 2000
+  "pi-ref-tools": {
+    "url": "https://api.ref.tools/mcp",
+    "timeoutMs": 30000,
+    "protocolVersion": "2025-06-18",
+    "maxBytes": 51200,
+    "maxLines": 2000
+  }
 }
 ```
+
+> Best practice: keep `REF_API_KEY` in an environment variable, not in `settings.json`.
+> If you need a persisted private file, use `--ref-mcp-config` or `REF_MCP_CONFIG` to point to a custom JSON config outside your project.
 
 ### Option 3: CLI Flags
 
@@ -57,8 +66,10 @@ pi --ref-mcp-api-key=your_key
 
 1. `--ref-mcp-config` flag path
 2. `REF_MCP_CONFIG` environment variable
-3. `./.pi/extensions/ref-tools.json` (project-level)
-4. `~/.pi/agent/extensions/ref-tools.json` (global)
+3. `.pi/settings.json` under `pi-ref-tools` (project-level)
+4. `~/.pi/agent/settings.json` under `pi-ref-tools` (global)
+5. legacy `.pi/extensions/ref-tools.json` (project-level fallback)
+6. legacy `~/.pi/agent/extensions/ref-tools.json` (global fallback)
 
 ## Tools
 

--- a/packages/pi-ref-tools/README.md
+++ b/packages/pi-ref-tools/README.md
@@ -53,8 +53,8 @@ Under the `pi-ref-tools` key:
 }
 ```
 
-> Best practice: keep `REF_API_KEY` in an environment variable, not in `settings.json`.
-> If you need a persisted private file, use `--ref-mcp-config` or `REF_MCP_CONFIG` to point to a custom JSON config outside your project.
+> Best practice: use `settings.json` for non-secret defaults only.
+> Keep `REF_API_KEY` in an environment variable, or use `--ref-mcp-config` / `REF_MCP_CONFIG` to point to a custom private JSON config file when you need to persist secrets outside your project.
 
 ### Option 3: CLI Flags
 

--- a/packages/pi-ref-tools/README.md
+++ b/packages/pi-ref-tools/README.md
@@ -54,7 +54,8 @@ Under the `pi-ref-tools` key:
 ```
 
 > Best practice: use `settings.json` for non-secret defaults only.
-> Keep `REF_API_KEY` in an environment variable, or use `--ref-mcp-config` / `REF_MCP_CONFIG` to point to a custom private JSON config file when you need to persist secrets outside your project.
+> Keep `REF_API_KEY` in an environment variable, or use `--ref-mcp-config-file` / `REF_MCP_CONFIG_FILE` to point to a custom private JSON config file when you need to persist secrets outside your project.
+> Legacy aliases `--ref-mcp-config` and `REF_MCP_CONFIG` are still accepted but deprecated.
 
 ### Option 3: CLI Flags
 
@@ -64,8 +65,10 @@ pi --ref-mcp-api-key=your_key
 
 ### Config Resolution Order
 
-1. `--ref-mcp-config` flag path
-2. `REF_MCP_CONFIG` environment variable
+1. `--ref-mcp-config-file` flag path
+2. `REF_MCP_CONFIG_FILE` environment variable
+3. legacy `--ref-mcp-config` flag path (deprecated)
+4. legacy `REF_MCP_CONFIG` environment variable (deprecated)
 3. `.pi/settings.json` under `pi-ref-tools` (project-level)
 4. `~/.pi/agent/settings.json` under `pi-ref-tools` (global)
 
@@ -99,7 +102,8 @@ Read a documentation URL and return optimized markdown. Pass the exact URL from 
 | `--ref-mcp-api-key` | `REF_API_KEY` | — | API key (sent as `x-ref-api-key` header) |
 | `--ref-mcp-timeout-ms` | `REF_MCP_TIMEOUT_MS` | `30000` | HTTP timeout in ms |
 | `--ref-mcp-protocol` | `REF_MCP_PROTOCOL_VERSION` | `2025-06-18` | MCP protocol version |
-| `--ref-mcp-config` | `REF_MCP_CONFIG` | — | Custom config file path |
+| `--ref-mcp-config-file` | `REF_MCP_CONFIG_FILE` | — | Custom config file path |
+| `--ref-mcp-config` | `REF_MCP_CONFIG` | — | Deprecated alias for the config file path |
 | `--ref-mcp-max-bytes` | `REF_MCP_MAX_BYTES` | `51200` | Max output bytes |
 | `--ref-mcp-max-lines` | `REF_MCP_MAX_LINES` | `2000` | Max output lines |
 

--- a/packages/pi-ref-tools/README.md
+++ b/packages/pi-ref-tools/README.md
@@ -68,8 +68,6 @@ pi --ref-mcp-api-key=your_key
 2. `REF_MCP_CONFIG` environment variable
 3. `.pi/settings.json` under `pi-ref-tools` (project-level)
 4. `~/.pi/agent/settings.json` under `pi-ref-tools` (global)
-5. legacy `.pi/extensions/ref-tools.json` (project-level fallback)
-6. legacy `~/.pi/agent/extensions/ref-tools.json` (global fallback)
 
 ## Tools
 

--- a/packages/pi-ref-tools/__tests__/helpers.test.ts
+++ b/packages/pi-ref-tools/__tests__/helpers.test.ts
@@ -116,6 +116,36 @@ describe("pi-ref-tools helpers", () => {
       else delete process.env.HOME;
     }
   });
+
+  it("warns when a legacy config file exists but is ignored", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-ref-legacy-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-ref-legacy-project-"));
+
+    mkdirSync(join(tempHome, ".pi", "agent", "extensions"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "extensions", "ref-tools.json"),
+      JSON.stringify({ apiKey: "legacy-key" }),
+      "utf-8",
+    );
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadRuntimeConfig({ getFlag: () => undefined } as never)).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Ignoring legacy config file"));
+    } finally {
+      warnSpy.mockRestore();
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
+  });
 });
 
 describe("pi-ref-tools type guards", () => {

--- a/packages/pi-ref-tools/__tests__/helpers.test.ts
+++ b/packages/pi-ref-tools/__tests__/helpers.test.ts
@@ -1,10 +1,9 @@
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_CONFIG_FILE,
-  ensureDefaultConfigFile,
   formatToolOutput,
   isJsonRpcResponse,
   isRecord,
@@ -72,32 +71,50 @@ describe("pi-ref-tools helpers", () => {
     expect(redactApiKey("abcdefghijklmnop")).toBe("abcd...mnop");
   });
 
-  it("writes default config when none exists", () => {
-    const base = mkdtempSync(join(tmpdir(), "pi-ref-config-"));
-    const projectConfigPath = join(base, "project", ".pi", "extensions", "ref-tools.json");
-    const globalConfigPath = join(base, "global", "extensions", "ref-tools.json");
-
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-
-    expect(existsSync(globalConfigPath)).toBe(true);
-    const raw = readFileSync(globalConfigPath, "utf-8");
-    expect(JSON.parse(raw)).toEqual(DEFAULT_CONFIG_FILE);
+  it("keeps DEFAULT_CONFIG_FILE available for reference", () => {
+    expect(DEFAULT_CONFIG_FILE).toMatchObject({
+      url: "https://api.ref.tools/mcp",
+      maxBytes: 51200,
+      maxLines: 2000,
+    });
   });
 
-  it("does not overwrite existing config", () => {
-    const base = mkdtempSync(join(tmpdir(), "pi-ref-config-exists-"));
-    const projectConfigPath = join(base, "project", ".pi", "extensions", "ref-tools.json");
-    const globalConfigPath = join(base, "global", "extensions", "ref-tools.json");
+  it("loads config from standard pi settings files", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-ref-settings-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-ref-settings-project-"));
 
-    // First call creates the file
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    const firstContent = readFileSync(globalConfigPath, "utf-8");
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    mkdirSync(join(tempProject, ".pi"), { recursive: true });
 
-    // Second call should not overwrite
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    const secondContent = readFileSync(globalConfigPath, "utf-8");
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({ "pi-ref-tools": { timeoutMs: 1234 } }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(tempProject, ".pi", "settings.json"),
+      JSON.stringify({ "pi-ref-tools": { url: "https://project.example/mcp", maxLines: 99 } }),
+      "utf-8",
+    );
 
-    expect(firstContent).toBe(secondContent);
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+
+    try {
+      const mod = await import("../extensions/index.js");
+      const config = mod.loadRuntimeConfig({ getFlag: () => undefined } as never);
+      expect(config?.apiKey).toBeUndefined();
+      expect(config?.timeoutMs).toBe(1234);
+      expect(config?.url).toBe("https://project.example/mcp");
+      expect(config?.maxLines).toBe(99);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
   });
 });
 

--- a/packages/pi-ref-tools/__tests__/index.test.ts
+++ b/packages/pi-ref-tools/__tests__/index.test.ts
@@ -30,6 +30,7 @@ describe("pi-ref-tools", () => {
         "--ref-mcp-api-key",
         "--ref-mcp-timeout-ms",
         "--ref-mcp-protocol",
+        "--ref-mcp-config-file",
         "--ref-mcp-config",
         "--ref-mcp-max-bytes",
         "--ref-mcp-max-lines",
@@ -45,12 +46,12 @@ describe("pi-ref-tools", () => {
     expect(toolNames).toHaveLength(2);
   });
 
-  it("registers exactly 7 flags", () => {
+  it("registers exactly 8 flags", () => {
     const mockPi = createMockPi();
     refTools(mockPi as unknown as ExtensionAPI);
 
     const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-    expect(flagNames).toHaveLength(7);
+    expect(flagNames).toHaveLength(8);
   });
 
   it("registers tool with correct parameters schema", () => {
@@ -124,6 +125,7 @@ describe("pi-ref-tools", () => {
     expect(flagNames).toContain("--ref-mcp-api-key");
     expect(flagNames).toContain("--ref-mcp-timeout-ms");
     expect(flagNames).toContain("--ref-mcp-protocol");
+    expect(flagNames).toContain("--ref-mcp-config-file");
     expect(flagNames).toContain("--ref-mcp-config");
     expect(flagNames).toContain("--ref-mcp-max-bytes");
     expect(flagNames).toContain("--ref-mcp-max-lines");
@@ -136,7 +138,7 @@ describe("pi-ref-tools", () => {
         getFlagCalls.push(name);
       }),
       getFlag: vi.fn((flag: string) => {
-        if (flag === "--ref-mcp-config") return "/path/to/config.json";
+        if (flag === "--ref-mcp-config-file") return "/path/to/config.json";
         return undefined;
       }),
       registerTool: vi.fn(),
@@ -145,7 +147,7 @@ describe("pi-ref-tools", () => {
 
     refTools(mockPi as unknown as ExtensionAPI);
 
-    expect(getFlagCalls).toContain("--ref-mcp-config");
+    expect(getFlagCalls).toContain("--ref-mcp-config-file");
   });
 
   it("registers tools with unique execute functions", () => {

--- a/packages/pi-ref-tools/__tests__/runtime.test.ts
+++ b/packages/pi-ref-tools/__tests__/runtime.test.ts
@@ -47,7 +47,7 @@ describe("pi-ref-tools runtime", () => {
     const configPath = join(base, "ref-tools.json");
     writeFileSync(configPath, JSON.stringify({ url: "https://docs.example.test/mcp", apiKey: "config-key" }), "utf-8");
 
-    const mockPi = createMockPi({ "--ref-mcp-config": configPath });
+    const mockPi = createMockPi({ "--ref-mcp-config-file": configPath });
     refTools(mockPi as unknown as ExtensionAPI);
 
     const sessionStart = getEventHandler(mockPi, "session_start");

--- a/packages/pi-ref-tools/extensions/index.ts
+++ b/packages/pi-ref-tools/extensions/index.ts
@@ -350,11 +350,9 @@ function loadConfig(configPath: string | undefined): RefMcpConfig | null {
 
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
-  const legacyGlobalConfigPath = join(getHomeDir(), ".pi", "agent", "extensions", "ref-tools.json");
-  const legacyProjectConfigPath = join(process.cwd(), ".pi", "extensions", "ref-tools.json");
 
-  const globalConfig = loadSettingsConfig(globalSettingsPath) ?? loadConfigFile(legacyGlobalConfigPath);
-  const projectConfig = loadSettingsConfig(projectSettingsPath) ?? loadConfigFile(legacyProjectConfigPath);
+  const globalConfig = loadSettingsConfig(globalSettingsPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath);
 
   if (!globalConfig && !projectConfig) {
     return null;

--- a/packages/pi-ref-tools/extensions/index.ts
+++ b/packages/pi-ref-tools/extensions/index.ts
@@ -8,7 +8,7 @@
  * 1. Install: pi install npm:@feniix/pi-ref-tools
  * 2. Optional config:
  *    - Settings file: ~/.pi/agent/settings.json or .pi/settings.json under the pi-ref-tools key
- *      (or set REF_MCP_CONFIG / --ref-mcp-config for a custom JSON config path)
+ *      (or set REF_MCP_CONFIG_FILE / --ref-mcp-config-file for a custom JSON config path)
  *      Keys: url, apiKey, timeoutMs, protocolVersion, maxBytes, maxLines
  *    - REF_MCP_URL (default: https://api.ref.tools/mcp)
  *    - REF_API_KEY (API key, sent as x-ref-api-key header)
@@ -18,7 +18,7 @@
  *    - REF_MCP_MAX_LINES (default: 2000)
  * 3. Or pass flags:
  *    --ref-mcp-url, --ref-mcp-api-key, --ref-mcp-timeout-ms,
- *    --ref-mcp-protocol, --ref-mcp-config, --ref-mcp-max-bytes, --ref-mcp-max-lines
+ *    --ref-mcp-protocol, --ref-mcp-config-file, --ref-mcp-max-bytes, --ref-mcp-max-lines
  *
  * Usage:
  *   "Search the docs for React Server Components"
@@ -339,14 +339,36 @@ function loadSettingsConfig(path: string): RefMcpConfig | null {
   }
 }
 
+function warnIgnoredLegacyConfigFiles(): void {
+  const legacyPaths = [
+    join(process.cwd(), ".pi", "extensions", "ref-tools.json"),
+    join(getHomeDir(), ".pi", "agent", "extensions", "ref-tools.json"),
+  ];
+
+  for (const legacyPath of legacyPaths) {
+    if (existsSync(legacyPath)) {
+      console.warn(
+        `[pi-ref-tools] Ignoring legacy config file ${legacyPath}. Migrate non-secret settings to .pi/settings.json or ~/.pi/agent/settings.json under "pi-ref-tools". Keep secrets in REF_API_KEY or an explicit custom config via --ref-mcp-config-file / REF_MCP_CONFIG_FILE.`,
+      );
+    }
+  }
+}
+
 function loadConfig(configPath: string | undefined): RefMcpConfig | null {
-  const envConfig = process.env.REF_MCP_CONFIG;
+  const envConfigFile = process.env.REF_MCP_CONFIG_FILE;
+  const legacyEnvConfig = process.env.REF_MCP_CONFIG;
   if (configPath) {
     return loadConfigFile(resolveConfigPath(configPath));
   }
-  if (envConfig) {
-    return loadConfigFile(resolveConfigPath(envConfig));
+  if (envConfigFile) {
+    return loadConfigFile(resolveConfigPath(envConfigFile));
   }
+  if (legacyEnvConfig) {
+    console.warn("[pi-ref-tools] REF_MCP_CONFIG is deprecated; use REF_MCP_CONFIG_FILE.");
+    return loadConfigFile(resolveConfigPath(legacyEnvConfig));
+  }
+
+  warnIgnoredLegacyConfigFiles();
 
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
@@ -715,8 +737,18 @@ const readUrlParams = Type.Object(
 // =============================================================================
 
 function getConfigOverride(pi: ExtensionAPI): string | undefined {
-  const configFlag = pi.getFlag("--ref-mcp-config");
-  return typeof configFlag === "string" ? configFlag : undefined;
+  const configFileFlag = pi.getFlag("--ref-mcp-config-file");
+  if (typeof configFileFlag === "string") {
+    return configFileFlag;
+  }
+
+  const legacyConfigFlag = pi.getFlag("--ref-mcp-config");
+  if (typeof legacyConfigFlag === "string") {
+    console.warn("[pi-ref-tools] --ref-mcp-config is deprecated; use --ref-mcp-config-file.");
+    return legacyConfigFlag;
+  }
+
+  return undefined;
 }
 
 type ApiKeySource = "CLI flag" | "REF_API_KEY env var" | "config file";
@@ -836,8 +868,12 @@ export default function refTools(pi: ExtensionAPI) {
     description: "MCP protocol version for initialize() (default: 2025-06-18).",
     type: "string",
   });
-  pi.registerFlag("--ref-mcp-config", {
+  pi.registerFlag("--ref-mcp-config-file", {
     description: "Path to custom JSON config file for private overrides such as API keys.",
+    type: "string",
+  });
+  pi.registerFlag("--ref-mcp-config", {
+    description: "Deprecated alias for --ref-mcp-config-file.",
     type: "string",
   });
   pi.registerFlag("--ref-mcp-max-bytes", {

--- a/packages/pi-ref-tools/extensions/index.ts
+++ b/packages/pi-ref-tools/extensions/index.ts
@@ -7,8 +7,8 @@
  * Setup:
  * 1. Install: pi install npm:@feniix/pi-ref-tools
  * 2. Optional config:
- *    - JSON config: ~/.pi/agent/extensions/ref-tools.json or .pi/extensions/ref-tools.json
- *      (or set REF_MCP_CONFIG / --ref-mcp-config for a custom path)
+ *    - Settings file: ~/.pi/agent/settings.json or .pi/settings.json under the pi-ref-tools key
+ *      (or set REF_MCP_CONFIG / --ref-mcp-config for a custom JSON config path)
  *      Keys: url, apiKey, timeoutMs, protocolVersion, maxBytes, maxLines
  *    - REF_MCP_URL (default: https://api.ref.tools/mcp)
  *    - REF_API_KEY (API key, sent as x-ref-api-key header)
@@ -29,9 +29,9 @@
  *   - ref_read_url: Fetch and read a documentation URL as optimized markdown
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
@@ -110,6 +110,10 @@ interface RefMcpConfig {
   protocolVersion?: string;
   maxBytes?: number;
   maxLines?: number;
+}
+
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
 }
 
 // =============================================================================
@@ -267,10 +271,10 @@ function resolveEffectiveLimits(
 function resolveConfigPath(configPath: string): string {
   const trimmed = configPath.trim();
   if (trimmed.startsWith("~/")) {
-    return join(homedir(), trimmed.slice(2));
+    return join(getHomeDir(), trimmed.slice(2));
   }
   if (trimmed.startsWith("~")) {
-    return join(homedir(), trimmed.slice(1));
+    return join(getHomeDir(), trimmed.slice(1));
   }
   if (isAbsolute(trimmed)) {
     return trimmed;
@@ -292,48 +296,78 @@ function parseConfig(raw: unknown, pathHint: string): RefMcpConfig {
   };
 }
 
-function loadConfig(configPath: string | undefined): RefMcpConfig | null {
-  const candidates: string[] = [];
-  const envConfig = process.env.REF_MCP_CONFIG;
-  if (configPath) {
-    candidates.push(resolveConfigPath(configPath));
-  } else if (envConfig) {
-    candidates.push(resolveConfigPath(envConfig));
-  } else {
-    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "ref-tools.json");
-    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "ref-tools.json");
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    candidates.push(projectConfigPath, globalConfigPath);
+function loadConfigFile(path: string): RefMcpConfig | null {
+  if (!existsSync(path)) {
+    return null;
   }
 
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) {
-      continue;
-    }
-    try {
-      const raw = readFileSync(candidate, "utf-8");
-      const parsed = JSON.parse(raw);
-      return parseConfig(parsed, candidate);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[pi-ref-tools] Failed to parse config ${candidate}: ${message}`);
-    }
-  }
-
-  return null;
-}
-
-function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-    return;
-  }
   try {
-    mkdirSync(dirname(globalConfigPath), { recursive: true });
-    writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parseConfig(parsed, path);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-ref-tools] Failed to write ${globalConfigPath}: ${message}`);
+    console.warn(`[pi-ref-tools] Failed to parse config ${path}: ${message}`);
+    return null;
   }
+}
+
+function loadSettingsConfig(path: string): RefMcpConfig | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const config = parsed["pi-ref-tools"];
+    if (!isRecord(config)) {
+      return null;
+    }
+    const parsedConfig = parseConfig(config, path);
+    return {
+      url: parsedConfig.url,
+      timeoutMs: parsedConfig.timeoutMs,
+      protocolVersion: parsedConfig.protocolVersion,
+      maxBytes: parsedConfig.maxBytes,
+      maxLines: parsedConfig.maxLines,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-ref-tools] Failed to parse settings ${path}: ${message}`);
+    return null;
+  }
+}
+
+function loadConfig(configPath: string | undefined): RefMcpConfig | null {
+  const envConfig = process.env.REF_MCP_CONFIG;
+  if (configPath) {
+    return loadConfigFile(resolveConfigPath(configPath));
+  }
+  if (envConfig) {
+    return loadConfigFile(resolveConfigPath(envConfig));
+  }
+
+  const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
+  const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
+  const legacyGlobalConfigPath = join(getHomeDir(), ".pi", "agent", "extensions", "ref-tools.json");
+  const legacyProjectConfigPath = join(process.cwd(), ".pi", "extensions", "ref-tools.json");
+
+  const globalConfig = loadSettingsConfig(globalSettingsPath) ?? loadConfigFile(legacyGlobalConfigPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath) ?? loadConfigFile(legacyProjectConfigPath);
+
+  if (!globalConfig && !projectConfig) {
+    return null;
+  }
+
+  return {
+    url: projectConfig?.url ?? globalConfig?.url,
+    apiKey: projectConfig?.apiKey ?? globalConfig?.apiKey,
+    timeoutMs: projectConfig?.timeoutMs ?? globalConfig?.timeoutMs,
+    protocolVersion: projectConfig?.protocolVersion ?? globalConfig?.protocolVersion,
+    maxBytes: projectConfig?.maxBytes ?? globalConfig?.maxBytes,
+    maxLines: projectConfig?.maxLines ?? globalConfig?.maxLines,
+  };
 }
 
 function redactApiKey(apiKey: string | undefined): string {
@@ -760,7 +794,6 @@ function formatSessionStartMessage(settings: RefRuntimeSettings): string {
 
 export {
   DEFAULT_CONFIG_FILE,
-  ensureDefaultConfigFile,
   extractMatchingSseResponse,
   extractSseData,
   formatSessionStartMessage,
@@ -806,7 +839,7 @@ export default function refTools(pi: ExtensionAPI) {
     type: "string",
   });
   pi.registerFlag("--ref-mcp-config", {
-    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/ref-tools.json).",
+    description: "Path to custom JSON config file for private overrides such as API keys.",
     type: "string",
   });
   pi.registerFlag("--ref-mcp-max-bytes", {

--- a/packages/pi-ref-tools/package.json
+++ b/packages/pi-ref-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-ref-tools",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Ref.tools MCP extension for pi — documentation search and URL reading via Ref's Model Context Protocol",
   "keywords": [
     "pi",

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -10,7 +10,7 @@
 - **Export Session** (`export_session`): Save thinking sessions to JSON files
 - **Import Session** (`import_session`): Load previously exported sessions
 - **Configurable Output Limits**: Client-side byte and line truncation
-- **Flexible Configuration**: JSON config files, environment variables, and CLI flags
+- **Flexible Configuration**: settings.json, custom JSON config files, environment variables, and CLI flags
 - **Native TypeScript**: No external dependencies or child processes
 
 ## Install
@@ -39,15 +39,22 @@ export SEQ_THINK_MAX_BYTES=102400
 export SEQ_THINK_MAX_LINES=5000
 ```
 
-### Option 3: JSON Config File
+### Option 3: Settings File
 
-Create `~/.pi/agent/extensions/sequential-thinking.json` (auto-created on first run):
+Use pi's standard settings locations:
+
+- project: `.pi/settings.json`
+- global: `~/.pi/agent/settings.json`
+
+Under the `pi-sequential-thinking` key:
 
 ```json
 {
-  "storageDir": null,
-  "maxBytes": 51200,
-  "maxLines": 2000
+  "pi-sequential-thinking": {
+    "storageDir": null,
+    "maxBytes": 51200,
+    "maxLines": 2000
+  }
 }
 ```
 
@@ -61,8 +68,8 @@ pi --seq-think-storage-dir=/tmp/thoughts --seq-think-max-bytes=102400
 
 1. `--seq-think-config` flag path
 2. `SEQ_THINK_CONFIG` environment variable
-3. `./.pi/extensions/sequential-thinking.json` (project-level)
-4. `~/.pi/agent/extensions/sequential-thinking.json` (global)
+3. `.pi/settings.json` under `pi-sequential-thinking` (project-level)
+4. `~/.pi/agent/settings.json` under `pi-sequential-thinking` (global)
 
 ## Tools
 
@@ -110,7 +117,7 @@ Import a previously exported thinking session from a JSON file.
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
 | `--seq-think-storage-dir` | `MCP_STORAGE_DIR` | — | Storage directory for sessions |
-| `--seq-think-config` | `SEQ_THINK_CONFIG` | — | Custom config file path |
+| `--seq-think-config` | `SEQ_THINK_CONFIG` | — | Custom JSON config file path (overrides settings.json lookup) |
 | `--seq-think-max-bytes` | `SEQ_THINK_MAX_BYTES` | `51200` | Max output bytes |
 | `--seq-think-max-lines` | `SEQ_THINK_MAX_LINES` | `2000` | Max output lines |
 

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -59,7 +59,8 @@ Under the `pi-sequential-thinking` key:
 ```
 
 > Best practice: use `settings.json` for non-secret defaults only.
-> If you want a separate private override file, use `--seq-think-config` or `SEQ_THINK_CONFIG` to point to a custom JSON config file.
+> If you want a separate private override file, use `--seq-think-config-file` or `SEQ_THINK_CONFIG_FILE` to point to a custom JSON config file.
+> Legacy aliases `--seq-think-config` and `SEQ_THINK_CONFIG` are still accepted but deprecated.
 
 ### Option 4: CLI Flags
 
@@ -69,8 +70,10 @@ pi --seq-think-storage-dir=/tmp/thoughts --seq-think-max-bytes=102400
 
 ### Config Resolution Order
 
-1. `--seq-think-config` flag path
-2. `SEQ_THINK_CONFIG` environment variable
+1. `--seq-think-config-file` flag path
+2. `SEQ_THINK_CONFIG_FILE` environment variable
+3. legacy `--seq-think-config` flag path (deprecated)
+4. legacy `SEQ_THINK_CONFIG` environment variable (deprecated)
 3. `.pi/settings.json` under `pi-sequential-thinking` (project-level)
 4. `~/.pi/agent/settings.json` under `pi-sequential-thinking` (global)
 
@@ -120,7 +123,8 @@ Import a previously exported thinking session from a JSON file.
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
 | `--seq-think-storage-dir` | `MCP_STORAGE_DIR` | — | Storage directory for sessions |
-| `--seq-think-config` | `SEQ_THINK_CONFIG` | — | Custom JSON config file path (overrides settings.json lookup) |
+| `--seq-think-config-file` | `SEQ_THINK_CONFIG_FILE` | — | Custom JSON config file path (overrides settings.json lookup) |
+| `--seq-think-config` | `SEQ_THINK_CONFIG` | — | Deprecated alias for the config file path |
 | `--seq-think-max-bytes` | `SEQ_THINK_MAX_BYTES` | `51200` | Max output bytes |
 | `--seq-think-max-lines` | `SEQ_THINK_MAX_LINES` | `2000` | Max output lines |
 

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -58,6 +58,9 @@ Under the `pi-sequential-thinking` key:
 }
 ```
 
+> Best practice: use `settings.json` for non-secret defaults only.
+> If you want a separate private override file, use `--seq-think-config` or `SEQ_THINK_CONFIG` to point to a custom JSON config file.
+
 ### Option 4: CLI Flags
 
 ```bash

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -1,12 +1,12 @@
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_CONFIG_FILE,
-  ensureDefaultConfigFile,
   formatToolOutput,
   isRecord,
+  loadConfig,
   normalizeNumber,
   normalizeString,
   parseConfig,
@@ -55,30 +55,53 @@ describe("pi-sequential-thinking helpers", () => {
     expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
   });
 
-  it("writes default config when none exists", () => {
-    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-config-"));
-    const projectConfigPath = join(base, "project", ".pi", "extensions", "sequential-thinking.json");
-    const globalConfigPath = join(base, "global", "extensions", "sequential-thinking.json");
-
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-
-    expect(existsSync(globalConfigPath)).toBe(true);
-    const raw = readFileSync(globalConfigPath, "utf-8");
-    expect(JSON.parse(raw)).toEqual(DEFAULT_CONFIG_FILE);
+  it("keeps DEFAULT_CONFIG_FILE available for reference", () => {
+    expect(DEFAULT_CONFIG_FILE).toMatchObject({
+      storageDir: null,
+      maxBytes: 51200,
+      maxLines: 2000,
+    });
   });
 
-  it("does not overwrite existing config", () => {
-    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-config-exists-"));
-    const projectConfigPath = join(base, "project", ".pi", "extensions", "sequential-thinking.json");
-    const globalConfigPath = join(base, "global", "extensions", "sequential-thinking.json");
+  it("loads config from standard pi settings files", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-seq-think-settings-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-seq-think-settings-project-"));
 
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    const firstContent = readFileSync(globalConfigPath, "utf-8");
+    const globalSettingsDir = join(tempHome, ".pi", "agent");
+    const projectSettingsDir = join(tempProject, ".pi");
 
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    const secondContent = readFileSync(globalConfigPath, "utf-8");
+    mkdirSync(globalSettingsDir, { recursive: true });
+    mkdirSync(projectSettingsDir, { recursive: true });
 
-    expect(firstContent).toBe(secondContent);
+    writeFileSync(
+      join(globalSettingsDir, "settings.json"),
+      JSON.stringify({ "pi-sequential-thinking": { maxBytes: 111 } }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(projectSettingsDir, "settings.json"),
+      JSON.stringify({ "pi-sequential-thinking": { storageDir: "/tmp/thoughts", maxLines: 22 } }),
+      "utf-8",
+    );
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadConfig(undefined)).toEqual({
+        storageDir: "/tmp/thoughts",
+        maxBytes: 111,
+        maxLines: 22,
+      });
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
   });
 });
 
@@ -153,6 +176,30 @@ describe("pi-sequential-thinking resolveConfigPath", () => {
   it("resolves relative paths from cwd", () => {
     const result = resolveConfigPath("relative/path.json");
     expect(result).toBe(resolve(process.cwd(), "relative/path.json"));
+  });
+});
+
+describe("pi-sequential-thinking loadConfig", () => {
+  it("returns null when no config exists", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-load-"));
+    const configPath = join(base, "nonexistent.json");
+    expect(loadConfig(configPath)).toBeNull();
+  });
+
+  it("loads valid config file", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-load-valid-"));
+    const configPath = join(base, "seq-think.json");
+    writeFileSync(configPath, JSON.stringify({ storageDir: "/custom", maxBytes: 123 }), "utf-8");
+
+    expect(loadConfig(configPath)).toEqual({ storageDir: "/custom", maxBytes: 123, maxLines: undefined });
+  });
+
+  it("returns null on invalid JSON", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-seq-think-load-invalid-"));
+    const configPath = join(base, "invalid.json");
+    writeFileSync(configPath, "not valid json", "utf-8");
+
+    expect(loadConfig(configPath)).toBeNull();
   });
 });
 

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -103,6 +103,36 @@ describe("pi-sequential-thinking helpers", () => {
       else delete process.env.HOME;
     }
   });
+
+  it("warns when a legacy config file exists but is ignored", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-seq-think-legacy-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-seq-think-legacy-project-"));
+
+    mkdirSync(join(tempHome, ".pi", "agent", "extensions"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "extensions", "sequential-thinking.json"),
+      JSON.stringify({ maxBytes: 111 }),
+      "utf-8",
+    );
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadConfig(undefined)).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Ignoring legacy config file"));
+    } finally {
+      warnSpy.mockRestore();
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
+  });
 });
 
 describe("pi-sequential-thinking type guards", () => {

--- a/packages/pi-sequential-thinking/__tests__/index.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/index.test.ts
@@ -35,6 +35,7 @@ describe("pi-sequential-thinking", () => {
     expect(flagNames).toEqual(
       expect.arrayContaining([
         "--seq-think-storage-dir",
+        "--seq-think-config-file",
         "--seq-think-config",
         "--seq-think-max-bytes",
         "--seq-think-max-lines",

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -7,7 +7,7 @@
  * Setup:
  * 1. Install: pi install npm:@feniix/pi-sequential-thinking
  * 2. Optional config:
- *    - JSON config: ~/.pi/agent/extensions/sequential-thinking.json or .pi/extensions/sequential-thinking.json
+ *    - Settings file: ~/.pi/agent/settings.json or .pi/settings.json under the pi-sequential-thinking key
  *      (or set SEQ_THINK_CONFIG / --seq-think-config for a custom path)
  *      Keys: storageDir, maxBytes, maxLines
  *    - MCP_STORAGE_DIR (storage directory for thought sessions)
@@ -29,9 +29,9 @@
  *   - import_session: Import a previously exported thinking session
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { AgentToolUpdateCallback, ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
@@ -48,6 +48,10 @@ const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
   maxBytes: DEFAULT_MAX_BYTES,
   maxLines: DEFAULT_MAX_LINES,
 };
+
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
 
 // =============================================================================
 // Types
@@ -208,42 +212,64 @@ function parseConfig(raw: unknown, pathHint: string): SeqThinkConfig {
   };
 }
 
-function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
-  const candidates: string[] = [];
-  const envConfig = process.env.SEQ_THINK_CONFIG;
-  if (configPath) {
-    candidates.push(resolveConfigPath(configPath));
-  } else if (envConfig) {
-    candidates.push(resolveConfigPath(envConfig));
-  } else {
-    const projectConfigPath = join(process.cwd(), ".pi", "extensions", "sequential-thinking.json");
-    const globalConfigPath = join(homedir(), ".pi", "agent", "extensions", "sequential-thinking.json");
-    ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
-    candidates.push(projectConfigPath, globalConfigPath);
+function loadSettingsConfig(path: string): SeqThinkConfig | null {
+  if (!existsSync(path)) {
+    return null;
   }
 
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) {
-      continue;
-    }
-    const raw = readFileSync(candidate, "utf-8");
-    const parsed = JSON.parse(raw);
-    return parseConfig(parsed, candidate);
-  }
-
-  return null;
-}
-
-function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
-  if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
-    return;
-  }
   try {
-    mkdirSync(dirname(globalConfigPath), { recursive: true });
-    writeFileSync(globalConfigPath, `${JSON.stringify(DEFAULT_CONFIG_FILE, null, 2)}\n`, "utf-8");
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    const config = parsed["pi-sequential-thinking"];
+    if (!isRecord(config)) {
+      return null;
+    }
+    return parseConfig(config, path);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-sequential-thinking] Failed to write ${globalConfigPath}: ${message}`);
+    console.warn(`[pi-sequential-thinking] Failed to parse settings ${path}: ${message}`);
+    return null;
+  }
+}
+
+function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
+  const envConfig = process.env.SEQ_THINK_CONFIG;
+  if (configPath) {
+    return loadConfigFile(resolveConfigPath(configPath));
+  }
+  if (envConfig) {
+    return loadConfigFile(resolveConfigPath(envConfig));
+  }
+
+  const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
+  const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
+
+  const globalConfig = loadSettingsConfig(globalSettingsPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath);
+
+  if (!globalConfig && !projectConfig) {
+    return null;
+  }
+
+  return {
+    storageDir: projectConfig?.storageDir ?? globalConfig?.storageDir,
+    maxBytes: projectConfig?.maxBytes ?? globalConfig?.maxBytes,
+    maxLines: projectConfig?.maxLines ?? globalConfig?.maxLines,
+  };
+}
+
+function loadConfigFile(path: string): SeqThinkConfig | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parseConfig(parsed, path);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-sequential-thinking] Failed to parse config ${path}: ${message}`);
+    return null;
   }
 }
 
@@ -349,7 +375,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     type: "string",
   });
   pi.registerFlag("--seq-think-config", {
-    description: "Path to JSON config file (defaults to ~/.pi/agent/extensions/sequential-thinking.json).",
+    description: "Path to custom JSON config file (overrides settings.json lookup).",
     type: "string",
   });
   pi.registerFlag("--seq-think-max-bytes", {
@@ -692,9 +718,9 @@ export default function sequentialThinking(pi: ExtensionAPI) {
 // Export utilities for testing
 export {
   DEFAULT_CONFIG_FILE,
-  ensureDefaultConfigFile,
   formatToolOutput,
   isRecord,
+  loadConfig,
   normalizeNumber,
   normalizeString,
   parseConfig,

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -8,13 +8,13 @@
  * 1. Install: pi install npm:@feniix/pi-sequential-thinking
  * 2. Optional config:
  *    - Settings file: ~/.pi/agent/settings.json or .pi/settings.json under the pi-sequential-thinking key
- *      (or set SEQ_THINK_CONFIG / --seq-think-config for a custom path)
+ *      (or set SEQ_THINK_CONFIG_FILE / --seq-think-config-file for a custom path)
  *      Keys: storageDir, maxBytes, maxLines
  *    - MCP_STORAGE_DIR (storage directory for thought sessions)
  *    - SEQ_THINK_MAX_BYTES (default: 51200)
  *    - SEQ_THINK_MAX_LINES (default: 2000)
  * 3. Or pass flags:
- *    --seq-think-storage-dir, --seq-think-config, --seq-think-max-bytes, --seq-think-max-lines
+ *    --seq-think-storage-dir, --seq-think-config-file, --seq-think-max-bytes, --seq-think-max-lines
  *
  * Usage:
  *   "Think through this architecture decision step by step"
@@ -231,14 +231,36 @@ function loadSettingsConfig(path: string): SeqThinkConfig | null {
   }
 }
 
+function warnIgnoredLegacyConfigFiles(): void {
+  const legacyPaths = [
+    join(process.cwd(), ".pi", "extensions", "sequential-thinking.json"),
+    join(getHomeDir(), ".pi", "agent", "extensions", "sequential-thinking.json"),
+  ];
+
+  for (const legacyPath of legacyPaths) {
+    if (existsSync(legacyPath)) {
+      console.warn(
+        `[pi-sequential-thinking] Ignoring legacy config file ${legacyPath}. Migrate non-secret settings to .pi/settings.json or ~/.pi/agent/settings.json under "pi-sequential-thinking", or pass --seq-think-config-file / SEQ_THINK_CONFIG_FILE explicitly.`,
+      );
+    }
+  }
+}
+
 function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
-  const envConfig = process.env.SEQ_THINK_CONFIG;
+  const envConfigFile = process.env.SEQ_THINK_CONFIG_FILE;
+  const legacyEnvConfig = process.env.SEQ_THINK_CONFIG;
   if (configPath) {
     return loadConfigFile(resolveConfigPath(configPath));
   }
-  if (envConfig) {
-    return loadConfigFile(resolveConfigPath(envConfig));
+  if (envConfigFile) {
+    return loadConfigFile(resolveConfigPath(envConfigFile));
   }
+  if (legacyEnvConfig) {
+    console.warn("[pi-sequential-thinking] SEQ_THINK_CONFIG is deprecated; use SEQ_THINK_CONFIG_FILE.");
+    return loadConfigFile(resolveConfigPath(legacyEnvConfig));
+  }
+
+  warnIgnoredLegacyConfigFiles();
 
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
@@ -374,8 +396,12 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     description: "Storage directory for thought sessions.",
     type: "string",
   });
-  pi.registerFlag("--seq-think-config", {
+  pi.registerFlag("--seq-think-config-file", {
     description: "Path to custom JSON config file (overrides settings.json lookup).",
+    type: "string",
+  });
+  pi.registerFlag("--seq-think-config", {
+    description: "Deprecated alias for --seq-think-config-file.",
     type: "string",
   });
   pi.registerFlag("--seq-think-max-bytes", {
@@ -393,8 +419,18 @@ export default function sequentialThinking(pi: ExtensionAPI) {
       return resolveConfigPath(storageDirFlag);
     }
 
-    const configFlag = pi.getFlag("--seq-think-config");
-    const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+    const configFileFlag = pi.getFlag("--seq-think-config-file");
+    const legacyConfigFlag = pi.getFlag("--seq-think-config");
+    const configFlag =
+      typeof configFileFlag === "string"
+        ? configFileFlag
+        : typeof legacyConfigFlag === "string"
+          ? legacyConfigFlag
+          : undefined;
+    if (typeof configFileFlag !== "string" && typeof legacyConfigFlag === "string") {
+      console.warn("[pi-sequential-thinking] --seq-think-config is deprecated; use --seq-think-config-file.");
+    }
+    const config = loadConfig(configFlag);
     const envStorageDir = normalizeString(process.env.MCP_STORAGE_DIR);
     if (envStorageDir) {
       return resolveConfigPath(envStorageDir);
@@ -412,8 +448,18 @@ export default function sequentialThinking(pi: ExtensionAPI) {
   const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
     const maxBytesFlag = pi.getFlag("--seq-think-max-bytes");
     const maxLinesFlag = pi.getFlag("--seq-think-max-lines");
-    const configFlag = pi.getFlag("--seq-think-config");
-    const config = loadConfig(typeof configFlag === "string" ? configFlag : undefined);
+    const configFileFlag = pi.getFlag("--seq-think-config-file");
+    const legacyConfigFlag = pi.getFlag("--seq-think-config");
+    const configFlag =
+      typeof configFileFlag === "string"
+        ? configFileFlag
+        : typeof legacyConfigFlag === "string"
+          ? legacyConfigFlag
+          : undefined;
+    if (typeof configFileFlag !== "string" && typeof legacyConfigFlag === "string") {
+      console.warn("[pi-sequential-thinking] --seq-think-config is deprecated; use --seq-think-config-file.");
+    }
+    const config = loadConfig(configFlag);
 
     const maxBytes =
       typeof maxBytesFlag === "string"

--- a/packages/pi-sequential-thinking/package.json
+++ b/packages/pi-sequential-thinking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-sequential-thinking",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Sequential Thinking MCP extension for pi — structured progressive thinking through defined stages",
   "keywords": [
     "pi",

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -79,7 +79,7 @@ Settings locations:
 - global: `~/.pi/agent/settings.json`
 - project: `.pi/settings.json`
 
-Use the `pi-statusline` key:
+Use the `pi-statusline` key for non-secret configuration:
 
 ```json
 {
@@ -91,6 +91,8 @@ Use the `pi-statusline` key:
   }
 }
 ```
+
+`pi-statusline` does not need secrets. As a general pi convention, keep `settings.json` for non-secret defaults; credentials belong in environment variables, OAuth/private auth files, or explicit custom config files used by extensions that support them.
 
 Supported palette keys:
 


### PR DESCRIPTION
## Summary
- standardize `pi-code-reasoning`, `pi-exa`, and `pi-ref-tools` to use standard pi settings locations for non-secret config
- keep secrets out of `settings.json` for `pi-exa`, `pi-ref-tools`, and `pi-notion`, while preserving legacy/private file fallbacks where appropriate
- update READMEs and tests to reflect the new config and secret-handling guidance

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [x] Refactor

## Test plan
- `npx biome check packages/pi-code-reasoning packages/pi-exa packages/pi-notion packages/pi-ref-tools`
- `npx tsc --noEmit --project packages/pi-code-reasoning/tsconfig.json`
- `npx tsc --noEmit --project packages/pi-exa/tsconfig.json`
- `npx tsc --noEmit --project packages/pi-notion/tsconfig.json`
- `npx tsc --noEmit --project packages/pi-ref-tools/tsconfig.json`
- `npx vitest run packages/pi-code-reasoning/__tests__ packages/pi-exa/__tests__ packages/pi-notion/__tests__ packages/pi-ref-tools/__tests__`