### PR TITLE
fix: accept string args in specdocs-format

### DIFF
--- a/docs/adr/ADR-0006-agent-session-based-foreground-run-execution.md
+++ b/docs/adr/ADR-0006-agent-session-based-foreground-run-execution.md
@@ -2,7 +2,7 @@
 title: "AgentSession-based foreground run execution for pi-conductor"
 adr: ADR-0006
 status: Proposed
-date: 2026-04-20
+date: 2026-04-21
 prd: "PRD-003-pi-conductor-single-worker-run"
 decision: "Use createAgentSession()-based foreground execution for /conductor run while preserving worker continuity through existing SessionManager-backed session lineage"
 ---
@@ -15,7 +15,7 @@ Proposed
 
 ## Date
 
-2026-04-20
+2026-04-21
 
 ## Requirement Source
 
@@ -83,7 +83,7 @@ Skip `createAgentSession()` as the v1 execution path and instead build foregroun
 
 Chosen option: **"Use `createAgentSession()` for foreground execution while reusing persisted lineage"**, because it best satisfies the decision drivers around real prompt execution, continuity of worker state, explicit conductor-owned lifecycle semantics, CI-safe testability, and incremental evolution from the SDK-first architecture established in `ADR-0001`.
 
-In v1, `/conductor run` should open the worker's persisted session lineage through `SessionManager.open(...)`, construct an executable session with `createAgentSession({ sessionManager, cwd })`, bind extensions for headless execution, run the task in the foreground, let `AgentSession` persist session updates incrementally, and then dispose the session cleanly.
+In v1, `/conductor run` should open the worker's persisted session lineage through `SessionManager.open(...)`, construct an executable session with `createAgentSession({ sessionManager, cwd })`, bind extensions for headless execution, run the task in the foreground, let `AgentSession` persist session updates incrementally, and then dispose the session cleanly. The extension binding and preflight policy for that execution path is governed separately by `ADR-0011`.
 
 ## Consequences
 
@@ -99,7 +99,7 @@ In v1, `/conductor run` should open the worker's persisted session lineage throu
 - Run behavior now depends on correct executable-session setup, including extension binding, model/provider preflight handling, and `session.dispose()` cleanup; mitigation is to isolate this behavior in `runtime.ts` and cover it with focused tests
 - The execution path must not reuse the older full-rewrite persistence helper, because `AgentSession` already performs append-only persistence; mitigation is to document and enforce that run execution does not call `persistSessionFile()`
 - Runtime metadata becomes slightly more nuanced because the execution session ID may not match previously persisted worker runtime session IDs; mitigation is to record explicit `lastRun.sessionId` semantics in storage and status output
-- Run outcome detection requires inspecting the raw `session.messages` array for the terminal `stopReason` on the last `AssistantMessage`, as `AgentSession` does not expose a dedicated stopReason accessor; the full `StopReason` union (`stop`, `length`, `toolUse`, `error`, `aborted`) must be exhaustively mapped to conductor run outcomes; mitigation is to define the mapping in `runtime.ts` and cover each branch with tests
+- Run outcome detection requires inspecting the session state message history (for example `session.state.messages`, or `session.agent.state.messages` if the SDK surface requires going through the agent) for the terminal `stopReason` on the last `AssistantMessage`, as `AgentSession` does not expose a dedicated stopReason accessor; the full `StopReason` union (`stop`, `length`, `toolUse`, `error`, `aborted`) must be exhaustively mapped to conductor run outcomes; mitigation is to define the mapping in `runtime.ts` and cover each branch with tests
 
 ### Neutral
 
@@ -108,6 +108,6 @@ In v1, `/conductor run` should open the worker's persisted session lineage throu
 
 ## Related
 
-- **Plan**: `docs/architecture/plan-pi-conductor-mvp.md`
-- **ADRs**: Relates to `ADR-0001`, `ADR-0002`, `ADR-0003`, and `ADR-0007`
+- **Plan**: `docs/architecture/plan-pi-conductor-single-worker-run.md`
+- **ADRs**: Relates to `ADR-0001`, `ADR-0002`, `ADR-0003`, `ADR-0007`, and `ADR-0011`
 - **Implementation**: `docs/prd/PRD-003-pi-conductor-single-worker-run.md`, PR #38 groundwork

--- a/docs/adr/ADR-0011-conductor-run-extension-binding-and-preflight-policy.md
+++ b/docs/adr/ADR-0011-conductor-run-extension-binding-and-preflight-policy.md
@@ -81,12 +81,16 @@ Worker runs would load most normal project-local extensions through an allowlist
 
 Chosen option: **"Use a conductor-defined minimal headless binding policy with best-effort runtime-owned preflight before mutating worker state to running"**, because it best satisfies the decision drivers around deterministic execution, explicit lifecycle ownership, CI-safe testing, and architectural fit with the existing conductor boundaries.
 
+For terminology, this ADR uses **extension binding/configuration policy** as the umbrella term for the headless-safe runtime setup applied to worker runs. In implementation this may map to a concrete SDK type such as `ExtensionBindings`, resource-loader controls, tool allowlists, or a combination of those mechanisms.
+
 Concretely, the first implementation of `/conductor run` should:
 
 * construct execution sessions through a conductor-owned runtime helper in `runtime.ts`
 * bind a minimal non-interactive set of extensions/bindings suitable for headless worker execution
 * treat the initial worker-run surface as **default deny, explicit allowlist** for runtime-visible capabilities rather than inheriting the full ambient extension environment
 * explicitly **exclude conductor’s own orchestration and state-mutation tools** (for example worker creation, recovery, lifecycle mutation, cleanup, and PR-prep helpers) from the worker-run binding set unless a later decision intentionally allows specific ones
+* enforce that exclusion through an explicit allowlist/filtering mechanism in the worker-run session construction path — preferably by using a resource-loading/configuration path that excludes the conductor extension and narrows runtime-visible capabilities before prompt execution begins; disabling conductor tool names after session construction is an acceptable fallback if the SDK does not provide a cleaner earlier filter
+* prefer construction-time narrowing of both discovered resources and tool surface; use post-construction tool-name filtering only when the SDK cannot express the needed allowlist early enough
 * decide intentionally, rather than implicitly, whether discovered project extensions, skills, prompt templates, and context-file discovery remain enabled, narrowed, or disabled for worker runs
 * perform best-effort model/provider preflight inside that runtime layer
 * treat that runtime preflight as an **early eligibility check before `session.prompt()`**, while still relying on the SDK’s own prompt acceptance/runtime behavior for the actual prompt lifecycle
@@ -94,6 +98,11 @@ Concretely, the first implementation of `/conductor run` should:
 * still catch and translate prompt-time provider/auth failures cleanly, since preflight can only be best-effort
 
 This intentionally does **not** guarantee full parity with ambient Pi sessions in the first phase. It prioritizes explicit, reproducible worker behavior over maximum extension surface area.
+
+Initial allowlist guidance for v1:
+- include the minimum headless-safe coding surface needed for real worker execution, such as file-system and code-analysis capabilities
+- exclude interactive UI-facing capabilities, conductor self-mutation/orchestration tools, and broad ambient prompt-template or discovery behavior unless explicitly justified
+- document the concrete allowlist in the implementation path (`runtime.ts` or adjacent runtime setup code) once the SDK integration details are finalized
 
 ## Consequences
 
@@ -111,7 +120,7 @@ This intentionally does **not** guarantee full parity with ambient Pi sessions i
 * Some useful capabilities may be unavailable in the first iteration — especially project-discovered extensions, nonessential skills, prompt templates, context-file discovery paths, or other repo-local runtime features that are not explicitly allowlisted; mitigation is to treat the binding set as an explicit allowlist that can be expanded intentionally as real gaps appear
 * A best-effort preflight cannot eliminate all prompt-time failures; mitigation is to keep prompt-time error translation and post-failure lifecycle recovery explicit in conductor state, and to treat runtime preflight as an early eligibility screen rather than a guarantee of prompt success
 * The package now owns an execution-policy surface that must be documented and maintained; mitigation is to keep the first policy minimal and non-interactive rather than over-designing it up front
-* The current CLI e2e harness is not sufficient by itself to validate the binding policy, because `packages/pi-conductor/__tests__/cli-e2e.test.ts` currently runs Pi with `--no-extensions`; mitigation is to add focused runtime/unit/integration coverage for binding-policy behavior rather than relying only on the existing CLI e2e path
+* The current CLI e2e harness is not sufficient by itself to validate the binding policy, because `packages/pi-conductor/__tests__/cli-e2e.test.ts` currently runs Pi with `--no-extensions`; mitigation is to add focused runtime/unit/integration coverage for binding-policy behavior, and only add a dedicated CLI e2e variant without `--no-extensions` later if end-to-end validation of the allowlist mechanism proves necessary
 
 ### Neutral
 

--- a/docs/architecture/plan-pi-conductor-single-worker-run.md
+++ b/docs/architecture/plan-pi-conductor-single-worker-run.md
@@ -30,7 +30,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 **Key Details**:
 
-* Add a `lastRun` object to `WorkerRecord` capturing `task`, `status`, `startedAt`, `finishedAt`, `errorMessage`, and run-time `sessionId`.
+* Add a `lastRun` object to `WorkerRecord` capturing `task`, `status`, `startedAt`, `finishedAt`, `errorMessage`, and run-time `sessionId`, with `status: null` representing a run that has started but has not yet reached a terminal outcome.
 * Normalize missing `lastRun` values in `readRun()` so existing worker records created under `0.2.0` continue loading safely.
 * Add storage helpers for the run lifecycle instead of overloading `setWorkerTask()` + `setWorkerLifecycle()` in ways that pass through `idle`.
 * Preserve current summary-staleness behavior by marking summaries stale when the accepted run updates `currentTask`.
@@ -43,7 +43,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 **Key Details**:
 
-* Add a dedicated runtime path in `runtime.ts` that opens `SessionManager.open(sessionFile)`, constructs `createAgentSession({ sessionManager, cwd: worktreePath })`, binds minimal non-interactive extensions, calls `session.prompt(task)`, extracts the final assistant text, maps terminal `stopReason`, and disposes the session.
+* Add a dedicated runtime path in `runtime.ts` that opens `SessionManager.open(sessionFile)`, constructs `createAgentSession({ sessionManager, cwd: worktreePath })`, applies the minimal non-interactive extension-binding/configuration policy described by ADR-0011, calls `session.prompt(task)`, extracts the final assistant text, maps terminal `stopReason`, and disposes the session.
 * Keep the existing create/resume/recover/summarize SessionManager helpers intact; execution should be a new seam rather than a rewrite of all runtime behavior.
 * Explicitly avoid `persistSessionFile()` on the execution path because `AgentSession` already performs append-only persistence.
 * Include best-effort preflight for model/provider availability before mutating worker state to `running`.
@@ -58,8 +58,8 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 * Add a conductor-level entrypoint such as `runWorkerForRepo(repoRoot, workerName, task)` that is the single orchestrator for the feature.
 * Reject workers that are missing, `broken`, missing worktree/session files, or already marked `running`.
-* Update `currentTask` only after preflight succeeds, then atomically move the worker into `running` with `lastRun.finishedAt = null` before execution begins.
-* Normalize post-run state to `idle` on success/abort and `blocked` on error; persist `lastRun` in all terminal outcomes.
+* Update `currentTask` only after preflight succeeds, then atomically move the worker into `running` with `lastRun.status = null` and `lastRun.finishedAt = null` before execution begins.
+* Normalize post-run state to `idle` on success/abort and `blocked` on error; complete the already-initialized `lastRun` record in all terminal outcomes by filling in the final status and `finishedAt`.
 * Leave crash-mid-run handling manual for this phase; preserve the persisted `running` + `finishedAt: null` signal so `/conductor state` or `/conductor recover` can repair it.
 
 **ADR Reference**: None — orchestration policy follows the PRD and existing conductor boundaries
@@ -72,7 +72,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 * Extend `/conductor` with `run <worker-name> <task>` in `commands.ts`.
 * Register a matching `conductor_run` tool in `index.ts` rather than composing lower-level tools externally.
-* Extend `status.ts` so `formatRunStatus()` displays `lastRun` metadata coherently, especially active/stuck `running` state, post-run outcomes, and run-specific session ids.
+* Extend the existing `formatRunStatus()` in `status.ts` so per-worker output includes `lastRun` metadata coherently, especially active/stuck `running` state, post-run outcomes, and run-specific session ids.
 * Keep the surface intentionally narrow: no concurrent run orchestration, no background worker management, and no automatic summary refresh.
 
 **ADR Reference**: `-> ADR-0007: Single-worker foreground run before multi-worker orchestration`
@@ -98,7 +98,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 * Update `packages/pi-conductor/README.md` to explain the new `/conductor run` scope and the fact that it is synchronous foreground execution, not an always-on worker loop.
 * Keep `docs/prd/PRD-003-pi-conductor-single-worker-run.md` as the requirements source and update this plan if runtime details diverge materially during implementation.
-* If implementation settles the execution-surface policy around extension binding or model/preflight behavior in a lasting way, consider a follow-up ADR.
+* Follow `ADR-0011` for the execution-surface policy around extension binding and model/preflight behavior; update that ADR only if implementation materially diverges from the accepted direction.
 
 **ADR Reference**: None — documentation alignment work
 
@@ -109,7 +109,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 | 1     | Run State Model and Backward-Compatible Storage     | None             | M               |
 | 2     | Executable Runtime Seam                             | Phase 1          | L               |
 | 3     | Run Orchestration and Lifecycle Transitions         | Phase 1, 2       | L               |
-| 4     | Command, Tool, and Status Surface                   | Phase 2, 3       | M               |
+| 4     | Command, Tool, and Status Surface                   | Phase 1, 2, 3    | M               |
 | 5     | Test and Opt-in CLI Coverage                        | Phase 1, 2, 3, 4 | L               |
 | 6     | Operator Documentation and Follow-on Spec Alignment | Phase 4, 5       | S               |
 
@@ -126,7 +126,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 ### Code dependencies
 
 * `packages/pi-conductor/extensions/types.ts` and `storage.ts` must stabilize the `lastRun` model before status or orchestration code can rely on it.
-* `packages/pi-conductor/extensions/runtime.ts` depends on Pi SDK executable session APIs being available through `@mariozechner/pi-coding-agent` in this workspace.
+* `packages/pi-conductor/extensions/runtime.ts` depends on Pi SDK executable session APIs being available through `@mariozechner/pi-coding-agent` in this workspace; in practice this means adding new `createAgentSession`-level imports to `runtime.ts`, not adding a new package dependency.
 * `packages/pi-conductor/extensions/conductor.ts` depends on both storage helpers and the new runtime execution seam.
 * `packages/pi-conductor/extensions/index.ts` and `commands.ts` depend on a stable conductor entrypoint for the run workflow.
 
@@ -140,7 +140,7 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 * Parts of Phase 5 test coverage can begin as soon as Phase 1 types/storage helpers land.
 * README updates and minor command-surface documentation can draft in parallel with late-phase test work, but should not merge until behavior is final.
-* If a new ADR is needed for extension-binding/model-preflight policy, that discussion can happen in parallel with Phases 3–4 once implementation pressure becomes concrete.
+* Any material implementation divergence from `ADR-0011` can be discussed in parallel with Phases 3–4, but the current plan assumes `ADR-0011` remains the governing policy.
 
 ## Risks and Mitigations
 
@@ -155,8 +155,8 @@ The safest rollout is to implement the run feature in five layers: storage/type 
 
 ## Open Questions
 
-* What exact minimal extension binding set should conductor use for headless worker runs: all normal repo extensions, a curated subset, or a dedicated binding policy?
-* Should runtime preflight live entirely in `runtime.ts`, or should conductor own a distinct “can this worker run now?” orchestration helper for clearer failure semantics?
+* **Resolved by ADR-0011:** Worker runs should use a curated minimal headless binding policy rather than broad ambient inheritance.
+* **Resolved by ADR-0011:** Runtime preflight should live in `runtime.ts` as an early eligibility check before conductor persists `running`.
 * How much `lastRun` detail should `formatRunStatus()` display inline before status becomes too verbose for multi-worker projects?
 * Should a future stale-run heuristic be time-based, heartbeat-based, or session-activity-based once foreground execution ships and operators start hitting stuck `running` states?
 

--- a/docs/prd/PRD-003-pi-conductor-single-worker-run.md
+++ b/docs/prd/PRD-003-pi-conductor-single-worker-run.md
@@ -110,20 +110,22 @@ For this phase, `run` means **real prompted execution**, not just metadata mutat
 Concretely, the run path should:
 
 * open the worker’s persisted session lineage via `SessionManager.open(worker.sessionFile)` when a session file exists
-* construct an executable Pi session by passing the opened session manager to `createAgentSession({ sessionManager: SessionManager.open(sessionFile), cwd: worktreePath })` so that execution is bound to the worker’s existing lineage
-* bind extensions for headless execution via `session.bindExtensions(bindings)` before prompting, where `bindings` should be minimal non-interactive bindings derived from the `runPrintMode` pattern (no terminal UI, no interactive prompts)
+* construct an executable Pi session by passing that opened session manager to `createAgentSession({ sessionManager, cwd: worktreePath })` so that execution is bound to the worker’s existing lineage
+* call `createAgentSession(...)` first, then apply headless extension overrides to the returned session through whatever binding/configuration mechanism the Pi SDK exposes for `AgentSession` construction and setup before prompting
+* define the relevant setup surface concretely in terms of minimal non-interactive extension bindings/configuration for headless execution (for example no terminal `uiContext` and no interactive command-context actions), rather than referring to `runPrintMode` as a binding pattern
+* explicitly decide how default extension, skill, prompt-template, and context-file discovery is narrowed for worker runs, since `createAgentSession()` normally performs resource discovery and loading unless conductor overrides that behavior through custom resource loading or equivalent session-construction controls
 * execute the operator-supplied task in the foreground via `session.prompt(task)` and await its completion
-* session persistence is handled automatically by `AgentSession` (append-only writes via `sessionManager.appendMessage()` on every `message_end` event); the run path must NOT call the existing `persistSessionFile()` from `runtime.ts`, which uses a full-rewrite strategy that would conflict with AgentSession's incremental persistence
-* dispose the `AgentSession` after run completion (in a `finally` block) to release event listeners and internal state — the SDK requires `session.dispose()` when done with a session
+* session persistence is handled internally by `AgentSession` via append-only writes; the run path must NOT call the existing `persistSessionFile()` from `runtime.ts`, which uses a full-rewrite strategy that would conflict with AgentSession's incremental persistence
+* dispose the `AgentSession` after run completion (in a `finally` block) to release event listeners and internal state — the SDK requires `session.dispose()` when done with a session; the implementation must also confirm whether any loaded extension resources require teardown beyond `session.dispose()` and document that if needed
 
 For this phase, the execution environment policy should be explicit and deterministic:
 
 * worker runs should use conductor-defined session construction via `createAgentSession()` rather than relying on unspecified ambient defaults
 * the implementation should decide and document which tools are enabled for worker runs
-* the implementation should decide and document whether normal extension/context-file discovery remains enabled or is narrowed for predictability
+* the implementation should decide and document whether normal extension, skill, prompt-template, and context-file discovery remains enabled, is narrowed through custom resource loading, or is disabled for predictability
 * model selection should use the operator’s configured/default Pi model unless conductor later adds worker-specific model policy
-* preflight should make a best-effort verification of model and provider availability before constructing the agent session
-* the implementation may use `ModelRegistry` to check configured auth before calling `createAgentSession()`
+* preflight should make a best-effort verification of model and provider availability before prompting and before conductor persists the worker as `running`; that check may happen before or during session construction depending on the SDK seam used by the runtime helper
+* the implementation may use `ModelRegistry` to check configured auth before calling `createAgentSession()` when that gives a cleaner earlier eligibility signal
 * provider/model/auth failures can still occur later at prompt execution time, so the run path must also catch and translate prompt-time failures into clear run errors
 * regardless of where failure occurs, the worker must never be left in `running` state after a preflight or early execution failure
 
@@ -238,7 +240,7 @@ The minimum v1 persisted shape should be:
 ```ts
 lastRun: {
   task: string;
-  status: "success" | "error" | "aborted";
+  status: "success" | "error" | "aborted" | null;
   startedAt: string;
   finishedAt: string | null;
   errorMessage: string | null;
@@ -246,13 +248,15 @@ lastRun: {
 }
 ```
 
-`finishedAt` is populated for all terminal statuses (`success`, `error`, `aborted`). `null` indicates the run is still in progress or the process terminated before recording completion.
+`status: null` represents "run started but no terminal outcome has been recorded yet." `finishedAt` is populated for all terminal statuses (`success`, `error`, `aborted`). `null` indicates the run is still in progress or the process terminated before recording completion. In-progress detection in this phase is intentionally a compound condition: `worker.lifecycle === "running"` together with `lastRun.finishedAt === null`.
 
-`lastRun.sessionId` should capture the `AgentSession.sessionId` from the execution session (i.e., the session ID active during the run), not the worker's pre-existing `runtime.sessionId`. These may differ because `createAgentSession()` can assign a new session ID.
+`lastRun.sessionId` should capture the `AgentSession.sessionId` from the execution session (i.e., the session ID active during the run), not the worker's pre-existing `runtime.sessionId`. These may differ because `createAgentSession()` can assign a new session ID. In the normal accepted run path, `sessionId` should be populated once the execution session is constructed; `null` remains valid for backward-compatible normalization and for partial records created before an execution session ID is available.
 
 Because existing persisted workers do not yet have `lastRun`, the implementation must normalize missing `lastRun` values when reading older run records so the new feature is backward-compatible with already-persisted worker state.
 
-In this phase, abort is not exposed as a separate operator command. An aborted run is detected when the agent's final assistant message has `stopReason = "aborted"` (e.g., due to signal interruption or process termination). A dedicated `/conductor abort` command is deferred to a future phase.
+In this phase, abort is not exposed as a separate operator command. An aborted run is detected when the agent's final assistant message has `stopReason = "aborted"`, meaning the SDK-observed execution ended with an explicit aborted terminal outcome. This is different from a hard crash, forced process exit, or other interruption that prevents a terminal assistant message from being recorded at all; those cases should be treated as interrupted/stuck runs with `finishedAt: null` rather than as a persisted `aborted` outcome. A dedicated `/conductor abort` command is deferred to a future phase.
+
+When a stuck `running` worker is manually reset via `/conductor state <worker> idle` or `/conductor recover <worker>`, `lastRun` should be preserved as-is, including `finishedAt: null` and any `status: null` or partial execution metadata already recorded. The manual reset clears lifecycle state for operator recovery, but it does not retroactively invent a terminal outcome for the interrupted run.
 
 **Acceptance criteria:**
 
@@ -461,10 +465,10 @@ Then unit and integration tests validate worker run behavior against real local 
 
 ## 11. Rollout Plan
 
-1. Implement the executable session-based runtime execution seam.
-2. Add command/tool wiring for single-worker run.
-3. Add lifecycle/status/storage updates, including structured `lastRun` persistence.
-4. Add integration tests.
+1. Extend types/storage with backward-compatible `lastRun` persistence and normalization.
+2. Implement the executable session-based runtime execution seam.
+3. Add conductor lifecycle orchestration plus command/tool wiring for single-worker run.
+4. Add status updates and integration/unit coverage.
 5. Optionally add or extend opt-in CLI e2e coverage.
 6. Update README and follow-on architecture docs if implementation diverges materially.
 
@@ -488,7 +492,7 @@ Then unit and integration tests validate worker run behavior against real local 
 | Date       | Change                                                                                                                                                                                                                                                                                                          | Author |
 | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
 | 2026-04-21 | Initial draft for adding a single-worker run capability to `pi-conductor`                                                                                                                                                                                                                                       | feniix |
-| 2026-04-21 | Refine pass: fix phantom `createAgentSessionRuntime()` API reference; make `createAgentSession({ sessionManager })` linkage explicit; specify `bindExtensions()` requirement; define run outcome detection via `stopReason`; clarify abort mechanism and `lastRun.sessionId`; add preflight validation guidance | feniix |
+| 2026-04-21 | Refine pass: fix phantom `createAgentSessionRuntime()` API reference; make `createAgentSession({ sessionManager })` linkage explicit; clarify headless binding/configuration requirements; define run outcome detection via `stopReason`; clarify abort mechanism and `lastRun.sessionId`; add preflight validation guidance | feniix |
 | 2026-04-21 | Refine pass 2: move stopReason prose out of Gherkin; add `session.dispose()` cleanup step; clarify AgentSession persistence behavior; add sessions test coverage note; clarify `finishedAt` null semantics                                                                                                      | feniix |
 | 2026-04-21 | Refine pass 3 and 4: complete stopReason mapping, add stuck-running crash note, fix final-message references to `session.state.messages`, and clarify prompt-time provider/auth failure handling                                                                                                                | feniix |
 | 2026-04-21 | Normalize File Breakdown, Related, and Changelog structure to satisfy current `pi-specdocs` PRD validation rules without changing document intent                                                                                                                                                               | Pi     |

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -240,6 +240,27 @@ describe("pi-specdocs runtime", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Duplicate PRD number: PRD-007"), "warning");
   });
 
+  it("accepts string-style command arguments for specdocs-format", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-string-"));
+    mkdirSync(join(base, "docs", "prd"), { recursive: true });
+    const filePath = join(base, "docs", "prd", "PRD-001-test.md");
+    writeFileSync(
+      filePath,
+      '---\ntitle: "Test"\nprd: PRD-001\nstatus: Draft\nowner: Alice\ndate: 2025-01-01\nissue: 1\nversion: 1\n---\n# Test\n## 1. Problem & Context\nBody\n',
+    );
+
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.("docs/prd/PRD-001-test.md", { cwd: base, ui: { notify } });
+
+    const updated = readFileSync(filePath, "utf-8");
+    expect(updated).toContain("---\n\n# Test\n\n## 1. Problem & Context\n\nBody\n");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
+  });
+
   it("reports a clear error when specdocs-format targets a nonexistent path", async () => {
     const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-"));
     const mockPi = createMockPi();
@@ -247,7 +268,7 @@ describe("pi-specdocs runtime", () => {
     const handler = getCommandHandler(mockPi, "specdocs-format");
     const notify = vi.fn();
 
-    await handler?.({ path: "docs/prd/PRD-999-missing.md" }, { cwd: base, ui: { notify } });
+    await handler?.("docs/prd/PRD-999-missing.md", { cwd: base, ui: { notify } });
 
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("does not exist"), "error");
   });

--- a/packages/pi-specdocs/__tests__/runtime.test.ts
+++ b/packages/pi-specdocs/__tests__/runtime.test.ts
@@ -261,6 +261,18 @@ describe("pi-specdocs runtime", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Formatted spec document"), "info");
   });
 
+  it("reports a clear error when specdocs-format gets a whitespace-only string path", async () => {
+    const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-whitespace-"));
+    const mockPi = createMockPi();
+    specdocs(mockPi as unknown as ExtensionAPI);
+    const handler = getCommandHandler(mockPi, "specdocs-format");
+    const notify = vi.fn();
+
+    await handler?.("   ", { cwd: base, ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("requires a single path argument"), "error");
+  });
+
   it("reports a clear error when specdocs-format targets a nonexistent path", async () => {
     const base = mkdtempSync(join(tmpdir(), "pi-specdocs-format-"));
     const mockPi = createMockPi();

--- a/packages/pi-specdocs/extensions/runtime.ts
+++ b/packages/pi-specdocs/extensions/runtime.ts
@@ -340,6 +340,27 @@ function resolveCommandPath(cwd: string, path: string): string {
   return path.startsWith("/") ? path : resolve(cwd, path);
 }
 
+function extractCommandPathArg(args: unknown): string {
+  if (typeof args === "string") {
+    return args.trim();
+  }
+
+  if (!args || typeof args !== "object") {
+    return "";
+  }
+
+  const params = args as Record<string, unknown>;
+  if (typeof params.path === "string") {
+    return params.path.trim();
+  }
+
+  if (typeof params.file_path === "string") {
+    return params.file_path.trim();
+  }
+
+  return "";
+}
+
 function isSupportedSpecPath(path: string): boolean {
   return isPrd(path) || isAdr(path) || isPlan(path);
 }
@@ -415,9 +436,7 @@ async function formatSpecDocument(content: string): Promise<string> {
 }
 
 export async function runFormat(args: unknown, ctx: { cwd: string } & ExtensionContext): Promise<void> {
-  const params = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-  const rawPath =
-    typeof params.path === "string" ? params.path : typeof params.file_path === "string" ? params.file_path : "";
+  const rawPath = extractCommandPathArg(args);
   if (!rawPath) {
     ctx.ui.notify("[specdocs] specdocs-format requires a single path argument.", "error");
     return;


### PR DESCRIPTION
## Summary
- make `specdocs-format` accept plain string command arguments in addition to `{ path }` and `{ file_path }`
- add regression coverage for string-style command invocation and nonexistent-path handling
- preserve existing object-style invocation behavior used by tests/helpers

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `npx vitest run packages/pi-specdocs/__tests__`
- `npx tsc --noEmit --project packages/pi-specdocs/tsconfig.json`

Closes #50