### PR TITLE
feat(pi-exa): align with exa-js API and add research/answer/find-similar tools

### DIFF
--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -1,13 +1,15 @@
 # @feniix/pi-exa
 
-[Exa AI](https://exa.ai) search extension for [pi](https://pi.dev/) — web search, content fetching, and advanced search with category filtering.
+[Exa AI](https://exa.ai) extension for [pi](https://pi.dev/) with search, fetch, research, and answer capabilities.
 
 ## Features
 
-- **Web Search** (`web_search_exa`): Real-time web search with semantic query understanding
-- **Web Fetch** (`web_fetch_exa`): Read URLs and extract clean content
-- **Advanced Search** (`web_search_advanced_exa`): Full-featured search with category filters, date ranges, domain restrictions (disabled by default)
-- **Skills**: Specialized search skills for code, companies, people, research papers, financial reports, and personal sites
+- **web_search_exa**: default web search (highlights + short text snippets).
+- **web_fetch_exa**: fetch page content by URL.
+- **web_search_advanced_exa**: advanced search options and category filters (disabled by default).
+- **web_research_exa**: deep-research synthesis (disabled by default).
+- **web_answer_exa**: quick grounded answers.
+- **web_find_similar_exa**: discover related URLs.
 
 ## Install
 
@@ -15,7 +17,7 @@
 pi install npm:@feniix/pi-exa
 ```
 
-Ephemeral (one-off) use:
+For ephemeral use:
 
 ```bash
 pi -e npm:@feniix/pi-exa
@@ -25,95 +27,75 @@ pi -e npm:@feniix/pi-exa
 
 You need an Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys).
 
-### Option 1: Environment Variable
+### Option 1: Environment variable
 
 ```bash
-export EXA_API_KEY="your_key"
+export EXA_API_KEY="your-key"
 ```
 
-### Option 2: Settings File
+### Option 2: Settings files
 
-Use pi's standard settings locations for non-secret configuration:
+Supports standard pi settings locations:
 
 - project: `.pi/settings.json`
 - global: `~/.pi/agent/settings.json`
 
-Under the `pi-exa` key:
+Example:
 
 ```json
 {
   "pi-exa": {
-    "enabledTools": ["web_search_exa", "web_fetch_exa"],
-    "advancedEnabled": false
+    "apiKey": "your-key",
+    "enabledTools": ["web_search_exa", "web_fetch_exa", "web_answer_exa", "web_find_similar_exa"],
+    "advancedEnabled": false,
+    "researchEnabled": false
   }
 }
 ```
 
-> Best practice: use `settings.json` for non-secret defaults only.
-> Keep `EXA_API_KEY` in an environment variable, or use `--exa-config-file` / `EXA_CONFIG_FILE` to point to a custom private JSON config file when you need to persist secrets outside your project.
-> Legacy aliases `--exa-config` and `EXA_CONFIG` are still accepted but deprecated.
+## CLI flags
 
-### Option 3: CLI Flags
-
-```bash
-pi --exa-api-key=your_key
-```
+- `--exa-api-key <key>`: API key override.
+- `--exa-enable-advanced`: enable `web_search_advanced_exa`.
+- `--exa-enable-research`: enable `web_research_exa`.
+- `--exa-config-file <path>`: load configuration from file.
+- `--exa-config <path>` (deprecated alias for `--exa-config-file`).
 
 ## Tools
 
-### `web_search_exa` (enabled by default)
+### web_search_exa
 
-Search the web for any topic and get clean, ready-to-use content.
+Params: `query` (required), `numResults`.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `query` | string | yes | Natural language search query |
-| `numResults` | integer | no | Number of results (1-20, default: 5) |
+Returns: formatted snippets with optional highlights and metadata (`costDollars`, `searchTime`, `resolvedSearchType`).
 
-**Best for:** Finding current information, news, facts, or answering questions about any topic.
+### web_fetch_exa
 
-### `web_fetch_exa` (enabled by default)
+Params: `urls` (required array), `maxCharacters`, `highlights`, `summary` (`query`), `maxAgeHours`.
 
-Read a webpage's full content as clean markdown.
+### web_search_advanced_exa
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `urls` | string[] | yes | URLs to read (batch multiple URLs) |
-| `maxCharacters` | integer | no | Max characters per page (default: 3000) |
+Params include `query`, `numResults`, `category`, `type` (`auto|neural|...`, no deep types), date filters, domain filters, and content controls.
 
-**Best for:** Extracting full content from known URLs after web search.
+### web_research_exa
 
-### `web_search_advanced_exa` (disabled by default)
+Params include:
 
-Advanced web search with full Exa API control.
+- `query` (required)
+- `type`: `deep-reasoning | deep-lite | deep`
+- `systemPrompt`
+- `outputSchema` (`type` may be `"object"` or `"text"`, default `"object"`)
+- optional `additionalQueries`, filters, and `numResults`
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `query` | string | yes | Search query |
-| `numResults` | integer | no | Number of results |
-| `category` | string | no | Filter: company, research paper, financial report, etc. |
-| `type` | string | no | Search type: auto, fast, deep, neural |
-| `startPublishedDate` | string | no | ISO date filter |
-| `endPublishedDate` | string | no | ISO date filter |
-| `includeDomains` | string[] | no | Domain whitelist |
-| `excludeDomains` | string[] | no | Domain blacklist |
+### web_answer_exa
 
-Enable via: `pi --exa-enable-advanced`
+Params include `query` (required), `systemPrompt`, `text`, and `outputSchema`.
 
-## Skills
+### web_find_similar_exa
 
-- **code-search**: Find code examples, API docs, debugging help
-- **company-research**: Competitor analysis, market research
-- **people-research**: Find experts, LinkedIn profiles
-- **research-paper-search**: Academic papers, arXiv
-- **financial-report-search**: SEC filings, earnings reports
-- **personal-site-search**: Independent blogs, tutorials
+Params include `url` (required), `numResults`, `excludeSourceDomain`, date filters, and domain filters.
 
-## Requirements
+## Notes
 
-- pi v0.51.0 or later
-- Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys)
-
-## License
-
-MIT
+- `web_search_advanced_exa` and `web_research_exa` are opt-in and disabled by default.
+- Research/tool output may include both `text` and `details.parsedOutput` depending on `outputSchema.type`.

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -95,6 +95,27 @@ Params include `query` (required), `systemPrompt`, `text`, and `outputSchema`.
 
 Params include `url` (required), `numResults`, `excludeSourceDomain`, date filters, and domain filters.
 
+## Integration tests
+
+Live integration coverage is available for `web_search_exa`, `web_fetch_exa`, and `web_research_exa`.
+
+These tests are:
+- skipped by default
+- only enabled when you opt in manually
+- always skipped in CI
+
+Run them locally with a real API key:
+
+```bash
+EXA_API_KEY=your-key npx vitest run packages/pi-exa/__tests__/integration.test.ts -- --exa-live
+```
+
+You can also enable them with an environment variable instead of the CLI flag:
+
+```bash
+PI_EXA_LIVE=1 EXA_API_KEY=your-key npx vitest run packages/pi-exa/__tests__/integration.test.ts
+```
+
 ## Notes
 
 - `web_search_advanced_exa` and `web_research_exa` are opt-in and disabled by default.

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -27,13 +27,32 @@ pi -e npm:@feniix/pi-exa
 
 You need an Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys).
 
-### Option 1: Environment variable
+### Recommended: environment variable
 
 ```bash
 export EXA_API_KEY="your-key"
 ```
 
-### Option 2: Settings files
+### Recommended for private overrides: explicit config file
+
+Use a private config file when you want to store an API key outside shared project settings:
+
+```json
+{
+  "apiKey": "your-key",
+  "enabledTools": ["web_search_exa", "web_fetch_exa", "web_answer_exa", "web_find_similar_exa"],
+  "advancedEnabled": false,
+  "researchEnabled": false
+}
+```
+
+Then run pi with:
+
+```bash
+pi -e npm:@feniix/pi-exa -- --exa-config-file ~/.config/pi/exa.json
+```
+
+### Shared non-secret settings
 
 Supports standard pi settings locations:
 
@@ -45,13 +64,14 @@ Example:
 ```json
 {
   "pi-exa": {
-    "apiKey": "your-key",
     "enabledTools": ["web_search_exa", "web_fetch_exa", "web_answer_exa", "web_find_similar_exa"],
     "advancedEnabled": false,
     "researchEnabled": false
   }
 }
 ```
+
+`apiKey` is accepted in settings files for compatibility, but `pi-exa` will warn when it is loaded there. Prefer `EXA_API_KEY` or `--exa-config-file` for secrets.
 
 ## CLI flags
 
@@ -75,7 +95,11 @@ Params: `urls` (required array), `maxCharacters`, `highlights`, `summary` (`quer
 
 ### web_search_advanced_exa
 
-Params include `query`, `numResults`, `category`, `type` (`auto|neural|...`, no deep types), date filters, domain filters, and content controls.
+Params include `query`, `numResults`, `category`, `type` (`auto|neural|...`, no deep types), date filters, domain filters, `textMaxCharacters`, and highlight controls.
+
+Notes:
+- Deep types are rejected here. Use `web_research_exa` for `deep-reasoning`, `deep-lite`, or `deep`.
+- Invalid categories return an error instead of silently falling back to an unfiltered search.
 
 ### web_research_exa
 
@@ -85,7 +109,7 @@ Params include:
 - `type`: `deep-reasoning | deep-lite | deep`
 - `systemPrompt`
 - `outputSchema` (`type` may be `"object"` or `"text"`, default `"object"`)
-- optional `additionalQueries`, filters, and `numResults`
+- optional `additionalQueries`, filters, `numResults`, and `textMaxCharacters`
 
 ### web_answer_exa
 
@@ -93,7 +117,7 @@ Params include `query` (required), `systemPrompt`, `text`, and `outputSchema`.
 
 ### web_find_similar_exa
 
-Params include `url` (required), `numResults`, `excludeSourceDomain`, date filters, and domain filters.
+Params include `url` (required), `numResults`, `textMaxCharacters`, `excludeSourceDomain`, date filters, and domain filters.
 
 ## Integration tests
 

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -12,9 +12,14 @@ const mockSearch = vi.fn();
 const mockGetContents = vi.fn();
 const mockAnswer = vi.fn();
 const mockFindSimilar = vi.fn();
+const mockExaConstructor = vi.fn();
 
 vi.mock("exa-js", () => ({
   Exa: class {
+    constructor(apiKey: string) {
+      mockExaConstructor(apiKey);
+    }
+
     search = mockSearch;
     getContents = mockGetContents;
     answer = mockAnswer;
@@ -22,6 +27,7 @@ vi.mock("exa-js", () => ({
   },
 }));
 
+import { resetExaClientCache } from "../extensions/exa-client.js";
 import exaExtension from "../extensions/index.js";
 
 const createMockPi = (flags: Record<string, string | boolean | undefined> = {}) =>
@@ -93,6 +99,8 @@ describe("pi-exa extension", () => {
     mockGetContents.mockReset();
     mockAnswer.mockReset();
     mockFindSimilar.mockReset();
+    mockExaConstructor.mockReset();
+    resetExaClientCache();
 
     delete process.env.EXA_API_KEY;
   });
@@ -378,6 +386,39 @@ describe("pi-exa extension", () => {
     expect(result.details.parsedOutput).toEqual({ summary: "research summary" });
   });
 
+  it("reuses a cached Exa client across tool calls for the same API key", async () => {
+    mockSearch.mockResolvedValue(defaultSearchResponse);
+    mockAnswer.mockResolvedValue({
+      answer: "A clear answer",
+      requestId: "answer-1",
+      citations: [],
+    });
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    const answerTool = getRegisteredTool(mockPi, "web_answer_exa");
+
+    await searchTool?.execute(
+      "call-1",
+      { query: "test query" },
+      { aborted: false } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+    await answerTool?.execute(
+      "call-2",
+      { query: "who invented TS" },
+      { aborted: false } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+
+    expect(mockExaConstructor).toHaveBeenCalledTimes(1);
+    expect(mockExaConstructor).toHaveBeenCalledWith("flag-key");
+  });
+
   it("executes web_answer_exa and formats answer with citations", async () => {
     mockAnswer.mockResolvedValue({
       answer: "A clear answer",
@@ -449,6 +490,72 @@ describe("pi-exa extension", () => {
       }),
     );
     expect(result.content[0].text).toContain("Similar 1");
+  });
+
+  it("returns an error when advanced search receives an invalid category", async () => {
+    const configPath = writeTempConfig({
+      enabledTools: [
+        "web_search_exa",
+        "web_fetch_exa",
+        "web_search_advanced_exa",
+        "web_answer_exa",
+        "web_find_similar_exa",
+      ],
+    });
+
+    const mockPi = createMockPi({ "--exa-config-file": configPath, "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    const result = await tool?.execute(
+      "call-1",
+      { query: "advanced query", category: "companey" },
+      { aborted: false } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Invalid category "companey"');
+  });
+
+  it("returns an error when search SDK calls fail", async () => {
+    mockSearch.mockRejectedValue(new Error("search down"));
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_search_exa");
+    const result = await tool.execute("call", { query: "test" }, undefined, undefined, undefined as never);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Exa search error: search down");
+  });
+
+  it("returns an error when research SDK calls fail", async () => {
+    mockSearch.mockRejectedValue(new Error("research down"));
+
+    const mockPi = createMockPi({ "--exa-enable-research": true, "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_research_exa");
+    const result = await tool.execute("call", { query: "test" }, undefined, undefined, undefined as never);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Exa research error: research down");
+  });
+
+  it("returns an error when answer SDK calls fail", async () => {
+    mockAnswer.mockRejectedValue(new Error("answer down"));
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_answer_exa");
+    const result = await tool.execute("call", { query: "test" }, undefined, undefined, undefined as never);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Exa answer error: answer down");
   });
 
   it("returns cancelled result when signal is aborted", async () => {

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -1,14 +1,24 @@
+/**
+ * Extension behavior tests for pi-exa.
+ */
+
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockRequest = vi.fn();
+const mockSearch = vi.fn();
+const mockGetContents = vi.fn();
+const mockAnswer = vi.fn();
+const mockFindSimilar = vi.fn();
 
 vi.mock("exa-js", () => ({
   Exa: class {
-    request = mockRequest;
+    search = mockSearch;
+    getContents = mockGetContents;
+    answer = mockAnswer;
+    findSimilar = mockFindSimilar;
   },
 }));
 
@@ -34,13 +44,26 @@ const writeTempConfig = (config: Record<string, unknown>) => {
   return configPath;
 };
 
+const defaultSearchResponse = {
+  requestId: "req-1",
+  costDollars: { total: 0.005 },
+  searchTime: 1200,
+  results: [
+    {
+      title: "Example Result",
+      url: "https://example.com/result",
+      text: "Result content",
+      publishedDate: "2025-01-15T10:30:00Z",
+      author: "Jane",
+    },
+  ],
+};
+
 describe("pi-exa extension", () => {
-  const originalApiKey = process.env.EXA_API_KEY;
   const originalHome = process.env.HOME;
   const originalCwd = process.cwd();
+  const originalApiKey = process.env.EXA_API_KEY;
 
-  // Isolate tests from real settings files (e.g. ~/.pi/agent/settings.json)
-  // so loadConfig(undefined) returns null and default tool enablement applies.
   let sandboxHome: string;
   let sandboxProject: string;
 
@@ -58,394 +81,411 @@ describe("pi-exa extension", () => {
     } else {
       delete process.env.HOME;
     }
-  });
-
-  beforeEach(() => {
-    mockRequest.mockReset();
-    if (originalApiKey === undefined) {
-      delete process.env.EXA_API_KEY;
-    } else {
+    if (originalApiKey !== undefined) {
       process.env.EXA_API_KEY = originalApiKey;
+    } else {
+      delete process.env.EXA_API_KEY;
     }
   });
 
-  it("registers flags", () => {
+  beforeEach(() => {
+    mockSearch.mockReset();
+    mockGetContents.mockReset();
+    mockAnswer.mockReset();
+    mockFindSimilar.mockReset();
+
+    delete process.env.EXA_API_KEY;
+  });
+
+  it("registers all expected flags", () => {
     const mockPi = createMockPi();
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-    expect(flagNames).toContain("--exa-api-key");
-    expect(flagNames).toContain("--exa-enable-advanced");
-    expect(flagNames).toContain("--exa-config-file");
-    expect(flagNames).toContain("--exa-config");
+    expect(flagNames).toEqual(
+      expect.arrayContaining([
+        "--exa-api-key",
+        "--exa-enable-advanced",
+        "--exa-enable-research",
+        "--exa-config-file",
+        "--exa-config",
+      ]),
+    );
+    expect(flagNames).toHaveLength(5);
   });
 
-  it("registers exactly 4 flags", () => {
-    const mockPi = createMockPi();
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const flagNames = mockPi.registerFlag.mock.calls.map(([name]) => name);
-    expect(flagNames).toHaveLength(4);
-  });
-
-  it("registers web_search_exa by default", () => {
-    const mockPi = createMockPi();
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-    expect(searchTool).toBeDefined();
-  });
-
-  it("registers web_fetch_exa by default", () => {
-    const mockPi = createMockPi();
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-    expect(fetchTool).toBeDefined();
-  });
-
-  it("does not register web_search_advanced_exa by default", () => {
+  it("registers default tools by default", () => {
     const mockPi = createMockPi();
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toContain("web_search_exa");
+    expect(toolNames).toContain("web_fetch_exa");
+    expect(toolNames).toContain("web_answer_exa");
+    expect(toolNames).toContain("web_find_similar_exa");
     expect(toolNames).not.toContain("web_search_advanced_exa");
+    expect(toolNames).not.toContain("web_research_exa");
   });
 
   it("registers web_search_advanced_exa when config enables it", () => {
     const configPath = writeTempConfig({
-      apiKey: "config-api-key",
-      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+      enabledTools: [
+        "web_search_exa",
+        "web_fetch_exa",
+        "web_search_advanced_exa",
+        "web_answer_exa",
+        "web_find_similar_exa",
+      ],
     });
     const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-    expect(advancedTool).toBeDefined();
+    expect(getRegisteredTool(mockPi, "web_search_advanced_exa")).toBeDefined();
+    expect(getRegisteredTool(mockPi, "web_research_exa")).toBeUndefined();
   });
 
-  it("registers tools with execute functions", () => {
-    const mockPi = createMockPi();
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    expect(tools.length).toBeGreaterThan(0);
-    tools.forEach((tool) => {
-      expect(tool.execute).toBeDefined();
-      expect(typeof tool.execute).toBe("function");
+  it("registers web_research_exa when researchEnabled is true in config", () => {
+    const configPath = writeTempConfig({
+      enabledTools: ["web_search_exa", "web_fetch_exa", "web_research_exa", "web_answer_exa", "web_find_similar_exa"],
+      researchEnabled: true,
     });
-  });
-
-  it("registers tools with labels", () => {
-    const mockPi = createMockPi();
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-    expect(searchTool?.label).toBe("Exa Web Search");
+    expect(getRegisteredTool(mockPi, "web_research_exa")).toBeDefined();
   });
 
-  it("registers tools with descriptions", () => {
-    const mockPi = createMockPi();
+  it("registers web_research_exa when --exa-enable-research flag is set", () => {
+    const mockPi = createMockPi({ "--exa-enable-research": true });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    tools.forEach((tool) => {
-      expect(tool.description).toBeDefined();
-      expect(tool.description.length).toBeGreaterThan(0);
-    });
+    expect(getRegisteredTool(mockPi, "web_research_exa")).toBeDefined();
   });
 
-  it("registers tools with parameters", () => {
-    const mockPi = createMockPi();
+  it("executes web_search_exa using typed SDK and reports metadata", async () => {
+    mockSearch.mockResolvedValue(defaultSearchResponse);
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    tools.forEach((tool) => {
-      expect(tool.parameters).toBeDefined();
-    });
-  });
-
-  it("registers flags with string type for api-key", () => {
-    const mockPi = createMockPi();
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const flags = mockPi.registerFlag.mock.calls.map(([name, opts]) => ({ name, ...opts }));
-    const apiKeyFlag = flags.find((f) => f.name === "--exa-api-key");
-    expect(apiKeyFlag?.type).toBe("string");
-  });
-
-  it("handles missing API key gracefully", async () => {
-    delete process.env.EXA_API_KEY;
-
-    const mockPi = createMockPi();
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-    const result = await searchTool?.execute("call-123", { query: "test" }, undefined, undefined, undefined);
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("API key not configured");
-  });
-
-  it("handles aborted signal for web_search_exa", async () => {
-    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
-    const abortedSignal = { aborted: true } as AbortSignal;
-    const result = await searchTool?.execute("call-123", { query: "test" }, abortedSignal, undefined, undefined);
-
-    expect(result.details.cancelled).toBe(true);
-  });
-
-  it("calls onUpdate callback for web_search_exa before executing", async () => {
-    mockRequest.mockResolvedValue({
-      results: [{ title: "Result", url: "https://example.com", text: "Search content" }],
-    });
-
-    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    const tool = getRegisteredTool(mockPi, "web_search_exa");
     const onUpdate = vi.fn();
-    const result = await searchTool?.execute(
-      "call-123",
-      { query: "test" },
+    const result = await tool?.execute(
+      "call-1",
+      { query: "test query", numResults: 3 },
       { aborted: false } as AbortSignal,
       onUpdate,
-      undefined,
+      undefined as never,
     );
 
+    expect(mockSearch).toHaveBeenCalledWith(
+      "test query",
+      expect.objectContaining({
+        type: "auto",
+        numResults: 3,
+        contents: {
+          text: { maxCharacters: 500 },
+          highlights: expect.objectContaining({
+            query: "test query",
+            numSentences: 3,
+          }),
+        },
+      }),
+    );
     expect(onUpdate).toHaveBeenCalledWith({
       content: [{ type: "text", text: "Searching the web via Exa..." }],
       details: { status: "pending" },
     });
-    expect(result.content[0].text).toContain("https://example.com");
+    expect(result.content[0].text).toContain("Example Result");
+    expect(result.details.costDollars?.total).toBe(0.005);
+    expect(result.details.searchTime).toBe(1200);
   });
 
-  it("handles multiple extension instances", () => {
-    const mockPi1 = createMockPi();
-    const mockPi2 = createMockPi();
-
-    exaExtension(mockPi1 as unknown as ExtensionAPI);
-    exaExtension(mockPi2 as unknown as ExtensionAPI);
-
-    expect(mockPi1.registerTool).toHaveBeenCalled();
-    expect(mockPi2.registerTool).toHaveBeenCalled();
-  });
-
-  it("web_fetch_exa handles missing API key", async () => {
-    delete process.env.EXA_API_KEY;
-
-    const mockPi = createMockPi();
+  it("executes web_fetch_exa with typed getContents args and returns formatted content", async () => {
+    mockGetContents.mockResolvedValue(defaultSearchResponse);
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-    const result = await fetchTool?.execute(
-      "call-123",
-      { urls: ["https://example.com"] },
-      undefined,
-      undefined,
-      undefined,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("API key not configured");
-  });
-
-  it("web_fetch_exa handles aborted signal", async () => {
-    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-    const result = await fetchTool?.execute(
-      "call-123",
-      { urls: ["https://example.com"] },
-      { aborted: true } as AbortSignal,
-      undefined,
-      undefined,
-    );
-
-    expect(result.details.cancelled).toBe(true);
-  });
-
-  it("web_fetch_exa returns formatted content and uses the relative contents endpoint", async () => {
-    mockRequest.mockResolvedValue({
-      results: [
-        {
-          title: "Fetched Page",
-          url: "https://example.com",
-          text: "Fetched content",
-          publishedDate: "2025-01-15T10:30:00Z",
-          author: "Jane Doe",
-        },
-      ],
-    });
-
-    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
+    const tool = getRegisteredTool(mockPi, "web_fetch_exa");
     const onUpdate = vi.fn();
-    const result = await fetchTool?.execute(
-      "call-123",
-      { urls: ["https://example.com"], maxCharacters: 1234 },
+    const result = await tool?.execute(
+      "call-1",
+      {
+        urls: ["https://example.com/a"],
+        maxCharacters: 2500,
+        highlights: true,
+        summary: { query: "quick" },
+        maxAgeHours: 6,
+      },
       { aborted: false } as AbortSignal,
       onUpdate,
-      undefined,
+      undefined as never,
     );
 
+    expect(mockGetContents).toHaveBeenCalledWith(
+      ["https://example.com/a"],
+      expect.objectContaining({
+        text: { maxCharacters: 2500 },
+        highlights: true,
+        summary: { query: "quick" },
+        maxAgeHours: 6,
+      }),
+    );
     expect(onUpdate).toHaveBeenCalledWith({
       content: [{ type: "text", text: "Fetching content via Exa..." }],
       details: { status: "pending" },
     });
-    expect(mockRequest).toHaveBeenCalledWith(
-      "/contents",
-      "POST",
-      expect.objectContaining({
-        ids: ["https://example.com"],
-        contents: { text: { maxCharacters: 1234 } },
-      }),
-    );
-    expect(result.details.tool).toBe("web_fetch_exa");
-    expect(result.content[0].text).toContain("Fetched Page");
-    expect(result.content[0].text).toContain("Fetched content");
+    expect(result.content[0].text).toContain("Example Result");
   });
 
-  it("web_fetch_exa returns an error result when the Exa request fails", async () => {
-    mockRequest.mockRejectedValue(new Error("fetch exploded"));
-
-    const mockPi = createMockPi({ "--exa-api-key": "flag-api-key" });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const fetchTool = getRegisteredTool(mockPi, "web_fetch_exa");
-    const result = await fetchTool?.execute(
-      "call-123",
-      { urls: ["https://example.com"] },
-      { aborted: false } as AbortSignal,
-      undefined,
-      undefined,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Exa fetch error: fetch exploded");
-    expect(result.details).toEqual({ tool: "web_fetch_exa", error: "fetch exploded" });
-  });
-
-  it("web_search_advanced_exa handles missing API key", async () => {
-    delete process.env.EXA_API_KEY;
+  it("executes web_search_advanced_exa with typed search args", async () => {
     const configPath = writeTempConfig({
-      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+      enabledTools: [
+        "web_search_exa",
+        "web_fetch_exa",
+        "web_search_advanced_exa",
+        "web_answer_exa",
+        "web_find_similar_exa",
+      ],
     });
-    const mockPi = createMockPi({ "--exa-config-file": configPath });
+    mockSearch.mockResolvedValue({
+      ...defaultSearchResponse,
+      results: [
+        {
+          ...defaultSearchResponse.results[0],
+          highlights: ["h1", "h2"],
+        },
+      ],
+    });
+
+    const mockPi = createMockPi({ "--exa-config-file": configPath, "--exa-api-key": "flag-key" });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-    const result = await advancedTool?.execute("call-123", { query: "test" }, undefined, undefined, undefined);
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("API key not configured");
-  });
-
-  it("web_search_advanced_exa handles aborted signal", async () => {
-    const configPath = writeTempConfig({
-      apiKey: "config-api-key",
-      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-    });
-    const mockPi = createMockPi({ "--exa-config-file": configPath });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-    const result = await advancedTool?.execute(
-      "call-123",
-      { query: "test" },
-      { aborted: true } as AbortSignal,
-      undefined,
-      undefined,
-    );
-
-    expect(result.details.cancelled).toBe(true);
-  });
-
-  it("web_search_advanced_exa forwards advanced options to Exa and formats the response", async () => {
-    mockRequest.mockResolvedValue({
-      results: [{ title: "Advanced Result", url: "https://example.com/advanced", text: "Advanced content" }],
-    });
-    const configPath = writeTempConfig({
-      apiKey: "config-api-key",
-      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
-    });
-    const mockPi = createMockPi({ "--exa-config-file": configPath });
-    exaExtension(mockPi as unknown as ExtensionAPI);
-
-    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-    const onUpdate = vi.fn();
-    const result = await advancedTool?.execute(
-      "call-123",
+    const tool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    await tool?.execute(
+      "call-1",
       {
-        query: "latest ai tools",
-        numResults: 7,
+        query: "advanced query",
+        type: "neural",
         category: "news",
-        type: "deep",
-        startPublishedDate: "2025-01-01",
-        endPublishedDate: "2025-02-01",
+        numResults: 7,
         includeDomains: ["example.com"],
-        excludeDomains: ["spam.com"],
-        textMaxCharacters: 1200,
+        textMaxCharacters: 900,
         enableHighlights: true,
-        highlightsNumSentences: 5,
       },
       { aborted: false } as AbortSignal,
-      onUpdate,
-      undefined,
+      vi.fn(),
+      undefined as never,
     );
 
-    expect(onUpdate).toHaveBeenCalledWith({
-      content: [{ type: "text", text: "Performing advanced search via Exa..." }],
-      details: { status: "pending" },
-    });
-    expect(mockRequest).toHaveBeenCalledWith(
-      "/search",
-      "POST",
+    expect(mockSearch).toHaveBeenCalledWith(
+      "advanced query",
       expect.objectContaining({
-        query: "latest ai tools",
+        type: "neural",
         numResults: 7,
         category: "news",
-        type: "deep",
-        startPublishedDate: "2025-01-01",
-        endPublishedDate: "2025-02-01",
         includeDomains: ["example.com"],
-        excludeDomains: ["spam.com"],
-        contents: {
-          text: { maxCharacters: 1200 },
-          highlights: { highlightsPerUrl: 5 },
-        },
+        contents: expect.objectContaining({
+          text: { maxCharacters: 900 },
+          highlights: expect.objectContaining({ numSentences: 3 }),
+        }),
       }),
     );
-    expect(result.details.tool).toBe("web_search_advanced_exa");
-    expect(result.content[0].text).toContain("Advanced Result");
   });
 
-  it("web_search_advanced_exa returns an error result when the Exa request fails", async () => {
-    mockRequest.mockRejectedValue(new Error("advanced exploded"));
+  it("rejects deep search types in web_search_advanced_exa", async () => {
     const configPath = writeTempConfig({
-      apiKey: "config-api-key",
-      enabledTools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"],
+      enabledTools: [
+        "web_search_exa",
+        "web_search_advanced_exa",
+        "web_fetch_exa",
+        "web_answer_exa",
+        "web_find_similar_exa",
+      ],
     });
-    const mockPi = createMockPi({ "--exa-config-file": configPath });
+    mockSearch.mockResolvedValue(defaultSearchResponse);
+
+    const mockPi = createMockPi({ "--exa-config-file": configPath, "--exa-api-key": "flag-key" });
     exaExtension(mockPi as unknown as ExtensionAPI);
 
-    const advancedTool = getRegisteredTool(mockPi, "web_search_advanced_exa");
-    const result = await advancedTool?.execute(
-      "call-123",
-      { query: "test" },
+    const tool = getRegisteredTool(mockPi, "web_search_advanced_exa");
+    const result = await tool?.execute(
+      "call-1",
+      { query: "advanced query", type: "deep" },
       { aborted: false } as AbortSignal,
-      undefined,
-      undefined,
+      vi.fn(),
+      undefined as never,
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Exa advanced search error: advanced exploded");
-    expect(result.details).toEqual({ tool: "web_search_advanced_exa", error: "advanced exploded" });
+    expect(result.content[0].text).toContain("does not support deep types");
+  });
+
+  it("executes web_research_exa and forwards deep search options", async () => {
+    mockSearch.mockResolvedValue({
+      requestId: "req-r",
+      costDollars: { total: 0.1 },
+      searchTime: 1800,
+      output: {
+        content: {
+          summary: "research summary",
+        },
+        grounding: [{ field: "Overview", citations: [{ url: "https://example.com", title: "Source" }] }],
+      },
+      results: [
+        {
+          title: "Research result",
+          url: "https://example.com/research",
+          text: "research text",
+        },
+      ],
+    });
+
+    const mockPi = createMockPi({ "--exa-enable-research": true, "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_research_exa");
+    const result = await tool?.execute(
+      "call-1",
+      {
+        query: "what is future AI",
+        type: "deep-reasoning",
+        systemPrompt: "Use only primary sources",
+        outputSchema: {
+          type: "object",
+          properties: {
+            summary: {
+              type: "string",
+            },
+          },
+        },
+        additionalQueries: ["future models", "AI roadmap"],
+      },
+      { aborted: false } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "what is future AI",
+      expect.objectContaining({
+        type: "deep-reasoning",
+        additionalQueries: ["future models", "AI roadmap"],
+        systemPrompt: "Use only primary sources",
+      }),
+    );
+    expect(result.content[0].text).toContain('"summary": "research summary"');
+    expect(result.details.parsedOutput).toEqual({ summary: "research summary" });
+  });
+
+  it("executes web_answer_exa and formats answer with citations", async () => {
+    mockAnswer.mockResolvedValue({
+      answer: "A clear answer",
+      requestId: "answer-1",
+      citations: [
+        { url: "https://example.com", title: "Source", publishedDate: "2025-01-01T00:00:00Z", author: "Jane" },
+      ],
+      costDollars: { total: 0.007 },
+    });
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_answer_exa");
+    const result = await tool?.execute(
+      "call-1",
+      { query: "who invented TS", systemPrompt: "Be concise" },
+      { aborted: false } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+
+    expect(mockAnswer).toHaveBeenCalledWith(
+      "who invented TS",
+      expect.objectContaining({
+        text: undefined,
+        systemPrompt: "Be concise",
+      }),
+    );
+    expect(result.content[0].text).toContain("A clear answer");
+    expect(result.details.costDollars).toEqual({ total: 0.007 });
+  });
+
+  it("executes web_find_similar_exa with findSimilar options", async () => {
+    mockFindSimilar.mockResolvedValue({
+      requestId: "sim-1",
+      results: [
+        {
+          title: "Similar 1",
+          url: "https://example.com/similar",
+          text: "similar content",
+        },
+      ],
+    });
+
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_find_similar_exa");
+    const result = await tool?.execute(
+      "call-1",
+      {
+        url: "https://example.com/source",
+        numResults: 2,
+        excludeSourceDomain: true,
+        includeDomains: ["example.com"],
+      },
+      { aborted: false } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+
+    expect(mockFindSimilar).toHaveBeenCalledWith(
+      "https://example.com/source",
+      expect.objectContaining({
+        numResults: 2,
+        excludeSourceDomain: true,
+        includeDomains: ["example.com"],
+      }),
+    );
+    expect(result.content[0].text).toContain("Similar 1");
+  });
+
+  it("returns cancelled result when signal is aborted", async () => {
+    const mockPi = createMockPi({ "--exa-api-key": "flag-key" });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_search_exa");
+    expect(tool).toBeDefined();
+    const result = await tool.execute(
+      "call",
+      { query: "test" },
+      { aborted: true } as AbortSignal,
+      vi.fn(),
+      undefined as never,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({ cancelled: true }),
+      }),
+    );
+  });
+
+  it("returns missing key errors when authentication is absent", async () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tool = getRegisteredTool(mockPi, "web_search_exa");
+    expect(tool).toBeDefined();
+    const result = await tool.execute("call", { query: "test" }, undefined, undefined, undefined as never);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        isError: true,
+        details: expect.objectContaining({ error: "missing_api_key" }),
+      }),
+    );
+    expect(result.content[0].text).toContain("API key not configured");
   });
 });

--- a/packages/pi-exa/__tests__/helpers.test.ts
+++ b/packages/pi-exa/__tests__/helpers.test.ts
@@ -135,6 +135,18 @@ describe("pi-exa formatSearchResults", () => {
     const result = formatSearchResults(results);
     expect(result).toContain("Fallback text content");
   });
+
+  it("includes subpage titles when available", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        subpages: [{ title: "Subpage One", url: "https://example.com/sub-1" }, { url: "https://example.com/sub-2" }],
+      },
+    ];
+    const result = formatSearchResults(results);
+    expect(result).toContain("Subpage One — https://example.com/sub-1");
+    expect(result).toContain("https://example.com/sub-2");
+  });
 });
 
 describe("pi-exa formatCrawlResults", () => {
@@ -223,6 +235,18 @@ describe("pi-exa formatCrawlResults", () => {
     expect(result).toContain("First page");
     expect(result).toContain("Second page");
   });
+
+  it("includes titled crawl subpages when available", () => {
+    const results = [
+      {
+        url: "https://example.com",
+        text: "Content",
+        subpages: [{ title: "Nested Page", url: "https://example.com/nested" }],
+      },
+    ];
+    const result = formatCrawlResults(results);
+    expect(result).toContain("Nested Page — https://example.com/nested");
+  });
 });
 
 describe("pi-exa constants", () => {
@@ -236,6 +260,26 @@ describe("pi-exa constants", () => {
 });
 
 describe("pi-exa settings config", () => {
+  it("returns null when no settings or legacy config files exist", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-empty-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-empty-project-"));
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadConfig(undefined)).toBeNull();
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
+  });
+
   it("loads settings from standard pi settings files", async () => {
     const originalHome = process.env.HOME;
     const originalCwd = process.cwd();
@@ -267,6 +311,36 @@ describe("pi-exa settings config", () => {
       expect(result?.enabledTools).toEqual(["web_search_exa"]);
       expect(result?.advancedEnabled).toBe(true);
     } finally {
+      process.chdir(originalCwd);
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
+  });
+
+  it("warns when apiKey is loaded from settings files", async () => {
+    const originalHome = process.env.HOME;
+    const originalCwd = process.cwd();
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-settings-warn-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-settings-warn-project-"));
+
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({ "pi-exa": { apiKey: "settings-key" } }),
+      "utf-8",
+    );
+
+    process.env.HOME = tempHome;
+    process.chdir(tempProject);
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const mod = await import("../extensions/index.js");
+      expect(mod.loadConfig(undefined)?.apiKey).toBe("settings-key");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Loaded apiKey from settings file"));
+    } finally {
+      warnSpy.mockRestore();
       process.chdir(originalCwd);
       if (originalHome) process.env.HOME = originalHome;
       else delete process.env.HOME;

--- a/packages/pi-exa/__tests__/helpers.test.ts
+++ b/packages/pi-exa/__tests__/helpers.test.ts
@@ -44,12 +44,14 @@ describe("pi-exa parseConfig", () => {
       apiKey: "test-key",
       enabledTools: ["web_search_exa", "web_fetch_exa"],
       advancedEnabled: true,
+      researchEnabled: true,
     };
     const result = parseConfig(raw);
     expect(result).toEqual({
       apiKey: "test-key",
       enabledTools: ["web_search_exa", "web_fetch_exa"],
       advancedEnabled: true,
+      researchEnabled: true,
     });
   });
 
@@ -66,9 +68,10 @@ describe("pi-exa parseConfig", () => {
     expect(result.enabledTools).toEqual(["web_search_exa", "web_fetch_exa"]);
   });
 
-  it("defaults advancedEnabled to false", () => {
+  it("defaults advancedEnabled and researchEnabled to false", () => {
     const result = parseConfig({ advancedEnabled: "not-a-boolean" });
     expect(result.advancedEnabled).toBe(false);
+    expect(result.researchEnabled).toBe(false);
   });
 
   it("trims api key", () => {
@@ -346,12 +349,19 @@ describe("pi-exa loadConfig", () => {
   it("loads valid config file", () => {
     const base = mkdtempSync(join(tmpdir(), "pi-exa-load-valid-"));
     const configPath = join(base, "exa.json");
-    const config = { apiKey: "test-api-key", enabledTools: ["web_search_exa"] };
+    const config = {
+      apiKey: "test-api-key",
+      enabledTools: ["web_search_exa"],
+      advancedEnabled: true,
+      researchEnabled: true,
+    };
     writeFileSync(configPath, JSON.stringify(config), "utf-8");
 
     const result = loadConfig(configPath);
     expect(result?.apiKey).toBe("test-api-key");
     expect(result?.enabledTools).toContain("web_search_exa");
+    expect(result?.advancedEnabled).toBe(true);
+    expect(result?.researchEnabled).toBe(true);
   });
 
   it("returns null on invalid JSON", () => {
@@ -402,11 +412,24 @@ describe("pi-exa loadConfig", () => {
     }
   });
 
-  it("returns null when no settings or legacy config exist", async () => {
+  it("loads researchEnabled from settings files", async () => {
     const originalHome = process.env.HOME;
     const originalCwd = process.cwd();
-    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-empty-home-"));
-    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-empty-project-"));
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-exa-research-home-"));
+    const tempProject = mkdtempSync(join(tmpdir(), "pi-exa-research-project-"));
+
+    mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
+    mkdirSync(join(tempProject, ".pi"), { recursive: true });
+
+    writeFileSync(
+      join(tempHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "pi-exa": {
+          researchEnabled: true,
+        },
+      }),
+      "utf-8",
+    );
 
     process.env.HOME = tempHome;
     process.chdir(tempProject);
@@ -414,7 +437,7 @@ describe("pi-exa loadConfig", () => {
 
     try {
       const mod = await import("../extensions/index.js");
-      expect(mod.loadConfig(undefined)).toBeNull();
+      expect(mod.loadConfig(undefined)?.researchEnabled).toBe(true);
     } finally {
       process.chdir(originalCwd);
       if (originalHome) process.env.HOME = originalHome;

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -25,47 +25,59 @@ describe("pi-exa", () => {
       expect(pkg.dependencies).toHaveProperty("exa-js");
     });
 
-    it("should use relative Exa SDK endpoints instead of full API URLs", () => {
+    it("should use typed SDK methods", () => {
       const searchModule = readFileSync(join(__dirname, "../extensions/web-search.ts"), "utf-8");
       const fetchModule = readFileSync(join(__dirname, "../extensions/web-fetch.ts"), "utf-8");
-      expect(searchModule).toContain('exa.request<ExaSearchResponse>("/search", "POST", searchRequest)');
-      expect(fetchModule).toContain('}>("/contents", "POST", crawlRequest)');
-      expect(searchModule).not.toContain(
-        'exa.request<ExaSearchResponse>("https://api.exa.ai/search", "POST", searchRequest)',
-      );
-      expect(fetchModule).not.toContain('}>("https://api.exa.ai/contents", "POST", crawlRequest)');
+      const answerModule = readFileSync(join(__dirname, "../extensions/web-answer.ts"), "utf-8");
+      const findSimilarModule = readFileSync(join(__dirname, "../extensions/web-find-similar.ts"), "utf-8");
+
+      expect(searchModule).toContain("exa.search(");
+      expect(fetchModule).toContain("exa.getContents(");
+      expect(answerModule).toContain("exa.answer(");
+      expect(findSimilarModule).toContain("exa.findSimilar(");
     });
   });
 
   describe("skills", () => {
-    it("should have code-search skill", () => {
+    it("code-search references web search and answer tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/code-search/SKILL.md"), "utf-8");
       expect(skill).toContain("web_search_exa");
+      expect(skill).toContain("web_answer_exa");
     });
 
-    it("should have company-research skill", () => {
+    it("company-research references deep and search tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/company-research/SKILL.md"), "utf-8");
-      expect(skill).toContain("web_search_exa");
+      expect(skill).toContain("web_search_advanced_exa");
+      expect(skill).toContain("web_research_exa");
+      expect(skill).toContain("web_answer_exa");
     });
 
-    it("should have people-research skill", () => {
+    it("people-research references advanced and research tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/people-research/SKILL.md"), "utf-8");
-      expect(skill).toContain("web_search_exa");
+      expect(skill).toContain("web_search_advanced_exa");
+      expect(skill).toContain("web_research_exa");
+      expect(skill).toContain("web_answer_exa");
     });
 
-    it("should have research-paper-search skill", () => {
+    it("research-paper-search references advanced and research tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/research-paper-search/SKILL.md"), "utf-8");
-      expect(skill).toContain("web_search_exa");
+      expect(skill).toContain("web_search_advanced_exa");
+      expect(skill).toContain("web_research_exa");
+      expect(skill).toContain("web_answer_exa");
     });
 
-    it("should have financial-report-search skill", () => {
+    it("financial-report-search references all required tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/financial-report-search/SKILL.md"), "utf-8");
-      expect(skill).toContain("web_search_exa");
+      expect(skill).toContain("web_search_advanced_exa");
+      expect(skill).toContain("web_research_exa");
+      expect(skill).toContain("web_answer_exa");
     });
 
-    it("should have personal-site-search skill", () => {
+    it("personal-site-search references all required tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/personal-site-search/SKILL.md"), "utf-8");
-      expect(skill).toContain("web_search_exa");
+      expect(skill).toContain("web_search_advanced_exa");
+      expect(skill).toContain("web_research_exa");
+      expect(skill).toContain("web_answer_exa");
     });
   });
 });

--- a/packages/pi-exa/__tests__/integration.test.ts
+++ b/packages/pi-exa/__tests__/integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { performWebFetch } from "../extensions/web-fetch.js";
+import { performResearch } from "../extensions/web-research.js";
+import { performWebSearch } from "../extensions/web-search.js";
+
+const hasManualFlag = process.argv.includes("--exa-live") || process.env.PI_EXA_LIVE === "1";
+const hasApiKey = typeof process.env.EXA_API_KEY === "string" && process.env.EXA_API_KEY.trim().length > 0;
+const shouldRunLiveTests = hasManualFlag && hasApiKey && !process.env.CI;
+const describeLive = shouldRunLiveTests ? describe : describe.skip;
+const apiKey = process.env.EXA_API_KEY?.trim() || "";
+
+describeLive("pi-exa live integration", () => {
+  it("performs a real web search against Exa", { timeout: 30_000 }, async () => {
+    const result = await performWebSearch(apiKey, "OpenAI official website", 3);
+
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.details.tool).toBe("web_search_exa");
+  });
+
+  it("fetches a real page through Exa", { timeout: 30_000 }, async () => {
+    const result = await performWebFetch(apiKey, ["https://example.com"], {
+      maxCharacters: 1500,
+      summary: { query: "What is this page for?" },
+    });
+
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.text).toContain("example.com");
+    expect(result.details.tool).toBe("web_fetch_exa");
+  });
+
+  it("runs a real deep research request through Exa", { timeout: 60_000 }, async () => {
+    const result = await performResearch(apiKey, {
+      query: "What is the purpose of the Example Domain page?",
+      type: "deep-lite",
+      systemPrompt: "Use concise wording and rely on the most relevant public web sources.",
+      numResults: 3,
+      textMaxCharacters: 4000,
+      outputSchema: {
+        type: "object",
+        properties: {
+          summary: { type: "string" },
+        },
+      },
+      includeDomains: ["example.com", "iana.org"],
+    });
+
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.details.tool).toBe("web_research_exa");
+  });
+});

--- a/packages/pi-exa/extensions/config.ts
+++ b/packages/pi-exa/extensions/config.ts
@@ -108,6 +108,11 @@ function loadSettingsConfig(path: string): ExaConfig | null {
       return null;
     }
     const parsedConfig = parseConfig(config);
+    if (parsedConfig.apiKey) {
+      console.warn(
+        `[pi-exa] Loaded apiKey from settings file ${path}. Prefer EXA_API_KEY or --exa-config-file for secrets.`,
+      );
+    }
     return {
       enabledTools: parsedConfig.enabledTools,
       apiKey: parsedConfig.apiKey,

--- a/packages/pi-exa/extensions/config.ts
+++ b/packages/pi-exa/extensions/config.ts
@@ -15,6 +15,7 @@ export interface ExaConfig {
   apiKey?: string;
   enabledTools?: string[];
   advancedEnabled?: boolean;
+  researchEnabled?: boolean;
 }
 
 export interface AuthResolution {
@@ -74,6 +75,7 @@ export function parseConfig(raw: unknown): ExaConfig {
           .filter((t) => t.length > 0)
       : undefined,
     advancedEnabled: typeof obj.advancedEnabled === "boolean" ? obj.advancedEnabled : false,
+    researchEnabled: typeof obj.researchEnabled === "boolean" ? obj.researchEnabled : false,
   };
 }
 
@@ -108,7 +110,9 @@ function loadSettingsConfig(path: string): ExaConfig | null {
     const parsedConfig = parseConfig(config);
     return {
       enabledTools: parsedConfig.enabledTools,
+      apiKey: parsedConfig.apiKey,
       advancedEnabled: parsedConfig.advancedEnabled,
+      researchEnabled: parsedConfig.researchEnabled,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -160,6 +164,7 @@ export function loadConfig(configPath?: string): ExaConfig | null {
     apiKey: projectConfig?.apiKey ?? globalConfig?.apiKey,
     enabledTools: projectConfig?.enabledTools ?? globalConfig?.enabledTools,
     advancedEnabled: projectConfig?.advancedEnabled ?? globalConfig?.advancedEnabled,
+    researchEnabled: projectConfig?.researchEnabled ?? globalConfig?.researchEnabled,
   };
 }
 
@@ -228,17 +233,34 @@ function isAdvancedToolEnabled(pi: ExtensionAPI, config: ExaConfig | null): bool
   return config?.advancedEnabled ?? false;
 }
 
+function isResearchToolEnabled(pi: ExtensionAPI, config: ExaConfig | null): boolean {
+  const researchFlag = pi.getFlag("--exa-enable-research");
+  if (typeof researchFlag === "boolean") {
+    return researchFlag;
+  }
+  return config?.researchEnabled ?? false;
+}
+
 export function isToolEnabledForConfig(pi: ExtensionAPI, config: ExaConfig | null, toolName: string): boolean {
   if (config?.enabledTools && Array.isArray(config.enabledTools)) {
     return config.enabledTools.includes(toolName);
   }
 
-  if (toolName === "web_search_exa" || toolName === "web_fetch_exa") {
+  if (
+    toolName === "web_search_exa" ||
+    toolName === "web_fetch_exa" ||
+    toolName === "web_answer_exa" ||
+    toolName === "web_find_similar_exa"
+  ) {
     return true;
   }
 
   if (toolName === "web_search_advanced_exa") {
     return isAdvancedToolEnabled(pi, config);
+  }
+
+  if (toolName === "web_research_exa") {
+    return isResearchToolEnabled(pi, config);
   }
 
   return false;

--- a/packages/pi-exa/extensions/constants.ts
+++ b/packages/pi-exa/extensions/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared Exa constants.
+ */
+
+export const DEEP_SEARCH_TYPES = ["deep-reasoning", "deep-lite", "deep"] as const;

--- a/packages/pi-exa/extensions/exa-client.ts
+++ b/packages/pi-exa/extensions/exa-client.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared Exa client cache.
+ */
+
+import { Exa } from "exa-js";
+
+const exaClients = new Map<string, Exa>();
+
+export function getExaClient(apiKey: string): Exa {
+  const existing = exaClients.get(apiKey);
+  if (existing) {
+    return existing;
+  }
+
+  const client = new Exa(apiKey);
+  exaClients.set(apiKey, client);
+  return client;
+}
+
+export function resetExaClientCache(): void {
+  exaClients.clear();
+}

--- a/packages/pi-exa/extensions/formatters.ts
+++ b/packages/pi-exa/extensions/formatters.ts
@@ -144,7 +144,12 @@ export function formatSearchResults(results: SearchResultForFormatting[]): strin
       if (subpages.length > 0) {
         lines.push("Subpages:");
         const formattedSubpages = subpages
-          .map((subpage, index) => `  ${index + 1}. ${subpage.url || "(no url)"}`)
+          .map((subpage, index) => {
+            const label = subpage.title || subpage.url || "(no url)";
+            return subpage.title && subpage.url
+              ? `  ${index + 1}. ${label} — ${subpage.url}`
+              : `  ${index + 1}. ${label}`;
+          })
           .join("\n");
         if (formattedSubpages.length > 0) {
           lines.push(formattedSubpages);
@@ -194,7 +199,12 @@ export function formatCrawlResults(results: SearchResultForFormatting[]): string
       if (subpages.length > 0) {
         lines.push("");
         lines.push("Subpages:");
-        const formattedSubpages = subpages.map((subpage, index) => `  ${index + 1}. ${subpage.url || "(no url)"}`);
+        const formattedSubpages = subpages.map((subpage, index) => {
+          const label = subpage.title || subpage.url || "(no url)";
+          return subpage.title && subpage.url
+            ? `  ${index + 1}. ${label} — ${subpage.url}`
+            : `  ${index + 1}. ${label}`;
+        });
         lines.push(...formattedSubpages);
       }
 

--- a/packages/pi-exa/extensions/formatters.ts
+++ b/packages/pi-exa/extensions/formatters.ts
@@ -2,37 +2,120 @@
  * Exa API response types and result formatters for pi-exa.
  */
 
+import type { AnswerResponse, CostDollars, DeepOutputSchema, DeepSearchOutput } from "exa-js";
+
+export type OutputSchema = DeepOutputSchema | { type?: "object" | "text" } | Record<string, unknown>;
+
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface SearchResult {
-  title?: string;
-  url: string;
-  publishedDate?: string;
-  author?: string;
-  highlights?: string[];
-  text?: string;
-}
-
-export interface ExaSearchResponse {
-  results?: SearchResult[];
+export interface ExaResponseMetadata {
+  costDollars?: CostDollars;
   searchTime?: number;
+  resolvedSearchType?: string;
 }
 
-export interface CrawlResult {
-  title?: string;
+export interface ToolPerformResult {
+  text: string;
+  details: ExaResponseMetadata & Record<string, unknown>;
+}
+
+export interface FormattedResearch {
+  text: string;
+  parsedOutput?: unknown;
+}
+
+type SearchResultSubpage = {
+  url?: string;
+  title?: string | null;
+  publishedDate?: string;
+  author?: string;
+  text?: string;
+  highlights?: string[];
+  summary?: string;
+};
+
+type SearchResultForFormatting = {
+  title?: string | null;
   url: string;
   publishedDate?: string;
   author?: string;
   text?: string;
+  highlights?: string[];
+  summary?: string;
+  subpages?: SearchResultSubpage[] | unknown[];
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatPublishedDate(date: string | undefined): string | undefined {
+  if (!date) return undefined;
+  return date.split("T")[0];
+}
+
+function parseOutputSchemaType(outputSchema: OutputSchema | undefined): "object" | "text" {
+  if (
+    typeof outputSchema === "object" &&
+    outputSchema !== null &&
+    "type" in outputSchema &&
+    outputSchema.type === "text"
+  ) {
+    return "text";
+  }
+
+  return "object";
+}
+
+function normalizeSubpages(subpages: SearchResultForFormatting["subpages"]): SearchResultSubpage[] {
+  if (!subpages) {
+    return [];
+  }
+
+  return subpages.flatMap((entry) =>
+    itemHasSubpages(entry)
+      ? normalizeSubpages((entry as { subpages: unknown[] }).subpages)
+      : [entry as SearchResultSubpage],
+  );
+}
+
+function itemHasSubpages(value: unknown): value is { subpages: unknown[] } {
+  return typeof value === "object" && value !== null && "subpages" in value && Array.isArray(value.subpages);
+}
+
+function formatCitations(
+  citations: Array<{ url: string; title?: string | null; publishedDate?: string; author?: string; text?: string }>,
+) {
+  if (citations.length === 0) {
+    return "";
+  }
+
+  const lines = [
+    "",
+    "Grounding:",
+    ...citations.map((citation) => {
+      const citationParts = [citation.title ? `${citation.title}` : citation.url, citation.url];
+      const details = [
+        citation.publishedDate ? formatPublishedDate(citation.publishedDate) : undefined,
+        citation.author,
+      ].filter(Boolean);
+      if (details.length > 0) {
+        citationParts.push(`(${details.join(", ")})`);
+      }
+      return `- ${citationParts.join(" ")}`;
+    }),
+  ];
+
+  return lines.join("\n");
 }
 
 // =============================================================================
 // Formatters
 // =============================================================================
 
-export function formatSearchResults(results: SearchResult[]): string {
+export function formatSearchResults(results: SearchResultForFormatting[]): string {
   if (results.length === 0) {
     return "No search results found. Please try a different query.";
   }
@@ -42,20 +125,38 @@ export function formatSearchResults(results: SearchResult[]): string {
       const lines: string[] = [
         `Title: ${r.title || "N/A"}`,
         `URL: ${r.url}`,
-        `Published: ${r.publishedDate || "N/A"}`,
+        `Published: ${formatPublishedDate(r.publishedDate) || "N/A"}`,
         `Author: ${r.author || "N/A"}`,
       ];
+
       if (Array.isArray(r.highlights) && r.highlights.length > 0) {
-        lines.push(`Highlights:\n${r.highlights.join("\n")}`);
+        lines.push("Highlights:");
+        lines.push(...r.highlights.map((entry) => `- ${entry}`));
+      } else if (r.summary) {
+        lines.push("Summary:");
+        lines.push(r.summary);
       } else if (r.text) {
-        lines.push(`Text: ${r.text}`);
+        lines.push("Text:");
+        lines.push(r.text);
       }
+
+      const subpages = normalizeSubpages(r.subpages);
+      if (subpages.length > 0) {
+        lines.push("Subpages:");
+        const formattedSubpages = subpages
+          .map((subpage, index) => `  ${index + 1}. ${subpage.url || "(no url)"}`)
+          .join("\n");
+        if (formattedSubpages.length > 0) {
+          lines.push(formattedSubpages);
+        }
+      }
+
       return lines.join("\n");
     })
     .join("\n\n---\n\n");
 }
 
-export function formatCrawlResults(results: CrawlResult[]): string {
+export function formatCrawlResults(results: SearchResultForFormatting[]): string {
   if (results.length === 0) {
     return "No content found.";
   }
@@ -63,18 +164,114 @@ export function formatCrawlResults(results: CrawlResult[]): string {
   return results
     .map((r) => {
       const lines: string[] = [`# ${r.title || "(no title)"}`, `URL: ${r.url}`];
-      if (r.publishedDate) {
-        lines.push(`Published: ${r.publishedDate.split("T")[0]}`);
+
+      const published = formatPublishedDate(r.publishedDate);
+      if (published) {
+        lines.push(`Published: ${published}`);
       }
       if (r.author) {
         lines.push(`Author: ${r.author}`);
       }
-      lines.push("");
+
+      if (r.highlights && r.highlights.length > 0) {
+        lines.push("");
+        lines.push("Highlights:");
+        lines.push(...r.highlights.map((entry) => `- ${entry}`));
+      }
+
+      if (r.summary) {
+        lines.push("");
+        lines.push("Summary:");
+        lines.push(r.summary);
+      }
+
       if (r.text) {
+        lines.push("");
         lines.push(r.text);
       }
-      lines.push("");
+
+      const subpages = normalizeSubpages(r.subpages);
+      if (subpages.length > 0) {
+        lines.push("");
+        lines.push("Subpages:");
+        const formattedSubpages = subpages.map((subpage, index) => `  ${index + 1}. ${subpage.url || "(no url)"}`);
+        lines.push(...formattedSubpages);
+      }
+
       return lines.join("\n");
     })
     .join("\n");
+}
+
+export function formatResearchOutput(
+  output: DeepSearchOutput | undefined,
+  outputSchema?: OutputSchema,
+): FormattedResearch {
+  if (!output) {
+    return {
+      text: "Deep search completed, but no synthesized output was returned. Try a different query or avoid unsupported filters.",
+    };
+  }
+
+  const outputSchemaType = parseOutputSchemaType(outputSchema);
+  const content = output.content;
+
+  const citationsText = Array.isArray(output.grounding)
+    ? formatCitations(output.grounding.flatMap((grounding) => grounding.citations || []))
+    : "";
+
+  if (outputSchemaType === "text") {
+    const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+    return {
+      text: [text, citationsText].filter(Boolean).join("\n\n"),
+    };
+  }
+
+  if (typeof content === "string") {
+    return {
+      text: [content, citationsText].filter(Boolean).join("\n\n"),
+    };
+  }
+
+  return {
+    text: ["```json", JSON.stringify(content, null, 2), "```", citationsText].filter(Boolean).join("\n\n"),
+    parsedOutput: content,
+  };
+}
+
+export function formatAnswerResult(response: AnswerResponse, outputSchema?: OutputSchema): FormattedResearch {
+  const outputSchemaType = parseOutputSchemaType(outputSchema);
+  const answer = response.answer;
+
+  const citationsText = formatCitations(response.citations ?? []);
+
+  if (outputSchemaType === "text") {
+    const text = typeof answer === "string" ? answer : JSON.stringify(answer, null, 2);
+    return {
+      text: [text, citationsText].filter(Boolean).join("\n\n"),
+    };
+  }
+
+  if (typeof answer === "string") {
+    return {
+      text: [answer, citationsText].filter(Boolean).join("\n\n"),
+    };
+  }
+
+  return {
+    text: ["```json", JSON.stringify(answer, null, 2), "```", citationsText].filter(Boolean).join("\n\n"),
+    parsedOutput: answer,
+  };
+}
+
+export function toMetadata(response: {
+  costDollars?: CostDollars;
+  searchTime?: number;
+  resolvedSearchType?: string;
+}): ExaResponseMetadata {
+  return {
+    ...(response.costDollars ? { costDollars: response.costDollars } : {}),
+    ...(response.searchTime !== undefined ? { searchTime: response.searchTime } : {}),
+    ...(response.resolvedSearchType ? { resolvedSearchType: response.resolvedSearchType } : {}),
+  };
 }

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -2,31 +2,22 @@
  * Exa AI MCP Extension for pi
  *
  * Provides Exa search tools via native TypeScript (no external MCP server required).
- * Tools: web_search_exa, web_fetch_exa, web_search_advanced_exa (disabled by default).
- *
- * Setup:
- * 1. Install: pi install npm:@feniix/pi-exa
- * 2. Get API key from: https://dashboard.exa.ai/api-keys
- * 3. Configure via:
- *    - Environment variable: EXA_API_KEY
- *    - Settings file for non-secret config: .pi/settings.json or ~/.pi/agent/settings.json under pi-exa
- *    - CLI flag: --exa-api-key
- *
- * Usage:
- *   "Search the web for recent AI news"
- *   "Read the content from https://example.com"
- *   "Find code examples for React hooks"
- *
- * Tools:
- *   - web_search_exa: Web search with highlights (enabled by default)
- *   - web_fetch_exa: Read URLs/crawl content (enabled by default)
- *   - web_search_advanced_exa: Full-featured search (disabled by default)
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getAuthStatusMessage, getResolvedConfig, isToolEnabledForConfig, resolveAuth } from "./config.js";
-import { webFetchParams, webSearchAdvancedParams, webSearchParams } from "./schemas.js";
-import { DEFAULT_MAX_CHARACTERS, performWebFetch } from "./web-fetch.js";
+import {
+  webAnswerParams,
+  webFetchParams,
+  webFindSimilarParams,
+  webResearchParams,
+  webSearchAdvancedParams,
+  webSearchParams,
+} from "./schemas.js";
+import { performAnswer } from "./web-answer.js";
+import { performWebFetch } from "./web-fetch.js";
+import { performFindSimilar } from "./web-find-similar.js";
+import { performResearch } from "./web-research.js";
 import { DEFAULT_NUM_RESULTS, performWebSearch } from "./web-search.js";
 import { performAdvancedSearch } from "./web-search-advanced.js";
 
@@ -62,6 +53,10 @@ export default function exaExtension(pi: ExtensionAPI) {
     description: "Enable web_search_advanced_exa tool",
     type: "boolean",
   });
+  pi.registerFlag("--exa-enable-research", {
+    description: "Enable web_research_exa tool",
+    type: "boolean",
+  });
   pi.registerFlag("--exa-config-file", {
     description: "Path to custom JSON config file for private overrides such as API keys.",
     type: "string",
@@ -72,8 +67,11 @@ export default function exaExtension(pi: ExtensionAPI) {
   });
 
   const getApiKey = (): string => resolveAuth(pi).apiKey;
-
   const isToolEnabled = (toolName: string): boolean => isToolEnabledForConfig(pi, getResolvedConfig(pi), toolName);
+
+  function toolDetails(toolName: string): { tool: string } {
+    return { tool: toolName };
+  }
 
   // Register web_search_exa tool
   if (isToolEnabled("web_search_exa")) {
@@ -81,9 +79,12 @@ export default function exaExtension(pi: ExtensionAPI) {
       name: "web_search_exa",
       label: "Exa Web Search",
       description:
-        "Search the web for any topic and get clean, ready-to-use content. " +
-        "Best for: Finding current information, news, facts, or answering questions. " +
-        "Query tips: describe the ideal page, not keywords. 'blog post comparing React and Vue' not 'React Vue'.",
+        "Search the web for any topic and get clean, ready-to-use content. Best for lookup and current information queries.",
+      promptSnippet: "Search web and return concise results using web_search_exa",
+      promptGuidelines: [
+        "Use web_search_exa for quick lookup and current facts.",
+        "Use web_search_exa before web_search_advanced_exa unless you need category/date/filter control.",
+      ],
       parameters: webSearchParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
         const apiKey = getApiKey();
@@ -98,7 +99,7 @@ export default function exaExtension(pi: ExtensionAPI) {
         if (signal?.aborted) {
           return {
             content: [{ type: "text", text: "Cancelled." }],
-            details: { cancelled: true },
+            details: { ...toolDetails("web_search_exa"), cancelled: true },
           };
         }
 
@@ -108,19 +109,15 @@ export default function exaExtension(pi: ExtensionAPI) {
         });
 
         try {
-          const typedParams = params as { query: string; numResults?: number };
-          const result = await performWebSearch(
-            apiKey,
-            typedParams.query,
-            typedParams.numResults || DEFAULT_NUM_RESULTS,
-          );
-          return { content: [{ type: "text", text: result }], details: { tool: "web_search_exa" } };
+          const { query, numResults } = params;
+          const result = await performWebSearch(apiKey, query, numResults || DEFAULT_NUM_RESULTS);
+          return { content: [{ type: "text", text: result.text }], details: result.details };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return {
             content: [{ type: "text", text: `Exa search error: ${message}` }],
             isError: true,
-            details: { tool: "web_search_exa", error: message },
+            details: { ...toolDetails("web_search_exa"), error: message },
           };
         }
       },
@@ -132,10 +129,12 @@ export default function exaExtension(pi: ExtensionAPI) {
     pi.registerTool({
       name: "web_fetch_exa",
       label: "Exa Web Fetch",
-      description:
-        "Read a webpage's full content as clean markdown. " +
-        "Use after web_search_exa when highlights are insufficient or to read any URL. " +
-        "Best for: Extracting full content from known URLs. Batch multiple URLs in one call.",
+      description: "Read a webpage's full content as clean markdown. Best for extracting full content from known URLs.",
+      promptSnippet: "Fetch URLs with web_fetch_exa when you need full page text",
+      promptGuidelines: [
+        "Use web_fetch_exa for content extraction after discovering URLs.",
+        "Enable highlights/summary only when extra context is needed.",
+      ],
       parameters: webFetchParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
         const apiKey = getApiKey();
@@ -143,14 +142,14 @@ export default function exaExtension(pi: ExtensionAPI) {
           return {
             content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
             isError: true,
-            details: { tool: "web_fetch_exa", error: "missing_api_key" },
+            details: { ...toolDetails("web_fetch_exa"), error: "missing_api_key" },
           };
         }
 
         if (signal?.aborted) {
           return {
             content: [{ type: "text", text: "Cancelled." }],
-            details: { cancelled: true },
+            details: { ...toolDetails("web_fetch_exa"), cancelled: true },
           };
         }
 
@@ -160,19 +159,19 @@ export default function exaExtension(pi: ExtensionAPI) {
         });
 
         try {
-          const typedParams = params as { urls: string[]; maxCharacters?: number };
-          const result = await performWebFetch(
-            apiKey,
-            typedParams.urls,
-            typedParams.maxCharacters || DEFAULT_MAX_CHARACTERS,
-          );
-          return { content: [{ type: "text", text: result }], details: { tool: "web_fetch_exa" } };
+          const result = await performWebFetch(apiKey, params.urls, {
+            maxCharacters: params.maxCharacters,
+            highlights: params.highlights,
+            summary: params.summary,
+            maxAgeHours: params.maxAgeHours,
+          });
+          return { content: [{ type: "text", text: result.text }], details: result.details };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return {
             content: [{ type: "text", text: `Exa fetch error: ${message}` }],
             isError: true,
-            details: { tool: "web_fetch_exa", error: message },
+            details: { ...toolDetails("web_fetch_exa"), error: message },
           };
         }
       },
@@ -185,8 +184,12 @@ export default function exaExtension(pi: ExtensionAPI) {
       name: "web_search_advanced_exa",
       label: "Exa Advanced Search",
       description:
-        "Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, " +
-        "highlights, summaries, and subpage crawling. Requires --exa-enable-advanced flag or advancedEnabled in config.",
+        "Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, highlights, and summaries.",
+      promptSnippet: "Use web_search_advanced_exa for filters, categories, and deep tuning",
+      promptGuidelines: [
+        "Prefer web_search_advanced_exa for non-deep query constraints (category, domains, dates).",
+        "Use web_search_exa for simpler lookups.",
+      ],
       parameters: webSearchAdvancedParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
         const apiKey = getApiKey();
@@ -194,14 +197,14 @@ export default function exaExtension(pi: ExtensionAPI) {
           return {
             content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
             isError: true,
-            details: { tool: "web_search_advanced_exa", error: "missing_api_key" },
+            details: { ...toolDetails("web_search_advanced_exa"), error: "missing_api_key" },
           };
         }
 
         if (signal?.aborted) {
           return {
             content: [{ type: "text", text: "Cancelled." }],
-            details: { cancelled: true },
+            details: { ...toolDetails("web_search_advanced_exa"), cancelled: true },
           };
         }
 
@@ -211,40 +214,197 @@ export default function exaExtension(pi: ExtensionAPI) {
         });
 
         try {
-          const typedParams = params as {
-            query: string;
-            numResults?: number;
-            category?: string;
-            type?: string;
-            startPublishedDate?: string;
-            endPublishedDate?: string;
-            includeDomains?: string[];
-            excludeDomains?: string[];
-            textMaxCharacters?: number;
-            enableHighlights?: boolean;
-            highlightsNumSentences?: number;
-          };
-
-          const result = await performAdvancedSearch(apiKey, typedParams.query, {
-            numResults: typedParams.numResults,
-            category: typedParams.category,
-            type: typedParams.type,
-            startPublishedDate: typedParams.startPublishedDate,
-            endPublishedDate: typedParams.endPublishedDate,
-            includeDomains: typedParams.includeDomains,
-            excludeDomains: typedParams.excludeDomains,
-            textMaxCharacters: typedParams.textMaxCharacters,
-            enableHighlights: typedParams.enableHighlights,
-            highlightsNumSentences: typedParams.highlightsNumSentences,
+          const result = await performAdvancedSearch(apiKey, params.query, {
+            numResults: params.numResults,
+            category: params.category,
+            type: params.type,
+            startPublishedDate: params.startPublishedDate,
+            endPublishedDate: params.endPublishedDate,
+            includeDomains: params.includeDomains,
+            excludeDomains: params.excludeDomains,
+            textMaxCharacters: params.textMaxCharacters,
+            enableHighlights: params.enableHighlights,
+            highlightsNumSentences: params.highlightsNumSentences,
           });
-
-          return { content: [{ type: "text", text: result }], details: { tool: "web_search_advanced_exa" } };
+          return { content: [{ type: "text", text: result.text }], details: result.details };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return {
             content: [{ type: "text", text: `Exa advanced search error: ${message}` }],
             isError: true,
-            details: { tool: "web_search_advanced_exa", error: message },
+            details: { ...toolDetails("web_search_advanced_exa"), error: message },
+          };
+        }
+      },
+    });
+  }
+
+  // Register web_research_exa tool (disabled by default, opt-in)
+  if (isToolEnabled("web_research_exa")) {
+    pi.registerTool({
+      name: "web_research_exa",
+      label: "Exa Deep Research",
+      description: "Deep-reasoning Exa search with synthesized, grounded output for complex research topics.",
+      promptSnippet: "Run deep research questions with web_research_exa",
+      promptGuidelines: [
+        "Use web_research_exa for synthesis-oriented questions, comparisons, and recommendations.",
+        "Provide a systemPrompt and use structured outputSchema when you need downstream automation.",
+        "Prefer web_search_exa for quick fact lookup.",
+      ],
+      parameters: webResearchParams,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+          return {
+            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
+            isError: true,
+            details: { ...toolDetails("web_research_exa"), error: "missing_api_key" },
+          };
+        }
+
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled." }],
+            details: { ...toolDetails("web_research_exa"), cancelled: true },
+          };
+        }
+
+        onUpdate?.({
+          content: [{ type: "text", text: "Performing deep research via Exa..." }],
+          details: { status: "pending" },
+        });
+
+        try {
+          const result = await performResearch(apiKey, {
+            query: params.query,
+            type: params.type,
+            systemPrompt: params.systemPrompt,
+            outputSchema: params.outputSchema,
+            additionalQueries: params.additionalQueries,
+            numResults: params.numResults,
+            includeDomains: params.includeDomains,
+            excludeDomains: params.excludeDomains,
+            startPublishedDate: params.startPublishedDate,
+            endPublishedDate: params.endPublishedDate,
+          });
+          return { content: [{ type: "text", text: result.text }], details: result.details };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: `Exa research error: ${message}` }],
+            isError: true,
+            details: { ...toolDetails("web_research_exa"), error: message },
+          };
+        }
+      },
+    });
+  }
+
+  // Register web_answer_exa tool
+  if (isToolEnabled("web_answer_exa")) {
+    pi.registerTool({
+      name: "web_answer_exa",
+      label: "Exa Answer",
+      description: "Get a grounded answer with source citations and optional structured output.",
+      promptSnippet: "Answer direct questions with web_answer_exa",
+      promptGuidelines: [
+        "Use web_answer_exa for direct, answer-style prompts needing grounded citations.",
+        "Use outputSchema for machine-consumable structured responses.",
+      ],
+      parameters: webAnswerParams,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+          return {
+            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
+            isError: true,
+            details: { ...toolDetails("web_answer_exa"), error: "missing_api_key" },
+          };
+        }
+
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled." }],
+            details: { ...toolDetails("web_answer_exa"), cancelled: true },
+          };
+        }
+
+        onUpdate?.({
+          content: [{ type: "text", text: "Fetching answer from Exa..." }],
+          details: { status: "pending" },
+        });
+
+        try {
+          const result = await performAnswer(apiKey, {
+            query: params.query,
+            systemPrompt: params.systemPrompt,
+            text: params.text,
+            outputSchema: params.outputSchema,
+          });
+          return { content: [{ type: "text", text: result.text }], details: result.details };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: `Exa answer error: ${message}` }],
+            isError: true,
+            details: { ...toolDetails("web_answer_exa"), error: message },
+          };
+        }
+      },
+    });
+  }
+
+  // Register web_find_similar_exa tool
+  if (isToolEnabled("web_find_similar_exa")) {
+    pi.registerTool({
+      name: "web_find_similar_exa",
+      label: "Exa Similar Pages",
+      description: "Find web pages similar to a given URL.",
+      promptSnippet: "Find similar pages with web_find_similar_exa",
+      promptGuidelines: [
+        "Use web_find_similar_exa for recommendations once a source URL is known.",
+        "Pair with web_fetch_exa for deeper inspection of any returned URLs.",
+      ],
+      parameters: webFindSimilarParams,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+          return {
+            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
+            isError: true,
+            details: { ...toolDetails("web_find_similar_exa"), error: "missing_api_key" },
+          };
+        }
+
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled." }],
+            details: { ...toolDetails("web_find_similar_exa"), cancelled: true },
+          };
+        }
+
+        onUpdate?.({
+          content: [{ type: "text", text: "Finding similar pages via Exa..." }],
+          details: { status: "pending" },
+        });
+
+        try {
+          const result = await performFindSimilar(apiKey, {
+            url: params.url,
+            numResults: params.numResults,
+            excludeSourceDomain: params.excludeSourceDomain,
+            startPublishedDate: params.startPublishedDate,
+            endPublishedDate: params.endPublishedDate,
+            includeDomains: params.includeDomains,
+            excludeDomains: params.excludeDomains,
+          });
+          return { content: [{ type: "text", text: result.text }], details: result.details };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: `Exa similar search error: ${message}` }],
+            isError: true,
+            details: { ...toolDetails("web_find_similar_exa"), error: message },
           };
         }
       },

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -279,6 +279,7 @@ export default function exaExtension(pi: ExtensionAPI) {
             query: params.query,
             type: params.type,
             systemPrompt: params.systemPrompt,
+            textMaxCharacters: params.textMaxCharacters,
             outputSchema: params.outputSchema,
             additionalQueries: params.additionalQueries,
             numResults: params.numResults,
@@ -392,6 +393,7 @@ export default function exaExtension(pi: ExtensionAPI) {
           const result = await performFindSimilar(apiKey, {
             url: params.url,
             numResults: params.numResults,
+            textMaxCharacters: params.textMaxCharacters,
             excludeSourceDomain: params.excludeSourceDomain,
             startPublishedDate: params.startPublishedDate,
             endPublishedDate: params.endPublishedDate,

--- a/packages/pi-exa/extensions/schemas.ts
+++ b/packages/pi-exa/extensions/schemas.ts
@@ -87,6 +87,9 @@ export const webResearchParams = Type.Object(
       Type.Array(Type.String({ description: "Alternative query formulations" }), { maxItems: 5 }),
     ),
     numResults: Type.Optional(Type.Integer({ description: "Number of source results", minimum: 1, maximum: 20 })),
+    textMaxCharacters: Type.Optional(
+      Type.Integer({ description: "Maximum characters to extract for synthesis", minimum: 1 }),
+    ),
     includeDomains: Type.Optional(Type.Array(Type.String())),
     excludeDomains: Type.Optional(Type.Array(Type.String())),
     startPublishedDate: Type.Optional(Type.String()),
@@ -109,7 +112,10 @@ export const webFindSimilarParams = Type.Object(
   {
     url: Type.String({ description: "Base URL to find similar pages for" }),
     numResults: Type.Optional(
-      Type.Integer({ description: "Number of similar pages to return (1-10, default: 5)", minimum: 1, maximum: 20 }),
+      Type.Integer({ description: "Number of similar pages to return (1-20, default: 5)", minimum: 1, maximum: 20 }),
+    ),
+    textMaxCharacters: Type.Optional(
+      Type.Integer({ description: "Maximum characters to extract per similar result", minimum: 1 }),
     ),
     excludeSourceDomain: Type.Optional(Type.Boolean({ description: "Do not include pages from the same domain" })),
     startPublishedDate: Type.Optional(Type.String({ description: "ISO date filter" })),

--- a/packages/pi-exa/extensions/schemas.ts
+++ b/packages/pi-exa/extensions/schemas.ts
@@ -4,6 +4,24 @@
 
 import { Type } from "@sinclair/typebox";
 
+const outputSchemaType = Type.Union([Type.Literal("object"), Type.Literal("text")]);
+
+const outputSchema = Type.Object(
+  {
+    type: Type.Optional(outputSchemaType),
+  },
+  { additionalProperties: true },
+);
+
+const advancedSearchType = Type.Union([
+  Type.Literal("auto"),
+  Type.Literal("fast"),
+  Type.Literal("neural"),
+  Type.Literal("keyword"),
+  Type.Literal("hybrid"),
+  Type.Literal("instant"),
+]);
+
 export const webSearchParams = Type.Object(
   {
     query: Type.String({
@@ -25,6 +43,15 @@ export const webFetchParams = Type.Object(
     maxCharacters: Type.Optional(
       Type.Integer({ description: "Maximum characters to extract per page (default: 3000)", minimum: 1 }),
     ),
+    highlights: Type.Optional(Type.Boolean({ description: "Include per-page highlights in the response" })),
+    summary: Type.Optional(
+      Type.Object({
+        query: Type.String({ description: "Query guiding summary generation" }),
+      }),
+    ),
+    maxAgeHours: Type.Optional(
+      Type.Integer({ description: "Use cached content only if older than this many hours", minimum: -1 }),
+    ),
   },
   { additionalProperties: true },
 );
@@ -38,7 +65,7 @@ export const webSearchAdvancedParams = Type.Object(
         description: "Category filter: company, research paper, financial report, people, news, etc.",
       }),
     ),
-    type: Type.Optional(Type.String({ description: "Search type: auto, fast, deep, neural" })),
+    type: Type.Optional(advancedSearchType),
     startPublishedDate: Type.Optional(Type.String({ description: "ISO date filter (e.g., 2024-01-01)" })),
     endPublishedDate: Type.Optional(Type.String({ description: "ISO date filter (e.g., 2024-12-31)" })),
     includeDomains: Type.Optional(Type.Array(Type.String())),
@@ -46,6 +73,49 @@ export const webSearchAdvancedParams = Type.Object(
     textMaxCharacters: Type.Optional(Type.Integer()),
     enableHighlights: Type.Optional(Type.Boolean()),
     highlightsNumSentences: Type.Optional(Type.Integer()),
+  },
+  { additionalProperties: true },
+);
+
+export const webResearchParams = Type.Object(
+  {
+    query: Type.String({ description: "Research question to synthesize" }),
+    type: Type.Optional(Type.Union([Type.Literal("deep-reasoning"), Type.Literal("deep-lite"), Type.Literal("deep")])),
+    systemPrompt: Type.Optional(Type.String({ description: "Guidance for source selection and synthesis style" })),
+    outputSchema: Type.Optional(outputSchema),
+    additionalQueries: Type.Optional(
+      Type.Array(Type.String({ description: "Alternative query formulations" }), { maxItems: 5 }),
+    ),
+    numResults: Type.Optional(Type.Integer({ description: "Number of source results", minimum: 1, maximum: 20 })),
+    includeDomains: Type.Optional(Type.Array(Type.String())),
+    excludeDomains: Type.Optional(Type.Array(Type.String())),
+    startPublishedDate: Type.Optional(Type.String()),
+    endPublishedDate: Type.Optional(Type.String()),
+  },
+  { additionalProperties: true },
+);
+
+export const webAnswerParams = Type.Object(
+  {
+    query: Type.String({ description: "Research question to answer" }),
+    systemPrompt: Type.Optional(Type.String({ description: "Prompt instructions for tone and style" })),
+    text: Type.Optional(Type.Boolean({ description: "Include full source text in the result" })),
+    outputSchema: Type.Optional(outputSchema),
+  },
+  { additionalProperties: true },
+);
+
+export const webFindSimilarParams = Type.Object(
+  {
+    url: Type.String({ description: "Base URL to find similar pages for" }),
+    numResults: Type.Optional(
+      Type.Integer({ description: "Number of similar pages to return (1-10, default: 5)", minimum: 1, maximum: 20 }),
+    ),
+    excludeSourceDomain: Type.Optional(Type.Boolean({ description: "Do not include pages from the same domain" })),
+    startPublishedDate: Type.Optional(Type.String({ description: "ISO date filter" })),
+    endPublishedDate: Type.Optional(Type.String({ description: "ISO date filter" })),
+    includeDomains: Type.Optional(Type.Array(Type.String())),
+    excludeDomains: Type.Optional(Type.Array(Type.String())),
   },
   { additionalProperties: true },
 );

--- a/packages/pi-exa/extensions/web-answer.ts
+++ b/packages/pi-exa/extensions/web-answer.ts
@@ -5,7 +5,7 @@
 import type { AnswerResponse } from "exa-js";
 import { Exa } from "exa-js";
 import type { ToolPerformResult } from "./formatters.js";
-import { formatAnswerResult } from "./formatters.js";
+import { formatAnswerResult, toMetadata } from "./formatters.js";
 
 interface AnswerParams {
   query: string;
@@ -29,7 +29,7 @@ export async function performAnswer(apiKey: string, params: AnswerParams): Promi
     text: formatted.text,
     details: {
       tool: "web_answer_exa",
-      ...(result.costDollars ? { costDollars: result.costDollars } : {}),
+      ...toMetadata(result),
       ...(formatted.parsedOutput === undefined ? {} : { parsedOutput: formatted.parsedOutput }),
     },
   };

--- a/packages/pi-exa/extensions/web-answer.ts
+++ b/packages/pi-exa/extensions/web-answer.ts
@@ -1,0 +1,36 @@
+/**
+ * Exa answer endpoint wrapper.
+ */
+
+import type { AnswerResponse } from "exa-js";
+import { Exa } from "exa-js";
+import type { ToolPerformResult } from "./formatters.js";
+import { formatAnswerResult } from "./formatters.js";
+
+interface AnswerParams {
+  query: string;
+  systemPrompt?: string;
+  text?: boolean;
+  outputSchema?: Record<string, unknown>;
+}
+
+export async function performAnswer(apiKey: string, params: AnswerParams): Promise<ToolPerformResult> {
+  const exa = new Exa(apiKey);
+
+  const result: AnswerResponse = await exa.answer(params.query, {
+    text: params.text,
+    systemPrompt: params.systemPrompt,
+    ...(params.outputSchema ? { outputSchema: params.outputSchema } : {}),
+  });
+
+  const formatted = formatAnswerResult(result, params.outputSchema);
+
+  return {
+    text: formatted.text,
+    details: {
+      tool: "web_answer_exa",
+      ...(result.costDollars ? { costDollars: result.costDollars } : {}),
+      ...(formatted.parsedOutput === undefined ? {} : { parsedOutput: formatted.parsedOutput }),
+    },
+  };
+}

--- a/packages/pi-exa/extensions/web-answer.ts
+++ b/packages/pi-exa/extensions/web-answer.ts
@@ -3,7 +3,7 @@
  */
 
 import type { AnswerResponse } from "exa-js";
-import { Exa } from "exa-js";
+import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatAnswerResult, toMetadata } from "./formatters.js";
 
@@ -15,7 +15,7 @@ interface AnswerParams {
 }
 
 export async function performAnswer(apiKey: string, params: AnswerParams): Promise<ToolPerformResult> {
-  const exa = new Exa(apiKey);
+  const exa = getExaClient(apiKey);
 
   const result: AnswerResponse = await exa.answer(params.query, {
     text: params.text,

--- a/packages/pi-exa/extensions/web-fetch.ts
+++ b/packages/pi-exa/extensions/web-fetch.ts
@@ -2,29 +2,75 @@
  * Exa web fetch — reads webpage content as clean text.
  */
 
+import type { ContentsOptions, SearchResponse, SearchResult } from "exa-js";
 import { Exa } from "exa-js";
-import type { CrawlResult } from "./formatters.js";
-import { formatCrawlResults } from "./formatters.js";
+import type { ToolPerformResult } from "./formatters.js";
+import { formatCrawlResults, toMetadata } from "./formatters.js";
 
 export const DEFAULT_MAX_CHARACTERS = 3000;
 
-export async function performWebFetch(apiKey: string, urls: string[], maxCharacters: number): Promise<string> {
+type FetchOptions = {
+  maxCharacters?: number;
+  highlights?: boolean;
+  summary?: {
+    query?: string;
+  };
+  maxAgeHours?: number;
+};
+
+type FetchedResult = SearchResult<{
+  text: ContentsOptions["text"];
+  highlights: ContentsOptions["highlights"];
+  summary: ContentsOptions["summary"];
+  subpages: number;
+}>;
+
+export async function performWebFetch(
+  apiKey: string,
+  urls: string[],
+  options: FetchOptions = {},
+): Promise<ToolPerformResult> {
   const exa = new Exa(apiKey);
 
-  const crawlRequest = {
-    ids: urls,
-    contents: {
-      text: {
-        maxCharacters,
-      },
+  const contents: ContentsOptions = {
+    text: {
+      maxCharacters: options.maxCharacters || DEFAULT_MAX_CHARACTERS,
     },
   };
 
-  const response = await exa.request<{ results?: CrawlResult[] }>("/contents", "POST", crawlRequest);
-
-  if (!response?.results || response.results.length === 0) {
-    return "No content found for the requested URLs.";
+  if (options.highlights) {
+    contents.highlights = true;
   }
 
-  return formatCrawlResults(response.results);
+  if (options.summary?.query) {
+    contents.summary = {
+      query: options.summary.query,
+    };
+  }
+
+  if (typeof options.maxAgeHours === "number") {
+    contents.maxAgeHours = options.maxAgeHours;
+  }
+
+  const result: SearchResponse<{
+    text: ContentsOptions["text"];
+    highlights: ContentsOptions["highlights"];
+    summary: ContentsOptions["summary"];
+    subpages: number;
+  }> = await exa.getContents(urls, contents);
+
+  if (!result?.results || result.results.length === 0) {
+    return {
+      text: "No content found for the requested URLs.",
+      details: { tool: "web_fetch_exa" },
+    };
+  }
+
+  return {
+    text: formatCrawlResults(result.results as FetchedResult[]),
+    details: {
+      tool: "web_fetch_exa",
+      ...toMetadata(result),
+    },
+  };
 }

--- a/packages/pi-exa/extensions/web-fetch.ts
+++ b/packages/pi-exa/extensions/web-fetch.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ContentsOptions, SearchResponse, SearchResult } from "exa-js";
-import { Exa } from "exa-js";
+import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatCrawlResults, toMetadata } from "./formatters.js";
 
@@ -30,7 +30,7 @@ export async function performWebFetch(
   urls: string[],
   options: FetchOptions = {},
 ): Promise<ToolPerformResult> {
-  const exa = new Exa(apiKey);
+  const exa = getExaClient(apiKey);
 
   const contents: ContentsOptions = {
     text: {

--- a/packages/pi-exa/extensions/web-find-similar.ts
+++ b/packages/pi-exa/extensions/web-find-similar.ts
@@ -12,6 +12,7 @@ const DEFAULT_NUM_RESULTS = 5;
 interface FindSimilarParams {
   url: string;
   numResults?: number;
+  textMaxCharacters?: number;
   excludeSourceDomain?: boolean;
   startPublishedDate?: string;
   endPublishedDate?: string;
@@ -35,7 +36,7 @@ export async function performFindSimilar(apiKey: string, params: FindSimilarPara
     excludeDomains: params.excludeDomains,
     contents: {
       text: {
-        maxCharacters: 5000,
+        maxCharacters: params.textMaxCharacters || 5000,
       },
     },
   });

--- a/packages/pi-exa/extensions/web-find-similar.ts
+++ b/packages/pi-exa/extensions/web-find-similar.ts
@@ -3,7 +3,7 @@
  */
 
 import type { SearchResponse, SearchResult, TextContentsOptions } from "exa-js";
-import { Exa } from "exa-js";
+import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatSearchResults, toMetadata } from "./formatters.js";
 
@@ -25,7 +25,7 @@ type SimilarResult = SearchResult<{
 }>;
 
 export async function performFindSimilar(apiKey: string, params: FindSimilarParams): Promise<ToolPerformResult> {
-  const exa = new Exa(apiKey);
+  const exa = getExaClient(apiKey);
 
   const result: SearchResponse<{ text: TextContentsOptions }> = await exa.findSimilar(params.url, {
     numResults: params.numResults || DEFAULT_NUM_RESULTS,

--- a/packages/pi-exa/extensions/web-find-similar.ts
+++ b/packages/pi-exa/extensions/web-find-similar.ts
@@ -1,0 +1,57 @@
+/**
+ * Exa findSimilar endpoint wrapper.
+ */
+
+import type { SearchResponse, SearchResult, TextContentsOptions } from "exa-js";
+import { Exa } from "exa-js";
+import type { ToolPerformResult } from "./formatters.js";
+import { formatSearchResults, toMetadata } from "./formatters.js";
+
+const DEFAULT_NUM_RESULTS = 5;
+
+interface FindSimilarParams {
+  url: string;
+  numResults?: number;
+  excludeSourceDomain?: boolean;
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+}
+
+type SimilarResult = SearchResult<{
+  text: TextContentsOptions;
+}>;
+
+export async function performFindSimilar(apiKey: string, params: FindSimilarParams): Promise<ToolPerformResult> {
+  const exa = new Exa(apiKey);
+
+  const result: SearchResponse<{ text: TextContentsOptions }> = await exa.findSimilar(params.url, {
+    numResults: params.numResults || DEFAULT_NUM_RESULTS,
+    excludeSourceDomain: params.excludeSourceDomain,
+    startPublishedDate: params.startPublishedDate,
+    endPublishedDate: params.endPublishedDate,
+    includeDomains: params.includeDomains,
+    excludeDomains: params.excludeDomains,
+    contents: {
+      text: {
+        maxCharacters: 5000,
+      },
+    },
+  });
+
+  if (!result?.results || result.results.length === 0) {
+    return {
+      text: "No similar pages found.",
+      details: { tool: "web_find_similar_exa" },
+    };
+  }
+
+  return {
+    text: formatSearchResults(result.results as SimilarResult[]),
+    details: {
+      tool: "web_find_similar_exa",
+      ...toMetadata(result),
+    },
+  };
+}

--- a/packages/pi-exa/extensions/web-research.ts
+++ b/packages/pi-exa/extensions/web-research.ts
@@ -14,6 +14,7 @@ interface ResearchParams {
   query: string;
   type?: (typeof DEEP_RESEARCH_TYPES)[number];
   systemPrompt?: string;
+  textMaxCharacters?: number;
   outputSchema?: Record<string, unknown>;
   additionalQueries?: string[];
   numResults?: number;
@@ -53,10 +54,10 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
     endPublishedDate: params.endPublishedDate,
     contents: {
       text: {
-        maxCharacters: 12000,
+        maxCharacters: params.textMaxCharacters || 12000,
       },
       highlights: {
-        query: params.systemPrompt,
+        query: params.systemPrompt || params.query,
         numSentences: 4,
       },
     },

--- a/packages/pi-exa/extensions/web-research.ts
+++ b/packages/pi-exa/extensions/web-research.ts
@@ -3,12 +3,13 @@
  */
 
 import type { DeepOutputSchema, DeepSearchOutput } from "exa-js";
-import { Exa } from "exa-js";
+import { DEEP_SEARCH_TYPES } from "./constants.js";
+import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatResearchOutput, toMetadata } from "./formatters.js";
 
 export const DEFAULT_DEEP_NUM_RESULTS = 10;
-export const DEEP_RESEARCH_TYPES = ["deep-reasoning", "deep-lite", "deep"] as const;
+export const DEEP_RESEARCH_TYPES = DEEP_SEARCH_TYPES;
 
 interface ResearchParams {
   query: string;
@@ -40,7 +41,7 @@ function parseOutputSchema(outputSchema: Record<string, unknown> | undefined): D
 export async function performResearch(apiKey: string, params: ResearchParams): Promise<ToolPerformResult> {
   const outputSchema = parseOutputSchema(params.outputSchema);
 
-  const exa = new Exa(apiKey);
+  const exa = getExaClient(apiKey);
 
   const response = await exa.search(params.query, {
     type: params.type || "deep-reasoning",

--- a/packages/pi-exa/extensions/web-research.ts
+++ b/packages/pi-exa/extensions/web-research.ts
@@ -1,0 +1,85 @@
+/**
+ * Exa deep research search — powered by deep search with synthesized output.
+ */
+
+import type { DeepOutputSchema, DeepSearchOutput } from "exa-js";
+import { Exa } from "exa-js";
+import type { ToolPerformResult } from "./formatters.js";
+import { formatResearchOutput, toMetadata } from "./formatters.js";
+
+export const DEFAULT_DEEP_NUM_RESULTS = 10;
+export const DEEP_RESEARCH_TYPES = ["deep-reasoning", "deep-lite", "deep"] as const;
+
+interface ResearchParams {
+  query: string;
+  type?: (typeof DEEP_RESEARCH_TYPES)[number];
+  systemPrompt?: string;
+  outputSchema?: Record<string, unknown>;
+  additionalQueries?: string[];
+  numResults?: number;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+}
+
+function parseOutputSchema(outputSchema: Record<string, unknown> | undefined): DeepOutputSchema | undefined {
+  if (!outputSchema || !Object.hasOwn(outputSchema, "type")) {
+    return undefined;
+  }
+
+  const schemaType = outputSchema.type;
+  if (schemaType !== "object" && schemaType !== "text") {
+    throw new Error('outputSchema.type must be either "object" or "text".');
+  }
+
+  return outputSchema as DeepOutputSchema;
+}
+
+export async function performResearch(apiKey: string, params: ResearchParams): Promise<ToolPerformResult> {
+  const outputSchema = parseOutputSchema(params.outputSchema);
+
+  const exa = new Exa(apiKey);
+
+  const response = await exa.search(params.query, {
+    type: params.type || "deep-reasoning",
+    additionalQueries: params.additionalQueries,
+    numResults: params.numResults || DEFAULT_DEEP_NUM_RESULTS,
+    systemPrompt: params.systemPrompt,
+    outputSchema,
+    includeDomains: params.includeDomains,
+    excludeDomains: params.excludeDomains,
+    startPublishedDate: params.startPublishedDate,
+    endPublishedDate: params.endPublishedDate,
+    contents: {
+      text: {
+        maxCharacters: 12000,
+      },
+      highlights: {
+        query: params.systemPrompt,
+        numSentences: 4,
+      },
+    },
+  });
+
+  if (!response?.output) {
+    return {
+      text: "Deep search completed, but no synthesized output was returned. Try a different query or simpler filters.",
+      details: {
+        tool: "web_research_exa",
+        ...toMetadata(response),
+      },
+    };
+  }
+
+  const formatted = formatResearchOutput(response.output as DeepSearchOutput, outputSchema);
+
+  return {
+    text: formatted.text,
+    details: {
+      tool: "web_research_exa",
+      ...toMetadata(response),
+      ...(formatted.parsedOutput === undefined ? {} : { parsedOutput: formatted.parsedOutput }),
+    },
+  };
+}

--- a/packages/pi-exa/extensions/web-search-advanced.ts
+++ b/packages/pi-exa/extensions/web-search-advanced.ts
@@ -3,11 +3,10 @@
  */
 
 import type { HighlightsContentsOptions, SearchResponse, SearchResult, TextContentsOptions } from "exa-js";
-import { Exa } from "exa-js";
+import { DEEP_SEARCH_TYPES } from "./constants.js";
+import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatSearchResults, toMetadata } from "./formatters.js";
-
-const DEEP_SEARCH_TYPES = ["deep-reasoning", "deep", "deep-lite"] as const;
 
 const SEARCH_CATEGORIES = [
   "company",
@@ -26,12 +25,16 @@ type AdvancedResult = SearchResult<{
   highlights?: HighlightsContentsOptions;
 }>;
 
-function sanitizeCategory(category: string | undefined): SearchCategory | undefined {
+function validateCategory(category: string | undefined): SearchCategory | undefined {
   if (!category) {
     return undefined;
   }
 
-  return SEARCH_CATEGORIES.includes(category as SearchCategory) ? (category as SearchCategory) : undefined;
+  if (SEARCH_CATEGORIES.includes(category as SearchCategory)) {
+    return category as SearchCategory;
+  }
+
+  throw new Error(`Invalid category "${category}". Supported categories: ${SEARCH_CATEGORIES.join(", ")}.`);
 }
 
 type AdvancedSearchOptions = {
@@ -66,7 +69,7 @@ export async function performAdvancedSearch(
 ): Promise<ToolPerformResult> {
   validateAdvancedType(options.type);
 
-  const exa = new Exa(apiKey);
+  const exa = getExaClient(apiKey);
 
   const searchOptions: {
     numResults?: number;
@@ -87,7 +90,7 @@ export async function performAdvancedSearch(
     };
   } = {
     numResults: options.numResults || 10,
-    category: sanitizeCategory(options.category),
+    category: validateCategory(options.category),
     type: options.type,
     startPublishedDate: options.startPublishedDate,
     endPublishedDate: options.endPublishedDate,

--- a/packages/pi-exa/extensions/web-search-advanced.ts
+++ b/packages/pi-exa/extensions/web-search-advanced.ts
@@ -2,69 +2,131 @@
  * Exa advanced web search — full API control with category filters, domain restrictions, and date ranges.
  */
 
+import type { HighlightsContentsOptions, SearchResponse, SearchResult, TextContentsOptions } from "exa-js";
 import { Exa } from "exa-js";
-import type { ExaSearchResponse } from "./formatters.js";
-import { formatSearchResults } from "./formatters.js";
+import type { ToolPerformResult } from "./formatters.js";
+import { formatSearchResults, toMetadata } from "./formatters.js";
+
+const DEEP_SEARCH_TYPES = ["deep-reasoning", "deep", "deep-lite"] as const;
+
+const SEARCH_CATEGORIES = [
+  "company",
+  "research paper",
+  "news",
+  "pdf",
+  "personal site",
+  "financial report",
+  "people",
+] as const;
+
+type SearchCategory = (typeof SEARCH_CATEGORIES)[number];
+
+type AdvancedResult = SearchResult<{
+  text: TextContentsOptions;
+  highlights?: HighlightsContentsOptions;
+}>;
+
+function sanitizeCategory(category: string | undefined): SearchCategory | undefined {
+  if (!category) {
+    return undefined;
+  }
+
+  return SEARCH_CATEGORIES.includes(category as SearchCategory) ? (category as SearchCategory) : undefined;
+}
+
+type AdvancedSearchOptions = {
+  numResults?: number;
+  category?: string;
+  type?: "keyword" | "neural" | "auto" | "hybrid" | "fast" | "instant";
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  textMaxCharacters?: number;
+  enableHighlights?: boolean;
+  highlightsNumSentences?: number;
+};
+
+function validateAdvancedType(type: AdvancedSearchOptions["type"] | undefined): void {
+  if (!type) {
+    return;
+  }
+
+  if (DEEP_SEARCH_TYPES.includes(type as (typeof DEEP_SEARCH_TYPES)[number])) {
+    throw new Error(
+      "web_search_advanced_exa does not support deep types. Use web_research_exa for deep-reasoning / deep-lite / deep.",
+    );
+  }
+}
 
 export async function performAdvancedSearch(
   apiKey: string,
   query: string,
-  options: {
+  options: AdvancedSearchOptions,
+): Promise<ToolPerformResult> {
+  validateAdvancedType(options.type);
+
+  const exa = new Exa(apiKey);
+
+  const searchOptions: {
     numResults?: number;
-    category?: string;
-    type?: string;
+    category?: SearchCategory;
+    type?: "keyword" | "neural" | "auto" | "hybrid" | "fast" | "instant";
     startPublishedDate?: string;
     endPublishedDate?: string;
     includeDomains?: string[];
     excludeDomains?: string[];
-    textMaxCharacters?: number;
-    enableHighlights?: boolean;
-    highlightsNumSentences?: number;
-  },
-): Promise<string> {
-  const exa = new Exa(apiKey);
-
-  const searchRequest: Record<string, unknown> = {
-    query,
-    numResults: options.numResults || 10,
     contents: {
-      text: { maxCharacters: options.textMaxCharacters || 3000 },
+      text: {
+        maxCharacters: number;
+      };
+      highlights?: {
+        numSentences?: number;
+        query: string;
+      };
+    };
+  } = {
+    numResults: options.numResults || 10,
+    category: sanitizeCategory(options.category),
+    type: options.type,
+    startPublishedDate: options.startPublishedDate,
+    endPublishedDate: options.endPublishedDate,
+    includeDomains: options.includeDomains,
+    excludeDomains: options.excludeDomains,
+    contents: {
+      text: {
+        maxCharacters: options.textMaxCharacters || 3000,
+      },
     },
   };
 
-  if (options.category) {
-    searchRequest.category = options.category;
-  }
-  if (options.type) {
-    searchRequest.type = options.type;
-  }
-  if (options.startPublishedDate) {
-    searchRequest.startPublishedDate = options.startPublishedDate;
-  }
-  if (options.endPublishedDate) {
-    searchRequest.endPublishedDate = options.endPublishedDate;
-  }
-  if (options.includeDomains && options.includeDomains.length > 0) {
-    searchRequest.includeDomains = options.includeDomains;
-  }
-  if (options.excludeDomains && options.excludeDomains.length > 0) {
-    searchRequest.excludeDomains = options.excludeDomains;
-  }
   if (options.enableHighlights) {
-    const existingContents = searchRequest.contents as Record<string, unknown>;
-    searchRequest.contents = {
-      ...existingContents,
+    searchOptions.contents = {
+      ...searchOptions.contents,
       highlights: {
-        highlightsPerUrl: options.highlightsNumSentences || 3,
+        numSentences: options.highlightsNumSentences || 3,
+        query,
       },
     };
   }
 
-  const response = await exa.request<ExaSearchResponse>("/search", "POST", searchRequest);
+  const result: SearchResponse<{
+    text: TextContentsOptions;
+    highlights?: HighlightsContentsOptions;
+  }> = await exa.search(query, searchOptions);
 
-  if (!response?.results || response.results.length === 0) {
-    return "No search results found. Please try a different query.";
+  if (!result?.results || result.results.length === 0) {
+    return {
+      text: "No search results found. Please try a different query.",
+      details: { tool: "web_search_advanced_exa" },
+    };
   }
 
-  return formatSearchResults(response.results);
+  return {
+    text: formatSearchResults(result.results as AdvancedResult[]),
+    details: {
+      tool: "web_search_advanced_exa",
+      ...toMetadata(result),
+    },
+  };
 }

--- a/packages/pi-exa/extensions/web-search.ts
+++ b/packages/pi-exa/extensions/web-search.ts
@@ -2,33 +2,47 @@
  * Exa web search — performs a search and returns formatted results with highlights.
  */
 
+import type { HighlightsContentsOptions, SearchResult, TextContentsOptions } from "exa-js";
 import { Exa } from "exa-js";
-import type { ExaSearchResponse } from "./formatters.js";
-import { formatSearchResults } from "./formatters.js";
+import type { ToolPerformResult } from "./formatters.js";
+import { formatSearchResults, toMetadata } from "./formatters.js";
 
 export const DEFAULT_NUM_RESULTS = 5;
 
-export async function performWebSearch(apiKey: string, query: string, numResults: number): Promise<string> {
+const DEFAULT_MAX_CHARACTERS = 500;
+
+type SearchResultWithHighlight = SearchResult<{
+  text: TextContentsOptions;
+  highlights: HighlightsContentsOptions;
+}>;
+
+export async function performWebSearch(apiKey: string, query: string, numResults: number): Promise<ToolPerformResult> {
   const exa = new Exa(apiKey);
 
-  const searchRequest = {
-    query,
+  const result = await exa.search(query, {
     type: "auto",
     numResults,
     contents: {
-      highlights: { query },
-      text: { maxCharacters: 300 },
+      text: { maxCharacters: DEFAULT_MAX_CHARACTERS },
+      highlights: {
+        query,
+        numSentences: 3,
+      },
     },
-  };
+  });
 
-  // Exa SDK already prefixes requests with its configured baseURL.
-  // Pass a relative endpoint here, not a full URL, or the SDK will build
-  // an invalid URL like "https://api.exa.aihttps://api.exa.ai/search".
-  const response = await exa.request<ExaSearchResponse>("/search", "POST", searchRequest);
-
-  if (!response?.results || response.results.length === 0) {
-    return "No search results found. Please try a different query.";
+  if (!result?.results || result.results.length === 0) {
+    return {
+      text: "No search results found. Please try a different query.",
+      details: { tool: "web_search_exa" },
+    };
   }
 
-  return formatSearchResults(response.results);
+  return {
+    text: formatSearchResults(result.results as SearchResultWithHighlight[]),
+    details: {
+      tool: "web_search_exa",
+      ...toMetadata(result),
+    },
+  };
 }

--- a/packages/pi-exa/extensions/web-search.ts
+++ b/packages/pi-exa/extensions/web-search.ts
@@ -3,7 +3,7 @@
  */
 
 import type { HighlightsContentsOptions, SearchResult, TextContentsOptions } from "exa-js";
-import { Exa } from "exa-js";
+import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatSearchResults, toMetadata } from "./formatters.js";
 
@@ -17,7 +17,7 @@ type SearchResultWithHighlight = SearchResult<{
 }>;
 
 export async function performWebSearch(apiKey: string, query: string, numResults: number): Promise<ToolPerformResult> {
-  const exa = new Exa(apiKey);
+  const exa = getExaClient(apiKey);
 
   const result = await exa.search(query, {
     type: "auto",

--- a/packages/pi-exa/package.json
+++ b/packages/pi-exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-exa",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Exa MCP extension for pi — web search, content fetching, and advanced search via Exa AI",
   "keywords": [
     "pi",

--- a/packages/pi-exa/skills/code-search/SKILL.md
+++ b/packages/pi-exa/skills/code-search/SKILL.md
@@ -1,73 +1,36 @@
 ---
 name: code-search
-description: Code context using Exa. Finds real snippets and docs from GitHub, StackOverflow, and technical docs. Use when searching for code examples, API syntax, library documentation, or debugging help.
+description: Code context using Exa. Finds reliable code docs, snippets, API references, and debugging examples.
 context: fork
 ---
 
-# Code Context (Exa)
+# Code Search (Exa)
 
-## Tool Restriction (Critical)
+## Tool Selection
 
-ONLY use `web_search_exa`. Do NOT use other Exa tools.
+| Intent | Primary Tool | Notes |
+|---|---|---|
+| Find code examples / API syntax | `web_search_exa` | Start with query + `numResults` |
+| Need grounded short answer or explanation | `web_answer_exa` | Use `systemPrompt` + optional `outputSchema` |
+| Need deep, synthesis-style comparison across sources | `web_research_exa` | Set `systemPrompt`, pass `additionalQueries`, prefer `outputSchema` |
+| Read a page after discovery | `web_fetch_exa` | Use on 1-3 URLs from search result |
 
-## Token Isolation (Critical)
+## Query Writing
 
-Never run Exa in main context. Always spawn Task agents:
-- Agent calls `web_search_exa`
-- Agent extracts the minimum viable snippet(s) + constraints
-- Agent deduplicates near-identical results (mirrors, forks, repeated StackOverflow answers) before presenting
-- Agent returns copyable snippets + brief explanation
-- Main context stays clean regardless of search volume
+- Include **language** and **version** (e.g., `TypeScript 5`, `React 19`, `Python 3.12`).
+- Prefer short, high-signal phrasing and exact identifiers when available.
 
-## When to Use
+## Recommended Parameters
 
-Use this tool for ANY programming-related request:
-- API usage and syntax
-- SDK/library examples
-- config and setup patterns
-- framework "how to" questions
-- debugging when you need authoritative snippets
+- **web_search_exa**
+  - `{ "query": "...", "numResults": 5 }`
+- **web_answer_exa**
+  - `{ "query": "...", "systemPrompt": "Prefer official docs and short code snippets" }`
+- **web_research_exa**
+  - `{ "query": "...,", "systemPrompt": "Focus on official references and compare approaches", "outputSchema": { "type": "text" } }`
 
-## Query Writing Patterns (High Signal)
+## Output Guidance
 
-To reduce irrelevant results and cross-language noise:
-- Always include the **programming language** in the query.
-  - Example: use **"Go generics"** instead of just **"generics"**.
-- When applicable, also include **framework + version** (e.g., "Next.js 14", "React 19", "Python 3.12").
-- Include exact identifiers (function/class names, config keys, error messages) when you have them.
-
-## Output Format (Recommended)
-
-Return:
-1) Best minimal working snippet(s) (keep it copy/paste friendly)
-2) Notes on version / constraints / gotchas
-3) Sources (URLs if present in returned context)
-
-Before presenting:
-- Deduplicate similar results and keep only the best representative snippet per approach.
-
-## Examples
-
-### Find React hook patterns
-```
-web_search_exa {
-  "query": "React useState TypeScript generic types hooks",
-  "numResults": 5
-}
-```
-
-### Find Python async patterns
-```
-web_search_exa {
-  "query": "Python asyncio gather concurrent tasks example",
-  "numResults": 5
-}
-```
-
-### Debug a specific error
-```
-web_search_exa {
-  "query": "TypeError Cannot read property of undefined JavaScript fix",
-  "numResults": 5
-}
-```
+1) Return concise snippets first.
+2) Cite source URLs where decisions came from.
+3) Keep follow-up calls minimal and focused.

--- a/packages/pi-exa/skills/company-research/SKILL.md
+++ b/packages/pi-exa/skills/company-research/SKILL.md
@@ -21,6 +21,14 @@ context: fork
 - `category: "company"` focuses on company-facing pages and profile-like structure.
 - Deep search (`deep`, `deep-lite`) belongs to **`web_research_exa`**, not `web_search_advanced_exa`.
 
+## Filter Restrictions
+
+When using `web_search_advanced_exa` with `category: "company"`, avoid:
+- `includeDomains`
+- `startPublishedDate` / `endPublishedDate`
+
+These filters commonly trigger Exa `400` errors for this category. Prefer running a broader query first, then post-filtering results locally if needed.
+
 ## Recommended settings
 
 ```json

--- a/packages/pi-exa/skills/company-research/SKILL.md
+++ b/packages/pi-exa/skills/company-research/SKILL.md
@@ -1,96 +1,50 @@
 ---
 name: company-research
-description: Company research using Exa search. Finds company info, competitors, news, financials, LinkedIn profiles, builds company lists. Use when researching companies, doing competitor analysis, market research, or building company lists.
+description: Company research using Exa search. Finds company context, competitors, and market signals.
 context: fork
 ---
 
 # Company Research (Exa)
 
-## Tool Restriction (Critical)
+## Tool Selection
 
-ONLY use `web_search_exa` for basic searches or `web_search_advanced_exa` if enabled with category filters. Do NOT use `web_fetch_exa` unless following up on specific URLs.
+| Intent | Primary Tool | Notes |
+|---|---|---|
+| Company discovery / competitive list | `web_search_exa` | Use category filters when needed |
+| Company page metadata or focused category search | `web_search_advanced_exa` | `category: "company"`, use domain filters |
+| Comparative write-up across multiple companies | `web_research_exa` | Requires `systemPrompt`, `additionalQueries`, optionally `outputSchema.type: "object"` |
+| Direct question about a company topic | `web_answer_exa` | Prefer `outputSchema` for downstream processing |
+| Follow-up deep reading | `web_fetch_exa` | Pulls content from selected URLs |
 
-## Token Isolation (Critical)
+## Category Behavior
 
-Never run Exa searches in main context. Always spawn Task agents:
-- Agent runs Exa search internally
-- Agent processes results using LLM intelligence
-- Agent returns only distilled output (compact JSON or brief markdown)
-- Main context stays clean regardless of search volume
+- `category: "company"` focuses on company-facing pages and profile-like structure.
+- Deep search (`deep`, `deep-lite`) belongs to **`web_research_exa`**, not `web_search_advanced_exa`.
 
-## Dynamic Tuning
+## Recommended settings
 
-No hardcoded numResults. Tune to user intent:
-- User says "a few" → 10-20
-- User says "comprehensive" → 50-100
-- User specifies number → match it
-- Ambiguous? Ask: "How many companies would you like?"
-
-## Query Variation
-
-Exa returns different results for different phrasings. For coverage:
-- Generate 2-3 query variations
-- Run in parallel if using Task agents
-- Merge and deduplicate
-
-## Categories (with web_search_advanced_exa)
-
-Use appropriate `category` depending on what you need:
-- `company` → homepages, rich metadata (headcount, location, funding, revenue)
-- `news` → press coverage, announcements
-- `people` → LinkedIn profiles (public data)
-- No category (`type: "auto"`) → general web results, deep dives, broader context
-
-Start with `category: "company"` for discovery, then use other categories or no category for deeper research.
-
-### Category-Specific Filter Restrictions
-
-When using `category: "company"`, these parameters cause 400 errors:
-- `includeDomains` / `excludeDomains`
-- `startPublishedDate` / `endPublishedDate`
-- `startCrawlDate` / `endCrawlDate`
-
-When searching without a category (or with `news`), domain and date filters work fine.
-
-## Browser Fallback
-
-Auto-fallback to Claude in Chrome when:
-- Exa returns insufficient results
-- Content is auth-gated
-- Dynamic pages need JavaScript
-
-## Examples
-
-### Discovery: find companies in a space
-```
-web_search_exa {
-  "query": "AI infrastructure startups San Francisco",
-  "numResults": 20
+```json
+{
+  "web_search_exa": { "query": "AI infrastructure startups in 2025", "numResults": 20 },
+  "web_search_advanced_exa": {
+    "category": "company",
+    "type": "auto",
+    "numResults": 12
+  },
+  "web_research_exa": {
+    "systemPrompt": "Prefer official sources and filings; return concise competitive summary.",
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "summary": { "type": "string" }
+      }
+    }
+  }
 }
 ```
 
-### With advanced search (if enabled)
-```
-web_search_advanced_exa {
-  "query": "AI infrastructure startups San Francisco",
-  "category": "company",
-  "numResults": 20
-}
-```
+## Output Guidance
 
-### News coverage
-```
-web_search_advanced_exa {
-  "query": "Anthropic AI safety",
-  "category": "news",
-  "numResults": 15,
-  "startPublishedDate": "2024-01-01"
-}
-```
-
-## Output Format
-
-Return:
-1) Results (structured list; one company per row)
-2) Sources (URLs; 1-line relevance each)
-3) Notes (uncertainty/conflicts)
+1) Return structured findings list first (name, signals, links).
+2) Note assumptions or data gaps.
+3) Avoid overclaiming on incomplete information.

--- a/packages/pi-exa/skills/financial-report-search/SKILL.md
+++ b/packages/pi-exa/skills/financial-report-search/SKILL.md
@@ -15,6 +15,13 @@ context: fork
 | Explain one metric or line item | `web_answer_exa` | Fast direct answers with citations |
 | Read full filing text | `web_fetch_exa` | Fetch 1-3 URLs only |
 
+## Filter Restrictions
+
+When using `web_search_advanced_exa` with `category: "financial report"`, avoid:
+- `excludeText`
+
+This option is rejected for this category by Exa and may return `400`.
+
 ## Recommended settings
 
 - `web_search_advanced_exa`

--- a/packages/pi-exa/skills/financial-report-search/SKILL.md
+++ b/packages/pi-exa/skills/financial-report-search/SKILL.md
@@ -1,81 +1,31 @@
 ---
 name: financial-report-search
-description: Search for financial reports using Exa advanced search. Near-full filter support for finding SEC filings, earnings reports, and financial documents. Use when searching for 10-K filings, quarterly earnings, or annual reports.
+description: Search financial reports using Exa. Finds SEC filings, earnings materials, and filings by company.
 context: fork
 ---
 
 # Financial Report Search (Exa)
 
-## Tool Restriction (Critical)
+## Tool Selection
 
-ONLY use `web_search_exa` for basic searches or `web_search_advanced_exa` with `category: "financial report"` if enabled. Do NOT use `web_fetch_exa` unless following up on specific URLs.
+| Intent | Primary Tool | Notes |
+|---|---|---|
+| Discovery of filings / reports | `web_search_advanced_exa` with `category: "financial report"` | Use date filters and domain filters |
+| Compare filings across firms | `web_research_exa` | Use `systemPrompt` and `outputSchema` for structured output |
+| Explain one metric or line item | `web_answer_exa` | Fast direct answers with citations |
+| Read full filing text | `web_fetch_exa` | Fetch 1-3 URLs only |
 
-## Token Isolation (Critical)
+## Recommended settings
 
-Never run Exa searches in main context. Always spawn Task agents:
-- Agent calls `web_search_exa` or `web_search_advanced_exa`
-- Agent merges + deduplicates results before presenting
-- Agent returns distilled output (brief markdown or compact JSON)
-- Main context stays clean regardless of search volume
+- `web_search_advanced_exa`
+  - `{ "query": "10-K AI company", "category": "financial report", "startPublishedDate": "2025-01-01", "numResults": 20 }`
+- `web_search_advanced_exa` for SEC-only domain filtering
+  - `{ "includeDomains": ["sec.report", "sec.gov"], "category": "financial report" }`
+- `web_research_exa`
+  - `{ "query": "Compare risk factors and revenue trend in latest reports", "systemPrompt": "Return only evidence-backed statements", "outputSchema": { "type": "object", "properties": { "risks": { "type": "array" } } } }`
 
-## When to Use
+## Output Guidance
 
-Use this category when you need:
-- SEC filings (10-K, 10-Q, 8-K, S-1)
-- Quarterly earnings reports
-- Annual reports
-- Investor presentations
-- Financial statements
-
-## Filter Restrictions
-
-The `financial report` category has one known restriction:
-
-- `excludeText` - NOT SUPPORTED (causes 400 error)
-
-## Examples
-
-### SEC filings for a company
-```
-web_search_exa {
-  "query": "Anthropic SEC filing S-1",
-  "numResults": 10
-}
-```
-
-### Recent earnings reports
-```
-web_search_advanced_exa {
-  "query": "Q4 2025 earnings report technology",
-  "category": "financial report",
-  "startPublishedDate": "2025-10-01",
-  "numResults": 20
-}
-```
-
-### Specific filing type
-```
-web_search_advanced_exa {
-  "query": "10-K annual report AI companies",
-  "category": "financial report",
-  "includeDomains": ["sec.gov"],
-  "startPublishedDate": "2025-01-01",
-  "numResults": 15
-}
-```
-
-### Risk factors analysis
-```
-web_search_advanced_exa {
-  "query": "risk factors cybersecurity",
-  "category": "financial report",
-  "numResults": 10
-}
-```
-
-## Output Format
-
-Return:
-1) Results (company name, filing type, date, key figures/highlights)
-2) Sources (Filing URLs)
-3) Notes (reporting period, any restatements, auditor notes)
+1) Separate numbers from interpretations.
+2) Include source links for every numeric claim.
+3) Call out filing periods clearly.

--- a/packages/pi-exa/skills/people-research/SKILL.md
+++ b/packages/pi-exa/skills/people-research/SKILL.md
@@ -15,6 +15,15 @@ context: fork
 | Direct answer about one person | `web_answer_exa` | Good for short factual checks |
 | Read profile details | `web_fetch_exa` | Fetch selected profile URLs |
 
+## Filter Restrictions
+
+When using `web_search_advanced_exa` with `category: "people"`, avoid:
+- `excludeText`
+- `excludeDomains`
+- `startPublishedDate` / `endPublishedDate`
+
+These filters are rejected for this category by Exa and typically return `400`.
+
 ## Recommended settings
 
 - People discovery

--- a/packages/pi-exa/skills/people-research/SKILL.md
+++ b/packages/pi-exa/skills/people-research/SKILL.md
@@ -1,103 +1,29 @@
 ---
 name: people-research
-description: People research using Exa search. Finds LinkedIn profiles, professional backgrounds, experts, team members, and public bios across the web. Use when searching for people, finding experts, or looking up professional profiles.
+description: People research using Exa search. Finds experts, professional profiles, and public bios.
 context: fork
 ---
 
 # People Research (Exa)
 
-## Tool Restriction (Critical)
+## Tool Selection
 
-ONLY use `web_search_exa` for basic searches or `web_search_advanced_exa` with `category: "people"` if enabled. Do NOT use `web_fetch_exa` unless following up on specific URLs.
+| Intent | Primary Tool | Notes |
+|---|---|---|
+| Professional profile discovery | `web_search_advanced_exa` with `category: "people"` | Use `query` for role/location/industry |
+| Compare multiple candidates | `web_research_exa` | Use `additionalQueries` + `systemPrompt` |
+| Direct answer about one person | `web_answer_exa` | Good for short factual checks |
+| Read profile details | `web_fetch_exa` | Fetch selected profile URLs |
 
-## Token Isolation (Critical)
+## Recommended settings
 
-Never run Exa searches in main context. Always spawn Task agents:
-- Agent runs Exa search internally
-- Agent processes results using LLM intelligence
-- Agent returns only distilled output (compact JSON or brief markdown)
-- Main context stays clean regardless of search volume
+- People discovery
+  - `web_search_advanced_exa` with `category: "people"`, `numResults: 20`
+- Deep compare
+  - `web_research_exa` with `outputSchema`: `{ "type": "object", "properties": { "experts": { "type": "array" } } }`
 
-## Dynamic Tuning
+## Output Guidance
 
-No hardcoded numResults. Tune to user intent:
-- User says "a few" → 10-20
-- User says "comprehensive" → 50-100
-- User specifies number → match it
-- Ambiguous? Ask: "How many profiles would you like?"
-
-## Query Variation
-
-Exa returns different results for different phrasings. For coverage:
-- Generate 2-3 query variations
-- Run in parallel if using Task agents
-- Merge and deduplicate
-
-## Categories (with web_search_advanced_exa)
-
-Use appropriate `category` depending on what you need:
-- `people` → LinkedIn profiles, public bios (primary for discovery)
-- `news` → press mentions, interviews, speaker bios
-- `personal site` → personal blogs, portfolio sites
-- No category (`type: "auto"`) → general web results, broader context
-
-Start with `category: "people"` for profile discovery, then use other categories or no category for deeper research.
-
-### Category-Specific Filter Restrictions
-
-When using `category: "people"`, these parameters cause errors:
-- `startPublishedDate` / `endPublishedDate`
-- `includeText` / `excludeText`
-- `excludeDomains`
-- `includeDomains` — **LinkedIn domains only** (e.g., "linkedin.com")
-
-## Browser Fallback
-
-Auto-fallback to Claude in Chrome when:
-- Exa returns insufficient results
-- Content is auth-gated
-- Dynamic pages need JavaScript
-
-## Examples
-
-### Discovery: find people by role
-```
-web_search_exa {
-  "query": "VP Engineering AI infrastructure San Francisco",
-  "numResults": 20
-}
-```
-
-### With advanced search (if enabled)
-```
-web_search_advanced_exa {
-  "query": "machine learning engineer San Francisco",
-  "category": "people",
-  "numResults": 25
-}
-```
-
-### Deep dive: research a specific person
-```
-web_search_exa {
-  "query": "Dario Amodei Anthropic CEO background",
-  "numResults": 15
-}
-```
-
-### News mentions
-```
-web_search_advanced_exa {
-  "query": "Dario Amodei interview",
-  "category": "news",
-  "numResults": 10,
-  "startPublishedDate": "2024-01-01"
-}
-```
-
-## Output Format
-
-Return:
-1) Results (name, title, company, location if available)
-2) Sources (Profile URLs)
-3) Notes (profile completeness, verification status)
+1) Return one row per person with source URL.
+2) Include role, company, and recency signals.
+3) Flag potential uncertainty (common-name collisions, sparse profiles).

--- a/packages/pi-exa/skills/personal-site-search/SKILL.md
+++ b/packages/pi-exa/skills/personal-site-search/SKILL.md
@@ -1,73 +1,29 @@
 ---
 name: personal-site-search
-description: Search personal websites and blogs using Exa advanced search. Full filter support for finding individual perspectives, portfolios, and personal blogs. Use when searching for personal sites, blog posts, or portfolio websites.
+description: Search personal websites and blogs using Exa. Finds practitioner perspectives and independent analysis.
 context: fork
 ---
 
 # Personal Site Search (Exa)
 
-## Tool Restriction (Critical)
+## Tool Selection
 
-ONLY use `web_search_exa` for basic searches or `web_search_advanced_exa` with `category: "personal site"` if enabled. Do NOT use `web_fetch_exa` unless following up on specific URLs.
+| Intent | Primary Tool | Notes |
+|---|---|---|
+| Practitioner blogs / opinion pieces | `web_search_advanced_exa` with `category: "personal site"` | Add date filters for freshness |
+| Distill cross-site viewpoints | `web_research_exa` | Provide a strong `systemPrompt` and optional object `outputSchema` |
+| Direct one-off answer | `web_answer_exa` | Keep answer concise |
+| Pull article bodies | `web_fetch_exa` | Use after discovering canonical URLs |
 
-## Token Isolation (Critical)
+## Recommended settings
 
-Never run Exa searches in main context. Always spawn Task agents:
-- Agent calls `web_search_exa` or `web_search_advanced_exa`
-- Agent merges + deduplicates results before presenting
-- Agent returns distilled output (brief markdown or compact JSON)
-- Main context stays clean regardless of search volume
+- `web_search_advanced_exa`
+  - `{ "query": "Rust async architecture", "category": "personal site", "excludeDomains": ["medium.com", "substack.com"], "numResults": 15 }`
+- `web_research_exa`
+  - `{ "query": "Compare recommendations from practitioner blogs", "systemPrompt": "Prioritize dated posts and call out opinion vs facts", "outputSchema": { "type": "text" } }`
 
-## When to Use
+## Output Guidance
 
-Use this category when you need:
-- Individual expert opinions and experiences
-- Personal blog posts on technical topics
-- Portfolio websites
-- Independent analysis (not corporate content)
-- Deep dives and tutorials from practitioners
-
-## Examples
-
-### Technical blog posts
-```
-web_search_exa {
-  "query": "building production LLM applications lessons learned",
-  "numResults": 15
-}
-```
-
-### Recent posts on a topic
-```
-web_search_exa {
-  "query": "Rust async runtime comparison 2024",
-  "numResults": 10
-}
-```
-
-### Exclude aggregators
-```
-web_search_advanced_exa {
-  "query": "startup founder lessons",
-  "category": "personal site",
-  "excludeDomains": ["medium.com", "substack.com"],
-  "numResults": 15
-}
-```
-
-### With date filter
-```
-web_search_advanced_exa {
-  "query": "TypeScript best practices",
-  "category": "personal site",
-  "startPublishedDate": "2025-01-01",
-  "numResults": 10
-}
-```
-
-## Output Format
-
-Return:
-1) Results (title, author/site name, date, key insights)
-2) Sources (URLs)
-3) Notes (author expertise, potential biases, depth of coverage)
+1) Identify author perspective and date.
+2) Distinguish opinion claims from verifiable facts.
+3) Return top 3–5 strongest links with rationale.

--- a/packages/pi-exa/skills/research-paper-search/SKILL.md
+++ b/packages/pi-exa/skills/research-paper-search/SKILL.md
@@ -1,71 +1,28 @@
 ---
 name: research-paper-search
-description: Search for research papers and academic content using Exa advanced search. Full filter support including date ranges and text filtering. Use when searching for academic papers, arXiv preprints, or scientific research.
+description: Search for research papers and academic content using Exa.
 context: fork
 ---
 
 # Research Paper Search (Exa)
 
-## Tool Restriction (Critical)
+## Tool Selection
 
-ONLY use `web_search_exa` for basic searches or `web_search_advanced_exa` with `category: "research paper"` if enabled. Do NOT use `web_fetch_exa` unless following up on specific URLs.
+| Intent | Primary Tool | Notes |
+|---|---|---|
+| Paper discovery | `web_search_advanced_exa` | `category: "research paper"`, optional `includeDomains` (e.g., `arxiv.org`) |
+| Evidence-weighted synthesis across papers | `web_research_exa` | Use `systemPrompt`, optional structured `outputSchema` |
+| One-off definition / quick answer | `web_answer_exa` | Keep it concise and citation-focused |
 
-## Token Isolation (Critical)
+## Recommended settings
 
-Never run Exa searches in main context. Always spawn Task agents:
-- Agent calls `web_search_exa` or `web_search_advanced_exa`
-- Agent merges + deduplicates results before presenting
-- Agent returns distilled output (brief markdown or compact JSON)
-- Main context stays clean regardless of search volume
+- `web_search_advanced_exa`
+  - `{ "query": "LLM fine-tuning methods", "category": "research paper", "includeDomains": ["arxiv.org"], "numResults": 20 }`
+- `web_research_exa`
+  - `{ "query": "Summarize methodological differences between X and Y", "systemPrompt": "Prioritize peer-reviewed sources and methods sections", "outputSchema": { "type": "text" } }`
 
-## When to Use
+## Output Guidance
 
-Use this skill when you need:
-- Academic papers from arXiv, OpenReview, PubMed, etc.
-- Scientific research on specific topics
-- Literature reviews with date filtering
-- Papers containing specific methodologies or terms
-
-## Query Writing Tips
-
-- Include research domain keywords
-- Include specific methodologies if known
-- Use version numbers for frameworks/libraries
-- Consider adding "paper" or "arxiv" to focus results
-
-## Examples
-
-### Recent papers on a topic
-```
-web_search_exa {
-  "query": "transformer attention mechanisms efficiency 2024",
-  "numResults": 15
-}
-```
-
-### From specific venues
-```
-web_search_advanced_exa {
-  "query": "large language model agents arxiv",
-  "category": "research paper",
-  "includeDomains": ["arxiv.org"],
-  "numResults": 20
-}
-```
-
-### With date filter (if advanced enabled)
-```
-web_search_advanced_exa {
-  "query": "RLHF reinforcement learning human feedback",
-  "category": "research paper",
-  "startPublishedDate": "2024-01-01",
-  "numResults": 15
-}
-```
-
-## Output Format
-
-Return:
-1) Results (structured list with title, authors, date, abstract summary)
-2) Sources (URLs with publication venue)
-3) Notes (methodology differences, conflicting findings)
+1) Return paper title, venue, and year.
+2) Prefer direct quotations for claims.
+3) Provide caveats for methodology limits.


### PR DESCRIPTION
## Summary
This PR lands the `pi-exa` API-alignment work with `exa-js` including:

- Added opt-in research support (`web_research_exa`) with config/flag control.
- Added `web_answer_exa` and `web_find_similar_exa` tools.
- Migrated `pi-exa` extension/search wrappers to typed SDK calls (`exa.search`, `exa.getContents`, `exa.answer`, `exa.findSimilar`) and aligned contracts with `exa-js` response/request types.
- Added output schema handling for `DeepOutputSchema` with `type` support (`object` / `text`) and preserved existing `outputSchema.type` validation behavior.
- Updated formatting/helpers for subpages/grounding/metadata rendering and deep search outputs.
- Updated tests and docs for the new behavior and tool matrix.

## Changes
- `packages/pi-exa/extensions/*`
- `packages/pi-exa/README.md`
- `packages/pi-exa/__tests__/*`
- `packages/pi-exa/skills/*`

## Commits
- `2920e96` feat(pi-exa): align exa tools with sdk typings and add research/answer/find-similar
- `a7cda02` test(pi-exa): update extension tests for sdk-aligned tool behaviors
- `c8d8a03` docs(pi-exa): update README and skill docs for new web tools

## Validation
- `npm run check`
- `npm run test -- packages/pi-exa/__tests__/extension.test.ts packages/pi-exa/__tests__/helpers.test.ts packages/pi-exa/__tests__/index.test.ts`
- `npm run test` (remaining unrelated failures currently only in `packages/pi-notion/__tests__/helpers.test.ts`, tracked in issue #33)

## Notes
- Full repo coverage is blocked by existing unrelated `pi-notion` helper test failures.
