### PR TITLE
feat: align remaining pi-exa PRD-005 follow-ups

### DIFF
--- a/docs/adr/ADR-0005-exa-deep-search-tool-strategy.md
+++ b/docs/adr/ADR-0005-exa-deep-search-tool-strategy.md
@@ -1,7 +1,7 @@
 ---
 title: "Exa Deep Search Tool Strategy"
 adr: ADR-0005
-status: Proposed
+status: Accepted
 date: 2026-04-20
 prd: "PRD-005-pi-exa-api-alignment"
 decision: "New dedicated web_research_exa tool"
@@ -11,7 +11,7 @@ decision: "New dedicated web_research_exa tool"
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -110,6 +110,6 @@ The `web_search_advanced_exa` tool will explicitly exclude deep search types (`d
 
 ## Related
 
-- **Plan**: N/A (implementation plan to be generated via `/plan-prd`)
+- **Plan**: `docs/architecture/plan-pi-exa-api-alignment.md`
 - **ADRs**: N/A
-- **Implementation**: `packages/pi-exa/extensions/index.ts` — new tool registration
+- **Implementation**: `packages/pi-exa/extensions/index.ts` and `packages/pi-exa/skills/` — shipped tool routing and skill guidance

--- a/docs/architecture/plan-pi-exa-api-alignment.md
+++ b/docs/architecture/plan-pi-exa-api-alignment.md
@@ -3,7 +3,7 @@ title: "pi-exa Full Exa API Alignment"
 prd: "PRD-005-pi-exa-api-alignment"
 date: 2026-04-20
 author: "Claude Code"
-status: Draft
+status: Implemented
 ---
 
 # Plan: pi-exa Full Exa API Alignment
@@ -16,11 +16,11 @@ status: Draft
 
 ## Architecture Overview
 
-This plan implements PRD-005: closing the gap between the Exa API surface and what pi-exa exposes. The work has two axes — **widening** (3 new tools, enhanced fetch parameters) and **deepening** (observability metadata, typed SDK methods, system prompt guidance).
+This plan implemented PRD-005: closing the gap between the Exa API surface and what pi-exa exposes. The work had two axes — **widening** (3 new tools, enhanced fetch parameters) and **deepening** (observability metadata, typed SDK methods, system prompt guidance).
 
 The foundation is a migration from raw `exa.request()` calls to the exa-js SDK's typed methods (`exa.search()`, `exa.getContents()`, `exa.answer()`, `exa.findSimilar()`). This migration unlocks observability for free — the SDK's response types (`SearchResponse`, `AnswerResponse`) already carry `costDollars`, `searchTime`, and `resolvedSearchType`. A new shared return type (`ToolPerformResult`) threads metadata from `perform*()` functions through execute handlers into the tool result `details` field.
 
-On top of this foundation, three new tools are added (`web_research_exa`, `web_answer_exa`, `web_find_similar_exa`), the existing fetch tool gains `highlights`/`summary`/`maxAgeHours`, the advanced search tool gets strict type enforcement, all tools get `promptSnippet`/`promptGuidelines` for LLM routing, and all six skills are rewritten as pi-native. The work is structured so that each phase produces a working, testable increment.
+On top of this foundation, three new tools were added (`web_research_exa`, `web_answer_exa`, `web_find_similar_exa`), the existing fetch tool gained `highlights`/`summary`/`maxAgeHours`, the advanced search tool got strict type enforcement, all tools got `promptSnippet`/`promptGuidelines` for LLM routing, and all six skills were rewritten as pi-native. The plan is retained as the implementation record for the shipped work.
 
 ## Components
 
@@ -260,4 +260,4 @@ Decisions related to this plan:
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| [ADR-0005](../adr/ADR-0005-exa-deep-search-tool-strategy.md) | Exa Deep Search Tool Strategy | Proposed |
+| [ADR-0005](../adr/ADR-0005-exa-deep-search-tool-strategy.md) | Exa Deep Search Tool Strategy | Accepted |

--- a/docs/prd/PRD-005-pi-exa-api-alignment.md
+++ b/docs/prd/PRD-005-pi-exa-api-alignment.md
@@ -1,14 +1,16 @@
 ---
 title: "pi-exa Full Exa API Alignment"
 prd: PRD-005
-status: Draft
+status: Implemented
 owner: "Sebastian Otaegui"
 issue: "N/A"
 date: 2026-04-20
-version: "1.6"
+version: "1.7"
 ---
 
 # PRD: pi-exa Full Exa API Alignment
+
+> Status update: Implemented in `packages/pi-exa/`. This document now serves as the shipped requirements record for the Exa API alignment work.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7616,7 +7616,7 @@
     },
     "packages/pi-exa": {
       "name": "@feniix/pi-exa",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "exa-js": "^2.8.0"

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -732,6 +732,56 @@ describe("pi-exa extension", () => {
     );
   });
 
+  it("adds cross-tool prompt guidance for all registered tools", () => {
+    const configPath = writeTempConfig({
+      enabledTools: [
+        "web_search_exa",
+        "web_fetch_exa",
+        "web_search_advanced_exa",
+        "web_research_exa",
+        "web_answer_exa",
+        "web_find_similar_exa",
+      ],
+      researchEnabled: true,
+    });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+    expect(tools).toHaveLength(6);
+
+    for (const tool of tools) {
+      expect(tool.promptSnippet).toBeTypeOf("string");
+      expect(tool.promptSnippet.length).toBeLessThan(100);
+      expect(tool.promptSnippet).not.toContain("\n");
+      expect(tool.promptGuidelines).toBeInstanceOf(Array);
+      expect(tool.promptGuidelines.length).toBeGreaterThan(0);
+      for (const guideline of tool.promptGuidelines) {
+        expect(guideline).toMatch(/web_(search|fetch|search_advanced|research|answer|find_similar)_exa/);
+      }
+    }
+  });
+
+  it("routes web_search_exa and web_research_exa with explicit cross-tool wording", () => {
+    const mockPi = createMockPi({ "--exa-enable-research": true });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const searchTool = getRegisteredTool(mockPi, "web_search_exa");
+    const researchTool = getRegisteredTool(mockPi, "web_research_exa");
+
+    expect(searchTool.promptGuidelines).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("web_answer_exa"),
+        expect.stringContaining("web_research_exa"),
+        expect.stringContaining("web_fetch_exa"),
+      ]),
+    );
+    expect(researchTool.promptSnippet).toMatch(/cost|latency|higher/);
+    expect(researchTool.promptGuidelines).toEqual(
+      expect.arrayContaining([expect.stringMatching(/simple lookups.*web_search_exa|web_search_exa.*simple lookups/)]),
+    );
+  });
+
   it("returns missing key errors when authentication is absent", async () => {
     const mockPi = createMockPi();
     exaExtension(mockPi as unknown as ExtensionAPI);

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -750,6 +750,8 @@ describe("pi-exa extension", () => {
     const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
     expect(tools).toHaveLength(6);
 
+    const exaToolNamePattern = /web_(search|fetch|search_advanced|research|answer|find_similar)_exa/g;
+
     for (const tool of tools) {
       expect(tool.promptSnippet).toBeTypeOf("string");
       expect(tool.promptSnippet.length).toBeLessThan(100);
@@ -757,7 +759,8 @@ describe("pi-exa extension", () => {
       expect(tool.promptGuidelines).toBeInstanceOf(Array);
       expect(tool.promptGuidelines.length).toBeGreaterThan(0);
       for (const guideline of tool.promptGuidelines) {
-        expect(guideline).toMatch(/web_(search|fetch|search_advanced|research|answer|find_similar)_exa/);
+        const matches = [...guideline.matchAll(exaToolNamePattern)].map((match) => match[0]);
+        expect(new Set(matches).size).toBeGreaterThanOrEqual(2);
       }
     }
   });

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -78,6 +78,14 @@ describe("pi-exa", () => {
       expect(skill).toContain("web_search_advanced_exa");
       expect(skill).toContain("web_research_exa");
       expect(skill).toContain("web_answer_exa");
+      expect(skill).toContain("web_find_similar_exa");
+    });
+
+    it("personal-site-search explains when to use find-similar vs search", () => {
+      const skill = readFileSync(join(__dirname, "../skills/personal-site-search/SKILL.md"), "utf-8");
+      expect(skill).toContain("find more like this");
+      expect(skill).toContain("web_find_similar_exa");
+      expect(skill).toContain("web_search_exa");
     });
   });
 });

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -80,10 +80,12 @@ export default function exaExtension(pi: ExtensionAPI) {
       label: "Exa Web Search",
       description:
         "Search the web for any topic and get clean, ready-to-use content. Best for lookup and current information queries.",
-      promptSnippet: "Search web and return concise results using web_search_exa",
+      promptSnippet: "Quick web search with highlights for lookups and discovery.",
       promptGuidelines: [
-        "Use web_search_exa for quick lookup and current facts.",
-        "Use web_search_exa before web_search_advanced_exa unless you need category/date/filter control.",
+        "Use web_search_exa for quick lookups and finding pages; use web_answer_exa for direct factual questions with citations.",
+        "Use web_search_exa for simple searches; use web_search_advanced_exa when you need category, domain, or date filters.",
+        "Use web_search_exa to discover candidate URLs; use web_fetch_exa to read a known page in full.",
+        "Use web_search_exa for retrieval; use web_research_exa for comparisons, synthesis, and recommendations.",
       ],
       parameters: webSearchParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
@@ -130,10 +132,11 @@ export default function exaExtension(pi: ExtensionAPI) {
       name: "web_fetch_exa",
       label: "Exa Web Fetch",
       description: "Read a webpage's full content as clean markdown. Best for extracting full content from known URLs.",
-      promptSnippet: "Fetch URLs with web_fetch_exa when you need full page text",
+      promptSnippet: "Read known URLs as clean page text with optional summaries.",
       promptGuidelines: [
-        "Use web_fetch_exa for content extraction after discovering URLs.",
-        "Enable highlights/summary only when extra context is needed.",
+        "Use web_fetch_exa after web_search_exa or web_search_advanced_exa when snippets are not enough.",
+        "Use web_fetch_exa to read a known URL in full; use web_answer_exa when the user only needs a concise cited answer.",
+        "Use web_fetch_exa to inspect returned pages; use web_find_similar_exa when you want more pages like a source URL.",
       ],
       parameters: webFetchParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
@@ -185,10 +188,11 @@ export default function exaExtension(pi: ExtensionAPI) {
       label: "Exa Advanced Search",
       description:
         "Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, highlights, and summaries.",
-      promptSnippet: "Use web_search_advanced_exa for filters, categories, and deep tuning",
+      promptSnippet: "Advanced search with category, domain, and date filters.",
       promptGuidelines: [
-        "Prefer web_search_advanced_exa for non-deep query constraints (category, domains, dates).",
-        "Use web_search_exa for simpler lookups.",
+        "Use web_search_advanced_exa when you need category, domain, or date filters; use web_search_exa for simpler lookups.",
+        "Use web_search_advanced_exa for retrieval with constraints; use web_research_exa for deep synthesis and comparisons.",
+        "Use web_search_advanced_exa to find filtered result sets; use web_fetch_exa to read the selected URLs.",
       ],
       parameters: webSearchAdvancedParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
@@ -245,11 +249,11 @@ export default function exaExtension(pi: ExtensionAPI) {
       name: "web_research_exa",
       label: "Exa Deep Research",
       description: "Deep-reasoning Exa search with synthesized, grounded output for complex research topics.",
-      promptSnippet: "Run deep research questions with web_research_exa",
+      promptSnippet: "Deep research with grounded synthesis; higher cost and latency.",
       promptGuidelines: [
-        "Use web_research_exa for synthesis-oriented questions, comparisons, and recommendations.",
-        "Provide a systemPrompt and use structured outputSchema when you need downstream automation.",
-        "Prefer web_search_exa for quick fact lookup.",
+        "Use web_research_exa for conclusions, comparisons, and recommendations; use web_search_exa for simple lookups.",
+        "Use web_research_exa for open-ended synthesis; use web_answer_exa for direct questions needing a concise cited answer.",
+        "Use web_research_exa when a systemPrompt or outputSchema is needed; use web_search_advanced_exa for filtered retrieval only.",
       ],
       parameters: webResearchParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
@@ -307,10 +311,11 @@ export default function exaExtension(pi: ExtensionAPI) {
       name: "web_answer_exa",
       label: "Exa Answer",
       description: "Get a grounded answer with source citations and optional structured output.",
-      promptSnippet: "Answer direct questions with web_answer_exa",
+      promptSnippet: "Grounded answers with citations for direct questions.",
       promptGuidelines: [
-        "Use web_answer_exa for direct, answer-style prompts needing grounded citations.",
-        "Use outputSchema for machine-consumable structured responses.",
+        "Use web_answer_exa for direct factual questions with sources; use web_research_exa for broader synthesis and comparisons.",
+        "Use web_answer_exa when the user wants a concise answer; use web_search_exa when you first need to discover candidate pages.",
+        "Use web_answer_exa for a cited response; use web_fetch_exa when you need the full source text.",
       ],
       parameters: webAnswerParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {
@@ -361,10 +366,11 @@ export default function exaExtension(pi: ExtensionAPI) {
       name: "web_find_similar_exa",
       label: "Exa Similar Pages",
       description: "Find web pages similar to a given URL.",
-      promptSnippet: "Find similar pages with web_find_similar_exa",
+      promptSnippet: "Find pages similar to a known source URL.",
       promptGuidelines: [
-        "Use web_find_similar_exa for recommendations once a source URL is known.",
-        "Pair with web_fetch_exa for deeper inspection of any returned URLs.",
+        "Use web_find_similar_exa when you have a good page and want more like it; use web_search_exa for keyword-based discovery.",
+        "Use web_find_similar_exa to expand from a source URL; use web_search_advanced_exa when you need explicit category, domain, or date filters.",
+        "Use web_find_similar_exa to discover related pages; use web_fetch_exa to inspect the returned URLs in full.",
       ],
       parameters: webFindSimilarParams,
       async execute(_toolCallId, params, signal, onUpdate, _ctx) {

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -80,7 +80,7 @@ export default function exaExtension(pi: ExtensionAPI) {
       label: "Exa Web Search",
       description:
         "Search the web for any topic and get clean, ready-to-use content. Best for lookup and current information queries.",
-      promptSnippet: "Quick web search with highlights for lookups and discovery.",
+      promptSnippet: "Quick web search for lookups, discovery, and current pages.",
       promptGuidelines: [
         "Use web_search_exa for quick lookups and finding pages; use web_answer_exa for direct factual questions with citations.",
         "Use web_search_exa for simple searches; use web_search_advanced_exa when you need category, domain, or date filters.",

--- a/packages/pi-exa/package.json
+++ b/packages/pi-exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-exa",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Exa MCP extension for pi — web search, content fetching, and advanced search via Exa AI",
   "keywords": [
     "pi",

--- a/packages/pi-exa/skills/personal-site-search/SKILL.md
+++ b/packages/pi-exa/skills/personal-site-search/SKILL.md
@@ -31,7 +31,7 @@ context: fork
   - `{ "query": "Rust async architecture", "category": "personal site", "excludeDomains": ["medium.com", "substack.com"], "numResults": 15 }`
 - `web_find_similar_exa`
   - `{ "url": "https://example.dev/posts/rust-async-architecture", "excludeSourceDomain": true, "numResults": 8 }`
-- `web_research_exa`
+- `web_research_exa` *(requires `--exa-enable-research`)*
   - `{ "query": "Compare recommendations from practitioner blogs", "systemPrompt": "Prioritize dated posts, independent authors, and call out opinion vs facts", "outputSchema": { "type": "text" } }`
 
 ## Query Writing

--- a/packages/pi-exa/skills/personal-site-search/SKILL.md
+++ b/packages/pi-exa/skills/personal-site-search/SKILL.md
@@ -10,20 +10,38 @@ context: fork
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Practitioner blogs / opinion pieces | `web_search_advanced_exa` with `category: "personal site"` | Add date filters for freshness |
-| Distill cross-site viewpoints | `web_research_exa` | Provide a strong `systemPrompt` and optional object `outputSchema` |
-| Direct one-off answer | `web_answer_exa` | Keep answer concise |
-| Pull article bodies | `web_fetch_exa` | Use after discovering canonical URLs |
+| Find practitioner blogs by topic | `web_search_exa` | Start broad with a keyword query when you do not already know a source site |
+| Filter to personal sites only | `web_search_advanced_exa` with `category: "personal site"` | Add date filters for freshness or domain filters for specific ecosystems |
+| Find more like this / recommend similar sites | `web_find_similar_exa` | Use when you already have one strong post or blog URL and want adjacent personal sites |
+| Distill viewpoints across multiple posts | `web_research_exa` | Requires `--exa-enable-research`; provide a strong `systemPrompt` and optional `outputSchema` |
+| Direct one-off answer from discovered sources | `web_answer_exa` | Use for concise cited answers after the topic is clear |
+| Pull full article bodies | `web_fetch_exa` | Use after discovery when snippets are not enough |
+
+## When to use find-similar vs search
+
+- Use `web_find_similar_exa` for **find more like this** workflows when you already have a canonical URL that matches the taste, style, or niche you want.
+- Use `web_search_exa` for **keyword-based discovery** when you are starting from a topic, technology, or opinion and do not yet have a seed URL.
+- Use `web_search_advanced_exa` instead of `web_find_similar_exa` when you need explicit controls like `category: "personal site"`, domain constraints, or date filtering.
 
 ## Recommended settings
 
+- `web_search_exa`
+  - `{ "query": "Rust async architecture practitioner blog", "numResults": 10 }`
 - `web_search_advanced_exa`
   - `{ "query": "Rust async architecture", "category": "personal site", "excludeDomains": ["medium.com", "substack.com"], "numResults": 15 }`
+- `web_find_similar_exa`
+  - `{ "url": "https://example.dev/posts/rust-async-architecture", "excludeSourceDomain": true, "numResults": 8 }`
 - `web_research_exa`
-  - `{ "query": "Compare recommendations from practitioner blogs", "systemPrompt": "Prioritize dated posts and call out opinion vs facts", "outputSchema": { "type": "text" } }`
+  - `{ "query": "Compare recommendations from practitioner blogs", "systemPrompt": "Prioritize dated posts, independent authors, and call out opinion vs facts", "outputSchema": { "type": "text" } }`
+
+## Query Writing
+
+- Include the topic, ecosystem, and audience: e.g. `postgres indexing practitioner blog`, `react compiler migration personal blog`.
+- Prefer wording like `blog`, `personal site`, `independent write-up`, or `practitioner perspective` when using `web_search_exa`.
+- After finding one excellent source, pivot to `web_find_similar_exa` instead of repeating broader keyword searches.
 
 ## Output Guidance
 
 1) Identify author perspective and date.
 2) Distinguish opinion claims from verifiable facts.
-3) Return top 3–5 strongest links with rationale.
+3) Return the top 3–5 strongest links with a short rationale for each.


### PR DESCRIPTION
## Summary
- align `personal-site-search` with `web_find_similar_exa` guidance
- tighten `promptGuidelines` cross-tool routing across all Exa tools
- update PRD / plan / ADR statuses to reflect shipped pi-exa behavior
- bump `@feniix/pi-exa` to `3.1.1`

## Affected package
- `packages/pi-exa`

## Tests run
- `npx vitest run packages/pi-exa/__tests__`
- `npx tsc --noEmit --project packages/pi-exa/tsconfig.json`
- `npx biome ci packages/pi-exa`
- `npm run check`

## Context
Closes #41
Closes #42
Closes #43