### PR TITLE
feat: complete PRD-004 specdocs validation and docs alignment

### DIFF
--- a/docs/adr/ADR-0008-specdocs-parser-pipeline-strategy.md
+++ b/docs/adr/ADR-0008-specdocs-parser-pipeline-strategy.md
@@ -1,7 +1,7 @@
 ---
 title: "Specdocs parser pipeline strategy"
 adr: ADR-0008
-status: Proposed
+status: Accepted
 date: 2026-04-21
 prd: "PRD-004-pi-specdocs-in-process-markdown-linting"
 decision: "Use an in-process unified/remark-based parser pipeline as the preferred parser stack"
@@ -11,7 +11,7 @@ decision: "Use an in-process unified/remark-based parser pipeline as the preferr
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adr/ADR-0009-specdocs-validation-layering-strategy.md
+++ b/docs/adr/ADR-0009-specdocs-validation-layering-strategy.md
@@ -1,7 +1,7 @@
 ---
 title: "Specdocs validation layering strategy"
 adr: ADR-0009
-status: Proposed
+status: Accepted
 date: 2026-04-21
 prd: "PRD-004-pi-specdocs-in-process-markdown-linting"
 decision: "Keep specdocs-specific validation and formatting rules as a separate layer on top of shared parsed document data"
@@ -11,7 +11,7 @@ decision: "Keep specdocs-specific validation and formatting rules as a separate 
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adr/ADR-0010-specdocs-formatting-activation-model.md
+++ b/docs/adr/ADR-0010-specdocs-formatting-activation-model.md
@@ -1,7 +1,7 @@
 ---
 title: "Specdocs formatting activation model"
 adr: ADR-0010
-status: Proposed
+status: Accepted
 date: 2026-04-21
 prd: "PRD-004-pi-specdocs-in-process-markdown-linting"
 decision: "Ship formatting as an explicit specdocs-format command and keep post-tool behavior lint-only in the first release"
@@ -11,7 +11,7 @@ decision: "Ship formatting as an explicit specdocs-format command and keep post-
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/architecture/plan-pi-specdocs-in-process-markdown-linting.md
+++ b/docs/architecture/plan-pi-specdocs-in-process-markdown-linting.md
@@ -3,7 +3,7 @@ title: "pi-specdocs in-process markdown linting and formatting"
 prd: "PRD-004-pi-specdocs-in-process-markdown-linting"
 date: 2026-04-21
 author: "Pi"
-status: Draft
+status: Implemented
 ---
 
 # Plan: pi-specdocs in-process markdown linting and formatting
@@ -16,11 +16,11 @@ status: Draft
 
 ## Architecture Overview
 
-This work should reshape `@feniix/pi-specdocs` around a two-layer document pipeline: a shared in-process parsing layer that produces structured document data for spec artifacts, and a specdocs-specific semantic layer that validates and formats PRDs, ADRs, and plans using repository rules. That architecture is already directionally established by the PRD and the existing ADRs: use a unified/remark-style parser pipeline for Markdown structure (`ADR-0008`), keep repo-specific rules separate from parser infrastructure (`ADR-0009`), and expose formatting only through an explicit `specdocs-format` command in the first release (`ADR-0010`).
+This work reshaped `@feniix/pi-specdocs` around a two-layer document pipeline: a shared in-process parsing layer that produces structured document data for spec artifacts, and a specdocs-specific semantic layer that validates and formats PRDs, ADRs, and plans using repository rules. The implemented architecture follows the PRD and the related ADRs: a unified/remark-style parser pipeline for Markdown structure (`ADR-0008`), repo-specific rules separated from parser infrastructure (`ADR-0009`), and formatting exposed only through an explicit `specdocs-format` command in the first release (`ADR-0010`).
 
-In the current codebase, the validation path is split across `extensions/frontmatter.ts`, `extensions/spec-validation.ts`, `extensions/runtime.ts`, and `extensions/workspace-scan.ts`, with most logic built on manual line parsing and filename checks. The implementation should preserve the existing extension shape rather than introducing a new subsystem: `frontmatter.ts` becomes the parser and normalization entry point, `spec-validation.ts` becomes the semantic rule engine, `runtime.ts` remains the orchestrator for post-tool linting and commands, and `workspace-scan.ts` continues to handle lightweight workspace summaries and tracker config behavior. The key change is that those modules should stop reasoning from raw strings and instead operate on a stable parsed document representation.
+In the shipped codebase, the validation path is split across `extensions/frontmatter.ts`, `extensions/spec-validation.ts`, `extensions/runtime.ts`, and `extensions/workspace-scan.ts`, with parsing and validation now centered on parser-backed frontmatter handling, markdown AST traversal, typed/schema-backed frontmatter checks, required section and table validation, plan-specific linting, and explicit formatting. `runtime.ts` remains the orchestrator for post-tool linting and commands, while `workspace-scan.ts` continues to handle lightweight workspace summaries and tracker config behavior.
 
-The safest delivery path is to build the parser-backed model first, then migrate validation in layers, then add formatting last. Validation touches session-start summaries, `tool_result` notifications, and workspace-wide command output, so the plan favors sequencing that keeps each stage testable and shippable. The formatter should be intentionally narrow in scope and reuse the same parsed representation so that rewrite safety, no-op detection, and future extensibility all rest on the same document model instead of a second formatting-only implementation.
+The implemented delivery path followed the intended sequencing closely: parser-backed model first, validation migration next, and formatting last. Validation continues to cover session-start summaries, `tool_result` notifications, and workspace-wide command output. A local benchmark pass against representative fixtures also confirmed the PRD performance targets: single-file validation `7.41 ms` and workspace validation over 25 docs `19.14 ms`.
 
 ## Components
 
@@ -232,8 +232,8 @@ Decisions made or relied on during this plan:
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| [ADR-0008](../adr/ADR-0008-specdocs-parser-pipeline-strategy.md) | Specdocs parser pipeline strategy | Proposed |
-| [ADR-0009](../adr/ADR-0009-specdocs-validation-layering-strategy.md) | Specdocs validation layering strategy | Proposed |
-| [ADR-0010](../adr/ADR-0010-specdocs-formatting-activation-model.md) | Specdocs formatting activation model | Proposed |
+| [ADR-0008](../adr/ADR-0008-specdocs-parser-pipeline-strategy.md) | Specdocs parser pipeline strategy | Accepted |
+| [ADR-0009](../adr/ADR-0009-specdocs-validation-layering-strategy.md) | Specdocs validation layering strategy | Accepted |
+| [ADR-0010](../adr/ADR-0010-specdocs-formatting-activation-model.md) | Specdocs formatting activation model | Accepted |
 
 No additional ADRs are required immediately beyond the three already created from PRD-004. If implementation uncovers a durable decision around parsed-document adapters/module boundaries or formatter serialization strategy that constrains future document types, that would be a reasonable follow-up ADR candidate.

--- a/docs/prd/PRD-004-pi-specdocs-in-process-markdown-linting.md
+++ b/docs/prd/PRD-004-pi-specdocs-in-process-markdown-linting.md
@@ -1,11 +1,11 @@
 ---
 title: "pi-specdocs in-process markdown linting and formatting"
 prd: PRD-004
-status: Draft
+status: Implemented
 owner: "Sebastian Otaegui"
 issue: "N/A"
 date: 2026-04-21
-version: "1.0"
+version: "1.1"
 ---
 
 # PRD: pi-specdocs in-process markdown linting and formatting
@@ -449,7 +449,7 @@ Then the command reports that no changes were needed
 
 | Issue | Relationship |
 |-------|-------------|
-| `docs/prd/PRD-005-pi-exa-api-alignment.md` | Draft; informed discussion about deprecated tool references and current runtime constraints |
+| `docs/prd/PRD-005-pi-exa-api-alignment.md` | Implemented; informed discussion about deprecated tool references and current runtime constraints |
 | `docs/adr/ADR-0005-exa-deep-search-tool-strategy.md` | Related; provides context for current Exa tool surface used by specdocs skills |
 | `docs/adr/ADR-0008-specdocs-parser-pipeline-strategy.md` | Derived from this PRD; records the preferred parser-stack strategy |
 | `docs/adr/ADR-0009-specdocs-validation-layering-strategy.md` | Derived from this PRD; records the semantic rule-layer architecture |
@@ -464,6 +464,7 @@ Then the command reports that no changes were needed
 | 2026-04-21 | Initial draft | Sebastian Otaegui |
 | 2026-04-21 | Refined requirements, clarified scope/edge cases, and added explicit ADR references for parser strategy, validation layering, and formatting activation | Sebastian Otaegui |
 | 2026-04-21 | Aligned cross-document references and implementation-ready decisions after iterative review passes | Sebastian Otaegui |
+| 2026-04-21 | Marked implemented after landing parser-backed validation, typed/schema-backed frontmatter checks, plan linting, explicit formatting, and recorded local performance measurements | Sebastian Otaegui |
 
 ---
 
@@ -474,5 +475,5 @@ Then the command reports that no changes were needed
 3. Include fixtures with duplicate `PRD-NNN` and `ADR-NNNN` filename prefixes and confirm workspace validation reports each collision as an error that identifies all conflicting files.
 4. Edit a spec document through pi and confirm post-tool linting still notifies immediately with the new validator.
 5. Run workspace validation over the current `docs/` tree and confirm existing valid docs do not produce false positives beyond known real issues.
-6. Measure single-file and workspace validation times against representative fixtures and confirm they meet the stated performance targets.
+6. Measure single-file and workspace validation times against representative fixtures and confirm they meet the stated performance targets. Latest recorded local benchmark from `PI_SPECDOCS_BENCH=1 npx vitest run packages/pi-specdocs/__tests__/performance.test.ts --reporter=verbose`: single-file validation `7.41 ms`, workspace validation over 25 docs `19.14 ms`.
 7. Run formatting against a sample malformed doc and confirm only targeted formatting changes occur.

--- a/packages/pi-specdocs/README.md
+++ b/packages/pi-specdocs/README.md
@@ -10,7 +10,7 @@ Structured spec documentation workflow for [pi](https://pi.dev/) — PRDs, ADRs,
 - **Architect Prompt** (`/architect`): End-to-end initiative planning — assess feasibility, decompose into workstreams, produce artifacts
 - **Refine Prompt** (`/refine`): Deep review of PRDs/ADRs for risks, bugs, ambiguities, errors, and inconsistencies
 - **Session Hook**: Automatically scans `docs/` on session start and displays a summary of existing spec documents
-- **Validation Command** (`specdocs-validate`): Checks spec docs for frontmatter, required sections/tables, numbering, duplicate IDs, and plan filename issues
+- **Validation Command** (`specdocs-validate`): Checks spec docs for typed frontmatter validity, required sections/tables, numbering, duplicate IDs, and plan filename issues
 - **Formatting Command** (`specdocs-format <path>`): Normalizes supported spec documents in-process without external tools while preserving common GFM constructs
 
 ## Install
@@ -61,6 +61,9 @@ Deep review of a PRD or ADR. Validates against the codebase, researches external
 
 - `specdocs-validate` — validate spec documents in the workspace
 - `specdocs-format <path>` — format a PRD, ADR, or plan document in place
+  - validates typed frontmatter, required headings, and required table shapes
+  - plan docs also warn on missing recommended sections such as `Risks and Mitigations` and `Open Questions`
+  - duplicate PRD/ADR numbers and invalid direct-child plan filenames are surfaced in workspace validation
   - normalizes frontmatter fences and section spacing
   - normalizes GFM table spacing/alignment
   - preserves thematic breaks, task lists, and other common GFM syntax
@@ -81,6 +84,20 @@ On session start, the extension scans `docs/prd/`, `docs/adr/`, and `docs/archit
 - Count of existing PRDs, ADRs, and plans
 - Proposed ADRs needing review
 - Draft PRDs still in progress
+
+## Performance verification
+
+A reproducible local benchmark is included for the PRD-004 validation targets.
+
+Run it from `packages/pi-specdocs/`:
+
+```bash
+npm run perf:validation
+```
+
+Latest recorded local measurement in this repo:
+- single-file validation: ~7.41 ms
+- workspace validation (25 docs): ~19.14 ms
 
 ## Requirements
 

--- a/packages/pi-specdocs/__tests__/performance.test.ts
+++ b/packages/pi-specdocs/__tests__/performance.test.ts
@@ -195,6 +195,9 @@ describe("pi-specdocs performance", () => {
     tempDirs.push(base);
     const { singleFile, allFiles } = createWorkspaceFixture(base);
 
+    // This first single-file measurement intentionally includes cold per-file
+    // costs (read + initial parse for that file), making it a conservative
+    // ceiling check rather than a pure steady-state number.
     const singleStart = performance.now();
     validateSpecFile(singleFile);
     const singleDurationMs = performance.now() - singleStart;

--- a/packages/pi-specdocs/__tests__/performance.test.ts
+++ b/packages/pi-specdocs/__tests__/performance.test.ts
@@ -185,9 +185,10 @@ describe("pi-specdocs performance", () => {
   const tempDirs: string[] = [];
 
   afterEach(() => {
-    for (const dir of tempDirs.splice(0)) {
+    for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
+    tempDirs.length = 0;
   });
 
   it.skipIf(!runBenchmarks)("measures single-file and workspace validation targets", () => {

--- a/packages/pi-specdocs/__tests__/performance.test.ts
+++ b/packages/pi-specdocs/__tests__/performance.test.ts
@@ -1,0 +1,215 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateSpecFile } from "../extensions/index.js";
+
+const runBenchmarks = process.env.PI_SPECDOCS_BENCH === "1";
+
+function createPrd(index: number): string {
+  const number = String(index).padStart(3, "0");
+  return `---
+title: "PRD ${number}"
+prd: PRD-${number}
+status: Draft
+owner: Alice
+date: 2026-04-21
+issue: N/A
+version: 1.0
+---
+
+# PRD ${number}
+
+## 1. Problem & Context
+Body
+
+## 2. Goals & Success Metrics
+Body
+
+## 3. Users & Use Cases
+Body
+
+## 4. Scope
+Body
+
+## 5. Functional Requirements
+Body
+
+## 6. Non-Functional Requirements
+Body
+
+## 7. Risks & Assumptions
+Body
+
+## 8. Design Decisions
+Body
+
+## 9. File Breakdown
+| File | Change type | FR | Description |
+| --- | --- | --- | --- |
+| file.ts | Modify | FR-1 | Test |
+
+## 10. Dependencies & Constraints
+Body
+
+## 11. Rollout Plan
+Body
+
+## 12. Open Questions
+| # | Question | Owner | Due | Status |
+| --- | --- | --- | --- | --- |
+| Q1 | Test? | Alice | Soon | Open |
+
+## 13. Related
+Body
+
+## 14. Changelog
+| Date | Change | Author |
+| --- | --- | --- |
+| 2026-04-21 | Added benchmark fixture | Pi |
+`;
+}
+
+function createAdr(index: number): string {
+  const number = String(index).padStart(4, "0");
+  return `---
+title: "ADR ${number}"
+adr: ADR-${number}
+status: Proposed
+date: 2026-04-21
+prd: "PRD-001-benchmark"
+---
+
+# ADR ${number}
+
+## Status
+Proposed
+
+## Date
+2026-04-21
+
+## Requirement Source
+Body
+
+## Context
+Body
+
+## Decision Drivers
+Body
+
+## Considered Options
+Body
+
+## Decision
+Body
+
+## Consequences
+Body
+
+## Related
+Body
+`;
+}
+
+function createPlan(index: number): string {
+  return `---
+title: "Plan ${index}"
+prd: "PRD-001-benchmark"
+date: 2026-04-21
+author: "Pi"
+status: Draft
+---
+
+# Plan ${index}
+
+## Source
+Body
+
+## Architecture Overview
+Body
+
+## Components
+Body
+
+## Implementation Order
+| Phase | Component | Dependencies | Estimated Scope |
+| --- | --- | --- | --- |
+| 1 | Parser | None | M |
+
+## Risks and Mitigations
+Body
+
+## Open Questions
+Body
+
+## ADR Index
+| ADR | Title | Status |
+| --- | --- | --- |
+| ADR-0001 | Example | Accepted |
+`;
+}
+
+function createWorkspaceFixture(base: string): { singleFile: string; allFiles: string[] } {
+  const prdDir = join(base, "docs", "prd");
+  const adrDir = join(base, "docs", "adr");
+  const planDir = join(base, "docs", "architecture");
+  mkdirSync(prdDir, { recursive: true });
+  mkdirSync(adrDir, { recursive: true });
+  mkdirSync(planDir, { recursive: true });
+
+  const allFiles: string[] = [];
+
+  for (let i = 1; i <= 10; i++) {
+    const path = join(prdDir, `PRD-${String(i).padStart(3, "0")}-benchmark-${i}.md`);
+    writeFileSync(path, createPrd(i));
+    allFiles.push(path);
+  }
+
+  for (let i = 1; i <= 10; i++) {
+    const path = join(adrDir, `ADR-${String(i).padStart(4, "0")}-benchmark-${i}.md`);
+    writeFileSync(path, createAdr(i));
+    allFiles.push(path);
+  }
+
+  for (let i = 1; i <= 5; i++) {
+    const path = join(planDir, `plan-benchmark-${i}.md`);
+    writeFileSync(path, createPlan(i));
+    allFiles.push(path);
+  }
+
+  return { singleFile: allFiles[0] as string, allFiles };
+}
+
+describe("pi-specdocs performance", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(!runBenchmarks)("measures single-file and workspace validation targets", () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-bench-"));
+    tempDirs.push(base);
+    const { singleFile, allFiles } = createWorkspaceFixture(base);
+
+    const singleStart = performance.now();
+    validateSpecFile(singleFile);
+    const singleDurationMs = performance.now() - singleStart;
+
+    const workspaceStart = performance.now();
+    for (const file of allFiles) {
+      validateSpecFile(file);
+    }
+    const workspaceDurationMs = performance.now() - workspaceStart;
+
+    console.log(
+      `[specdocs-bench] single_file_ms=${singleDurationMs.toFixed(2)} workspace_ms=${workspaceDurationMs.toFixed(2)} files=${allFiles.length}`,
+    );
+
+    expect(singleDurationMs).toBeLessThan(250);
+    expect(workspaceDurationMs).toBeLessThan(2000);
+  });
+});

--- a/packages/pi-specdocs/__tests__/spec-validation.test.ts
+++ b/packages/pi-specdocs/__tests__/spec-validation.test.ts
@@ -225,6 +225,24 @@ describe("validate PRD", () => {
       rmSync(dir, { recursive: true });
     }
   });
+
+  it("reports typed field validation errors for invalid frontmatter field types", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "prd"),
+        "PRD-001-test.md",
+        '---\ntitle:\n  nested: nope\nprd: PRD-001\nstatus: Draft\nowner: [Alice]\ndate: 2026-04-14\nissue: 1\nversion: "1.0"\n---\n# Test\n',
+      );
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Field 'title' must be a string"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Field 'owner' must be a string"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Missing required frontmatter field: title"))).toBe(false);
+      expect(warnings.some((w) => w.includes("Missing required frontmatter field: owner"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });
 
 // --- ADR validation ---
@@ -362,6 +380,22 @@ describe("validate required sections", () => {
       );
       const warnings = validateRequiredSections(path);
       expect(warnings.some((w) => w.includes("## ADR Index"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports missing recommended plan sections as warnings", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "architecture"),
+        "plan-test-feature.md",
+        `${VALID_PLAN}\n## Source\n\n## Architecture Overview\n\n## Components\n\n## Implementation Order\n\n## ADR Index\n`,
+      );
+      const warnings = validateRequiredSections(path);
+      expect(warnings.some((w) => w.includes("Missing recommended section: ## Risks and Mitigations"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Missing recommended section: ## Open Questions"))).toBe(true);
     } finally {
       rmSync(dir, { recursive: true });
     }

--- a/packages/pi-specdocs/__tests__/spec-validation.test.ts
+++ b/packages/pi-specdocs/__tests__/spec-validation.test.ts
@@ -235,8 +235,8 @@ describe("validate PRD", () => {
         '---\ntitle:\n  nested: nope\nprd: PRD-001\nstatus: Draft\nowner: [Alice]\ndate: 2026-04-14\nissue: 1\nversion: "1.0"\n---\n# Test\n',
       );
       const warnings = validateFrontmatter(path);
-      expect(warnings.some((w) => w.includes("Field 'title' must be a string"))).toBe(true);
-      expect(warnings.some((w) => w.includes("Field 'owner' must be a string"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Field 'title' must be a string, not an object"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Field 'owner' must be a string, not an array"))).toBe(true);
       expect(warnings.some((w) => w.includes("Missing required frontmatter field: title"))).toBe(false);
       expect(warnings.some((w) => w.includes("Missing required frontmatter field: owner"))).toBe(false);
     } finally {
@@ -332,6 +332,29 @@ describe("validate Plan", () => {
     }
   });
 
+  it("accepts unquoted YAML dates in plan frontmatter", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(join(dir, "docs", "architecture"), "plan-test-feature.md", VALID_PLAN);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Field 'date' must be"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("reports a clearer type error for boolean frontmatter values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const content = VALID_PLAN.replace("status: Draft", "status: true");
+      const path = writeTempDoc(join(dir, "docs", "architecture"), "plan-test-feature.md", content);
+      const warnings = validateFrontmatter(path);
+      expect(warnings.some((w) => w.includes("Field 'status' must be a string, not a boolean"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
   it("reports non-canonical plan prd format", () => {
     const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
     try {
@@ -396,6 +419,22 @@ describe("validate required sections", () => {
       const warnings = validateRequiredSections(path);
       expect(warnings.some((w) => w.includes("Missing recommended section: ## Risks and Mitigations"))).toBe(true);
       expect(warnings.some((w) => w.includes("Missing recommended section: ## Open Questions"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("suppresses recommended plan warnings when required sections are missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spec-test-"));
+    try {
+      const path = writeTempDoc(
+        join(dir, "docs", "architecture"),
+        "plan-test-feature.md",
+        `${VALID_PLAN}\n## Source\n`,
+      );
+      const warnings = validateRequiredSections(path);
+      expect(warnings.some((w) => w.includes("Missing required section: ## ADR Index"))).toBe(true);
+      expect(warnings.some((w) => w.includes("Missing recommended section:"))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true });
     }

--- a/packages/pi-specdocs/extensions/frontmatter.ts
+++ b/packages/pi-specdocs/extensions/frontmatter.ts
@@ -46,7 +46,7 @@ export function parseFrontmatterResult(filepath: string): FrontmatterParseResult
   const body = lines.slice(closingIndex + 1).join("\n");
 
   try {
-    const parsed = YAML.parse(yamlText);
+    const parsed = YAML.parse(yamlText, { schema: "core" });
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return { fields: {}, rawFields: {}, error: null, content, body };
     }

--- a/packages/pi-specdocs/extensions/frontmatter.ts
+++ b/packages/pi-specdocs/extensions/frontmatter.ts
@@ -3,6 +3,7 @@ import YAML from "yaml";
 
 export interface FrontmatterParseResult {
   fields: Record<string, string> | null;
+  rawFields: Record<string, unknown> | null;
   error: string | null;
   content: string | null;
   body: string;
@@ -21,12 +22,12 @@ function readDocument(filepath: string): string | null {
 export function parseFrontmatterResult(filepath: string): FrontmatterParseResult {
   const content = readDocument(filepath);
   if (content === null) {
-    return { fields: null, error: null, content: null, body: "" };
+    return { fields: null, rawFields: null, error: null, content: null, body: "" };
   }
 
   const lines = content.split("\n");
   if (!lines.length || lines[0].trim() !== "---") {
-    return { fields: null, error: null, content, body: content };
+    return { fields: null, rawFields: null, error: null, content, body: content };
   }
 
   let closingIndex = -1;
@@ -38,7 +39,7 @@ export function parseFrontmatterResult(filepath: string): FrontmatterParseResult
   }
 
   if (closingIndex === -1) {
-    return { fields: null, error: "Unterminated YAML frontmatter.", content, body: "" };
+    return { fields: null, rawFields: null, error: "Unterminated YAML frontmatter.", content, body: "" };
   }
 
   const yamlText = lines.slice(1, closingIndex).join("\n");
@@ -47,19 +48,17 @@ export function parseFrontmatterResult(filepath: string): FrontmatterParseResult
   try {
     const parsed = YAML.parse(yamlText);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return { fields: {}, error: null, content, body };
+      return { fields: {}, rawFields: {}, error: null, content, body };
     }
 
+    const rawFields = parsed as Record<string, unknown>;
     const fields = Object.fromEntries(
-      Object.entries(parsed as Record<string, unknown>).map(([key, value]) => [
-        key,
-        value == null ? "" : String(value),
-      ]),
+      Object.entries(rawFields).map(([key, value]) => [key, value == null ? "" : String(value)]),
     );
-    return { fields, error: null, content, body };
+    return { fields, rawFields, error: null, content, body };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { fields: null, error: message, content, body };
+    return { fields: null, rawFields: null, error: message, content, body };
   }
 }
 

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -82,7 +82,6 @@ type FrontmatterFieldType = "string" | "stringOrNumber";
 
 interface FrontmatterFieldSchema {
   type: FrontmatterFieldType;
-  required?: boolean;
 }
 
 interface DocValidationConfig {
@@ -99,13 +98,13 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
     return {
       docType: "PRD",
       fieldSchemas: {
-        title: { type: "string", required: true },
-        prd: { type: "string", required: true },
-        status: { type: "string", required: true },
-        owner: { type: "string", required: true },
-        date: { type: "string", required: true },
-        issue: { type: "stringOrNumber", required: true },
-        version: { type: "stringOrNumber", required: true },
+        title: { type: "string" },
+        prd: { type: "string" },
+        status: { type: "string" },
+        owner: { type: "string" },
+        date: { type: "string" },
+        issue: { type: "stringOrNumber" },
+        version: { type: "stringOrNumber" },
       },
       validStatuses: PRD_VALID_STATUSES,
       numberPattern: /^PRD-\d{3}$/,
@@ -118,11 +117,11 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
     return {
       docType: "ADR",
       fieldSchemas: {
-        title: { type: "string", required: true },
-        adr: { type: "string", required: true },
-        status: { type: "string", required: true },
-        date: { type: "string", required: true },
-        prd: { type: "string", required: true },
+        title: { type: "string" },
+        adr: { type: "string" },
+        status: { type: "string" },
+        date: { type: "string" },
+        prd: { type: "string" },
       },
       validStatuses: ADR_VALID_STATUSES,
       numberPattern: /^ADR-\d{4}$/,
@@ -135,11 +134,11 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
     return {
       docType: "PLAN",
       fieldSchemas: {
-        title: { type: "string", required: true },
-        prd: { type: "string", required: true },
-        date: { type: "string", required: true },
-        author: { type: "string", required: true },
-        status: { type: "string", required: true },
+        title: { type: "string" },
+        prd: { type: "string" },
+        date: { type: "string" },
+        author: { type: "string" },
+        status: { type: "string" },
       },
       validStatuses: PLAN_VALID_STATUSES,
     };
@@ -174,9 +173,7 @@ function validateSchemaFields(
   for (const [field, schema] of Object.entries(config.fieldSchemas)) {
     const rawValue = rawFields[field];
     if (rawValue == null || rawValue === "") {
-      if (schema.required) {
-        warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
-      }
+      warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
       continue;
     }
 
@@ -247,7 +244,7 @@ function validateFrontmatterFromResult(filepath: string, result: ReturnType<type
     return [`⚠ ${config.docType}: Frontmatter parse error: ${result.error}`];
   }
 
-  if (result.fields === null || result.rawFields === null) {
+  if (result.rawFields === null) {
     return [`⚠ ${config.docType}: No YAML frontmatter found.`];
   }
 

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -6,10 +6,6 @@ import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { parseFrontmatterResult } from "./frontmatter.js";
 
-const PRD_REQUIRED_FIELDS = ["title", "prd", "status", "owner", "date", "issue", "version"] as const;
-const ADR_REQUIRED_FIELDS = ["title", "adr", "status", "date", "prd"] as const;
-const PLAN_REQUIRED_FIELDS = ["title", "prd", "date", "author", "status"] as const;
-
 const PRD_VALID_STATUSES = ["Draft", "Implemented", "Superseded", "Archived"] as const;
 const ADR_VALID_STATUSES = ["Proposed", "Accepted", "Deprecated", "Superseded"] as const;
 const PLAN_VALID_STATUSES = ["Draft", "Implemented", "Archived"] as const;
@@ -51,6 +47,7 @@ const PLAN_REQUIRED_SECTIONS = [
   "## Implementation Order",
   "## ADR Index",
 ] as const;
+const PLAN_RECOMMENDED_WARNING_SECTIONS = ["## Risks and Mitigations", "## Open Questions"] as const;
 
 const REQUIRED_TABLE_COLUMNS: Record<string, Record<string, readonly string[]>> = {
   PRD: {
@@ -81,9 +78,16 @@ export function isPlan(path: string): boolean {
   return path.includes("docs/architecture/plan-");
 }
 
+type FrontmatterFieldType = "string" | "stringOrNumber";
+
+interface FrontmatterFieldSchema {
+  type: FrontmatterFieldType;
+  required?: boolean;
+}
+
 interface DocValidationConfig {
   docType: "PRD" | "ADR" | "PLAN";
-  requiredFields: readonly string[];
+  fieldSchemas: Record<string, FrontmatterFieldSchema>;
   validStatuses: readonly string[];
   numberPattern?: RegExp;
   numberField?: "prd" | "adr";
@@ -94,7 +98,15 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
   if (isPrd(filepath)) {
     return {
       docType: "PRD",
-      requiredFields: PRD_REQUIRED_FIELDS,
+      fieldSchemas: {
+        title: { type: "string", required: true },
+        prd: { type: "string", required: true },
+        status: { type: "string", required: true },
+        owner: { type: "string", required: true },
+        date: { type: "string", required: true },
+        issue: { type: "stringOrNumber", required: true },
+        version: { type: "stringOrNumber", required: true },
+      },
       validStatuses: PRD_VALID_STATUSES,
       numberPattern: /^PRD-\d{3}$/,
       numberField: "prd",
@@ -105,7 +117,13 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
   if (isAdr(filepath)) {
     return {
       docType: "ADR",
-      requiredFields: ADR_REQUIRED_FIELDS,
+      fieldSchemas: {
+        title: { type: "string", required: true },
+        adr: { type: "string", required: true },
+        status: { type: "string", required: true },
+        date: { type: "string", required: true },
+        prd: { type: "string", required: true },
+      },
       validStatuses: ADR_VALID_STATUSES,
       numberPattern: /^ADR-\d{4}$/,
       numberField: "adr",
@@ -116,7 +134,13 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
   if (isPlan(filepath)) {
     return {
       docType: "PLAN",
-      requiredFields: PLAN_REQUIRED_FIELDS,
+      fieldSchemas: {
+        title: { type: "string", required: true },
+        prd: { type: "string", required: true },
+        date: { type: "string", required: true },
+        author: { type: "string", required: true },
+        status: { type: "string", required: true },
+      },
       validStatuses: PLAN_VALID_STATUSES,
     };
   }
@@ -124,16 +148,48 @@ function getDocValidationConfig(filepath: string): DocValidationConfig | null {
   return null;
 }
 
-function collectMissingFieldWarnings(
-  fields: Record<string, string>,
-  config: DocValidationConfig,
-  warnings: string[],
-): void {
-  for (const field of config.requiredFields) {
-    if (!fields[field]) {
-      warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
-    }
+function normalizeFieldValue(value: unknown, type: FrontmatterFieldType): string | null {
+  if (type === "string") {
+    return typeof value === "string" ? value : null;
   }
+
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+
+  return null;
+}
+
+function formatFieldType(type: FrontmatterFieldType): string {
+  return type === "stringOrNumber" ? "a string or number" : "a string";
+}
+
+function validateSchemaFields(
+  rawFields: Record<string, unknown>,
+  config: DocValidationConfig,
+): { normalizedFields: Record<string, string>; warnings: string[] } {
+  const warnings: string[] = [];
+  const normalizedFields: Record<string, string> = {};
+
+  for (const [field, schema] of Object.entries(config.fieldSchemas)) {
+    const rawValue = rawFields[field];
+    if (rawValue == null || rawValue === "") {
+      if (schema.required) {
+        warnings.push(`⚠ ${config.docType}: Missing required frontmatter field: ${field}`);
+      }
+      continue;
+    }
+
+    const normalized = normalizeFieldValue(rawValue, schema.type);
+    if (normalized === null) {
+      warnings.push(`⚠ ${config.docType}: Field '${field}' must be ${formatFieldType(schema.type)}.`);
+      continue;
+    }
+
+    normalizedFields[field] = normalized;
+  }
+
+  return { normalizedFields, warnings };
 }
 
 function collectNumberWarnings(
@@ -191,17 +247,15 @@ function validateFrontmatterFromResult(filepath: string, result: ReturnType<type
     return [`⚠ ${config.docType}: Frontmatter parse error: ${result.error}`];
   }
 
-  const fields = result.fields;
-  if (fields === null) {
+  if (result.fields === null || result.rawFields === null) {
     return [`⚠ ${config.docType}: No YAML frontmatter found.`];
   }
 
-  const warnings: string[] = [];
-  collectMissingFieldWarnings(fields, config, warnings);
-  collectNumberWarnings(fields, config, basename(filepath), warnings);
-  collectStatusWarnings(fields, config, warnings);
+  const { normalizedFields, warnings } = validateSchemaFields(result.rawFields, config);
+  collectNumberWarnings(normalizedFields, config, basename(filepath), warnings);
+  collectStatusWarnings(normalizedFields, config, warnings);
   if (config.docType === "PLAN") {
-    collectPlanWarnings(fields, warnings);
+    collectPlanWarnings(normalizedFields, warnings);
   }
   return warnings;
 }
@@ -295,14 +349,20 @@ function parseSpecDocument(filepath: string): ParsedSpecDocument {
 
 function validateRequiredSectionsFromDocument(document: ParsedSpecDocument): string[] {
   const requiredSections = getRequiredSections(document.filepath);
-  if (requiredSections.length === 0) {
-    return [];
-  }
-
   const label = document.label ?? "PRD";
-  return requiredSections
+  const warnings = requiredSections
     .filter((section) => !document.headings.has(section))
     .map((section) => `⚠ ${label}: Missing required section: ${section}`);
+
+  if (document.label === "PLAN") {
+    warnings.push(
+      ...PLAN_RECOMMENDED_WARNING_SECTIONS.filter((section) => !document.headings.has(section)).map(
+        (section) => `⚠ PLAN: Missing recommended section: ${section}`,
+      ),
+    );
+  }
+
+  return warnings;
 }
 
 function validateRequiredTablesFromDocument(document: ParsedSpecDocument): string[] {

--- a/packages/pi-specdocs/extensions/spec-validation.ts
+++ b/packages/pi-specdocs/extensions/spec-validation.ts
@@ -163,6 +163,22 @@ function formatFieldType(type: FrontmatterFieldType): string {
   return type === "stringOrNumber" ? "a string or number" : "a string";
 }
 
+function describeInvalidValue(value: unknown): string {
+  if (typeof value === "boolean") {
+    return "a boolean";
+  }
+  if (typeof value === "number") {
+    return "a number";
+  }
+  if (Array.isArray(value)) {
+    return "an array";
+  }
+  if (value && typeof value === "object") {
+    return "an object";
+  }
+  return `a ${typeof value}`;
+}
+
 function validateSchemaFields(
   rawFields: Record<string, unknown>,
   config: DocValidationConfig,
@@ -179,7 +195,9 @@ function validateSchemaFields(
 
     const normalized = normalizeFieldValue(rawValue, schema.type);
     if (normalized === null) {
-      warnings.push(`⚠ ${config.docType}: Field '${field}' must be ${formatFieldType(schema.type)}.`);
+      warnings.push(
+        `⚠ ${config.docType}: Field '${field}' must be ${formatFieldType(schema.type)}, not ${describeInvalidValue(rawValue)}.`,
+      );
       continue;
     }
 
@@ -347,11 +365,10 @@ function parseSpecDocument(filepath: string): ParsedSpecDocument {
 function validateRequiredSectionsFromDocument(document: ParsedSpecDocument): string[] {
   const requiredSections = getRequiredSections(document.filepath);
   const label = document.label ?? "PRD";
-  const warnings = requiredSections
-    .filter((section) => !document.headings.has(section))
-    .map((section) => `⚠ ${label}: Missing required section: ${section}`);
+  const missingRequiredSections = requiredSections.filter((section) => !document.headings.has(section));
+  const warnings = missingRequiredSections.map((section) => `⚠ ${label}: Missing required section: ${section}`);
 
-  if (document.label === "PLAN") {
+  if (document.label === "PLAN" && missingRequiredSections.length === 0) {
     warnings.push(
       ...PLAN_RECOMMENDED_WARNING_SECTIONS.filter((section) => !document.headings.has(section)).map(
         (section) => `⚠ PLAN: Missing recommended section: ${section}`,

--- a/packages/pi-specdocs/package.json
+++ b/packages/pi-specdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-specdocs",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Structured spec documentation — PRDs, ADRs, and implementation plans with cross-referencing",
   "keywords": [
     "pi",

--- a/packages/pi-specdocs/package.json
+++ b/packages/pi-specdocs/package.json
@@ -15,6 +15,9 @@
     "specs"
   ],
   "type": "module",
+  "scripts": {
+    "perf:validation": "PI_SPECDOCS_BENCH=1 vitest run __tests__/performance.test.ts --reporter=verbose"
+  },
   "files": [
     "extensions/",
     "skills/",


### PR DESCRIPTION
## Summary
- add schema-backed frontmatter validation for PRD, ADR, and plan documents in `pi-specdocs`
- add warning-level plan checks for recommended sections and an opt-in validation performance benchmark
- mark PRD-004 and its related specdocs ADRs/plan as implemented and record benchmark results

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `npx vitest run packages/pi-specdocs/__tests__`
- `npx tsc --noEmit --project packages/pi-specdocs/tsconfig.json`
- `npx biome check packages/pi-specdocs docs/prd/PRD-004-pi-specdocs-in-process-markdown-linting.md docs/architecture/plan-pi-specdocs-in-process-markdown-linting.md docs/adr/ADR-0008-specdocs-parser-pipeline-strategy.md docs/adr/ADR-0009-specdocs-validation-layering-strategy.md docs/adr/ADR-0010-specdocs-formatting-activation-model.md`
- `PI_SPECDOCS_BENCH=1 npx vitest run packages/pi-specdocs/__tests__/performance.test.ts --reporter=verbose`