### PR TITLE
feat: add single-worker foreground runs to pi-conductor

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -4,12 +4,16 @@ Long-lived multi-session worker orchestration for Pi.
 
 ## Status
 
-Implemented MVP for the `pi-extensions` workspace, based on:
+Implemented for the `pi-extensions` workspace, based on:
 - `docs/prd/PRD-002-pi-conductor-persistent-resumable-workers.md`
+- `docs/prd/PRD-003-pi-conductor-single-worker-run.md`
 - `docs/adr/ADR-0001-sdk-first-worker-runtime.md`
 - `docs/adr/ADR-0002-conductor-project-scoped-storage.md`
 - `docs/adr/ADR-0003-continuity-based-worktree-reuse.md`
 - `docs/adr/ADR-0004-minimal-conductor-local-git-gh-layer.md`
+- `docs/adr/ADR-0006-agent-session-based-foreground-run-execution.md`
+- `docs/adr/ADR-0007-single-worker-run-before-multi-worker-orchestration.md`
+- `docs/adr/ADR-0011-conductor-run-extension-binding-and-preflight-policy.md`
 
 PRD-001 remains in the repo as the original design document and is now superseded.
 
@@ -22,12 +26,14 @@ PRD-001 remains in the repo as the original design document and is now supersede
 - worker git worktree creation and recovery
 - real persisted Pi session linkage
 - a SessionManager-backed runtime boundary for worker creation, resume, recovery, and summary refresh
+- AgentSession-based foreground worker execution through `/conductor run <worker-name> <task>`
 - persisted runtime metadata (`sessionId`, `lastResumedAt`, backend)
+- persisted per-worker `lastRun` metadata for started/completed/error/aborted runs
 - explicit worker resume against persisted worktree/session metadata
-- task updates and session-derived summaries
+- task updates, run-aware task mutation, and session-derived summaries
 - lifecycle controls for `idle`, `running`, `blocked`, `ready_for_pr`, and `done`
 - health-aware status output distinguishing healthy, stale, and broken workers
-- status output that includes worktree path, session file, and runtime metadata
+- status output that includes worktree path, session file, runtime metadata, and last-run state
 - broken-state detection and targeted recovery
 - targeted worker cleanup
 - minimal PR preparation flow:
@@ -46,6 +52,7 @@ Primary operator UX is the `/conductor` command group:
 /conductor start <worker-name>
 /conductor task <worker-name> <task>
 /conductor resume <worker-name>
+/conductor run <worker-name> <task>
 /conductor state <worker-name> <lifecycle>
 /conductor summarize <worker-name>
 /conductor recover <worker-name>
@@ -67,6 +74,7 @@ Registered tools:
 - `conductor_summary_refresh`
 - `conductor_cleanup`
 - `conductor_resume`
+- `conductor_run`
 - `conductor_lifecycle_update`
 - `conductor_commit`
 - `conductor_push`
@@ -74,17 +82,26 @@ Registered tools:
 
 ## Runtime model
 
-The current MVP does **not** supervise always-on autonomous worker agents.
+`pi-conductor` does **not** supervise always-on autonomous worker agents.
 
 Instead, it uses a narrow Pi SDK runtime seam around persisted sessions:
 - create a worker session when a worker is created
 - reopen that session on `/conductor resume`
-- record runtime metadata in conductor state
+- run one foreground task in the existing worker session lineage via `/conductor run`
+- record runtime metadata and last-run outcome in conductor state
 - derive summaries from the worker session history
 
-In this MVP, `/conductor resume` intentionally normalizes the worker lifecycle back to `idle`. Resume currently means “reopen and relink the persisted worker session”, not “reattach to an always-running autonomous worker”.
+`/conductor run` is intentionally synchronous foreground execution. It runs one task in one existing worker, waits for completion, persists the outcome, and returns. It is not a background scheduler, daemon, or multi-worker orchestrator.
 
-This keeps the worker model durable today while leaving room for a future `AgentSession`-managed or subprocess-backed subagent backend.
+Worker runs use a curated non-interactive execution surface rather than broad ambient inheritance. The run path performs best-effort model/provider preflight before the worker is persisted as `running`, reuses the worker worktree and session file, and records:
+- `success`
+- `error`
+- `aborted`
+- or an intentionally preserved in-progress/stuck signal when a process dies mid-run (`lifecycle=running` with `lastRun.finishedAt=null`)
+
+In this package, `/conductor resume` still intentionally normalizes the worker lifecycle back to `idle`. Resume means “reopen and relink the persisted worker session”, not “reattach to an always-running autonomous worker”.
+
+This keeps the worker model durable today while leaving room for future multi-worker or subprocess-backed backends.
 
 ## Development
 

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -56,9 +56,9 @@ describe("runConductorCommand", () => {
     expect(status).toContain("task=implement status command");
   });
 
-  it("shows an error for run without a worker name or task", async () => {
+  it("shows an error for run without a task", async () => {
     const text = await runConductorCommand(repoDir, "run backend");
-    expect(text).toContain("error: missing worker name or task");
+    expect(text).toContain("error: missing task");
   });
 
   it("refreshes a worker summary from its session", async () => {

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -56,6 +56,11 @@ describe("runConductorCommand", () => {
     expect(status).toContain("task=implement status command");
   });
 
+  it("shows an error for run without a worker name or task", async () => {
+    const text = await runConductorCommand(repoDir, "run backend");
+    expect(text).toContain("error: missing worker name or task");
+  });
+
   it("refreshes a worker summary from its session", async () => {
     await runConductorCommand(repoDir, "start backend");
     const text = await runConductorCommand(repoDir, "summarize backend");

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -21,5 +21,6 @@ describe("pi-conductor extension", () => {
     expect(extension).toContain('name: "conductor_commit"');
     expect(extension).toContain('name: "conductor_push"');
     expect(extension).toContain('name: "conductor_pr_create"');
+    expect(extension).toContain('name: "conductor_run"');
   });
 });

--- a/packages/pi-conductor/__tests__/lifecycle.test.ts
+++ b/packages/pi-conductor/__tests__/lifecycle.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createWorkerForRepo,
   getOrCreateRunForRepo,
+  recoverWorkerForRepo,
   resumeWorkerForRepo,
   updateWorkerLifecycleForRepo,
 } from "../extensions/conductor.js";
@@ -51,5 +52,44 @@ describe("worker lifecycle flows", () => {
     expect(updateWorkerLifecycleForRepo(repoDir, "backend", "ready_for_pr").lifecycle).toBe("ready_for_pr");
     expect(updateWorkerLifecycleForRepo(repoDir, "backend", "done").lifecycle).toBe("done");
     expect(getOrCreateRunForRepo(repoDir).workers[0]?.lifecycle).toBe("done");
+  });
+
+  it("preserves interrupted lastRun metadata when lifecycle is manually reset or recovered", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const run = getOrCreateRunForRepo(repoDir);
+    const existingWorker = run.workers[0];
+    if (!existingWorker) {
+      throw new Error("expected worker to exist");
+    }
+    run.workers[0] = {
+      ...existingWorker,
+      lifecycle: "running",
+      lastRun: {
+        task: "half finished task",
+        status: null,
+        startedAt: "2026-04-21T00:00:00.000Z",
+        finishedAt: null,
+        errorMessage: null,
+        sessionId: "run-session-stuck",
+      },
+    };
+
+    const { writeRun } = await import("../extensions/storage.js");
+    writeRun(run);
+
+    const reset = updateWorkerLifecycleForRepo(repoDir, "backend", "idle");
+    expect(reset.lifecycle).toBe("idle");
+    expect(reset.lastRun?.finishedAt).toBeNull();
+    expect(reset.lastRun?.status).toBeNull();
+    expect(reset.lastRun?.sessionId).toBe("run-session-stuck");
+
+    if (worker.sessionFile && existsSync(worker.sessionFile)) {
+      rmSync(worker.sessionFile, { force: true });
+    }
+    const recovered = await recoverWorkerForRepo(repoDir, "backend");
+    expect(recovered.lifecycle).toBe("idle");
+    expect(recovered.lastRun?.finishedAt).toBeNull();
+    expect(recovered.lastRun?.status).toBeNull();
+    expect(recovered.lastRun?.sessionId).toBe("run-session-stuck");
   });
 });

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -1,0 +1,184 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => ({
+  preflightWorkerRunRuntime: vi.fn(),
+  runWorkerPromptRuntime: vi.fn(),
+}));
+
+vi.mock("../extensions/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../extensions/runtime.js")>();
+  return {
+    ...actual,
+    preflightWorkerRunRuntime: runtimeMocks.preflightWorkerRunRuntime,
+    runWorkerPromptRuntime: runtimeMocks.runWorkerPromptRuntime,
+  };
+});
+
+import {
+  createWorkerForRepo,
+  getOrCreateRunForRepo,
+  runWorkerForRepo,
+  updateWorkerLifecycleForRepo,
+  updateWorkerTaskForRepo,
+} from "../extensions/conductor.js";
+
+describe("worker run flows", () => {
+  let repoDir: string;
+  let conductorHome: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeMocks.preflightWorkerRunRuntime.mockResolvedValue(undefined);
+    runtimeMocks.runWorkerPromptRuntime.mockResolvedValue({
+      status: "success",
+      finalText: "implemented status output",
+      errorMessage: null,
+      sessionId: "run-session-1",
+    });
+
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello\n");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
+
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    for (const dir of [repoDir, conductorHome]) {
+      if (dir && existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("runs a task in an existing worker session lineage and records success metadata", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    updateWorkerTaskForRepo(repoDir, "backend", "old task");
+
+    const result = await runWorkerForRepo(repoDir, "backend", "implement status output");
+
+    expect(result).toMatchObject({
+      workerName: "backend",
+      status: "success",
+      finalText: "implemented status output",
+    });
+    expect(runtimeMocks.preflightWorkerRunRuntime).toHaveBeenCalledWith({
+      worktreePath: worker.worktreePath,
+      sessionFile: worker.sessionFile,
+    });
+    expect(runtimeMocks.runWorkerPromptRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreePath: worker.worktreePath,
+        sessionFile: worker.sessionFile,
+        task: "implement status output",
+      }),
+    );
+
+    const persisted = getOrCreateRunForRepo(repoDir).workers[0];
+    expect(persisted?.lifecycle).toBe("idle");
+    expect(persisted?.currentTask).toBe("implement status output");
+    expect(persisted?.lastRun).toMatchObject({
+      task: "implement status output",
+      status: "success",
+      errorMessage: null,
+      sessionId: "run-session-1",
+    });
+  });
+
+  it("fails fast on preflight without mutating currentTask or lifecycle", async () => {
+    await createWorkerForRepo(repoDir, "backend");
+    updateWorkerTaskForRepo(repoDir, "backend", "old task");
+    runtimeMocks.preflightWorkerRunRuntime.mockRejectedValueOnce(new Error("No usable model configured"));
+
+    await expect(runWorkerForRepo(repoDir, "backend", "new task")).rejects.toThrow("No usable model configured");
+
+    const persisted = getOrCreateRunForRepo(repoDir).workers[0];
+    expect(persisted?.currentTask).toBe("old task");
+    expect(persisted?.lifecycle).toBe("idle");
+    expect(persisted?.lastRun).toBeNull();
+    expect(runtimeMocks.runWorkerPromptRuntime).not.toHaveBeenCalled();
+  });
+
+  it("persists the execution session id as soon as the runtime session is created", async () => {
+    await createWorkerForRepo(repoDir, "backend");
+    runtimeMocks.runWorkerPromptRuntime.mockImplementationOnce(async ({ onSessionReady }) => {
+      await onSessionReady?.("run-session-early");
+      const duringRun = getOrCreateRunForRepo(repoDir).workers[0];
+      expect(duringRun?.lifecycle).toBe("running");
+      expect(duringRun?.lastRun?.finishedAt).toBeNull();
+      expect(duringRun?.lastRun?.sessionId).toBe("run-session-early");
+      return {
+        status: "success",
+        finalText: "done",
+        errorMessage: null,
+        sessionId: "run-session-early",
+      };
+    });
+
+    await runWorkerForRepo(repoDir, "backend", "record session id early");
+  });
+
+  it("marks errored runs blocked and persists the run error message", async () => {
+    await createWorkerForRepo(repoDir, "backend");
+    runtimeMocks.runWorkerPromptRuntime.mockResolvedValueOnce({
+      status: "error",
+      finalText: null,
+      errorMessage: "model crashed",
+      sessionId: "run-session-2",
+    });
+
+    const result = await runWorkerForRepo(repoDir, "backend", "dangerous task");
+
+    expect(result.status).toBe("error");
+    const persisted = getOrCreateRunForRepo(repoDir).workers[0];
+    expect(persisted?.lifecycle).toBe("blocked");
+    expect(persisted?.lastRun).toMatchObject({
+      status: "error",
+      errorMessage: "model crashed",
+      sessionId: "run-session-2",
+    });
+  });
+
+  it("returns aborted runs to idle and preserves aborted metadata", async () => {
+    await createWorkerForRepo(repoDir, "backend");
+    runtimeMocks.runWorkerPromptRuntime.mockResolvedValueOnce({
+      status: "aborted",
+      finalText: "stopped early",
+      errorMessage: null,
+      sessionId: "run-session-3",
+    });
+
+    const result = await runWorkerForRepo(repoDir, "backend", "abortable task");
+
+    expect(result.status).toBe("aborted");
+    const persisted = getOrCreateRunForRepo(repoDir).workers[0];
+    expect(persisted?.lifecycle).toBe("idle");
+    expect(persisted?.lastRun).toMatchObject({
+      task: "abortable task",
+      status: "aborted",
+      sessionId: "run-session-3",
+    });
+  });
+
+  it("rejects already running workers and workers with missing session files", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    updateWorkerLifecycleForRepo(repoDir, "backend", "running");
+    await expect(runWorkerForRepo(repoDir, "backend", "task")).rejects.toThrow(/already running/i);
+
+    updateWorkerLifecycleForRepo(repoDir, "backend", "idle");
+    if (worker.sessionFile) {
+      unlinkSync(worker.sessionFile);
+    }
+    await expect(runWorkerForRepo(repoDir, "backend", "task")).rejects.toThrow(/recover the worker first/i);
+  });
+});

--- a/packages/pi-conductor/__tests__/runtime-run.test.ts
+++ b/packages/pi-conductor/__tests__/runtime-run.test.ts
@@ -1,5 +1,12 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { extractFinalAssistantText, mapStopReasonToRunOutcome } from "../extensions/runtime.js";
+import {
+  extractFinalAssistantText,
+  mapStopReasonToRunOutcome,
+  preflightWorkerRunRuntime,
+} from "../extensions/runtime.js";
 
 describe("worker run runtime helpers", () => {
   it("maps Pi stop reasons to conductor run outcomes", () => {
@@ -15,6 +22,18 @@ describe("worker run runtime helpers", () => {
       errorMessage:
         "Run stopped because the model hit its output or context length limit; shorten or split the task and retry",
     });
+  });
+
+  it("validates worker context before declaring preflight success", async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), "pi-conductor-runtime-"));
+    const sessionFile = join(worktreePath, "session.jsonl");
+    writeFileSync(sessionFile, "{}\n", "utf-8");
+
+    await expect(preflightWorkerRunRuntime({ worktreePath, sessionFile })).resolves.toBeUndefined();
+    await expect(preflightWorkerRunRuntime({ worktreePath: "/missing", sessionFile })).rejects.toThrow(/worktree/i);
+    await expect(preflightWorkerRunRuntime({ worktreePath, sessionFile: "/missing/session.jsonl" })).rejects.toThrow(
+      /session file/i,
+    );
   });
 
   it("extracts final assistant text content and falls back cleanly when absent", () => {

--- a/packages/pi-conductor/__tests__/runtime-run.test.ts
+++ b/packages/pi-conductor/__tests__/runtime-run.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { extractFinalAssistantText, mapStopReasonToRunOutcome } from "../extensions/runtime.js";
+
+describe("worker run runtime helpers", () => {
+  it("maps Pi stop reasons to conductor run outcomes", () => {
+    expect(mapStopReasonToRunOutcome("stop")).toEqual({ status: "success", errorMessage: null });
+    expect(mapStopReasonToRunOutcome("aborted")).toEqual({ status: "aborted", errorMessage: null });
+    expect(mapStopReasonToRunOutcome("error")).toEqual({ status: "error", errorMessage: null });
+    expect(mapStopReasonToRunOutcome("toolUse")).toEqual({
+      status: "error",
+      errorMessage: "Run ended unexpectedly while waiting on tool execution",
+    });
+    expect(mapStopReasonToRunOutcome("length")).toEqual({
+      status: "error",
+      errorMessage:
+        "Run stopped because the model hit its output or context length limit; shorten or split the task and retry",
+    });
+  });
+
+  it("extracts final assistant text content and falls back cleanly when absent", () => {
+    expect(
+      extractFinalAssistantText([
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "..." },
+            { type: "text", text: "Implemented status output." },
+            { type: "text", text: "Tests are green." },
+          ],
+        },
+      ]),
+    ).toBe("Implemented status output.\n\nTests are green.");
+
+    expect(
+      extractFinalAssistantText([
+        {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "..." }],
+        },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/packages/pi-conductor/__tests__/runtime-run.test.ts
+++ b/packages/pi-conductor/__tests__/runtime-run.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractFinalAssistantText,
   mapStopReasonToRunOutcome,
@@ -9,6 +10,9 @@ import {
 } from "../extensions/runtime.js";
 
 describe("worker run runtime helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it("maps Pi stop reasons to conductor run outcomes", () => {
     expect(mapStopReasonToRunOutcome("stop")).toEqual({ status: "success", errorMessage: null });
     expect(mapStopReasonToRunOutcome("aborted")).toEqual({ status: "aborted", errorMessage: null });
@@ -25,6 +29,10 @@ describe("worker run runtime helpers", () => {
   });
 
   it("validates worker context before declaring preflight success", async () => {
+    vi.spyOn(ModelRegistry, "create").mockReturnValue({
+      getAvailable: () => [{ id: "fake-model" }],
+    } as unknown as ModelRegistry);
+
     const worktreePath = mkdtempSync(join(tmpdir(), "pi-conductor-runtime-"));
     const sessionFile = join(worktreePath, "session.jsonl");
     writeFileSync(sessionFile, "{}\n", "utf-8");

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -10,7 +10,7 @@ describe("formatRunStatus", () => {
     expect(text).toContain("workers: 0");
   });
 
-  it("includes task, session, pr, and summary staleness details", () => {
+  it("includes task, session, pr, summary, and run details", () => {
     const run = createEmptyRun("abc", "/tmp/repo");
     const worker = createWorkerRecord({
       workerId: "worker-1",
@@ -29,6 +29,14 @@ describe("formatRunStatus", () => {
     worker.pr.commitSucceeded = true;
     worker.pr.pushSucceeded = true;
     worker.pr.prCreationAttempted = true;
+    worker.lastRun = {
+      task: "implement status command",
+      status: "success",
+      startedAt: "2026-04-20T01:00:00.000Z",
+      finishedAt: "2026-04-20T01:05:00.000Z",
+      errorMessage: null,
+      sessionId: "run-session-123",
+    };
 
     const text = formatRunStatus({ ...run, workers: [worker] });
     expect(text).toContain("health=stale");
@@ -44,5 +52,33 @@ describe("formatRunStatus", () => {
     expect(text).toContain("prAttempted=true");
     expect(text).toContain("recoverable=false");
     expect(text).toContain("summary=stale: Half done");
+    expect(text).toContain("lastRun=success");
+    expect(text).toContain("runSessionId=run-session-123");
+    expect(text).toContain("runStartedAt=2026-04-20T01:00:00.000Z");
+    expect(text).toContain("runFinishedAt=2026-04-20T01:05:00.000Z");
+  });
+
+  it("shows active running runs distinctly", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    worker.lifecycle = "running";
+    worker.lastRun = {
+      task: "ship feature",
+      status: null,
+      startedAt: "2026-04-20T02:00:00.000Z",
+      finishedAt: null,
+      errorMessage: null,
+      sessionId: "run-session-456",
+    };
+
+    const text = formatRunStatus({ ...run, workers: [worker] });
+    expect(text).toContain("lastRun=running");
+    expect(text).toContain("runFinishedAt=none");
   });
 });

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -1,14 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   addWorker,
   createEmptyRun,
   createWorkerRecord,
+  finishWorkerRun,
   getConductorProjectDir,
+  readRun,
   setWorkerLifecycle,
   setWorkerRuntimeState,
+  startWorkerRun,
 } from "../extensions/storage.js";
 
 describe("storage helpers", () => {
+  let conductorHome: string;
+
+  beforeEach(() => {
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+  });
+
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (conductorHome && existsSync(conductorHome)) {
+      rmSync(conductorHome, { recursive: true, force: true });
+    }
+  });
   it("creates an empty run", () => {
     const run = createEmptyRun("abc", "/tmp/repo");
     expect(run.projectKey).toBe("abc");
@@ -18,7 +37,7 @@ describe("storage helpers", () => {
 
   it("builds a conductor project dir", () => {
     const dir = getConductorProjectDir("abc");
-    expect(dir).toContain(".pi/agent/conductor/projects/abc");
+    expect(dir).toBe(join(conductorHome, "projects", "abc"));
   });
 
   it("creates a worker record with default lifecycle metadata", () => {
@@ -40,6 +59,41 @@ describe("storage helpers", () => {
     expect(worker.runtime.backend).toBe("session_manager");
     expect(worker.runtime.sessionId).toBeNull();
     expect(worker.runtime.lastResumedAt).toBeNull();
+    expect(worker.lastRun).toBeNull();
+  });
+
+  it("normalizes missing lastRun when reading older persisted workers", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
+
+    mkdirSync(run.storageDir, { recursive: true });
+    const path = join(run.storageDir, "run.json");
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        {
+          ...run,
+          workers: [
+            JSON.parse(JSON.stringify(worker, (_key, value) => (value === null ? null : value))) as Record<
+              string,
+              unknown
+            >,
+          ].map(({ lastRun: _lastRun, ...legacyWorker }) => legacyWorker),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    const persisted = readRun("abc");
+    expect(persisted?.workers[0]?.lastRun).toBeNull();
   });
 
   it("marks an existing summary stale when the worker lifecycle changes", () => {
@@ -56,6 +110,68 @@ describe("storage helpers", () => {
 
     const updated = setWorkerLifecycle({ ...run, workers: [worker] }, worker.workerId, "running");
     expect(updated.workers[0]?.summary.stale).toBe(true);
+  });
+
+  it("marks a worker as running and persists lastRun metadata when a run starts", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    worker.summary.text = "Half done";
+    worker.summary.updatedAt = new Date().toISOString();
+
+    const updated = startWorkerRun({ ...run, workers: [worker] }, worker.workerId, {
+      task: "implement status output",
+      sessionId: "run-session-1",
+    });
+
+    expect(updated.workers[0]?.lifecycle).toBe("running");
+    expect(updated.workers[0]?.currentTask).toBe("implement status output");
+    expect(updated.workers[0]?.summary.stale).toBe(true);
+    expect(updated.workers[0]?.lastRun).toMatchObject({
+      task: "implement status output",
+      status: null,
+      finishedAt: null,
+      errorMessage: null,
+      sessionId: "run-session-1",
+    });
+    expect(updated.workers[0]?.lastRun?.startedAt).toBeTruthy();
+  });
+
+  it("completes a run with success, aborted, and error lifecycle semantics", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    const started = startWorkerRun({ ...run, workers: [worker] }, worker.workerId, {
+      task: "implement status output",
+      sessionId: "run-session-1",
+    });
+
+    const succeeded = finishWorkerRun(started, worker.workerId, { status: "success" });
+    expect(succeeded.workers[0]?.lifecycle).toBe("idle");
+    expect(succeeded.workers[0]?.lastRun?.status).toBe("success");
+    expect(succeeded.workers[0]?.lastRun?.finishedAt).toBeTruthy();
+
+    const aborted = finishWorkerRun(started, worker.workerId, { status: "aborted" });
+    expect(aborted.workers[0]?.lifecycle).toBe("idle");
+    expect(aborted.workers[0]?.lastRun?.status).toBe("aborted");
+
+    const errored = finishWorkerRun(started, worker.workerId, {
+      status: "error",
+      errorMessage: "model unavailable",
+    });
+    expect(errored.workers[0]?.lifecycle).toBe("blocked");
+    expect(errored.workers[0]?.lastRun?.status).toBe("error");
+    expect(errored.workers[0]?.lastRun?.errorMessage).toBe("model unavailable");
   });
 
   it("does not persist sessionFile inside worker.runtime", () => {

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -10,6 +10,7 @@ import {
   getConductorProjectDir,
   readRun,
   setWorkerLifecycle,
+  setWorkerRunSessionId,
   setWorkerRuntimeState,
   startWorkerRun,
 } from "../extensions/storage.js";
@@ -74,17 +75,14 @@ describe("storage helpers", () => {
 
     mkdirSync(run.storageDir, { recursive: true });
     const path = join(run.storageDir, "run.json");
+    const legacyWorker = JSON.parse(JSON.stringify(worker)) as Record<string, unknown>;
+    delete legacyWorker.lastRun;
     writeFileSync(
       path,
       `${JSON.stringify(
         {
           ...run,
-          workers: [
-            JSON.parse(JSON.stringify(worker, (_key, value) => (value === null ? null : value))) as Record<
-              string,
-              unknown
-            >,
-          ].map(({ lastRun: _lastRun, ...legacyWorker }) => legacyWorker),
+          workers: [legacyWorker],
         },
         null,
         2,
@@ -140,6 +138,21 @@ describe("storage helpers", () => {
       sessionId: "run-session-1",
     });
     expect(updated.workers[0]?.lastRun?.startedAt).toBeTruthy();
+  });
+
+  it("requires an active run before attaching a run session id", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+
+    expect(() => setWorkerRunSessionId({ ...run, workers: [worker] }, worker.workerId, "run-session-1")).toThrow(
+      /does not have an active lastRun/i,
+    );
   });
 
   it("completes a run with success, aborted, and error lifecycle semantics", () => {

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -9,6 +9,7 @@ import {
   refreshWorkerSummaryForRepo,
   removeWorkerForRepo,
   resumeWorkerForRepo,
+  runWorkerForRepo,
   updateWorkerLifecycleForRepo,
   updateWorkerTaskForRepo,
 } from "./conductor.js";
@@ -21,6 +22,7 @@ function getUsage(): string {
     "  /conductor start <worker-name>",
     "  /conductor task <worker-name> <task>",
     "  /conductor resume <worker-name>",
+    "  /conductor run <worker-name> <task>",
     "  /conductor state <worker-name> <lifecycle>",
     "  /conductor recover <worker-name>",
     "  /conductor summarize <worker-name>",
@@ -65,6 +67,16 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
     }
     const worker = await resumeWorkerForRepo(cwd, workerName);
     return `resumed worker ${worker.name}: session=${worker.sessionFile}`;
+  }
+  if (subcommand === "run") {
+    const [workerName, ...taskParts] = rest;
+    const task = taskParts.join(" ").trim();
+    if (!workerName || !task) {
+      return `${getUsage()}\n\nerror: missing worker name or task`;
+    }
+    const result = await runWorkerForRepo(cwd, workerName, task);
+    const summary = result.finalText ?? result.errorMessage ?? "Run completed without a final assistant summary";
+    return `ran worker ${result.workerName}: outcome=${result.status} result=${summary}`;
   }
   if (subcommand === "state") {
     const [workerName, lifecycle] = rest;

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -71,8 +71,11 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
   if (subcommand === "run") {
     const [workerName, ...taskParts] = rest;
     const task = taskParts.join(" ").trim();
-    if (!workerName || !task) {
-      return `${getUsage()}\n\nerror: missing worker name or task`;
+    if (!workerName) {
+      return `${getUsage()}\n\nerror: missing worker name`;
+    }
+    if (!task) {
+      return `${getUsage()}\n\nerror: missing task`;
     }
     const result = await runWorkerForRepo(cwd, workerName, task);
     const summary = result.finalText ?? result.errorMessage ?? "Run completed without a final assistant summary";

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -316,7 +316,6 @@ export async function runWorkerForRepo(repoRoot: string, workerName: string, tas
   // single foreground run can durably record the execution session id before the
   // prompt completes. This path is single-session and single-threaded.
   let latestRun = runningRun;
-  let originalRuntimeError: Error | null = null;
 
   try {
     const runtimeResult = await runWorkerPromptRuntime({
@@ -350,8 +349,7 @@ export async function runWorkerForRepo(repoRoot: string, workerName: string, tas
       sessionId: runtimeResult.sessionId,
     };
   } catch (error) {
-    originalRuntimeError = error instanceof Error ? error : new Error(String(error));
-    const message = originalRuntimeError.message;
+    const message = error instanceof Error ? error.message : String(error);
 
     try {
       const completedRun = finishWorkerRun(latestRun, worker.workerId, {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -10,24 +10,29 @@ import {
 import { deriveProjectKey } from "./project-key.js";
 import {
   createWorkerSessionRuntime,
+  preflightWorkerRunRuntime,
   recoverWorkerSessionRuntime,
   resumeWorkerSessionRuntime,
+  runWorkerPromptRuntime,
   summarizeWorkerSessionRuntime,
 } from "./runtime.js";
 import {
   addWorker,
   createEmptyRun,
   createWorkerRecord,
+  finishWorkerRun,
   readRun,
   removeWorker,
   setWorkerLifecycle,
   setWorkerPrState,
+  setWorkerRunSessionId,
   setWorkerRuntimeState,
   setWorkerSummary,
   setWorkerTask,
+  startWorkerRun,
   writeRun,
 } from "./storage.js";
-import type { RunRecord, WorkerLifecycleState, WorkerRecord } from "./types.js";
+import type { RunRecord, WorkerLifecycleState, WorkerRecord, WorkerRunResult } from "./types.js";
 import { createWorkerId } from "./workers.js";
 import {
   createManagedWorktree,
@@ -274,6 +279,86 @@ export function createWorkerPrForRepo(
     });
     writeRun(updatedRun);
     throw error;
+  }
+}
+
+export async function runWorkerForRepo(repoRoot: string, workerName: string, task: string): Promise<WorkerRunResult> {
+  const run = reconcileWorkerHealth(getOrCreateRunForRepo(repoRoot));
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  if (worker.lifecycle === "broken") {
+    throw new Error(`Worker named ${workerName} is broken and must recover the worker first`);
+  }
+  if (worker.lifecycle === "running") {
+    throw new Error(`Worker named ${workerName} is already running and cannot accept overlapping runs`);
+  }
+  if (!worker.sessionFile || !existsSync(worker.sessionFile)) {
+    throw new Error(`Worker named ${workerName} is missing its session file; recover the worker first`);
+  }
+  if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
+    throw new Error(`Worker named ${workerName} is missing its worktree; recover the worker first`);
+  }
+
+  await preflightWorkerRunRuntime({
+    worktreePath: worker.worktreePath,
+    sessionFile: worker.sessionFile,
+  });
+
+  const runningRun = startWorkerRun(run, worker.workerId, {
+    task,
+    sessionId: null,
+  });
+  writeRun(runningRun);
+
+  let latestRun = runningRun;
+
+  try {
+    const runtimeResult = await runWorkerPromptRuntime({
+      worktreePath: worker.worktreePath,
+      sessionFile: worker.sessionFile,
+      task,
+      onSessionReady: async (sessionId) => {
+        latestRun = setWorkerRunSessionId(latestRun, worker.workerId, sessionId);
+        writeRun(latestRun);
+      },
+    });
+
+    if (
+      runtimeResult.sessionId &&
+      latestRun.workers.find((entry) => entry.workerId === worker.workerId)?.lastRun?.sessionId !==
+        runtimeResult.sessionId
+    ) {
+      latestRun = setWorkerRunSessionId(latestRun, worker.workerId, runtimeResult.sessionId);
+    }
+    const completedRun = finishWorkerRun(latestRun, worker.workerId, {
+      status: runtimeResult.status,
+      errorMessage: runtimeResult.errorMessage,
+    });
+    writeRun(completedRun);
+
+    return {
+      workerName: worker.name,
+      status: runtimeResult.status,
+      finalText: runtimeResult.finalText,
+      errorMessage: runtimeResult.errorMessage,
+      sessionId: runtimeResult.sessionId,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const completedRun = finishWorkerRun(latestRun, worker.workerId, {
+      status: "error",
+      errorMessage: message,
+    });
+    writeRun(completedRun);
+    return {
+      workerName: worker.name,
+      status: "error",
+      finalText: null,
+      errorMessage: message,
+      sessionId: null,
+    };
   }
 }
 

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -312,7 +312,11 @@ export async function runWorkerForRepo(repoRoot: string, workerName: string, tas
   });
   writeRun(runningRun);
 
+  // latestRun is intentionally captured by the onSessionReady callback so the
+  // single foreground run can durably record the execution session id before the
+  // prompt completes. This path is single-session and single-threaded.
   let latestRun = runningRun;
+  let originalRuntimeError: Error | null = null;
 
   try {
     const runtimeResult = await runWorkerPromptRuntime({
@@ -346,12 +350,21 @@ export async function runWorkerForRepo(repoRoot: string, workerName: string, tas
       sessionId: runtimeResult.sessionId,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const completedRun = finishWorkerRun(latestRun, worker.workerId, {
-      status: "error",
-      errorMessage: message,
-    });
-    writeRun(completedRun);
+    originalRuntimeError = error instanceof Error ? error : new Error(String(error));
+    const message = originalRuntimeError.message;
+
+    try {
+      const completedRun = finishWorkerRun(latestRun, worker.workerId, {
+        status: "error",
+        errorMessage: message,
+      });
+      writeRun(completedRun);
+    } catch (persistenceError) {
+      const persistenceMessage =
+        persistenceError instanceof Error ? persistenceError.message : String(persistenceError);
+      throw new Error(`${message} (Additionally failed to persist worker run error state: ${persistenceMessage})`);
+    }
+
     return {
       workerName: worker.name,
       status: "error",

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -14,6 +14,7 @@ import {
   refreshWorkerSummaryForRepo,
   removeWorkerForRepo,
   resumeWorkerForRepo,
+  runWorkerForRepo,
   updateWorkerLifecycleForRepo,
   updateWorkerTaskForRepo,
 } from "./conductor.js";
@@ -182,6 +183,32 @@ export default function conductorExtension(pi: ExtensionAPI) {
       return {
         content: [{ type: "text", text: `resumed worker ${worker.name}: session=${worker.sessionFile}` }],
         details: { workerId: worker.workerId, sessionFile: worker.sessionFile, worktreePath: worker.worktreePath },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "conductor_run",
+    label: "Conductor Run",
+    description: "Run one foreground task in a named pi-conductor worker",
+    parameters: Type.Object({
+      name: Type.String({ description: "Worker name" }),
+      task: Type.String({ description: "Task text" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const result = await runWorkerForRepo(ctx.cwd, params.name, params.task);
+      const summary = result.finalText ?? result.errorMessage ?? "Run completed without a final assistant summary";
+      return {
+        content: [
+          { type: "text", text: `ran worker ${result.workerName}: outcome=${result.status} result=${summary}` },
+        ],
+        details: {
+          workerName: result.workerName,
+          status: result.status,
+          finalText: result.finalText,
+          errorMessage: result.errorMessage,
+          sessionId: result.sessionId,
+        },
       };
     },
   });

--- a/packages/pi-conductor/extensions/runtime.ts
+++ b/packages/pi-conductor/extensions/runtime.ts
@@ -1,8 +1,28 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { StopReason } from "@mariozechner/pi-ai";
+import {
+  AuthStorage,
+  createAgentSession,
+  createBashTool,
+  createEditTool,
+  createExtensionRuntime,
+  createFindTool,
+  createGrepTool,
+  createLsTool,
+  createReadTool,
+  createWriteTool,
+  ModelRegistry,
+  SessionManager,
+} from "@mariozechner/pi-coding-agent";
 import { generateWorkerSummaryFromSession } from "./summaries.js";
-import type { WorkerRuntimeState } from "./types.js";
+import type {
+  RuntimeRunContext,
+  RuntimeRunPreflightContext,
+  RuntimeRunResult,
+  WorkerRunStatus,
+  WorkerRuntimeState,
+} from "./types.js";
 
 export interface WorkerRuntimeHandle extends WorkerRuntimeState {
   sessionFile: string | null;
@@ -31,6 +51,148 @@ function buildRuntimeHandle(sessionManager: SessionManager, lastResumedAt: strin
     lastResumedAt,
     sessionFile,
   };
+}
+
+function createMinimalRunResourceLoader() {
+  return {
+    getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () =>
+      [
+        "You are a headless pi-conductor worker run.",
+        "Operate non-interactively.",
+        "Use the available coding tools to inspect and modify the repository in the current working tree.",
+        "Do not rely on slash commands, interactive UI affordances, or conductor management tools.",
+        "Be concise and finish with a short outcome summary.",
+      ].join(" "),
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function getModelRegistryForRun(): ModelRegistry {
+  const authStorage = AuthStorage.create();
+  return ModelRegistry.create(authStorage);
+}
+
+export function mapStopReasonToRunOutcome(stopReason: StopReason): {
+  status: WorkerRunStatus;
+  errorMessage: string | null;
+} {
+  switch (stopReason) {
+    case "stop":
+      return { status: "success", errorMessage: null };
+    case "aborted":
+      return { status: "aborted", errorMessage: null };
+    case "error":
+      return { status: "error", errorMessage: null };
+    case "length":
+      return {
+        status: "error",
+        errorMessage:
+          "Run stopped because the model hit its output or context length limit; shorten or split the task and retry",
+      };
+    case "toolUse":
+      return {
+        status: "error",
+        errorMessage: "Run ended unexpectedly while waiting on tool execution",
+      };
+    default: {
+      const exhaustive: never = stopReason;
+      return exhaustive;
+    }
+  }
+}
+
+export function extractFinalAssistantText(messages: unknown[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index] as { role?: string; content?: unknown } | undefined;
+    if (message?.role !== "assistant") {
+      continue;
+    }
+    const content = Array.isArray(message.content) ? message.content : [];
+    const text = content
+      .flatMap((item) => {
+        const block = item as { type?: string; text?: string };
+        return block.type === "text" && typeof block.text === "string" ? [block.text.trim()] : [];
+      })
+      .filter(Boolean)
+      .join("\n\n")
+      .trim();
+    return text || null;
+  }
+  return null;
+}
+
+export async function preflightWorkerRunRuntime(_input: RuntimeRunPreflightContext): Promise<void> {
+  const modelRegistry = getModelRegistryForRun();
+  if (modelRegistry.getAvailable().length === 0) {
+    throw new Error("No usable model or provider configuration is available for pi-conductor worker runs");
+  }
+}
+
+export async function runWorkerPromptRuntime(input: RuntimeRunContext): Promise<RuntimeRunResult> {
+  const sessionManager = SessionManager.open(input.sessionFile);
+  const modelRegistry = getModelRegistryForRun();
+  const authStorage = modelRegistry.authStorage;
+  const resourceLoader = createMinimalRunResourceLoader();
+  const { session } = await createAgentSession({
+    cwd: input.worktreePath,
+    sessionManager,
+    authStorage,
+    modelRegistry,
+    resourceLoader,
+    tools: [
+      createReadTool(input.worktreePath),
+      createBashTool(input.worktreePath),
+      createEditTool(input.worktreePath),
+      createWriteTool(input.worktreePath),
+      createGrepTool(input.worktreePath),
+      createFindTool(input.worktreePath),
+      createLsTool(input.worktreePath),
+    ],
+  });
+
+  try {
+    await session.bindExtensions({});
+    await input.onSessionReady?.(session.sessionId);
+
+    await session.prompt(input.task);
+
+    const finalAssistant = [...session.messages].reverse().find((message) => message.role === "assistant");
+    if (!finalAssistant || finalAssistant.role !== "assistant") {
+      return {
+        status: "error",
+        finalText: null,
+        errorMessage: "Run finished without a terminal assistant message",
+        sessionId: session.sessionId,
+      };
+    }
+
+    const mapped = mapStopReasonToRunOutcome(finalAssistant.stopReason);
+    const finalText = extractFinalAssistantText(session.messages);
+    const errorMessage = mapped.errorMessage ?? finalAssistant.errorMessage ?? null;
+
+    return {
+      status: mapped.status,
+      finalText,
+      errorMessage,
+      sessionId: session.sessionId,
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      finalText: null,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      sessionId: session.sessionId,
+    };
+  } finally {
+    session.dispose();
+  }
 }
 
 export async function createWorkerSessionRuntime(worktreePath: string): Promise<WorkerRuntimeHandle> {

--- a/packages/pi-conductor/extensions/runtime.ts
+++ b/packages/pi-conductor/extensions/runtime.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import type { StopReason } from "@mariozechner/pi-ai";
+import type { AssistantMessage, StopReason } from "@mariozechner/pi-ai";
 import {
   AuthStorage,
   createAgentSession,
@@ -108,10 +108,16 @@ export function mapStopReasonToRunOutcome(stopReason: StopReason): {
   }
 }
 
+function isAssistantMessage(message: unknown): message is AssistantMessage {
+  return typeof message === "object" && message !== null && "role" in message && message.role === "assistant";
+}
+
 export function extractFinalAssistantText(messages: unknown[]): string | null {
   // AgentSession.messages contains a broader union than the final assistant-shaping
-  // logic actually needs here, so keep the helper intentionally loose and extract
-  // only the assistant text blocks conductor cares about for operator summaries.
+  // logic actually needs here, and it may include non-assistant or even malformed
+  // entries from conductor's point of view. Keep the helper intentionally loose
+  // and extract only the assistant text blocks conductor cares about for operator
+  // summaries.
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index] as { role?: string; content?: unknown } | undefined;
     if (message?.role !== "assistant") {
@@ -173,8 +179,8 @@ export async function runWorkerPromptRuntime(input: RuntimeRunContext): Promise<
 
     await session.prompt(input.task);
 
-    const finalAssistant = [...session.messages].reverse().find((message) => message.role === "assistant");
-    if (!finalAssistant || finalAssistant.role !== "assistant") {
+    const finalAssistant = [...session.messages].reverse().find(isAssistantMessage);
+    if (!finalAssistant) {
       return {
         status: "error",
         finalText: null,

--- a/packages/pi-conductor/extensions/runtime.ts
+++ b/packages/pi-conductor/extensions/runtime.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { StopReason } from "@mariozechner/pi-ai";
 import {
@@ -109,6 +109,9 @@ export function mapStopReasonToRunOutcome(stopReason: StopReason): {
 }
 
 export function extractFinalAssistantText(messages: unknown[]): string | null {
+  // AgentSession.messages contains a broader union than the final assistant-shaping
+  // logic actually needs here, so keep the helper intentionally loose and extract
+  // only the assistant text blocks conductor cares about for operator summaries.
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index] as { role?: string; content?: unknown } | undefined;
     if (message?.role !== "assistant") {
@@ -128,7 +131,14 @@ export function extractFinalAssistantText(messages: unknown[]): string | null {
   return null;
 }
 
-export async function preflightWorkerRunRuntime(_input: RuntimeRunPreflightContext): Promise<void> {
+export async function preflightWorkerRunRuntime(input: RuntimeRunPreflightContext): Promise<void> {
+  if (!input.worktreePath || !existsSync(input.worktreePath)) {
+    throw new Error("Worker worktree is not available for a foreground run");
+  }
+  if (!input.sessionFile || !existsSync(input.sessionFile)) {
+    throw new Error("Worker session file is not available for a foreground run");
+  }
+
   const modelRegistry = getModelRegistryForRun();
   if (modelRegistry.getAvailable().length === 0) {
     throw new Error("No usable model or provider configuration is available for pi-conductor worker runs");

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -11,6 +11,24 @@ function getWorkerHealth(worker: WorkerRecord): "healthy" | "stale" | "broken" {
   return "healthy";
 }
 
+function formatLastRunStatus(worker: WorkerRecord): string {
+  if (!worker.lastRun) {
+    return "lastRun=none";
+  }
+
+  const status =
+    worker.lastRun.status ??
+    (worker.lifecycle === "running" && worker.lastRun.finishedAt === null ? "running" : "unknown");
+  return [
+    `lastRun=${status}`,
+    `runTask=${worker.lastRun.task}`,
+    `runSessionId=${worker.lastRun.sessionId ?? "none"}`,
+    `runStartedAt=${worker.lastRun.startedAt}`,
+    `runFinishedAt=${worker.lastRun.finishedAt ?? "none"}`,
+    `runError=${worker.lastRun.errorMessage ?? "none"}`,
+  ].join(" ");
+}
+
 export function formatRunStatus(run: RunRecord): string {
   const lines = [
     `projectKey: ${run.projectKey}`,
@@ -39,7 +57,8 @@ export function formatRunStatus(run: RunRecord): string {
         `commit=${worker.pr.commitSucceeded} ` +
         `push=${worker.pr.pushSucceeded} ` +
         `prAttempted=${worker.pr.prCreationAttempted} ` +
-        `summary=${summary}`,
+        `summary=${summary} ` +
+        `${formatLastRunStatus(worker)}`,
     );
   }
 

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -302,26 +302,32 @@ export function startWorkerRun(
 
 export function setWorkerRunSessionId(run: RunRecord, workerId: string, sessionId: string): RunRecord {
   let found = false;
+  let workerHadLastRun = true;
   const now = new Date().toISOString();
   const workers = run.workers.map((worker) => {
     if (worker.workerId !== workerId) {
       return worker;
     }
     found = true;
+    if (!worker.lastRun) {
+      workerHadLastRun = false;
+      return worker;
+    }
     return {
       ...worker,
-      lastRun: worker.lastRun
-        ? {
-            ...worker.lastRun,
-            sessionId,
-          }
-        : worker.lastRun,
+      lastRun: {
+        ...worker.lastRun,
+        sessionId,
+      },
       updatedAt: now,
     };
   });
 
   if (!found) {
     throw new Error(`Worker ${workerId} not found`);
+  }
+  if (!workerHadLastRun) {
+    throw new Error(`Worker ${workerId} does not have an active lastRun to attach a session id to`);
   }
 
   return {

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -1,7 +1,15 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { RunRecord, WorkerLifecycleState, WorkerPrState, WorkerRecord, WorkerRuntimeState } from "./types.js";
+import type {
+  RunRecord,
+  WorkerLastRun,
+  WorkerLifecycleState,
+  WorkerPrState,
+  WorkerRecord,
+  WorkerRunStatus,
+  WorkerRuntimeState,
+} from "./types.js";
 
 function getConductorRoot(): string {
   const override = process.env.PI_CONDUCTOR_HOME?.trim();
@@ -31,6 +39,7 @@ function normalizeWorkerRecord(worker: WorkerRecord): WorkerRecord {
       sessionId: null,
       lastResumedAt: null,
     },
+    lastRun: worker.lastRun ?? null,
   };
 }
 
@@ -87,6 +96,7 @@ export function createWorkerRecord(input: {
     currentTask: null,
     lifecycle: "idle",
     recoverable: false,
+    lastRun: null,
     summary: {
       text: null,
       updatedAt: null,
@@ -240,6 +250,119 @@ export function setWorkerPrState(run: RunRecord, workerId: string, pr: Partial<W
   if (!found) {
     throw new Error(`Worker ${workerId} not found`);
   }
+  return {
+    ...run,
+    workers,
+    updatedAt: now,
+  };
+}
+
+export function startWorkerRun(
+  run: RunRecord,
+  workerId: string,
+  input: { task: string; sessionId: string | null },
+): RunRecord {
+  let found = false;
+  const now = new Date().toISOString();
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    return {
+      ...worker,
+      currentTask: input.task,
+      lifecycle: "running" as const,
+      lastRun: {
+        task: input.task,
+        status: null,
+        startedAt: now,
+        finishedAt: null,
+        errorMessage: null,
+        sessionId: input.sessionId,
+      },
+      summary: {
+        ...worker.summary,
+        stale: worker.summary.text !== null ? true : worker.summary.stale,
+      },
+      updatedAt: now,
+    };
+  });
+
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
+
+  return {
+    ...run,
+    workers,
+    updatedAt: now,
+  };
+}
+
+export function setWorkerRunSessionId(run: RunRecord, workerId: string, sessionId: string): RunRecord {
+  let found = false;
+  const now = new Date().toISOString();
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    return {
+      ...worker,
+      lastRun: worker.lastRun
+        ? {
+            ...worker.lastRun,
+            sessionId,
+          }
+        : worker.lastRun,
+      updatedAt: now,
+    };
+  });
+
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
+
+  return {
+    ...run,
+    workers,
+    updatedAt: now,
+  };
+}
+
+export function finishWorkerRun(
+  run: RunRecord,
+  workerId: string,
+  input: { status: WorkerRunStatus; errorMessage?: string | null },
+): RunRecord {
+  let found = false;
+  const now = new Date().toISOString();
+  const workers = run.workers.map((worker) => {
+    if (worker.workerId !== workerId) {
+      return worker;
+    }
+    found = true;
+    const lastRun: WorkerLastRun = {
+      task: worker.lastRun?.task ?? worker.currentTask ?? "(unknown task)",
+      status: input.status,
+      startedAt: worker.lastRun?.startedAt ?? now,
+      finishedAt: now,
+      errorMessage: input.errorMessage ?? null,
+      sessionId: worker.lastRun?.sessionId ?? null,
+    };
+    return {
+      ...worker,
+      lifecycle: input.status === "error" ? ("blocked" as const) : ("idle" as const),
+      lastRun,
+      updatedAt: now,
+    };
+  });
+
+  if (!found) {
+    throw new Error(`Worker ${workerId} not found`);
+  }
+
   return {
     ...run,
     workers,

--- a/packages/pi-conductor/extensions/types.ts
+++ b/packages/pi-conductor/extensions/types.ts
@@ -1,4 +1,5 @@
 export type WorkerLifecycleState = "idle" | "running" | "blocked" | "ready_for_pr" | "done" | "broken";
+export type WorkerRunStatus = "success" | "error" | "aborted";
 
 export interface WorkerSummary {
   text: string | null;
@@ -20,6 +21,15 @@ export interface WorkerRuntimeState {
   lastResumedAt: string | null;
 }
 
+export interface WorkerLastRun {
+  task: string;
+  status: WorkerRunStatus | null;
+  startedAt: string;
+  finishedAt: string | null;
+  errorMessage: string | null;
+  sessionId: string | null;
+}
+
 export interface WorkerRecord {
   workerId: string;
   name: string;
@@ -30,6 +40,7 @@ export interface WorkerRecord {
   currentTask: string | null;
   lifecycle: WorkerLifecycleState;
   recoverable: boolean;
+  lastRun: WorkerLastRun | null;
   summary: WorkerSummary;
   pr: WorkerPrState;
   createdAt: string;
@@ -43,4 +54,31 @@ export interface RunRecord {
   workers: WorkerRecord[];
   createdAt: string;
   updatedAt: string;
+}
+
+export interface WorkerRunResult {
+  workerName: string;
+  status: WorkerRunStatus;
+  finalText: string | null;
+  errorMessage: string | null;
+  sessionId: string | null;
+}
+
+export interface RuntimeRunResult {
+  status: WorkerRunStatus;
+  finalText: string | null;
+  errorMessage: string | null;
+  sessionId: string | null;
+}
+
+export interface RuntimeRunContext {
+  worktreePath: string;
+  sessionFile: string;
+  task: string;
+  onSessionReady?: (sessionId: string) => void | Promise<void>;
+}
+
+export interface RuntimeRunPreflightContext {
+  worktreePath: string;
+  sessionFile: string;
 }


### PR DESCRIPTION
## Summary
- add durable single-worker foreground run support to `pi-conductor` with persisted `lastRun` state and `AgentSession`-based execution
- expose `/conductor run` and `conductor_run`, plus run-aware lifecycle and status reporting
- cover the new run flow with storage, runtime, orchestration, command, status, and lifecycle tests

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `npm run check`
- `npm run test`