### PR TITLE
fix: isolate pi-notion auth tests from env auth config

### DIFF
--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -362,10 +362,13 @@ describe("pi-notion checkNotionAuth", () => {
   }
 
   async function importCheckNotionAuthInIsolatedEnv(apiKey?: string) {
-    return withIsolatedAuthEnv(async () => {
-      const { checkNotionAuth } = await import("../extensions/index.js");
-      return checkNotionAuth();
-    }, { apiKey });
+    return withIsolatedAuthEnv(
+      async () => {
+        const { checkNotionAuth } = await import("../extensions/index.js");
+        return checkNotionAuth();
+      },
+      { apiKey },
+    );
   }
 
   it("returns not authenticated when no config exists", async () => {

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -317,15 +317,19 @@ describe("pi-notion loadConfig", () => {
 });
 
 describe("pi-notion checkNotionAuth", () => {
-  async function importCheckNotionAuthInIsolatedEnv(apiKey?: string) {
+  async function withIsolatedAuthEnv<T>(
+    run: (paths: { tempHome: string; tempProject: string }) => Promise<T>,
+    options?: { apiKey?: string; tempPrefix?: string },
+  ): Promise<T> {
     const originalHome = process.env.HOME;
     const originalApiKey = process.env.NOTION_API_KEY;
     const originalToken = process.env.NOTION_TOKEN;
     const originalMcpAuthFile = process.env.NOTION_MCP_AUTH_FILE;
     const originalLegacyMcpAuthFile = process.env.NOTION_MCP_AUTH;
     const originalCwd = process.cwd();
-    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-auth-home-"));
-    const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-auth-project-"));
+    const tempPrefix = options?.tempPrefix ?? "pi-notion-auth";
+    const tempHome = mkdtempSync(join(tmpdir(), `${tempPrefix}-home-`));
+    const tempProject = mkdtempSync(join(tmpdir(), `${tempPrefix}-project-`));
 
     mkdirSync(join(tempHome, ".pi", "agent"), { recursive: true });
     mkdirSync(join(tempProject, ".pi"), { recursive: true });
@@ -335,14 +339,13 @@ describe("pi-notion checkNotionAuth", () => {
     delete process.env.NOTION_MCP_AUTH_FILE;
     delete process.env.NOTION_MCP_AUTH;
     delete process.env.NOTION_TOKEN;
-    if (apiKey) process.env.NOTION_API_KEY = apiKey;
+    if (options?.apiKey) process.env.NOTION_API_KEY = options.apiKey;
     else delete process.env.NOTION_API_KEY;
 
     vi.resetModules();
 
     try {
-      const { checkNotionAuth } = await import("../extensions/index.js");
-      return checkNotionAuth();
+      return await run({ tempHome, tempProject });
     } finally {
       process.chdir(originalCwd);
       if (originalHome) process.env.HOME = originalHome;
@@ -358,6 +361,13 @@ describe("pi-notion checkNotionAuth", () => {
     }
   }
 
+  async function importCheckNotionAuthInIsolatedEnv(apiKey?: string) {
+    return withIsolatedAuthEnv(async () => {
+      const { checkNotionAuth } = await import("../extensions/index.js");
+      return checkNotionAuth();
+    }, { apiKey });
+  }
+
   it("returns not authenticated when no config exists", async () => {
     const result = await importCheckNotionAuthInIsolatedEnv();
     expect(result.authenticated).toBe(false);
@@ -365,48 +375,27 @@ describe("pi-notion checkNotionAuth", () => {
   });
 
   it("migrates legacy MCP auth file to the new filename", async () => {
-    const originalHome = process.env.HOME;
-    const originalToken = process.env.NOTION_TOKEN;
-    const originalMcpAuthFile = process.env.NOTION_MCP_AUTH_FILE;
-    const originalLegacyMcpAuthFile = process.env.NOTION_MCP_AUTH;
-    const originalCwd = process.cwd();
-    const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-migrate-home-"));
-    const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-migrate-project-"));
-    const configDir = join(tempHome, ".pi", "agent", "extensions");
-    const agentDir = join(tempHome, ".pi", "agent");
+    await withIsolatedAuthEnv(
+      async ({ tempHome }) => {
+        const configDir = join(tempHome, ".pi", "agent", "extensions");
+        const agentDir = join(tempHome, ".pi", "agent");
 
-    mkdirSync(configDir, { recursive: true });
-    writeFileSync(
-      join(configDir, "notion-mcp.json"),
-      JSON.stringify({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" }),
-      "utf-8",
+        mkdirSync(configDir, { recursive: true });
+        writeFileSync(
+          join(configDir, "notion-mcp.json"),
+          JSON.stringify({ mcpUrl: "https://mcp.notion.com/mcp", accessToken: "token-123" }),
+          "utf-8",
+        );
+
+        const mod = await import("../extensions/index.js");
+        const result = mod.checkNotionAuth();
+        expect(result.authenticated).toBe(true);
+        expect(existsSync(join(configDir, "notion-mcp.json"))).toBe(false);
+        expect(existsSync(join(configDir, "notion-mcp-auth.json"))).toBe(false);
+        expect(existsSync(join(agentDir, "notion-mcp-auth.json"))).toBe(true);
+      },
+      { tempPrefix: "pi-notion-migrate" },
     );
-
-    process.env.HOME = tempHome;
-    process.chdir(tempProject);
-    delete process.env.NOTION_MCP_AUTH_FILE;
-    delete process.env.NOTION_MCP_AUTH;
-    delete process.env.NOTION_TOKEN;
-    vi.resetModules();
-
-    try {
-      const mod = await import("../extensions/index.js");
-      const result = mod.checkNotionAuth();
-      expect(result.authenticated).toBe(true);
-      expect(existsSync(join(configDir, "notion-mcp.json"))).toBe(false);
-      expect(existsSync(join(configDir, "notion-mcp-auth.json"))).toBe(false);
-      expect(existsSync(join(agentDir, "notion-mcp-auth.json"))).toBe(true);
-    } finally {
-      process.chdir(originalCwd);
-      if (originalHome) process.env.HOME = originalHome;
-      else delete process.env.HOME;
-      if (originalToken) process.env.NOTION_TOKEN = originalToken;
-      else delete process.env.NOTION_TOKEN;
-      if (originalMcpAuthFile) process.env.NOTION_MCP_AUTH_FILE = originalMcpAuthFile;
-      else delete process.env.NOTION_MCP_AUTH_FILE;
-      if (originalLegacyMcpAuthFile) process.env.NOTION_MCP_AUTH = originalLegacyMcpAuthFile;
-      else delete process.env.NOTION_MCP_AUTH;
-    }
   });
 
   it("detects NOTION_API_KEY but still requires MCP auth", async () => {

--- a/packages/pi-notion/__tests__/helpers.test.ts
+++ b/packages/pi-notion/__tests__/helpers.test.ts
@@ -320,6 +320,9 @@ describe("pi-notion checkNotionAuth", () => {
   async function importCheckNotionAuthInIsolatedEnv(apiKey?: string) {
     const originalHome = process.env.HOME;
     const originalApiKey = process.env.NOTION_API_KEY;
+    const originalToken = process.env.NOTION_TOKEN;
+    const originalMcpAuthFile = process.env.NOTION_MCP_AUTH_FILE;
+    const originalLegacyMcpAuthFile = process.env.NOTION_MCP_AUTH;
     const originalCwd = process.cwd();
     const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-auth-home-"));
     const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-auth-project-"));
@@ -329,6 +332,9 @@ describe("pi-notion checkNotionAuth", () => {
 
     process.env.HOME = tempHome;
     process.chdir(tempProject);
+    delete process.env.NOTION_MCP_AUTH_FILE;
+    delete process.env.NOTION_MCP_AUTH;
+    delete process.env.NOTION_TOKEN;
     if (apiKey) process.env.NOTION_API_KEY = apiKey;
     else delete process.env.NOTION_API_KEY;
 
@@ -343,6 +349,12 @@ describe("pi-notion checkNotionAuth", () => {
       else delete process.env.HOME;
       if (originalApiKey) process.env.NOTION_API_KEY = originalApiKey;
       else delete process.env.NOTION_API_KEY;
+      if (originalToken) process.env.NOTION_TOKEN = originalToken;
+      else delete process.env.NOTION_TOKEN;
+      if (originalMcpAuthFile) process.env.NOTION_MCP_AUTH_FILE = originalMcpAuthFile;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+      if (originalLegacyMcpAuthFile) process.env.NOTION_MCP_AUTH = originalLegacyMcpAuthFile;
+      else delete process.env.NOTION_MCP_AUTH;
     }
   }
 
@@ -354,6 +366,9 @@ describe("pi-notion checkNotionAuth", () => {
 
   it("migrates legacy MCP auth file to the new filename", async () => {
     const originalHome = process.env.HOME;
+    const originalToken = process.env.NOTION_TOKEN;
+    const originalMcpAuthFile = process.env.NOTION_MCP_AUTH_FILE;
+    const originalLegacyMcpAuthFile = process.env.NOTION_MCP_AUTH;
     const originalCwd = process.cwd();
     const tempHome = mkdtempSync(join(tmpdir(), "pi-notion-migrate-home-"));
     const tempProject = mkdtempSync(join(tmpdir(), "pi-notion-migrate-project-"));
@@ -369,6 +384,9 @@ describe("pi-notion checkNotionAuth", () => {
 
     process.env.HOME = tempHome;
     process.chdir(tempProject);
+    delete process.env.NOTION_MCP_AUTH_FILE;
+    delete process.env.NOTION_MCP_AUTH;
+    delete process.env.NOTION_TOKEN;
     vi.resetModules();
 
     try {
@@ -382,6 +400,12 @@ describe("pi-notion checkNotionAuth", () => {
       process.chdir(originalCwd);
       if (originalHome) process.env.HOME = originalHome;
       else delete process.env.HOME;
+      if (originalToken) process.env.NOTION_TOKEN = originalToken;
+      else delete process.env.NOTION_TOKEN;
+      if (originalMcpAuthFile) process.env.NOTION_MCP_AUTH_FILE = originalMcpAuthFile;
+      else delete process.env.NOTION_MCP_AUTH_FILE;
+      if (originalLegacyMcpAuthFile) process.env.NOTION_MCP_AUTH = originalLegacyMcpAuthFile;
+      else delete process.env.NOTION_MCP_AUTH;
     }
   });
 


### PR DESCRIPTION
## Summary
- isolate `pi-notion` auth helper tests from host Notion auth environment variables
- clear and restore MCP auth env vars so `checkNotionAuth()` exercises the intended test scenarios
- restore legacy migration test coverage for default-path auth file migration behavior

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `npm run test -- packages/pi-notion/__tests__/helpers.test.ts`
- `npx vitest run packages/pi-notion/__tests__`

Closes #33