### PR TITLE
fix: change notion auth default path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6496,7 +6496,7 @@
     },
     "packages/pi-notion": {
       "name": "@feniix/pi-notion",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.1",

--- a/packages/pi-notion/README.md
+++ b/packages/pi-notion/README.md
@@ -70,12 +70,12 @@ This package requires MCP OAuth (`/notion` or `notion_mcp_connect`) for tool con
 
 Session-start status checks for:
 
-1. MCP OAuth config (`~/.pi/agent/extensions/notion-mcp-auth.json`, or `NOTION_MCP_AUTH_FILE` / `--notion-mcp-auth-file` if explicitly set)
+1. MCP OAuth config (`~/.pi/agent/notion-mcp-auth.json`, or `NOTION_MCP_AUTH_FILE` / `--notion-mcp-auth-file` if explicitly set)
 2. Legacy OAuth token files under `~/.pi/agent/extensions/`
 3. Legacy direct API token hints (`NOTION_API_KEY`, `NOTION_TOKEN`) and warns that MCP OAuth is still required.
 
 Best practice: use `settings.json` for non-secret defaults only.
-Keep Notion credentials in dedicated private files under `~/.pi/agent/extensions/` (for example `notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` or pass `--notion-mcp-auth-file` with a custom file path. Legacy aliases `NOTION_MCP_AUTH` and `--notion-mcp-auth` are still accepted but deprecated.
+Keep Notion credentials in a dedicated private file (by default `~/.pi/agent/notion-mcp-auth.json`) or in environment variables. If you want to move the auth file, set `NOTION_MCP_AUTH_FILE` or pass `--notion-mcp-auth-file` with a custom file path. Legacy aliases `NOTION_MCP_AUTH` and `--notion-mcp-auth` are still accepted but deprecated.
 
 For the legacy direct-token compatibility config path, prefer `NOTION_CONFIG_FILE` / `--notion-config-file`. Legacy aliases `NOTION_CONFIG` and `--notion-config` are still accepted but deprecated.
 

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -358,6 +358,7 @@ describe("pi-notion checkNotionAuth", () => {
     const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-migrate-home-"));
     const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-migrate-project-"));
     const configDir = join(tempHome, ".pi", "agent", "extensions");
+    const agentDir = join(tempHome, ".pi", "agent");
 
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
@@ -375,7 +376,8 @@ describe("pi-notion checkNotionAuth", () => {
       const result = mod.checkNotionAuth();
       expect(result.authenticated).toBe(true);
       expect(existsSync(join(configDir, "notion-mcp.json"))).toBe(false);
-      expect(existsSync(join(configDir, "notion-mcp-auth.json"))).toBe(true);
+      expect(existsSync(join(configDir, "notion-mcp-auth.json"))).toBe(false);
+      expect(existsSync(join(agentDir, "notion-mcp-auth.json"))).toBe(true);
     } finally {
       process.chdir(originalCwd);
       if (originalHome) process.env.HOME = originalHome;

--- a/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
+++ b/packages/pi-notion/__tests__/mcp-client.runtime.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import notionMCPClientExtension, {
@@ -255,6 +255,22 @@ describe("pi-notion mcp client runtime helpers", () => {
     expect(success.content[0]?.text).toBe("done");
   });
 
+  it("uses ~/.pi/agent/notion-mcp-auth.json as the default auth file path", () => {
+    const original = process.env.NOTION_MCP_AUTH_FILE;
+    const originalLegacy = process.env.NOTION_MCP_AUTH;
+    delete process.env.NOTION_MCP_AUTH_FILE;
+    delete process.env.NOTION_MCP_AUTH;
+
+    try {
+      expect(getDefaultAuthFilePath()).toBe(join(homedir(), ".pi", "agent", "notion-mcp-auth.json"));
+    } finally {
+      if (original) process.env.NOTION_MCP_AUTH_FILE = original;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+      if (originalLegacy) process.env.NOTION_MCP_AUTH = originalLegacy;
+      else delete process.env.NOTION_MCP_AUTH;
+    }
+  });
+
   it("resolves auth file path from environment when configured", () => {
     const original = process.env.NOTION_MCP_AUTH_FILE;
     process.env.NOTION_MCP_AUTH_FILE = "~/custom-notion-auth.json";
@@ -283,6 +299,42 @@ describe("pi-notion mcp client runtime helpers", () => {
       else delete process.env.NOTION_MCP_AUTH;
       if (originalFile) process.env.NOTION_MCP_AUTH_FILE = originalFile;
       else delete process.env.NOTION_MCP_AUTH_FILE;
+    }
+  });
+
+  it("migrates the previous default auth file path under extensions", () => {
+    const originalHome = process.env.HOME;
+    const originalFile = process.env.NOTION_MCP_AUTH_FILE;
+    const originalLegacy = process.env.NOTION_MCP_AUTH;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-auth-home-"));
+    const legacyDir = join(tempHome, ".pi", "agent", "extensions");
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, "notion-mcp-auth.json"),
+      JSON.stringify({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" }),
+      "utf-8",
+    );
+    delete process.env.NOTION_MCP_AUTH_FILE;
+    delete process.env.NOTION_MCP_AUTH;
+    process.env.HOME = tempHome;
+
+    try {
+      const nextPath = join(tempHome, ".pi", "agent", "notion-mcp-auth.json");
+      expect(getDefaultAuthFilePath()).toBe(nextPath);
+      expect(existsSync(join(legacyDir, "notion-mcp-auth.json"))).toBe(false);
+      expect(existsSync(nextPath)).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        `[pi-notion] Migrated legacy MCP auth file from ${join(legacyDir, "notion-mcp-auth.json")} to ${nextPath}.`,
+      );
+    } finally {
+      warnSpy.mockRestore();
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (originalFile) process.env.NOTION_MCP_AUTH_FILE = originalFile;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+      if (originalLegacy) process.env.NOTION_MCP_AUTH = originalLegacy;
+      else delete process.env.NOTION_MCP_AUTH;
     }
   });
 

--- a/packages/pi-notion/extensions/index.ts
+++ b/packages/pi-notion/extensions/index.ts
@@ -19,8 +19,12 @@ function getHomeDir(): string {
   return process.env.HOME || homedir();
 }
 
+function getAgentDir(): string {
+  return join(getHomeDir(), ".pi", "agent");
+}
+
 function getConfigDir(): string {
-  return join(getHomeDir(), ".pi", "agent", "extensions");
+  return join(getAgentDir(), "extensions");
 }
 
 function resolveOptionalPath(path: string): string {
@@ -41,6 +45,10 @@ function getLegacyMcpConfigFile(): string {
   return join(getConfigDir(), "notion-mcp.json");
 }
 
+function getLegacyAuthFile(): string {
+  return join(getConfigDir(), "notion-mcp-auth.json");
+}
+
 function migrateLegacyMcpConfigFile(): string {
   const configuredPath = process.env.NOTION_MCP_AUTH_FILE;
   if (typeof configuredPath === "string" && configuredPath.trim().length > 0) {
@@ -53,17 +61,19 @@ function migrateLegacyMcpConfigFile(): string {
     return resolveOptionalPath(legacyConfiguredPath);
   }
 
-  const nextPath = join(getConfigDir(), "notion-mcp-auth.json");
-  const legacyPath = getLegacyMcpConfigFile();
+  const nextPath = join(getAgentDir(), "notion-mcp-auth.json");
+  const legacyPaths = [getLegacyAuthFile(), getLegacyMcpConfigFile()];
 
-  if (!existsSync(nextPath) && existsSync(legacyPath)) {
-    try {
-      mkdirSync(getConfigDir(), { recursive: true });
-      renameSync(legacyPath, nextPath);
-      console.warn(`[pi-notion] Migrated legacy MCP auth file from ${legacyPath} to ${nextPath}.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[pi-notion] Failed to migrate legacy MCP auth file ${legacyPath}: ${message}`);
+  for (const legacyPath of legacyPaths) {
+    if (!existsSync(nextPath) && existsSync(legacyPath)) {
+      try {
+        mkdirSync(getAgentDir(), { recursive: true });
+        renameSync(legacyPath, nextPath);
+        console.warn(`[pi-notion] Migrated legacy MCP auth file from ${legacyPath} to ${nextPath}.`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[pi-notion] Failed to migrate legacy MCP auth file ${legacyPath}: ${message}`);
+      }
     }
   }
 

--- a/packages/pi-notion/extensions/mcp-client.ts
+++ b/packages/pi-notion/extensions/mcp-client.ts
@@ -570,18 +570,21 @@ function getDefaultAuthFilePath(): string {
     return resolveAuthFilePath(legacyConfiguredPath);
   }
 
-  const configDir = join(getHomeDir(), ".pi", "agent", "extensions");
-  const nextPath = join(configDir, "notion-mcp-auth.json");
-  const legacyPath = getLegacyAuthFilePath();
+  const agentDir = join(getHomeDir(), ".pi", "agent");
+  const legacyDir = join(agentDir, "extensions");
+  const nextPath = join(agentDir, "notion-mcp-auth.json");
+  const legacyPaths = [join(legacyDir, "notion-mcp-auth.json"), getLegacyAuthFilePath()];
 
-  if (!existsSync(nextPath) && existsSync(legacyPath)) {
-    try {
-      mkdirSync(configDir, { recursive: true });
-      renameSync(legacyPath, nextPath);
-      console.warn(`[pi-notion] Migrated legacy MCP auth file from ${legacyPath} to ${nextPath}.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[pi-notion] Failed to migrate legacy MCP auth file ${legacyPath}: ${message}`);
+  for (const legacyPath of legacyPaths) {
+    if (!existsSync(nextPath) && existsSync(legacyPath)) {
+      try {
+        mkdirSync(agentDir, { recursive: true });
+        renameSync(legacyPath, nextPath);
+        console.warn(`[pi-notion] Migrated legacy MCP auth file from ${legacyPath} to ${nextPath}.`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[pi-notion] Failed to migrate legacy MCP auth file ${legacyPath}: ${message}`);
+      }
     }
   }
 

--- a/packages/pi-notion/package.json
+++ b/packages/pi-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-notion",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Notion API extension for pi — read, search, and manage Notion pages, databases, and content",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary
- change the default `pi-notion` MCP OAuth auth file path to `~/.pi/agent/notion-mcp-auth.json`
- migrate older auth files from legacy locations under `~/.pi/agent/extensions/`
- update tests and README to reflect the new default path and migration behavior

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- run `npx vitest run packages/pi-notion/__tests__/helpers.test.ts packages/pi-notion/__tests__/mcp-client.runtime.test.ts`
- verify legacy auth files are migrated to the new default location
- verify `pi-notion` resolves the new default auth path when `NOTION_MCP_AUTH_FILE` is not set
