### PR TITLE
feat: add in-process specdocs markdown validation and formatting

### DIFF
--- a/docs/architecture/plan-pi-specdocs-in-process-markdown-linting.md
+++ b/docs/architecture/plan-pi-specdocs-in-process-markdown-linting.md
@@ -38,6 +38,7 @@ The safest delivery path is to build the parser-backed model first, then migrate
   - normalized frontmatter serialization for formatting
 - Keep `.claude/tracker.md` parsing stable for `packages/pi-specdocs/extensions/workspace-scan.ts`; if the full parser is too heavy for config reads, keep config parsing on a dedicated helper path instead of forcing tracker files through the spec document pipeline.
 - Define a stable internal shape such as `ParsedSpecDocument` so semantic rules do not depend directly on raw parser nodes.
+- Ensure that representation can associate multiple tables with a single section so required-table validation remains correct when documents include auxiliary tables alongside required ones.
 
 **ADR Reference**: -> `ADR-0008-specdocs-parser-pipeline-strategy.md`; -> `ADR-0009-specdocs-validation-layering-strategy.md`
 
@@ -69,7 +70,7 @@ The safest delivery path is to build the parser-backed model first, then migrate
   - workspace-wide `specdocs-validate`
   - new `specdocs-format <path>` execution
 - Post-tool behavior should stay lint-only, but now include supported plan documents in addition to PRDs and ADRs, per `ADR-0010`.
-- Validation output should become richer and more structured, but still grouped into human-readable notifications with the affected file, rule type, and section/table when applicable.
+- Validation output should become richer and more structured, grouped by file when possible, while still surfacing the affected rule type and section/table when applicable.
 - Command-path validation and formatting should share the same detection logic so unsupported paths, malformed docs, and no-op results behave consistently.
 
 **ADR Reference**: -> `ADR-0010-specdocs-formatting-activation-model.md`
@@ -85,6 +86,7 @@ The safest delivery path is to build the parser-backed model first, then migrate
   - blank-line normalization around frontmatter and top-level sections
   - table padding/alignment and surrounding blank lines
   - preservation of thematic breaks rather than insertion/removal
+  - preservation of common GFM constructs such as task lists and strikethrough while whitespace is normalized
 - `specdocs-format <path>` should validate target eligibility before writing and must fail safely on unsupported paths, missing files, or documents that cannot be normalized confidently.
 - Formatter results should distinguish between rewritten files and explicit no-op outcomes.
 

--- a/docs/prd/PRD-004-pi-specdocs-in-process-markdown-linting.md
+++ b/docs/prd/PRD-004-pi-specdocs-in-process-markdown-linting.md
@@ -35,7 +35,7 @@ The desired improvement is an in-process Markdown linting and formatting layer t
 | **Robust parsing** | Spec documents are parsed through a real Markdown + frontmatter pipeline instead of manual line parsing | 100% of PRD, ADR, and plan validation paths use the new parser |
 | **Broader validation** | Validation covers frontmatter, explicitly defined required sections/headings, and required table structures for supported document types | PRDs, ADRs, and plans all receive the structural validation explicitly defined for their document type in this PRD |
 | **In-process operation** | No subprocess spawning for linting or formatting | 0 shell-outs required for document lint/format flows |
-| **Actionable author feedback** | Validation output identifies the file and precise issue type | Warnings/errors are grouped and human-readable in extension notifications/command output |
+| **Actionable author feedback** | Validation output identifies the file and precise issue type | Warnings/errors are grouped by file when possible and remain human-readable in extension notifications/command output |
 | **Required normalization** | Formatting pass rewrites at least frontmatter layout and table/section spacing safely | Autofix support for a scoped initial set of formatting rules ships in the first release |
 
 **Guardrails (must not regress):**
@@ -302,6 +302,7 @@ Canonical normalization rules for the first release must be limited to the follo
 - exactly one blank line surrounds top-level section headings
 - existing thematic breaks written as standalone `---` lines between major sections may be normalized for surrounding blank lines, but must be preserved rather than removed or inserted opportunistically in the first release
 - Markdown tables may be re-padded for consistent pipe alignment and surrounding blank lines, but cell content must not be rewritten semantically
+- Common GFM constructs such as thematic breaks, task lists, and strikethrough must be preserved semantically during formatting even if their whitespace is normalized
 - formatting must not rename headings, reorder sections, alter prose text, or change frontmatter field values
 
 **Acceptance criteria:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,6 +2580,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2594,10 +2603,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2613,6 +2637,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -2930,6 +2960,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3072,6 +3112,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3092,6 +3142,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cli-highlight": {
@@ -3326,6 +3386,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -3358,6 +3431,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3366,6 +3448,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -3508,6 +3603,18 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -3789,6 +3896,19 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3933,6 +4053,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -4383,6 +4511,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4783,6 +4923,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
@@ -4830,6 +4980,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -4849,6 +5009,213 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -4871,6 +5238,585 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -5442,6 +6388,71 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5983,6 +6994,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -6050,6 +7071,80 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6066,6 +7161,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -6448,6 +7571,16 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "packages/pi-code-reasoning": {
       "name": "@feniix/pi-code-reasoning",
       "version": "2.1.0",
@@ -6536,6 +7669,14 @@
       "name": "@feniix/pi-specdocs",
       "version": "2.1.5",
       "license": "MIT",
+      "dependencies": {
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "yaml": "^2.8.3"
+      },
       "peerDependencies": {
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*"

--- a/packages/pi-specdocs/README.md
+++ b/packages/pi-specdocs/README.md
@@ -10,8 +10,8 @@ Structured spec documentation workflow for [pi](https://pi.dev/) — PRDs, ADRs,
 - **Architect Prompt** (`/architect`): End-to-end initiative planning — assess feasibility, decompose into workstreams, produce artifacts
 - **Refine Prompt** (`/refine`): Deep review of PRDs/ADRs for risks, bugs, ambiguities, errors, and inconsistencies
 - **Session Hook**: Automatically scans `docs/` on session start and displays a summary of existing spec documents
-- **Validation Command** (`specdocs-validate`): Checks spec docs for frontmatter, numbering, duplicate IDs, and plan filename issues
-- **Formatting Command** (`specdocs-format <path>`): Normalizes supported spec documents in-process without external tools
+- **Validation Command** (`specdocs-validate`): Checks spec docs for frontmatter, required sections/tables, numbering, duplicate IDs, and plan filename issues
+- **Formatting Command** (`specdocs-format <path>`): Normalizes supported spec documents in-process without external tools while preserving common GFM constructs
 
 ## Install
 
@@ -61,6 +61,9 @@ Deep review of a PRD or ADR. Validates against the codebase, researches external
 
 - `specdocs-validate` — validate spec documents in the workspace
 - `specdocs-format <path>` — format a PRD, ADR, or plan document in place
+  - normalizes frontmatter fences and section spacing
+  - normalizes GFM table spacing/alignment
+  - preserves thematic breaks, task lists, and other common GFM syntax
 
 ## Tool Integration
 

--- a/packages/pi-specdocs/README.md
+++ b/packages/pi-specdocs/README.md
@@ -10,6 +10,8 @@ Structured spec documentation workflow for [pi](https://pi.dev/) — PRDs, ADRs,
 - **Architect Prompt** (`/architect`): End-to-end initiative planning — assess feasibility, decompose into workstreams, produce artifacts
 - **Refine Prompt** (`/refine`): Deep review of PRDs/ADRs for risks, bugs, ambiguities, errors, and inconsistencies
 - **Session Hook**: Automatically scans `docs/` on session start and displays a summary of existing spec documents
+- **Validation Command** (`specdocs-validate`): Checks spec docs for frontmatter, numbering, duplicate IDs, and plan filename issues
+- **Formatting Command** (`specdocs-format <path>`): Normalizes supported spec documents in-process without external tools
 
 ## Install
 
@@ -54,6 +56,11 @@ Deep review of a PRD or ADR. Validates against the codebase, researches external
 | PRDs | `docs/prd/` | `PRD-NNN-slug.md` (3-digit) |
 | ADRs | `docs/adr/` | `ADR-NNNN-slug.md` (4-digit) |
 | Plans | `docs/architecture/` | `plan-slug.md` |
+
+## Commands
+
+- `specdocs-validate` — validate spec documents in the workspace
+- `specdocs-format <path>` — format a PRD, ADR, or plan document in place
 
 ## Tool Integration
 

--- a/packages/pi-specdocs/__tests__/index.test.ts
+++ b/packages/pi-specdocs/__tests__/index.test.ts
@@ -40,6 +40,18 @@ describe("pi-specdocs", () => {
     );
   });
 
+  it("registers specdocs-format command", () => {
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+
+    expect(mockPi.registerCommand).toHaveBeenCalledWith(
+      "specdocs-format",
+      expect.objectContaining({
+        description: expect.stringContaining("format"),
+      }),
+    );
+  });
+
   it("does not register any tools", () => {
     const mockPi = createMockPi();
     specdocs(mockPi as unknown as ExtensionAPI);

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -64,7 +64,7 @@ describe("pi-specdocs runtime", () => {
     const toolResult = getEventHandler(mockPi, "tool_result");
     const notify = vi.fn();
 
-    await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { ui: { notify } });
+    await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { cwd: base, ui: { notify } });
 
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Frontmatter warnings"), "warning");
   });
@@ -88,6 +88,11 @@ describe("pi-specdocs runtime", () => {
       join(base, "docs", "adr", "ADR-0002-gap.md"),
       '---\nadr: ADR-0002\ntitle: "Gap ADR"\nstatus: Proposed\ndate: 2025-01-01\nprd: PRD-001\n---\n',
     );
+    writeFileSync(
+      join(base, "docs", "architecture", "plan-invalid.md"),
+      '---\ntitle: "Plan"\nprd: "PRD-001"\ndate: 2025-01-01\nstatus: Draft\n---\n',
+    );
+    writeFileSync(join(base, "docs", "architecture", "architecture-outline.md"), "# invalid plan filename\n");
 
     const mockPi = createMockPi();
     specdocs(mockPi as unknown as ExtensionAPI);
@@ -101,5 +106,139 @@ describe("pi-specdocs runtime", () => {
       expect.stringContaining("filename doesn't match PRD-NNN-*.md pattern"),
       "error",
     );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("docs/architecture/architecture-outline.md: filename doesn't match plan-*.md pattern"),
+      "error",
+    );
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("PLAN"), "error");
+  });
+
+  it("reports duplicate PRD and ADR numbers during workspace validation", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-duplicate-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    mkdirSync(join(base, "docs", "adr"), { recursive: true });
+
+    writeFileSync(
+      join(base, "docs", "prd", "PRD-002-alpha.md"),
+      '---\nprd: PRD-002\ntitle: "Alpha"\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n',
+    );
+    writeFileSync(
+      join(base, "docs", "prd", "PRD-002-beta.md"),
+      '---\nprd: PRD-002\ntitle: "Beta"\nstatus: Draft\nowner: Bob\ndate: 2025-01-01\nissue: 2\nversion: 1\n---\n',
+    );
+    writeFileSync(
+      join(base, "docs", "adr", "ADR-0003-first.md"),
+      '---\nadr: ADR-0003\ntitle: "First"\nstatus: Proposed\ndate: 2025-01-01\nprd: PRD-002\n---\n',
+    );
+    writeFileSync(
+      join(base, "docs", "adr", "ADR-0003-second.md"),
+      '---\nadr: ADR-0003\ntitle: "Second"\nstatus: Proposed\ndate: 2025-01-01\nprd: PRD-002\n---\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-validate");
+    const notify = vi.fn();
+
+    await handler?.({}, { cwd: base, ui: { notify } });
+
+    const [message, level] = notify.mock.calls.at(-1) ?? [];
+    expect(level).toBe("error");
+    expect(message).toContain("Duplicate PRD number: PRD-002");
+    expect(message).toContain("docs/prd/PRD-002-alpha.md");
+    expect(message).toContain("docs/prd/PRD-002-beta.md");
+    expect(message).toContain("Duplicate ADR number: ADR-0003");
+    expect(message).toContain("docs/adr/ADR-0003-first.md");
+    expect(message).toContain("docs/adr/ADR-0003-second.md");
+  });
+
+  it("warns on duplicate numbers after write/edit tool results", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-duplicate-lint-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const first = join(base, "docs", "prd", "PRD-007-first.md");
+    const second = join(base, "docs", "prd", "PRD-007-second.md");
+
+    writeFileSync(
+      first,
+      '---\nprd: PRD-007\ntitle: "First"\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n',
+    );
+    writeFileSync(
+      second,
+      '---\nprd: PRD-007\ntitle: "Second"\nstatus: Draft\nowner: Bob\ndate: 2025-01-01\nissue: 2\nversion: 1\n---\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const toolResult = getEventHandler(mockPi, "tool_result");
+    const notify = vi.fn();
+
+    await toolResult?.({ toolName: "write", input: { file_path: second } }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Duplicate PRD number: PRD-007"), "warning");
+  });
+
+  it("reports a clear error when specdocs-format targets a nonexistent path", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-"));
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: "docs/prd/PRD-999-missing.md" }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("does not exist"), "error");
+  });
+
+  it("reports a clear error when specdocs-format targets an unsupported markdown file", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-unsupported-"));
+    mkdirSync(join(base, "docs"), { recursive: true });
+    writeFileSync(join(base, "docs", "notes.md"), "# Notes\n");
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: "docs/notes.md" }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("unsupported spec document path"), "error");
+  });
+
+  it("reports no changes for an already normalized spec document", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-noop-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    const content =
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n\n# Test\n\n## 1. Problem & Context\n\nBody\n';
+    writeFileSync(filePath, content);
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("No formatting changes were needed"), "info");
+  });
+
+  it("formats frontmatter and section spacing in place", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-rewrite-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n# Test\n## 1. Problem & Context\nBody\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain('---\n\n# Test\n\n## 1. Problem & Context\n\nBody\n');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 });

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -300,6 +300,50 @@ describe("pi-specdocs runtime", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 
+  it("preserves thematic breaks while normalizing surrounding spacing", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-break-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n# Test\n---\n## 1. Problem & Context\nBody\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain('# Test\n\n---\n\n## 1. Problem & Context');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
+  it("preserves gfm task list and strikethrough content", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-gfm-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n\n# Test\n\n## 1. Problem & Context\n- [x] done\n- [ ] todo\n~~old~~ text\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain('[x] done');
+    expect(updated).toContain('[ ] todo');
+    expect(updated).toContain('~~old~~ text');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
   it("reports a clear error when specdocs-format targets malformed frontmatter", async () => {
     const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-malformed-"));
     mkdirSync(join(base, "docs", "prd"), { recursive: true });

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -69,6 +69,22 @@ describe("pi-specdocs runtime", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Frontmatter warnings"), "warning");
   });
 
+  it("warns on invalid architecture filename after write/edit tool results", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-lint-plan-name-"));
+    const filePath = join(base, "docs", "architecture", "architecture-outline.md");
+    mkdirSync(join(base, "docs", "architecture"), { recursive: true });
+    writeFileSync(filePath, "# Invalid plan name\n");
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const toolResult = getEventHandler(mockPi, "tool_result");
+    const notify = vi.fn();
+
+    await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("plan-*.md pattern"), "warning");
+  });
+
   it("runs specdocs-validate and reports errors/warnings", async () => {
     const base = mkdtempSync(join(tmpdir(), "pi-specdocs-validate-"));
     mkdirSync(join(base, "docs", "prd"), { recursive: true });
@@ -240,5 +256,43 @@ describe("pi-specdocs runtime", () => {
     const updated = readFileSync(filePath, "utf-8");
     expect(updated).toContain('---\n\n# Test\n\n## 1. Problem & Context\n\nBody\n');
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
+  it("formats gfm tables with normalized spacing", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-table-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n\n# Test\n\n## 1. Problem & Context\n\n|A|B|\n|-|-|\n|1|22|\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain('| A | B  |');
+    expect(updated).toContain('| - | -- |');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
+  it("reports a clear error when specdocs-format targets malformed frontmatter", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-malformed-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(filePath, '---\ntitle: "Broken"\nstatus: [Draft\n---\n# Test\n');
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("malformed frontmatter"), "error");
   });
 });

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -66,7 +66,7 @@ describe("pi-specdocs runtime", () => {
 
     await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { cwd: base, ui: { notify } });
 
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Frontmatter warnings"), "warning");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Validation warnings"), "warning");
   });
 
   it("warns on invalid architecture filename after write/edit tool results", async () => {
@@ -368,6 +368,93 @@ describe("pi-specdocs runtime", () => {
     expect(updated).toContain("[x] done");
     expect(updated).toContain("[ ] todo");
     expect(updated).toContain("~~old~~ text");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
+  it("formats ADR documents in place", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-adr-"));
+    mkdirSync(join(base, "docs", "adr"), { recursive: true });
+    const filePath = join(base, "docs", "adr", "ADR-0001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "ADR"\nadr: ADR-0001\nstatus: Proposed\ndate: 2025-01-01\nprd: PRD-001-test\n---\n# ADR\n## Status\nProposed\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain("---\n\n# ADR\n\n## Status\n\nProposed\n");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
+  it("formats plan documents in place", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-plan-"));
+    mkdirSync(join(base, "docs", "architecture"), { recursive: true });
+    const filePath = join(base, "docs", "architecture", "plan-test-feature.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Plan"\nprd: PRD-001-test-feature\ndate: 2025-01-01\nauthor: Alice\nstatus: Draft\n---\n# Plan\n## Source\nBody\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain("---\n\n# Plan\n\n## Source\n\nBody\n");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
+  it("is idempotent when formatting the same document twice", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-idempotent-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n# Test\n## 1. Problem & Context\nBody\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+    const onceFormatted = readFileSync(filePath, "utf-8");
+
+    notify.mockClear();
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    expect(readFileSync(filePath, "utf-8")).toBe(onceFormatted);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("No formatting changes were needed"), "info");
+  });
+
+  it("preserves tables with alignment markers", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-alignment-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n\n# Test\n\n## 1. Problem & Context\n\n| Left | Center | Right |\n| :--- | :----: | ----: |\n| a | b | c |\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toMatch(/\|\s*:---\s*\|\s*:----:\s*\|\s*----:\s*\|/);
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -102,7 +102,10 @@ describe("pi-specdocs runtime", () => {
     await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { cwd: base, ui: { notify } });
 
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Missing required section: ## ADR Index"), "warning");
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Missing required table in section ADR Index"), "warning");
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Missing required table in section ADR Index"),
+      "warning",
+    );
   });
 
   it("runs specdocs-validate and reports errors/warnings", async () => {
@@ -143,7 +146,9 @@ describe("pi-specdocs runtime", () => {
       "error",
     );
     expect(notify).toHaveBeenCalledWith(
-      expect.stringContaining("docs/architecture/architecture-outline.md\n    ✗ filename doesn't match plan-*.md pattern"),
+      expect.stringContaining(
+        "docs/architecture/architecture-outline.md\n    ✗ filename doesn't match plan-*.md pattern",
+      ),
       "error",
     );
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("PLAN"), "error");
@@ -296,7 +301,7 @@ describe("pi-specdocs runtime", () => {
     await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
 
     const updated = readFileSync(filePath, "utf-8");
-    expect(updated).toContain('---\n\n# Test\n\n## 1. Problem & Context\n\nBody\n');
+    expect(updated).toContain("---\n\n# Test\n\n## 1. Problem & Context\n\nBody\n");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 
@@ -317,8 +322,8 @@ describe("pi-specdocs runtime", () => {
     await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
 
     const updated = readFileSync(filePath, "utf-8");
-    expect(updated).toContain('| A | B  |');
-    expect(updated).toContain('| - | -- |');
+    expect(updated).toContain("| A | B  |");
+    expect(updated).toContain("| - | -- |");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 
@@ -339,7 +344,7 @@ describe("pi-specdocs runtime", () => {
     await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
 
     const updated = readFileSync(filePath, "utf-8");
-    expect(updated).toContain('# Test\n\n---\n\n## 1. Problem & Context');
+    expect(updated).toContain("# Test\n\n---\n\n## 1. Problem & Context");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 
@@ -360,9 +365,9 @@ describe("pi-specdocs runtime", () => {
     await handler?.({ path: filePath }, { cwd: base, ui: { notify } });
 
     const updated = readFileSync(filePath, "utf-8");
-    expect(updated).toContain('[x] done');
-    expect(updated).toContain('[ ] todo');
-    expect(updated).toContain('~~old~~ text');
+    expect(updated).toContain("[x] done");
+    expect(updated).toContain("[ ] todo");
+    expect(updated).toContain("~~old~~ text");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -143,7 +143,7 @@ describe("pi-specdocs runtime", () => {
       "error",
     );
     expect(notify).toHaveBeenCalledWith(
-      expect.stringContaining("docs/architecture/architecture-outline.md: filename doesn't match plan-*.md pattern"),
+      expect.stringContaining("docs/architecture/architecture-outline.md\n    ✗ filename doesn't match plan-*.md pattern"),
       "error",
     );
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("PLAN"), "error");
@@ -186,6 +186,28 @@ describe("pi-specdocs runtime", () => {
     expect(message).toContain("Duplicate ADR number: ADR-0003");
     expect(message).toContain("docs/adr/ADR-0003-first.md");
     expect(message).toContain("docs/adr/ADR-0003-second.md");
+  });
+
+  it("groups workspace validation warnings by file path", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-grouped-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    writeFileSync(
+      join(base, "docs", "prd", "PRD-001-grouped.md"),
+      '---\nprd: PRD-001\ntitle: "Grouped"\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n\n# Grouped\n\n## 1. Problem & Context\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-validate");
+    const notify = vi.fn();
+
+    await handler?.({}, { cwd: base, ui: { notify } });
+
+    const [message, level] = notify.mock.calls.at(-1) ?? [];
+    expect(level).toBe("warning");
+    expect(message).toContain("docs/prd/PRD-001-grouped.md");
+    expect(message).toContain("Missing required section: ## 2. Goals & Success Metrics");
+    expect(message).toContain("Missing required table in section File Breakdown");
   });
 
   it("warns on duplicate numbers after write/edit tool results", async () => {

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -85,6 +85,26 @@ describe("pi-specdocs runtime", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("plan-*.md pattern"), "warning");
   });
 
+  it("warns on missing required sections and tables for a plan after write/edit tool results", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-lint-plan-structure-"));
+    const filePath = join(base, "docs", "architecture", "plan-test-feature.md");
+    mkdirSync(join(base, "docs", "architecture"), { recursive: true });
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Plan"\nprd: "PRD-001-test-feature"\ndate: 2025-01-01\nauthor: "Alice"\nstatus: Draft\n---\n\n# Plan: Test\n\n## Source\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const toolResult = getEventHandler(mockPi, "tool_result");
+    const notify = vi.fn();
+
+    await toolResult?.({ toolName: "write", input: { file_path: filePath } }, { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Missing required section: ## ADR Index"), "warning");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Missing required table in section ADR Index"), "warning");
+  });
+
   it("runs specdocs-validate and reports errors/warnings", async () => {
     const base = mkdtempSync(join(tmpdir(), "pi-specdocs-validate-"));
     mkdirSync(join(base, "docs", "prd"), { recursive: true });

--- a/packages/pi-specdocs/__tests__/spec-validation.test.ts
+++ b/packages/pi-specdocs/__tests__/spec-validation.test.ts
@@ -6,7 +6,14 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { isAdr, isPrd, parseFrontmatter, validateFrontmatter } from "../extensions/index.js";
+import {
+  isAdr,
+  isPrd,
+  parseFrontmatter,
+  validateFrontmatter,
+  validateRequiredSections,
+  validateRequiredTables,
+} from "../extensions/index.js";
 
 const VALID_PRD = `---
 title: "Test PRD"
@@ -30,6 +37,17 @@ prd: "PRD-001-test"
 ---
 
 # Test ADR
+`;
+
+const VALID_PLAN = `---
+title: "Test Plan"
+prd: "PRD-001-test-feature"
+date: 2026-04-14
+author: "Test User"
+status: Draft
+---
+
+# Plan: Test Plan
 `;
 
 function writeTempDoc(directory: string, filename: string, content: string): string {
@@ -81,6 +99,17 @@ describe("parseFrontmatter", () => {
 
   it("returns null for nonexistent file", () => {
     expect(parseFrontmatter("/nonexistent/file.md")).toBeNull();
+  });
+
+  it("returns null for malformed yaml frontmatter", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = join(dir, "test.md");
+      writeFileSync(path, '---\ntitle: "Broken"\nstatus: [Draft\n---\n');
+      expect(parseFrontmatter(path)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
   });
 });
 
@@ -180,6 +209,21 @@ describe("validate PRD", () => {
       rmSync(dir, { recursive: true });
     }
   });
+
+  it("reports malformed yaml frontmatter as a parse error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "prd"),
+        "PRD-001-test.md",
+        '---\ntitle: "Broken"\nstatus: [Draft\nowner: Test\n---\n# Test\n',
+      );
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Frontmatter parse error"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });
 
 // --- ADR validation ---
@@ -226,6 +270,133 @@ describe("validate ADR", () => {
       const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", content);
       const warnings = validateFrontmatter(path);
       expect(warnings.some((w) => w.includes("Active"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+
+// --- Plan validation ---
+
+describe("validate Plan", () => {
+  it("returns no warnings for valid plan", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "architecture"), "plan-test-feature.md", VALID_PLAN);
+      expect(validateFrontmatter(path)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports missing author field", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_PLAN.replace('author: "Test User"\n', "");
+      const path = writeTempDoc(join(dir, "docs", "architecture"), "plan-test-feature.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("author"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports invalid plan status", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_PLAN.replace("status: Draft", "status: Active");
+      const path = writeTempDoc(join(dir, "docs", "architecture"), "plan-test-feature.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Active"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports non-canonical plan prd format", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_PLAN.replace('prd: "PRD-001-test-feature"', 'prd: "PRD-001"');
+      const path = writeTempDoc(join(dir, "docs", "architecture"), "plan-test-feature.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("PRD-NNN-descriptive-slug"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+
+// --- Required section validation ---
+
+describe("validate required sections", () => {
+  it("reports missing required PRD sections", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "prd"), "PRD-001-test.md", `${VALID_PRD}\n## 1. Problem & Context\n`);
+      const warnings = validateRequiredSections(path);
+      expect(warnings.some((w) => w.includes("## 2. Goals & Success Metrics"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports missing required ADR sections", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "adr"), "ADR-0001-test.md", `${VALID_ADR}\n## Status\nProposed\n`);
+      const warnings = validateRequiredSections(path);
+      expect(warnings.some((w) => w.includes("## Decision"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports missing required plan sections", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "architecture"),
+        "plan-test-feature.md",
+        `${VALID_PLAN}\n## Source\n\n## Architecture Overview\n`,
+      );
+      const warnings = validateRequiredSections(path);
+      expect(warnings.some((w) => w.includes("## ADR Index"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+
+// --- Required table validation ---
+
+describe("validate required tables", () => {
+  it("reports missing required PRD table columns", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "prd"),
+        "PRD-001-test.md",
+        `${VALID_PRD}\n## 12. Open Questions\n| # | Question | Owner | Due |\n|---|---|---|---|\n| Q1 | Test? | Alice | Soon |\n`,
+      );
+      const warnings = validateRequiredTables(path);
+      expect(warnings.some((w) => w.includes("Open Questions"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Status"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports missing required plan table columns", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "architecture"),
+        "plan-test-feature.md",
+        `${VALID_PLAN}\n## Implementation Order\n| Phase | Component | Estimated Scope |\n|---|---|---|\n| 1 | Parser | M |\n`,
+      );
+      const warnings = validateRequiredTables(path);
+      expect(warnings.some((w) => w.includes("Implementation Order"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Dependencies"))).toBe(true);
     } finally {
       rmSync(dir, { recursive: true });
     }

--- a/packages/pi-specdocs/__tests__/spec-validation.test.ts
+++ b/packages/pi-specdocs/__tests__/spec-validation.test.ts
@@ -13,6 +13,7 @@ import {
   validateFrontmatter,
   validateRequiredSections,
   validateRequiredTables,
+  validateSpecFile,
 } from "../extensions/index.js";
 
 const VALID_PRD = `---
@@ -405,6 +406,25 @@ describe("validate required tables", () => {
 
 // --- Non-spec files ---
 
+describe("validateSpecFile", () => {
+  it("combines frontmatter, section, and table warnings in one pass", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "architecture"),
+        "plan-test-feature.md",
+        '---\ntitle: "Plan"\nprd: "PRD-001"\nstatus: Active\n---\n\n# Plan: Test\n\n## Source\n',
+      );
+      const warnings = validateSpecFile(path);
+      expect(warnings.some((w) => w.includes("Missing required frontmatter field: date"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Missing required section: ## ADR Index"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Missing required table in section ADR Index"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+
 describe("non-spec files", () => {
   it("returns empty warnings for non-spec files", () => {
     const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
@@ -412,6 +432,7 @@ describe("non-spec files", () => {
       const path = join(dir, "README.md");
       writeFileSync(path, "# README\n");
       expect(validateFrontmatter(path)).toEqual([]);
+      expect(validateSpecFile(path)).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true });
     }

--- a/packages/pi-specdocs/__tests__/spec-validation.test.ts
+++ b/packages/pi-specdocs/__tests__/spec-validation.test.ts
@@ -387,6 +387,20 @@ describe("validate required tables", () => {
     }
   });
 
+  it("accepts a required table when another table also appears in the same section", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "prd"),
+        "PRD-001-test.md",
+        `${VALID_PRD}\n## 9. File Breakdown\n| File | Change type | FR | Description |\n|---|---|---|---|\n| a.ts | Modify | FR-1 | Test |\n\n## 12. Open Questions\n| # | Question | Owner | Due | Status |\n|---|---|---|---|---|\n| Q1 | Test? | Alice | Soon | Open |\n\n| Note | Value |\n|---|---|\n| Summary | Keep |\n\n## 14. Changelog\n| Date | Change | Author |\n|---|---|---|\n| 2026-04-21 | Added test | Pi |\n`,
+      );
+      expect(validateRequiredTables(path)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
   it("reports missing required plan table columns", () => {
     const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
     try {

--- a/packages/pi-specdocs/extensions/frontmatter.ts
+++ b/packages/pi-specdocs/extensions/frontmatter.ts
@@ -1,32 +1,67 @@
 import { existsSync, readFileSync } from "node:fs";
+import YAML from "yaml";
 
-export function parseFrontmatter(filepath: string): Record<string, string> | null {
+export interface FrontmatterParseResult {
+  fields: Record<string, string> | null;
+  error: string | null;
+  content: string | null;
+  body: string;
+}
+
+function readDocument(filepath: string): string | null {
   if (!existsSync(filepath)) return null;
 
-  let content: string;
   try {
-    content = readFileSync(filepath, "utf-8");
+    return readFileSync(filepath, "utf-8");
   } catch {
     return null;
   }
+}
 
-  const lines = content.split("\n");
-  if (!lines.length || lines[0].trim() !== "---") return null;
-
-  const fields: Record<string, string> = {};
-  for (let i = 1; i < lines.length; i++) {
-    if (lines[i].trim() === "---") break;
-    const colonIdx = lines[i].indexOf(":");
-    if (colonIdx === -1) continue;
-    const key = lines[i].slice(0, colonIdx).trim();
-    const value = lines[i]
-      .slice(colonIdx + 1)
-      .trim()
-      .replace(/^["']|["']$/g, "");
-    fields[key] = value;
+export function parseFrontmatterResult(filepath: string): FrontmatterParseResult {
+  const content = readDocument(filepath);
+  if (content === null) {
+    return { fields: null, error: null, content: null, body: "" };
   }
 
-  return Object.keys(fields).length ? fields : null;
+  const lines = content.split("\n");
+  if (!lines.length || lines[0].trim() !== "---") {
+    return { fields: null, error: null, content, body: content };
+  }
+
+  let closingIndex = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      closingIndex = i;
+      break;
+    }
+  }
+
+  if (closingIndex === -1) {
+    return { fields: null, error: "Unterminated YAML frontmatter.", content, body: "" };
+  }
+
+  const yamlText = lines.slice(1, closingIndex).join("\n");
+  const body = lines.slice(closingIndex + 1).join("\n");
+
+  try {
+    const parsed = YAML.parse(yamlText);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { fields: {}, error: null, content, body };
+    }
+
+    const fields = Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).map(([key, value]) => [key, value == null ? "" : String(value)]),
+    );
+    return { fields, error: null, content, body };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { fields: null, error: message, content, body };
+  }
+}
+
+export function parseFrontmatter(filepath: string): Record<string, string> | null {
+  return parseFrontmatterResult(filepath).error ? null : parseFrontmatterResult(filepath).fields;
 }
 
 export function extractFrontmatterField(filepath: string, field: string): string {

--- a/packages/pi-specdocs/extensions/frontmatter.ts
+++ b/packages/pi-specdocs/extensions/frontmatter.ts
@@ -64,7 +64,8 @@ export function parseFrontmatterResult(filepath: string): FrontmatterParseResult
 }
 
 export function parseFrontmatter(filepath: string): Record<string, string> | null {
-  return parseFrontmatterResult(filepath).error ? null : parseFrontmatterResult(filepath).fields;
+  const result = parseFrontmatterResult(filepath);
+  return result.error ? null : result.fields;
 }
 
 export function extractFrontmatterField(filepath: string, field: string): string {

--- a/packages/pi-specdocs/extensions/frontmatter.ts
+++ b/packages/pi-specdocs/extensions/frontmatter.ts
@@ -51,7 +51,10 @@ export function parseFrontmatterResult(filepath: string): FrontmatterParseResult
     }
 
     const fields = Object.fromEntries(
-      Object.entries(parsed as Record<string, unknown>).map(([key, value]) => [key, value == null ? "" : String(value)]),
+      Object.entries(parsed as Record<string, unknown>).map(([key, value]) => [
+        key,
+        value == null ? "" : String(value),
+      ]),
     );
     return { fields, error: null, content, body };
   } catch (error) {

--- a/packages/pi-specdocs/extensions/index.ts
+++ b/packages/pi-specdocs/extensions/index.ts
@@ -1,7 +1,18 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { extractFrontmatterField, parseFrontmatter } from "./frontmatter.js";
 import { handleDocLint, runFormat, runValidation } from "./runtime.js";
-import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateFrontmatter, validateRequiredSections, validateRequiredTables, validateSpecFile } from "./spec-validation.js";
+import {
+  ADR_FILENAME_PATTERN,
+  isAdr,
+  isPlan,
+  isPrd,
+  PLAN_FILENAME_PATTERN,
+  PRD_FILENAME_PATTERN,
+  validateFrontmatter,
+  validateRequiredSections,
+  validateRequiredTables,
+  validateSpecFile,
+} from "./spec-validation.js";
 import { formatConfig, formatSummary, listMatchingFiles, readConfig, scanWorkspace } from "./workspace-scan.js";
 
 export {

--- a/packages/pi-specdocs/extensions/index.ts
+++ b/packages/pi-specdocs/extensions/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { extractFrontmatterField, parseFrontmatter } from "./frontmatter.js";
 import { handleDocLint, runFormat, runValidation } from "./runtime.js";
-import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateFrontmatter, validateRequiredSections, validateRequiredTables } from "./spec-validation.js";
+import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateFrontmatter, validateRequiredSections, validateRequiredTables, validateSpecFile } from "./spec-validation.js";
 import { formatConfig, formatSummary, listMatchingFiles, readConfig, scanWorkspace } from "./workspace-scan.js";
 
 export {
@@ -21,6 +21,7 @@ export {
   validateFrontmatter,
   validateRequiredSections,
   validateRequiredTables,
+  validateSpecFile,
 };
 
 export default function specdocs(pi: ExtensionAPI) {

--- a/packages/pi-specdocs/extensions/index.ts
+++ b/packages/pi-specdocs/extensions/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { extractFrontmatterField, parseFrontmatter } from "./frontmatter.js";
-import { handleDocLint, runValidation } from "./runtime.js";
-import { ADR_FILENAME_PATTERN, isAdr, isPrd, PRD_FILENAME_PATTERN, validateFrontmatter } from "./spec-validation.js";
+import { handleDocLint, runFormat, runValidation } from "./runtime.js";
+import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateFrontmatter, validateRequiredSections, validateRequiredTables } from "./spec-validation.js";
 import { formatConfig, formatSummary, listMatchingFiles, readConfig, scanWorkspace } from "./workspace-scan.js";
 
 export {
@@ -10,13 +10,17 @@ export {
   formatConfig,
   formatSummary,
   isAdr,
+  isPlan,
   isPrd,
   listMatchingFiles,
+  PLAN_FILENAME_PATTERN,
   PRD_FILENAME_PATTERN,
   parseFrontmatter,
   readConfig,
   scanWorkspace,
   validateFrontmatter,
+  validateRequiredSections,
+  validateRequiredTables,
 };
 
 export default function specdocs(pi: ExtensionAPI) {
@@ -40,6 +44,13 @@ export default function specdocs(pi: ExtensionAPI) {
       "(specdocs plugin) Validate all spec documents for frontmatter completeness, naming conventions, and cross-references",
     handler: async (_args, ctx) => {
       await runValidation(ctx);
+    },
+  });
+
+  pi.registerCommand("specdocs-format", {
+    description: "(specdocs plugin) format a spec document in-process without spawning external tools",
+    handler: async (args, ctx) => {
+      await runFormat(args, ctx);
     },
   });
 }

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -1,8 +1,14 @@
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { ADR_FILENAME_PATTERN, isAdr, isPrd, PRD_FILENAME_PATTERN, validateFrontmatter } from "./spec-validation.js";
-import { ADR_DIR, listMatchingFiles, PRD_DIR } from "./workspace-scan.js";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateFrontmatter, validateRequiredSections, validateRequiredTables } from "./spec-validation.js";
+import { parseFrontmatterResult } from "./frontmatter.js";
+import { ADR_DIR, listMatchingFiles, PLAN_DIR, PRD_DIR } from "./workspace-scan.js";
 
 function extractFilePath(input: Record<string, unknown> | undefined): string {
   if (!input) return "";
@@ -18,13 +24,18 @@ export async function handleDocLint(
   }
 
   const filePath = extractFilePath(event.input);
-  if (!filePath || (!isPrd(filePath) && !isAdr(filePath)) || !existsSync(filePath)) {
+  if (!filePath || (!isPrd(filePath) && !isAdr(filePath) && !isPlan(filePath)) || !existsSync(filePath)) {
     return;
   }
 
-  const warnings = validateFrontmatter(filePath);
-  if (warnings.length > 0) {
-    ctx.ui.notify(`[specdocs] Frontmatter warnings:\n${warnings.join("\n")}`, "warning");
+  const warnings = [...validateFrontmatter(filePath), ...validateRequiredSections(filePath), ...validateRequiredTables(filePath)];
+  const duplicateIssues = typeof ctx.cwd === "string"
+    ? collectDuplicateValidationIssues(getValidationFiles(ctx.cwd), filePath)
+    : [];
+  const messages = [...warnings, ...duplicateIssues.map((issue) => issue.message)];
+
+  if (messages.length > 0) {
+    ctx.ui.notify(`[specdocs] Frontmatter warnings:\n${messages.join("\n")}`, "warning");
   }
 }
 
@@ -36,19 +47,32 @@ interface ValidationIssue {
 interface ValidationFiles {
   prdDir: string;
   adrDir: string;
+  planDir: string;
   prdFiles: string[];
   adrFiles: string[];
+  planFiles: string[];
+}
+
+interface DuplicateDocumentIssueConfig {
+  files: string[];
+  pattern: RegExp;
+  prefix: string;
+  width: number;
+  displayDir: string;
 }
 
 function getValidationFiles(cwd: string): ValidationFiles {
   const prdDir = join(cwd, PRD_DIR);
   const adrDir = join(cwd, ADR_DIR);
+  const planDir = join(cwd, PLAN_DIR);
 
   return {
     prdDir,
     adrDir,
+    planDir,
     prdFiles: listMatchingFiles(prdDir, PRD_FILENAME_PATTERN),
     adrFiles: listMatchingFiles(adrDir, ADR_FILENAME_PATTERN),
+    planFiles: listMatchingFiles(planDir, PLAN_FILENAME_PATTERN),
   };
 }
 
@@ -56,18 +80,87 @@ function toWarningIssues(messages: string[]): ValidationIssue[] {
   return messages.map((message) => ({ type: "warning", message }));
 }
 
+function collectDuplicateNumberIssues(config: DuplicateDocumentIssueConfig): ValidationIssue[] {
+  const grouped = new Map<number, string[]>();
+
+  for (const filename of config.files) {
+    const match = filename.match(config.pattern);
+    if (!match) {
+      continue;
+    }
+
+    const number = parseInt(match[1], 10);
+    const existing = grouped.get(number) ?? [];
+    existing.push(`${config.displayDir}/${filename}`);
+    grouped.set(number, existing);
+  }
+
+  const issues: ValidationIssue[] = [];
+  for (const [number, filenames] of grouped.entries()) {
+    if (filenames.length < 2) {
+      continue;
+    }
+
+    issues.push({
+      type: "error",
+      message: `✗ Duplicate ${config.prefix} number: ${config.prefix}-${String(number).padStart(config.width, "0")} is used by ${filenames.join(", ")}`,
+    });
+  }
+
+  return issues.sort((a, b) => a.message.localeCompare(b.message));
+}
+
 function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
   for (const filename of files.prdFiles) {
-    issues.push(...toWarningIssues(validateFrontmatter(join(files.prdDir, filename))));
+    const filepath = join(files.prdDir, filename);
+    issues.push(...toWarningIssues(validateFrontmatter(filepath)));
+    issues.push(...toWarningIssues(validateRequiredSections(filepath)));
+    issues.push(...toWarningIssues(validateRequiredTables(filepath)));
   }
 
   for (const filename of files.adrFiles) {
-    issues.push(...toWarningIssues(validateFrontmatter(join(files.adrDir, filename))));
+    const filepath = join(files.adrDir, filename);
+    issues.push(...toWarningIssues(validateFrontmatter(filepath)));
+    issues.push(...toWarningIssues(validateRequiredSections(filepath)));
+    issues.push(...toWarningIssues(validateRequiredTables(filepath)));
+  }
+
+  for (const filename of files.planFiles) {
+    const filepath = join(files.planDir, filename);
+    issues.push(...toWarningIssues(validateFrontmatter(filepath)));
+    issues.push(...toWarningIssues(validateRequiredSections(filepath)));
+    issues.push(...toWarningIssues(validateRequiredTables(filepath)));
   }
 
   return issues;
+}
+
+function collectDuplicateValidationIssues(files: ValidationFiles, changedFilePath?: string): ValidationIssue[] {
+  const issues = [
+    ...collectDuplicateNumberIssues({
+      files: files.prdFiles,
+      pattern: /^PRD-(\d{3})-.*\.md$/,
+      prefix: "PRD",
+      width: 3,
+      displayDir: PRD_DIR,
+    }),
+    ...collectDuplicateNumberIssues({
+      files: files.adrFiles,
+      pattern: /^ADR-(\d{4})-.*\.md$/,
+      prefix: "ADR",
+      width: 4,
+      displayDir: ADR_DIR,
+    }),
+  ];
+
+  if (!changedFilePath) {
+    return issues;
+  }
+
+  const changedFilename = basename(changedFilePath);
+  return issues.filter((issue) => issue.message.includes(changedFilename));
 }
 
 function listMarkdownFiles(directory: string): string[] {
@@ -157,9 +250,134 @@ export async function runValidation(ctx: { cwd: string } & ExtensionContext) {
     ...collectFrontmatterIssues(files),
     ...collectFilenameIssues(files.prdDir, PRD_DIR, PRD_FILENAME_PATTERN, "PRD-NNN-*.md"),
     ...collectFilenameIssues(files.adrDir, ADR_DIR, ADR_FILENAME_PATTERN, "ADR-NNNN-*.md"),
+    ...collectFilenameIssues(files.planDir, PLAN_DIR, PLAN_FILENAME_PATTERN, "plan-*.md"),
+    ...collectDuplicateValidationIssues(files),
     ...collectNumberingGapIssues(files.prdFiles, /^PRD-(\d{3})-.*\.md$/, "PRD", 3),
     ...collectNumberingGapIssues(files.adrFiles, /^ADR-(\d{4})-.*\.md$/, "ADR", 4),
   ];
   const result = formatValidationIssues(issues);
   ctx.ui.notify(result.message, result.level);
+}
+
+function resolveCommandPath(cwd: string, path: string): string {
+  return path.startsWith("/") ? path : resolve(cwd, path);
+}
+
+function isSupportedSpecPath(path: string): boolean {
+  return isPrd(path) || isAdr(path) || isPlan(path);
+}
+
+function normalizeBodyLines(lines: string[]): string[] {
+  const result: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/[\t ]+$/g, "");
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("## ")) {
+      while (result.length > 0 && result[result.length - 1] === "") {
+        result.pop();
+      }
+      if (result.length > 0) {
+        result.push("");
+      }
+      result.push(trimmed);
+      while (i + 1 < lines.length && lines[i + 1].trim() === "") {
+        i++;
+      }
+      result.push("");
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  while (result.length > 0 && result[result.length - 1] === "") {
+    result.pop();
+  }
+
+  return result;
+}
+
+async function formatSpecDocument(content: string): Promise<string> {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter, ["yaml"])
+    .use(remarkGfm)
+    .use(remarkStringify, {
+      fences: true,
+      listItemIndent: "one",
+    })
+    .process(content);
+
+  const formatted = String(file);
+  const lines = formatted.split("\n");
+  if (!lines.length || lines[0].trim() !== "---") {
+    return formatted;
+  }
+
+  let closingIndex = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      closingIndex = i;
+      break;
+    }
+  }
+
+  if (closingIndex === -1) {
+    return formatted;
+  }
+
+  const frontmatterLines = lines.slice(0, closingIndex + 1).map((line, index) => {
+    if (index === 0 || index === closingIndex) {
+      return "---";
+    }
+    return line.replace(/[\t ]+$/g, "");
+  });
+  const bodyLines = normalizeBodyLines(lines.slice(closingIndex + 1).filter((line, index, arr) => !(index === 0 && line.trim() === "" && arr.length > 0)));
+  return `${frontmatterLines.join("\n")}\n\n${bodyLines.join("\n")}\n`;
+}
+
+export async function runFormat(
+  args: unknown,
+  ctx: { cwd: string } & ExtensionContext,
+): Promise<void> {
+  const params = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  const rawPath = typeof params.path === "string" ? params.path : typeof params.file_path === "string" ? params.file_path : "";
+  if (!rawPath) {
+    ctx.ui.notify("[specdocs] specdocs-format requires a single path argument.", "error");
+    return;
+  }
+
+  const targetPath = resolveCommandPath(ctx.cwd, rawPath);
+  if (!existsSync(targetPath)) {
+    ctx.ui.notify(`[specdocs] Format target does not exist: ${rawPath}`, "error");
+    return;
+  }
+
+  if (!isSupportedSpecPath(targetPath)) {
+    ctx.ui.notify(`[specdocs] Format target is an unsupported spec document path: ${rawPath}`, "error");
+    return;
+  }
+
+  const parseResult = parseFrontmatterResult(targetPath);
+  if (parseResult.error) {
+    ctx.ui.notify(`[specdocs] Cannot format document with malformed frontmatter: ${parseResult.error}`, "error");
+    return;
+  }
+
+  if (parseResult.fields === null) {
+    ctx.ui.notify("[specdocs] Cannot format a spec document without YAML frontmatter.", "error");
+    return;
+  }
+
+  const original = readFileSync(targetPath, "utf-8");
+  const formatted = await formatSpecDocument(original);
+  if (formatted === original) {
+    ctx.ui.notify("[specdocs] No formatting changes were needed.", "info");
+    return;
+  }
+
+  writeFileSync(targetPath, formatted);
+  ctx.ui.notify(`[specdocs] Formatted spec document: ${rawPath}`, "info");
 }

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -50,6 +50,7 @@ export async function handleDocLint(
 interface ValidationIssue {
   type: "error" | "warning";
   message: string;
+  filePath?: string;
 }
 
 interface ValidationFiles {
@@ -84,8 +85,8 @@ function getValidationFiles(cwd: string): ValidationFiles {
   };
 }
 
-function toWarningIssues(messages: string[]): ValidationIssue[] {
-  return messages.map((message) => ({ type: "warning", message }));
+function toWarningIssues(messages: string[], filePath?: string): ValidationIssue[] {
+  return messages.map((message) => ({ type: "warning", message, filePath }));
 }
 
 function collectDuplicateNumberIssues(config: DuplicateDocumentIssueConfig): ValidationIssue[] {
@@ -120,20 +121,17 @@ function collectDuplicateNumberIssues(config: DuplicateDocumentIssueConfig): Val
 
 function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
+  const groups = [
+    { files: files.prdFiles, absoluteDir: files.prdDir, displayDir: PRD_DIR },
+    { files: files.adrFiles, absoluteDir: files.adrDir, displayDir: ADR_DIR },
+    { files: files.planFiles, absoluteDir: files.planDir, displayDir: PLAN_DIR },
+  ];
 
-  for (const filename of files.prdFiles) {
-    const filepath = join(files.prdDir, filename);
-    issues.push(...toWarningIssues(validateSpecFile(filepath)));
-  }
-
-  for (const filename of files.adrFiles) {
-    const filepath = join(files.adrDir, filename);
-    issues.push(...toWarningIssues(validateSpecFile(filepath)));
-  }
-
-  for (const filename of files.planFiles) {
-    const filepath = join(files.planDir, filename);
-    issues.push(...toWarningIssues(validateSpecFile(filepath)));
+  for (const group of groups) {
+    for (const filename of group.files) {
+      const filepath = join(group.absoluteDir, filename);
+      issues.push(...toWarningIssues(validateSpecFile(filepath), `${group.displayDir}/${filename}`));
+    }
   }
 
   return issues;
@@ -145,7 +143,9 @@ function filterIssuesForChangedFile(issues: ValidationIssue[], changedFilePath?:
   }
 
   const changedFilename = basename(changedFilePath);
-  return issues.filter((issue) => issue.message.includes(changedFilename));
+  return issues.filter(
+    (issue) => issue.message.includes(changedFilename) || issue.filePath?.endsWith(`/${changedFilename}`),
+  );
 }
 
 function collectDuplicateValidationIssues(files: ValidationFiles, changedFilePath?: string): ValidationIssue[] {
@@ -196,7 +196,8 @@ function collectFilenameIssues(
     .filter((filename) => !pattern.test(filename))
     .map((filename) => ({
       type: "error" as const,
-      message: `✗ ${displayDir}/${filename}: filename doesn't match ${expected} pattern`,
+      filePath: `${displayDir}/${filename}`,
+      message: `✗ filename doesn't match ${expected} pattern`,
     }));
 }
 
@@ -226,6 +227,39 @@ function collectNumberingGapIssues(files: string[], pattern: RegExp, prefix: str
   return issues;
 }
 
+function formatIssueGroup(title: string, issues: ValidationIssue[]): string[] {
+  const lines: string[] = [title];
+  const grouped = new Map<string, ValidationIssue[]>();
+  const globalIssues: ValidationIssue[] = [];
+
+  for (const issue of issues) {
+    if (!issue.filePath) {
+      globalIssues.push(issue);
+      continue;
+    }
+
+    const existing = grouped.get(issue.filePath) ?? [];
+    existing.push(issue);
+    grouped.set(issue.filePath, existing);
+  }
+
+  for (const filePath of Array.from(grouped.keys()).sort((a, b) => a.localeCompare(b))) {
+    lines.push(`  ${filePath}`);
+    for (const issue of grouped.get(filePath) ?? []) {
+      lines.push(`    ${issue.message}`);
+    }
+  }
+
+  if (globalIssues.length > 0) {
+    lines.push("  Workspace");
+    for (const issue of globalIssues) {
+      lines.push(`    ${issue.message}`);
+    }
+  }
+
+  return lines;
+}
+
 function formatValidationIssues(issues: ValidationIssue[]): { message: string; level: "error" | "warning" | "info" } {
   if (issues.length === 0) {
     return { message: "[specdocs] Validation passed: no issues found.", level: "info" };
@@ -236,17 +270,11 @@ function formatValidationIssues(issues: ValidationIssue[]): { message: string; l
   const lines: string[] = [];
 
   if (errors.length > 0) {
-    lines.push(`Errors (${errors.length}):`);
-    for (const error of errors) {
-      lines.push(`  ${error.message}`);
-    }
+    lines.push(...formatIssueGroup(`Errors (${errors.length}):`, errors));
   }
 
   if (warnings.length > 0) {
-    lines.push(`Warnings (${warnings.length}):`);
-    for (const warning of warnings) {
-      lines.push(`  ${warning.message}`);
-    }
+    lines.push(...formatIssueGroup(`Warnings (${warnings.length}):`, warnings));
   }
 
   return {

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -278,6 +278,10 @@ function isSupportedSpecPath(path: string): boolean {
   return isPrd(path) || isAdr(path) || isPlan(path);
 }
 
+function isThematicBreak(line: string): boolean {
+  return /^(?:\*\*\*|---|___)$/.test(line.trim());
+}
+
 function normalizeBodyLines(lines: string[]): string[] {
   const result: string[] = [];
 
@@ -285,14 +289,14 @@ function normalizeBodyLines(lines: string[]): string[] {
     const line = lines[i].replace(/[\t ]+$/g, "");
     const trimmed = line.trim();
 
-    if (trimmed.startsWith("## ")) {
+    if (trimmed.startsWith("## ") || isThematicBreak(trimmed)) {
       while (result.length > 0 && result[result.length - 1] === "") {
         result.pop();
       }
       if (result.length > 0) {
         result.push("");
       }
-      result.push(trimmed);
+      result.push(isThematicBreak(trimmed) ? "---" : trimmed);
       while (i + 1 < lines.length && lines[i + 1].trim() === "") {
         i++;
       }

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -445,7 +445,7 @@ export async function runFormat(args: unknown, ctx: { cwd: string } & ExtensionC
     return;
   }
 
-  const original = readFileSync(targetPath, "utf-8");
+  const original = parseResult.content ?? readFileSync(targetPath, "utf-8");
   const formatted = await formatSpecDocument(original);
   if (formatted === original) {
     ctx.ui.notify("[specdocs] No formatting changes were needed.", "info");

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -15,6 +15,10 @@ function extractFilePath(input: Record<string, unknown> | undefined): string {
   return (input.file_path as string) || (input.path as string) || "";
 }
 
+function isArchitectureMarkdown(path: string): boolean {
+  return path.includes(`${PLAN_DIR}/`) && path.endsWith(".md");
+}
+
 export async function handleDocLint(
   event: { toolName: string; input?: Record<string, unknown> },
   ctx: ExtensionContext,
@@ -24,15 +28,19 @@ export async function handleDocLint(
   }
 
   const filePath = extractFilePath(event.input);
-  if (!filePath || (!isPrd(filePath) && !isAdr(filePath) && !isPlan(filePath)) || !existsSync(filePath)) {
+  if (!filePath || (!isPrd(filePath) && !isAdr(filePath) && !isPlan(filePath) && !isArchitectureMarkdown(filePath)) || !existsSync(filePath)) {
     return;
   }
 
   const warnings = [...validateFrontmatter(filePath), ...validateRequiredSections(filePath), ...validateRequiredTables(filePath)];
-  const duplicateIssues = typeof ctx.cwd === "string"
-    ? collectDuplicateValidationIssues(getValidationFiles(ctx.cwd), filePath)
-    : [];
-  const messages = [...warnings, ...duplicateIssues.map((issue) => issue.message)];
+  const validationFiles = typeof ctx.cwd === "string" ? getValidationFiles(ctx.cwd) : null;
+  const duplicateIssues = validationFiles ? collectDuplicateValidationIssues(validationFiles, filePath) : [];
+  const architectureFilenameIssues = validationFiles ? collectArchitectureFilenameIssues(validationFiles, filePath) : [];
+  const messages = [
+    ...warnings,
+    ...duplicateIssues.map((issue) => issue.message),
+    ...architectureFilenameIssues.map((issue) => issue.message),
+  ];
 
   if (messages.length > 0) {
     ctx.ui.notify(`[specdocs] Frontmatter warnings:\n${messages.join("\n")}`, "warning");
@@ -137,6 +145,15 @@ function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
   return issues;
 }
 
+function filterIssuesForChangedFile(issues: ValidationIssue[], changedFilePath?: string): ValidationIssue[] {
+  if (!changedFilePath) {
+    return issues;
+  }
+
+  const changedFilename = basename(changedFilePath);
+  return issues.filter((issue) => issue.message.includes(changedFilename));
+}
+
 function collectDuplicateValidationIssues(files: ValidationFiles, changedFilePath?: string): ValidationIssue[] {
   const issues = [
     ...collectDuplicateNumberIssues({
@@ -155,12 +172,12 @@ function collectDuplicateValidationIssues(files: ValidationFiles, changedFilePat
     }),
   ];
 
-  if (!changedFilePath) {
-    return issues;
-  }
+  return filterIssuesForChangedFile(issues, changedFilePath);
+}
 
-  const changedFilename = basename(changedFilePath);
-  return issues.filter((issue) => issue.message.includes(changedFilename));
+function collectArchitectureFilenameIssues(files: ValidationFiles, changedFilePath?: string): ValidationIssue[] {
+  const issues = collectFilenameIssues(files.planDir, PLAN_DIR, PLAN_FILENAME_PATTERN, "plan-*.md");
+  return filterIssuesForChangedFile(issues, changedFilePath);
 }
 
 function listMarkdownFiles(directory: string): string[] {

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -6,8 +6,16 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateSpecFile } from "./spec-validation.js";
 import { parseFrontmatterResult } from "./frontmatter.js";
+import {
+  ADR_FILENAME_PATTERN,
+  isAdr,
+  isPlan,
+  isPrd,
+  PLAN_FILENAME_PATTERN,
+  PRD_FILENAME_PATTERN,
+  validateSpecFile,
+} from "./spec-validation.js";
 import { ADR_DIR, listMatchingFiles, PLAN_DIR, PRD_DIR } from "./workspace-scan.js";
 
 function extractFilePath(input: Record<string, unknown> | undefined): string {
@@ -28,14 +36,20 @@ export async function handleDocLint(
   }
 
   const filePath = extractFilePath(event.input);
-  if (!filePath || (!isPrd(filePath) && !isAdr(filePath) && !isPlan(filePath) && !isArchitectureMarkdown(filePath)) || !existsSync(filePath)) {
+  if (
+    !filePath ||
+    (!isPrd(filePath) && !isAdr(filePath) && !isPlan(filePath) && !isArchitectureMarkdown(filePath)) ||
+    !existsSync(filePath)
+  ) {
     return;
   }
 
   const warnings = validateSpecFile(filePath);
   const validationFiles = typeof ctx.cwd === "string" ? getValidationFiles(ctx.cwd) : null;
   const duplicateIssues = validationFiles ? collectDuplicateValidationIssues(validationFiles, filePath) : [];
-  const architectureFilenameIssues = validationFiles ? collectArchitectureFilenameIssues(validationFiles, filePath) : [];
+  const architectureFilenameIssues = validationFiles
+    ? collectArchitectureFilenameIssues(validationFiles, filePath)
+    : [];
   const messages = [
     ...warnings,
     ...duplicateIssues.map((issue) => issue.message),
@@ -377,16 +391,16 @@ async function formatSpecDocument(content: string): Promise<string> {
     }
     return line.replace(/[\t ]+$/g, "");
   });
-  const bodyLines = normalizeBodyLines(lines.slice(closingIndex + 1).filter((line, index, arr) => !(index === 0 && line.trim() === "" && arr.length > 0)));
+  const bodyLines = normalizeBodyLines(
+    lines.slice(closingIndex + 1).filter((line, index, arr) => !(index === 0 && line.trim() === "" && arr.length > 0)),
+  );
   return `${frontmatterLines.join("\n")}\n\n${bodyLines.join("\n")}\n`;
 }
 
-export async function runFormat(
-  args: unknown,
-  ctx: { cwd: string } & ExtensionContext,
-): Promise<void> {
+export async function runFormat(args: unknown, ctx: { cwd: string } & ExtensionContext): Promise<void> {
   const params = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-  const rawPath = typeof params.path === "string" ? params.path : typeof params.file_path === "string" ? params.file_path : "";
+  const rawPath =
+    typeof params.path === "string" ? params.path : typeof params.file_path === "string" ? params.file_path : "";
   if (!rawPath) {
     ctx.ui.notify("[specdocs] specdocs-format requires a single path argument.", "error");
     return;

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
@@ -17,6 +17,15 @@ import {
   validateSpecFile,
 } from "./spec-validation.js";
 import { ADR_DIR, listMatchingFiles, PLAN_DIR, PRD_DIR } from "./workspace-scan.js";
+
+const formatProcessor = unified()
+  .use(remarkParse)
+  .use(remarkFrontmatter, ["yaml"])
+  .use(remarkGfm)
+  .use(remarkStringify, {
+    fences: true,
+    listItemIndent: "one",
+  });
 
 function extractFilePath(input: Record<string, unknown> | undefined): string {
   if (!input) return "";
@@ -46,9 +55,9 @@ export async function handleDocLint(
 
   const warnings = validateSpecFile(filePath);
   const validationFiles = typeof ctx.cwd === "string" ? getValidationFiles(ctx.cwd) : null;
-  const duplicateIssues = validationFiles ? collectDuplicateValidationIssues(validationFiles, filePath) : [];
+  const duplicateIssues = validationFiles ? collectDuplicateValidationIssues(validationFiles, filePath, ctx.cwd) : [];
   const architectureFilenameIssues = validationFiles
-    ? collectArchitectureFilenameIssues(validationFiles, filePath)
+    ? collectArchitectureFilenameIssues(validationFiles, filePath, ctx.cwd)
     : [];
   const messages = [
     ...warnings,
@@ -57,7 +66,7 @@ export async function handleDocLint(
   ];
 
   if (messages.length > 0) {
-    ctx.ui.notify(`[specdocs] Frontmatter warnings:\n${messages.join("\n")}`, "warning");
+    ctx.ui.notify(`[specdocs] Validation warnings:\n${messages.join("\n")}`, "warning");
   }
 }
 
@@ -151,18 +160,29 @@ function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
   return issues;
 }
 
-function filterIssuesForChangedFile(issues: ValidationIssue[], changedFilePath?: string): ValidationIssue[] {
+function toRepoRelativePath(cwd: string, path: string): string {
+  const relativePath = relative(cwd, path).replace(/\\/g, "/");
+  return relativePath.startsWith("../") ? path : relativePath;
+}
+
+function filterIssuesForChangedFile(
+  issues: ValidationIssue[],
+  changedFilePath?: string,
+  cwd?: string,
+): ValidationIssue[] {
   if (!changedFilePath) {
     return issues;
   }
 
-  const changedFilename = basename(changedFilePath);
-  return issues.filter(
-    (issue) => issue.message.includes(changedFilename) || issue.filePath?.endsWith(`/${changedFilename}`),
-  );
+  const changedPath = cwd ? toRepoRelativePath(cwd, changedFilePath) : changedFilePath.replace(/\\/g, "/");
+  return issues.filter((issue) => issue.message.includes(changedPath) || issue.filePath === changedPath);
 }
 
-function collectDuplicateValidationIssues(files: ValidationFiles, changedFilePath?: string): ValidationIssue[] {
+function collectDuplicateValidationIssues(
+  files: ValidationFiles,
+  changedFilePath?: string,
+  cwd?: string,
+): ValidationIssue[] {
   const issues = [
     ...collectDuplicateNumberIssues({
       files: files.prdFiles,
@@ -180,12 +200,16 @@ function collectDuplicateValidationIssues(files: ValidationFiles, changedFilePat
     }),
   ];
 
-  return filterIssuesForChangedFile(issues, changedFilePath);
+  return filterIssuesForChangedFile(issues, changedFilePath, cwd);
 }
 
-function collectArchitectureFilenameIssues(files: ValidationFiles, changedFilePath?: string): ValidationIssue[] {
+function collectArchitectureFilenameIssues(
+  files: ValidationFiles,
+  changedFilePath?: string,
+  cwd?: string,
+): ValidationIssue[] {
   const issues = collectFilenameIssues(files.planDir, PLAN_DIR, PLAN_FILENAME_PATTERN, "plan-*.md");
-  return filterIssuesForChangedFile(issues, changedFilePath);
+  return filterIssuesForChangedFile(issues, changedFilePath, cwd);
 }
 
 function listMarkdownFiles(directory: string): string[] {
@@ -321,7 +345,8 @@ function isSupportedSpecPath(path: string): boolean {
 }
 
 function isThematicBreak(line: string): boolean {
-  return /^(?:\*\*\*|---|___)$/.test(line.trim());
+  // Accept common CommonMark thematic-break spellings; formatting canonicalizes them to `---`.
+  return /^(?:(?:\*\s*){3,}|(?:-\s*){3,}|(?:_\s*){3,})$/.test(line.trim());
 }
 
 function normalizeBodyLines(lines: string[]): string[] {
@@ -357,15 +382,7 @@ function normalizeBodyLines(lines: string[]): string[] {
 }
 
 async function formatSpecDocument(content: string): Promise<string> {
-  const file = await unified()
-    .use(remarkParse)
-    .use(remarkFrontmatter, ["yaml"])
-    .use(remarkGfm)
-    .use(remarkStringify, {
-      fences: true,
-      listItemIndent: "one",
-    })
-    .process(content);
+  const file = await formatProcessor.process(content);
 
   const formatted = String(file);
   const lines = formatted.split("\n");

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateFrontmatter, validateRequiredSections, validateRequiredTables } from "./spec-validation.js";
+import { ADR_FILENAME_PATTERN, isAdr, isPlan, isPrd, PLAN_FILENAME_PATTERN, PRD_FILENAME_PATTERN, validateSpecFile } from "./spec-validation.js";
 import { parseFrontmatterResult } from "./frontmatter.js";
 import { ADR_DIR, listMatchingFiles, PLAN_DIR, PRD_DIR } from "./workspace-scan.js";
 
@@ -32,7 +32,7 @@ export async function handleDocLint(
     return;
   }
 
-  const warnings = [...validateFrontmatter(filePath), ...validateRequiredSections(filePath), ...validateRequiredTables(filePath)];
+  const warnings = validateSpecFile(filePath);
   const validationFiles = typeof ctx.cwd === "string" ? getValidationFiles(ctx.cwd) : null;
   const duplicateIssues = validationFiles ? collectDuplicateValidationIssues(validationFiles, filePath) : [];
   const architectureFilenameIssues = validationFiles ? collectArchitectureFilenameIssues(validationFiles, filePath) : [];
@@ -123,23 +123,17 @@ function collectFrontmatterIssues(files: ValidationFiles): ValidationIssue[] {
 
   for (const filename of files.prdFiles) {
     const filepath = join(files.prdDir, filename);
-    issues.push(...toWarningIssues(validateFrontmatter(filepath)));
-    issues.push(...toWarningIssues(validateRequiredSections(filepath)));
-    issues.push(...toWarningIssues(validateRequiredTables(filepath)));
+    issues.push(...toWarningIssues(validateSpecFile(filepath)));
   }
 
   for (const filename of files.adrFiles) {
     const filepath = join(files.adrDir, filename);
-    issues.push(...toWarningIssues(validateFrontmatter(filepath)));
-    issues.push(...toWarningIssues(validateRequiredSections(filepath)));
-    issues.push(...toWarningIssues(validateRequiredTables(filepath)));
+    issues.push(...toWarningIssues(validateSpecFile(filepath)));
   }
 
   for (const filename of files.planFiles) {
     const filepath = join(files.planDir, filename);
-    issues.push(...toWarningIssues(validateFrontmatter(filepath)));
-    issues.push(...toWarningIssues(validateRequiredSections(filepath)));
-    issues.push(...toWarningIssues(validateRequiredTables(filepath)));
+    issues.push(...toWarningIssues(validateSpecFile(filepath)));
   }
 
   return issues;

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -179,10 +179,7 @@ function collectPlanWarnings(fields: Record<string, string>, warnings: string[])
   }
 }
 
-function validateFrontmatterFromResult(
-  filepath: string,
-  result: ReturnType<typeof parseFrontmatterResult>,
-): string[] {
+function validateFrontmatterFromResult(filepath: string, result: ReturnType<typeof parseFrontmatterResult>): string[] {
   const config = getDocValidationConfig(filepath);
   if (!config) {
     return [];

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -252,7 +252,7 @@ interface ParsedSpecDocument {
   label: "PRD" | "ADR" | "PLAN" | null;
   frontmatter: ReturnType<typeof parseFrontmatterResult>;
   headings: Set<string>;
-  tables: Map<string, string[]>;
+  tables: Map<string, string[][]>;
 }
 
 function parseSpecDocument(filepath: string): ParsedSpecDocument {
@@ -261,7 +261,7 @@ function parseSpecDocument(filepath: string): ParsedSpecDocument {
   const tree = parseMarkdownTree(body);
   const children = Array.isArray(tree.children) ? tree.children : [];
   const headings = new Set<string>();
-  const tables = new Map<string, string[]>();
+  const tables = new Map<string, string[][]>();
   let currentSection = "";
 
   for (const node of children) {
@@ -278,10 +278,9 @@ function parseSpecDocument(filepath: string): ParsedSpecDocument {
 
     const headerRow = node.children[0];
     const headerCells = Array.isArray(headerRow?.children) ? headerRow.children : [];
-    tables.set(
-      currentSection,
-      headerCells.map((cell) => extractNodeText(cell).trim()),
-    );
+    const sectionTables = tables.get(currentSection) ?? [];
+    sectionTables.push(headerCells.map((cell) => extractNodeText(cell).trim()));
+    tables.set(currentSection, sectionTables);
   }
 
   return {
@@ -313,14 +312,16 @@ function validateRequiredTablesFromDocument(document: ParsedSpecDocument): strin
 
   const warnings: string[] = [];
   for (const [section, requiredColumns] of Object.entries(REQUIRED_TABLE_COLUMNS[label])) {
-    const headers = document.tables.get(section);
-    if (!headers) {
+    const sectionTables = document.tables.get(section);
+    if (!sectionTables || sectionTables.length === 0) {
       warnings.push(`⚠ ${label}: Missing required table in section ${section}.`);
       continue;
     }
 
-    const missingColumns = requiredColumns.filter((column) => !headers.includes(column));
-    if (missingColumns.length > 0) {
+    const matchingTable = sectionTables.find((headers) => requiredColumns.every((column) => headers.includes(column)));
+    if (!matchingTable) {
+      const combinedHeaders = Array.from(new Set(sectionTables.flat()));
+      const missingColumns = requiredColumns.filter((column) => !combinedHeaders.includes(column));
       warnings.push(`⚠ ${label}: Table ${section} is missing required columns: ${missingColumns.join(", ")}.`);
     }
   }

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -1,4 +1,5 @@
 import { basename } from "node:path";
+import type { Heading, Root, Table, TableCell } from "mdast";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
@@ -57,6 +58,7 @@ const REQUIRED_TABLE_COLUMNS: Record<string, Record<string, readonly string[]>> 
     "File Breakdown": ["File", "Change type", "FR", "Description"],
     Changelog: ["Date", "Change", "Author"],
   },
+  // ADRs intentionally have no required tables in the first release.
   PLAN: {
     "Implementation Order": ["Phase", "Component", "Dependencies", "Estimated Scope"],
     "ADR Index": ["ADR", "Title", "Status"],
@@ -226,22 +228,25 @@ function normalizeHeadingText(heading: string): string {
   return heading.replace(/^\d+\.\s+/, "").trim();
 }
 
-type MdNode = {
-  type?: string;
-  depth?: number;
-  value?: string;
-  children?: MdNode[];
-};
+const markdownParser = unified().use(remarkParse).use(remarkFrontmatter, ["yaml"]).use(remarkGfm);
 
-function extractNodeText(node: MdNode | undefined): string {
+function extractNodeText(node: { value?: string; children?: unknown[] } | undefined): string {
   if (!node) return "";
   if (typeof node.value === "string") return node.value;
   if (!Array.isArray(node.children)) return "";
-  return node.children.map((child) => extractNodeText(child)).join("");
+  return node.children.map((child) => extractNodeText(child as { value?: string; children?: unknown[] })).join("");
 }
 
-function parseMarkdownTree(body: string): MdNode {
-  return unified().use(remarkParse).use(remarkFrontmatter, ["yaml"]).use(remarkGfm).parse(body) as MdNode;
+function parseMarkdownTree(body: string): Root {
+  return markdownParser.parse(body) as Root;
+}
+
+function isHeadingNode(node: Root["children"][number]): node is Heading {
+  return node.type === "heading";
+}
+
+function isTableNode(node: Root["children"][number]): node is Table {
+  return node.type === "table";
 }
 
 interface ParsedSpecDocument {
@@ -256,25 +261,24 @@ function parseSpecDocument(filepath: string): ParsedSpecDocument {
   const frontmatter = parseFrontmatterResult(filepath);
   const body = frontmatter.content === null ? "" : frontmatter.body;
   const tree = parseMarkdownTree(body);
-  const children = Array.isArray(tree.children) ? tree.children : [];
   const headings = new Set<string>();
   const tables = new Map<string, string[][]>();
   let currentSection = "";
 
-  for (const node of children) {
-    if (node.type === "heading" && node.depth === 2) {
+  for (const node of tree.children) {
+    if (isHeadingNode(node) && node.depth === 2) {
       const headingText = extractNodeText(node).trim();
       headings.add(`## ${headingText}`);
       currentSection = normalizeHeadingText(headingText);
       continue;
     }
 
-    if (!currentSection || node.type !== "table" || !Array.isArray(node.children) || node.children.length === 0) {
+    if (!currentSection || !isTableNode(node) || node.children.length === 0) {
       continue;
     }
 
     const headerRow = node.children[0];
-    const headerCells = Array.isArray(headerRow?.children) ? headerRow.children : [];
+    const headerCells = Array.isArray(headerRow?.children) ? (headerRow.children as TableCell[]) : [];
     const sectionTables = tables.get(currentSection) ?? [];
     sectionTables.push(headerCells.map((cell) => extractNodeText(cell).trim()));
     tables.set(currentSection, sectionTables);

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -1,14 +1,67 @@
 import { basename } from "node:path";
-import { parseFrontmatter } from "./frontmatter.js";
+import { parseFrontmatterResult } from "./frontmatter.js";
 
 const PRD_REQUIRED_FIELDS = ["title", "prd", "status", "owner", "date", "issue", "version"] as const;
 const ADR_REQUIRED_FIELDS = ["title", "adr", "status", "date", "prd"] as const;
+const PLAN_REQUIRED_FIELDS = ["title", "prd", "date", "author", "status"] as const;
 
 const PRD_VALID_STATUSES = ["Draft", "Implemented", "Superseded", "Archived"] as const;
 const ADR_VALID_STATUSES = ["Proposed", "Accepted", "Deprecated", "Superseded"] as const;
+const PLAN_VALID_STATUSES = ["Draft", "Implemented", "Archived"] as const;
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const PLAN_PRD_PATTERN = /^PRD-\d{3}-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const PRD_REQUIRED_SECTIONS = [
+  "## 1. Problem & Context",
+  "## 2. Goals & Success Metrics",
+  "## 3. Users & Use Cases",
+  "## 4. Scope",
+  "## 5. Functional Requirements",
+  "## 6. Non-Functional Requirements",
+  "## 7. Risks & Assumptions",
+  "## 8. Design Decisions",
+  "## 9. File Breakdown",
+  "## 10. Dependencies & Constraints",
+  "## 11. Rollout Plan",
+  "## 12. Open Questions",
+  "## 13. Related",
+  "## 14. Changelog",
+] as const;
+const ADR_REQUIRED_SECTIONS = [
+  "## Status",
+  "## Date",
+  "## Requirement Source",
+  "## Context",
+  "## Decision Drivers",
+  "## Considered Options",
+  "## Decision",
+  "## Consequences",
+  "## Related",
+] as const;
+const PLAN_REQUIRED_SECTIONS = [
+  "## Source",
+  "## Architecture Overview",
+  "## Components",
+  "## Implementation Order",
+  "## ADR Index",
+] as const;
+
+const REQUIRED_TABLE_COLUMNS: Record<string, Record<string, readonly string[]>> = {
+  PRD: {
+    "Open Questions": ["#", "Question", "Owner", "Due", "Status"],
+    "File Breakdown": ["File", "Change type", "FR", "Description"],
+    Changelog: ["Date", "Change", "Author"],
+  },
+  PLAN: {
+    "Implementation Order": ["Phase", "Component", "Dependencies", "Estimated Scope"],
+    "ADR Index": ["ADR", "Title", "Status"],
+  },
+};
 
 export const PRD_FILENAME_PATTERN = /^PRD-\d{3}-.*\.md$/;
 export const ADR_FILENAME_PATTERN = /^ADR-\d{4}-.*\.md$/;
+export const PLAN_FILENAME_PATTERN = /^plan-.*\.md$/;
 
 export function isPrd(path: string): boolean {
   return path.includes("docs/prd/PRD-");
@@ -18,13 +71,17 @@ export function isAdr(path: string): boolean {
   return path.includes("docs/adr/ADR-");
 }
 
+export function isPlan(path: string): boolean {
+  return path.includes("docs/architecture/plan-");
+}
+
 interface DocValidationConfig {
-  docType: "PRD" | "ADR";
+  docType: "PRD" | "ADR" | "PLAN";
   requiredFields: readonly string[];
   validStatuses: readonly string[];
-  numberPattern: RegExp;
-  numberField: "prd" | "adr";
-  expectedNumberFormat: string;
+  numberPattern?: RegExp;
+  numberField?: "prd" | "adr";
+  expectedNumberFormat?: string;
 }
 
 function getDocValidationConfig(filepath: string): DocValidationConfig | null {
@@ -50,6 +107,14 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
     };
   }
 
+  if (isPlan(filepath)) {
+    return {
+      docType: "PLAN",
+      requiredFields: PLAN_REQUIRED_FIELDS,
+      validStatuses: PLAN_VALID_STATUSES,
+    };
+  }
+
   return null;
 }
 
@@ -71,6 +136,10 @@ function collectNumberWarnings(
   filename: string,
   warnings: string[],
 ): void {
+  if (!config.numberField || !config.numberPattern || !config.expectedNumberFormat) {
+    return;
+  }
+
   const numberValue = fields[config.numberField] ?? "";
   if (!numberValue) {
     return;
@@ -94,13 +163,30 @@ function collectStatusWarnings(fields: Record<string, string>, config: DocValida
   }
 }
 
+function collectPlanWarnings(fields: Record<string, string>, warnings: string[]): void {
+  const date = fields.date ?? "";
+  if (date && !ISO_DATE_PATTERN.test(date)) {
+    warnings.push("⚠ PLAN: date must use ISO format YYYY-MM-DD.");
+  }
+
+  const prd = fields.prd ?? "";
+  if (prd && !PLAN_PRD_PATTERN.test(prd)) {
+    warnings.push("⚠ PLAN: prd must use the format PRD-NNN-descriptive-slug.");
+  }
+}
+
 export function validateFrontmatter(filepath: string): string[] {
   const config = getDocValidationConfig(filepath);
   if (!config) {
     return [];
   }
 
-  const fields = parseFrontmatter(filepath);
+  const result = parseFrontmatterResult(filepath);
+  if (result.error) {
+    return [`⚠ ${config.docType}: Frontmatter parse error: ${result.error}`];
+  }
+
+  const fields = result.fields;
   if (fields === null) {
     return [`⚠ ${config.docType}: No YAML frontmatter found.`];
   }
@@ -109,5 +195,107 @@ export function validateFrontmatter(filepath: string): string[] {
   collectMissingFieldWarnings(fields, config, warnings);
   collectNumberWarnings(fields, config, basename(filepath), warnings);
   collectStatusWarnings(fields, config, warnings);
+  if (config.docType === "PLAN") {
+    collectPlanWarnings(fields, warnings);
+  }
+  return warnings;
+}
+
+function getRequiredSections(filepath: string): readonly string[] {
+  if (isPrd(filepath)) return PRD_REQUIRED_SECTIONS;
+  if (isAdr(filepath)) return ADR_REQUIRED_SECTIONS;
+  if (isPlan(filepath)) return PLAN_REQUIRED_SECTIONS;
+  return [];
+}
+
+function collectHeadings(body: string): string[] {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("## "));
+}
+
+function getDocTypeLabel(filepath: string): "PRD" | "ADR" | "PLAN" | null {
+  if (isPrd(filepath)) return "PRD";
+  if (isAdr(filepath)) return "ADR";
+  if (isPlan(filepath)) return "PLAN";
+  return null;
+}
+
+function normalizeHeadingText(heading: string): string {
+  return heading.replace(/^##\s+/, "").replace(/^\d+\.\s+/, "").trim();
+}
+
+function extractSectionTables(body: string): Map<string, string[]> {
+  const lines = body.split("\n");
+  const tables = new Map<string, string[]>();
+  let currentSection = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("## ")) {
+      currentSection = normalizeHeadingText(trimmed);
+      continue;
+    }
+
+    if (!currentSection || !trimmed.startsWith("|")) {
+      continue;
+    }
+
+    const separator = lines[i + 1]?.trim() ?? "";
+    if (!separator.startsWith("|") || !separator.includes("---")) {
+      continue;
+    }
+
+    const headers = trimmed
+      .split("|")
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+    tables.set(currentSection, headers);
+  }
+
+  return tables;
+}
+
+export function validateRequiredSections(filepath: string): string[] {
+  const requiredSections = getRequiredSections(filepath);
+  if (requiredSections.length === 0) {
+    return [];
+  }
+
+  const result = parseFrontmatterResult(filepath);
+  const body = result.content === null ? "" : result.body;
+  const headings = new Set(collectHeadings(body));
+  const label = getDocTypeLabel(filepath) ?? "PRD";
+
+  return requiredSections
+    .filter((section) => !headings.has(section))
+    .map((section) => `⚠ ${label}: Missing required section: ${section}`);
+}
+
+export function validateRequiredTables(filepath: string): string[] {
+  const label = getDocTypeLabel(filepath);
+  if (!label || !(label in REQUIRED_TABLE_COLUMNS)) {
+    return [];
+  }
+
+  const result = parseFrontmatterResult(filepath);
+  const body = result.content === null ? "" : result.body;
+  const tables = extractSectionTables(body);
+  const warnings: string[] = [];
+
+  for (const [section, requiredColumns] of Object.entries(REQUIRED_TABLE_COLUMNS[label])) {
+    const headers = tables.get(section);
+    if (!headers) {
+      warnings.push(`⚠ ${label}: Missing required table in section ${section}.`);
+      continue;
+    }
+
+    const missingColumns = requiredColumns.filter((column) => !headers.includes(column));
+    if (missingColumns.length > 0) {
+      warnings.push(`⚠ ${label}: Table ${section} is missing required columns: ${missingColumns.join(", ")}.`);
+    }
+  }
+
   return warnings;
 }

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -1,4 +1,8 @@
 import { basename } from "node:path";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
 import { parseFrontmatterResult } from "./frontmatter.js";
 
 const PRD_REQUIRED_FIELDS = ["title", "prd", "status", "owner", "date", "issue", "version"] as const;
@@ -208,13 +212,6 @@ function getRequiredSections(filepath: string): readonly string[] {
   return [];
 }
 
-function collectHeadings(body: string): string[] {
-  return body
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("## "));
-}
-
 function getDocTypeLabel(filepath: string): "PRD" | "ADR" | "PLAN" | null {
   if (isPrd(filepath)) return "PRD";
   if (isAdr(filepath)) return "ADR";
@@ -223,34 +220,54 @@ function getDocTypeLabel(filepath: string): "PRD" | "ADR" | "PLAN" | null {
 }
 
 function normalizeHeadingText(heading: string): string {
-  return heading.replace(/^##\s+/, "").replace(/^\d+\.\s+/, "").trim();
+  return heading.replace(/^\d+\.\s+/, "").trim();
+}
+
+type MdNode = {
+  type?: string;
+  depth?: number;
+  value?: string;
+  children?: MdNode[];
+};
+
+function extractNodeText(node: MdNode | undefined): string {
+  if (!node) return "";
+  if (typeof node.value === "string") return node.value;
+  if (!Array.isArray(node.children)) return "";
+  return node.children.map((child) => extractNodeText(child)).join("");
+}
+
+function parseMarkdownTree(body: string): MdNode {
+  return unified().use(remarkParse).use(remarkFrontmatter, ["yaml"]).use(remarkGfm).parse(body) as MdNode;
+}
+
+function collectHeadings(body: string): string[] {
+  const tree = parseMarkdownTree(body);
+  const children = Array.isArray(tree.children) ? tree.children : [];
+  return children
+    .filter((node) => node.type === "heading" && node.depth === 2)
+    .map((node) => `## ${extractNodeText(node).trim()}`);
 }
 
 function extractSectionTables(body: string): Map<string, string[]> {
-  const lines = body.split("\n");
+  const tree = parseMarkdownTree(body);
   const tables = new Map<string, string[]>();
+  const children = Array.isArray(tree.children) ? tree.children : [];
   let currentSection = "";
 
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (trimmed.startsWith("## ")) {
-      currentSection = normalizeHeadingText(trimmed);
+  for (const node of children) {
+    if (node.type === "heading" && node.depth === 2) {
+      currentSection = normalizeHeadingText(extractNodeText(node));
       continue;
     }
 
-    if (!currentSection || !trimmed.startsWith("|")) {
+    if (!currentSection || node.type !== "table" || !Array.isArray(node.children) || node.children.length === 0) {
       continue;
     }
 
-    const separator = lines[i + 1]?.trim() ?? "";
-    if (!separator.startsWith("|") || !separator.includes("---")) {
-      continue;
-    }
-
-    const headers = trimmed
-      .split("|")
-      .slice(1, -1)
-      .map((cell) => cell.trim());
+    const headerRow = node.children[0];
+    const headerCells = Array.isArray(headerRow?.children) ? headerRow.children : [];
+    const headers = headerCells.map((cell) => extractNodeText(cell).trim());
     tables.set(currentSection, headers);
   }
 

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -179,13 +179,15 @@ function collectPlanWarnings(fields: Record<string, string>, warnings: string[])
   }
 }
 
-export function validateFrontmatter(filepath: string): string[] {
+function validateFrontmatterFromResult(
+  filepath: string,
+  result: ReturnType<typeof parseFrontmatterResult>,
+): string[] {
   const config = getDocValidationConfig(filepath);
   if (!config) {
     return [];
   }
 
-  const result = parseFrontmatterResult(filepath);
   if (result.error) {
     return [`⚠ ${config.docType}: Frontmatter parse error: ${result.error}`];
   }
@@ -203,6 +205,10 @@ export function validateFrontmatter(filepath: string): string[] {
     collectPlanWarnings(fields, warnings);
   }
   return warnings;
+}
+
+export function validateFrontmatter(filepath: string): string[] {
+  return validateFrontmatterFromResult(filepath, parseFrontmatterResult(filepath));
 }
 
 function getRequiredSections(filepath: string): readonly string[] {
@@ -241,23 +247,28 @@ function parseMarkdownTree(body: string): MdNode {
   return unified().use(remarkParse).use(remarkFrontmatter, ["yaml"]).use(remarkGfm).parse(body) as MdNode;
 }
 
-function collectHeadings(body: string): string[] {
-  const tree = parseMarkdownTree(body);
-  const children = Array.isArray(tree.children) ? tree.children : [];
-  return children
-    .filter((node) => node.type === "heading" && node.depth === 2)
-    .map((node) => `## ${extractNodeText(node).trim()}`);
+interface ParsedSpecDocument {
+  filepath: string;
+  label: "PRD" | "ADR" | "PLAN" | null;
+  frontmatter: ReturnType<typeof parseFrontmatterResult>;
+  headings: Set<string>;
+  tables: Map<string, string[]>;
 }
 
-function extractSectionTables(body: string): Map<string, string[]> {
+function parseSpecDocument(filepath: string): ParsedSpecDocument {
+  const frontmatter = parseFrontmatterResult(filepath);
+  const body = frontmatter.content === null ? "" : frontmatter.body;
   const tree = parseMarkdownTree(body);
-  const tables = new Map<string, string[]>();
   const children = Array.isArray(tree.children) ? tree.children : [];
+  const headings = new Set<string>();
+  const tables = new Map<string, string[]>();
   let currentSection = "";
 
   for (const node of children) {
     if (node.type === "heading" && node.depth === 2) {
-      currentSection = normalizeHeadingText(extractNodeText(node));
+      const headingText = extractNodeText(node).trim();
+      headings.add(`## ${headingText}`);
+      currentSection = normalizeHeadingText(headingText);
       continue;
     }
 
@@ -267,42 +278,42 @@ function extractSectionTables(body: string): Map<string, string[]> {
 
     const headerRow = node.children[0];
     const headerCells = Array.isArray(headerRow?.children) ? headerRow.children : [];
-    const headers = headerCells.map((cell) => extractNodeText(cell).trim());
-    tables.set(currentSection, headers);
+    tables.set(
+      currentSection,
+      headerCells.map((cell) => extractNodeText(cell).trim()),
+    );
   }
 
-  return tables;
+  return {
+    filepath,
+    label: getDocTypeLabel(filepath),
+    frontmatter,
+    headings,
+    tables,
+  };
 }
 
-export function validateRequiredSections(filepath: string): string[] {
-  const requiredSections = getRequiredSections(filepath);
+function validateRequiredSectionsFromDocument(document: ParsedSpecDocument): string[] {
+  const requiredSections = getRequiredSections(document.filepath);
   if (requiredSections.length === 0) {
     return [];
   }
 
-  const result = parseFrontmatterResult(filepath);
-  const body = result.content === null ? "" : result.body;
-  const headings = new Set(collectHeadings(body));
-  const label = getDocTypeLabel(filepath) ?? "PRD";
-
+  const label = document.label ?? "PRD";
   return requiredSections
-    .filter((section) => !headings.has(section))
+    .filter((section) => !document.headings.has(section))
     .map((section) => `⚠ ${label}: Missing required section: ${section}`);
 }
 
-export function validateRequiredTables(filepath: string): string[] {
-  const label = getDocTypeLabel(filepath);
+function validateRequiredTablesFromDocument(document: ParsedSpecDocument): string[] {
+  const label = document.label;
   if (!label || !(label in REQUIRED_TABLE_COLUMNS)) {
     return [];
   }
 
-  const result = parseFrontmatterResult(filepath);
-  const body = result.content === null ? "" : result.body;
-  const tables = extractSectionTables(body);
   const warnings: string[] = [];
-
   for (const [section, requiredColumns] of Object.entries(REQUIRED_TABLE_COLUMNS[label])) {
-    const headers = tables.get(section);
+    const headers = document.tables.get(section);
     if (!headers) {
       warnings.push(`⚠ ${label}: Missing required table in section ${section}.`);
       continue;
@@ -315,4 +326,21 @@ export function validateRequiredTables(filepath: string): string[] {
   }
 
   return warnings;
+}
+
+export function validateRequiredSections(filepath: string): string[] {
+  return validateRequiredSectionsFromDocument(parseSpecDocument(filepath));
+}
+
+export function validateRequiredTables(filepath: string): string[] {
+  return validateRequiredTablesFromDocument(parseSpecDocument(filepath));
+}
+
+export function validateSpecFile(filepath: string): string[] {
+  const document = parseSpecDocument(filepath);
+  return [
+    ...validateFrontmatterFromResult(filepath, document.frontmatter),
+    ...validateRequiredSectionsFromDocument(document),
+    ...validateRequiredTablesFromDocument(document),
+  ];
 }

--- a/packages/pi-specdocs/package.json
+++ b/packages/pi-specdocs/package.json
@@ -33,6 +33,14 @@
       "./prompts"
     ]
   },
+  "dependencies": {
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.5",
+    "yaml": "^2.8.3"
+  },
   "peerDependencies": {
     "@mariozechner/pi-ai": "*",
     "@mariozechner/pi-coding-agent": "*"

--- a/packages/pi-specdocs/package.json
+++ b/packages/pi-specdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-specdocs",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Structured spec documentation — PRDs, ADRs, and implementation plans with cross-referencing",
   "keywords": [
     "pi",

--- a/packages/pi-specdocs/prompts/architect.md
+++ b/packages/pi-specdocs/prompts/architect.md
@@ -91,6 +91,10 @@ After user approval, produce artifacts in this order:
 
 Cross-reference between all artifacts. PRDs should reference relevant ADRs. ADRs should link back to the PRD that motivated them.
 
+After saving each artifact:
+- run `specdocs-validate` so structural/frontmatter issues are surfaced immediately
+- if formatting cleanup is needed, run `specdocs-format <path>` explicitly on that artifact before moving on
+
 **Checkpoint after each artifact** — briefly confirm with the user before moving to the next one. Don't produce everything in a single uninterruptible run.
 
 ### 5. Present the Roadmap

--- a/packages/pi-specdocs/prompts/refine.md
+++ b/packages/pi-specdocs/prompts/refine.md
@@ -34,6 +34,11 @@ Read the document fully. Determine whether it's a PRD or ADR from its structure 
 
 Before flagging issues, do the homework. Use **sequential-thinking** to structure your approach when helpful — identify what needs checking, work through it methodically, and track what you've verified vs what remains.
 
+Start with structural validation when the target is a supported spec document:
+- run `specdocs-validate` to capture frontmatter, numbering, required section, required table, and plan filename issues as a baseline
+- if the document clearly has formatting drift, mention that `specdocs-format <path>` is the explicit normalization path rather than treating formatting cleanup as implicit
+
+Then continue with deeper review work:
 - **Codebase validation** — use `read` and `bash` to verify that file paths actually exist, that referenced modules behave as described, and that the blast radius is accurately captured. Use **code-reasoning** when you encounter complex dependency chains.
 - **External research** — use **exa** and **ref** to validate technology claims, check for known issues with proposed approaches, and verify that referenced standards or specifications are current.
 

--- a/packages/pi-specdocs/skills/adr/SKILL.md
+++ b/packages/pi-specdocs/skills/adr/SKILL.md
@@ -123,7 +123,11 @@ Do not save the ADR until:
 - the user explicitly authorized drafting all qualifying candidates, or
 - the input already specified the exact decision to document.
 
-Always report the file path and summarize the recommendation.
+After saving:
+- run `specdocs-validate` so structural/frontmatter issues are surfaced immediately
+- if formatting cleanup is needed, run `specdocs-format <path>` explicitly on the saved ADR
+
+Always report the file path, summarize the recommendation, and mention any validation/formatting follow-up you performed.
 
 ### 6. Cross-reference carefully
 

--- a/packages/pi-specdocs/skills/plan-prd/SKILL.md
+++ b/packages/pi-specdocs/skills/plan-prd/SKILL.md
@@ -96,10 +96,17 @@ Write the plan to:
 
 `docs/architecture/plan-slug.md`
 
+Implementation plans are first-class validated spec documents, so keep the canonical `plan-*.md` naming convention.
+
+After saving:
+- run `specdocs-validate` so plan frontmatter, required sections, required tables, and filename issues are caught immediately
+- if formatting cleanup is needed, run `specdocs-format <path>` explicitly on the saved plan
+
 Always report the file path and summarize:
 - the architecture shape
 - the implementation order
 - the main dependencies or risk hotspots
+- any validation/formatting follow-up you performed
 
 ### 7. Cross-reference
 

--- a/packages/pi-specdocs/skills/prd/SKILL.md
+++ b/packages/pi-specdocs/skills/prd/SKILL.md
@@ -93,7 +93,12 @@ Use the shared document conventions to determine the next PRD number and write t
 
 `docs/prd/PRD-NNN-slug.md`
 
-Always save the local artifact first and report the file path.
+Always save the local artifact first.
+
+After saving:
+- run `specdocs-validate` so structural/frontmatter issues are caught immediately
+- if spacing or table formatting needs normalization, run `specdocs-format <path>` explicitly on the saved PRD
+- report the final file path and any validation/formatting follow-up you performed
 
 ### 6. Publish intentionally
 


### PR DESCRIPTION
## Summary
- add parser-backed spec validation and explicit in-process `specdocs-format` support for PRDs, ADRs, and plans
- migrate section and table validation onto a shared remark-based parsed document path with improved runtime reporting grouped by file
- preserve common GFM constructs during formatting and sync the PRD/implementation plan docs with the delivered behavior

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `npm run lint`
- `npx tsc --noEmit --project packages/pi-specdocs/tsconfig.json`
- `npx vitest run packages/pi-specdocs/__tests__`