### PR TITLE
feat(pi-conductor): add gate approval dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7659,7 +7659,7 @@
     },
     "packages/pi-conductor": {
       "name": "@feniix/pi-conductor",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@feniix/worktrees-core": "^1.1.0"

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -184,7 +184,7 @@ conductor_list_artifacts({ taskId })
 conductor_read_artifact({ artifactId, maxBytes: 8192 })
 ```
 
-Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI command `/conductor human decide gate <gate-id> [reason]`, which shows gate context, readiness, evidence, timeline, and a human review packet before approve/reject/cancel.
+Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI command `/conductor human decide gate <gate-id> [reason]`, which opens a keyboard-navigable approval dashboard when the host supports custom UI components, falls back to standard dialogs otherwise, and shows gate context, readiness, evidence, timeline, and a human review packet before approve/reject/cancel.
 
 ## Development
 

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -118,10 +118,89 @@ describe("trusted human gate approval UI", () => {
 
     expect(dashboardText).toContain("Conductor Gate Approval Dashboard");
     expect(dashboardText).toContain("Evidence:");
+    expect(dashboardText).toContain("Review Packet Preview");
+    expect(dashboardText).toContain("Conductor Human Review Packet");
     expect(dashboardText).toContain("Approve gate");
     expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
       status: "approved",
       resolutionReason: "approved from dashboard",
+    });
+  });
+
+  it("supports custom dashboard packet, reject, and cancel actions", async () => {
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Review before merge",
+    });
+    const customChoices = ["packet", "reject"];
+    let editorText = "";
+
+    await conductorHandler()(`human decide gate ${gate.gateId}`, {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          const choice = customChoices.shift();
+          if (choice === "packet") component.handleInput?.("\r");
+          if (choice === "reject") {
+            component.handleInput?.("\u001b[B");
+            component.handleInput?.("\u001b[B");
+            component.handleInput?.("\r");
+          }
+          return result;
+        },
+        editor: async (_title: string, text: string) => {
+          editorText = text;
+          return text;
+        },
+        input: async () => "rejected after packet review",
+        notify: () => undefined,
+      },
+    });
+
+    expect(editorText).toContain("Conductor Human Review Packet");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
+      status: "rejected",
+      resolutionReason: "rejected after packet review",
+    });
+
+    const cancelGate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "Cancel?",
+    });
+    await conductorHandler()(`human decide gate ${cancelGate.gateId}`, {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          component.handleInput?.("\u001b");
+          return result;
+        },
+        notify: () => undefined,
+      },
+    });
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === cancelGate.gateId)).toMatchObject({
+      status: "open",
     });
   });
 

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -9,6 +9,14 @@ type CommandContext = {
   cwd: string;
   hasUI: boolean;
   ui: {
+    custom?: <T>(
+      factory: (
+        tui: { requestRender: () => void },
+        theme: { fg: (_color: string, text: string) => string; bold: (text: string) => string },
+        keybindings: unknown,
+        done: (value: T) => void,
+      ) => { render: (width: number) => string[]; handleInput?: (data: string) => void },
+    ) => Promise<T | undefined> | T | undefined;
     select?: (message: string) => Promise<string> | string;
     editor?: (title: string, text: string) => Promise<string | undefined> | string | undefined;
     input?: (message: string, placeholder?: string) => Promise<string | undefined> | string | undefined;
@@ -74,6 +82,47 @@ describe("trusted human gate approval UI", () => {
     expect(prompt).toContain("Review Packet");
     const resolved = getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId);
     expect(resolved).toMatchObject({ status: "approved", resolvedBy: { type: "human" } });
+  });
+
+  it("prefers a custom approval dashboard when the host supports it", async () => {
+    const gate = createGateForRepo(repoRoot, {
+      type: "destructive_cleanup",
+      resourceRefs: {},
+      requestedDecision: "Approve cleanup?",
+    });
+    let dashboardText = "";
+
+    await conductorHandler()(`human decide gate ${gate.gateId}`, {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          dashboardText = component.render(100).join("\n");
+          component.handleInput?.("\u001b[B");
+          component.handleInput?.("\r");
+          return result;
+        },
+        input: async () => "approved from dashboard",
+        notify: () => undefined,
+      },
+    });
+
+    expect(dashboardText).toContain("Conductor Gate Approval Dashboard");
+    expect(dashboardText).toContain("Evidence:");
+    expect(dashboardText).toContain("Approve gate");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "approved from dashboard",
+    });
   });
 
   it("can open a full review packet and collect a decision reason", async () => {

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -103,6 +103,7 @@ function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
     ? `${readiness.status}: blockers=${readiness.blockers.length} warnings=${readiness.warnings.length}`
     : "not applicable";
   const eventLines = timeline.events.slice(-10).map((event) => `#${event.sequence} ${event.type}`);
+  const reviewPreview = review.markdown.split("\n").slice(0, 8);
   const dashboardLines = [
     "Conductor Gate Approval",
     `Gate: ${gate.gateId}`,
@@ -113,6 +114,9 @@ function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
     `Evidence: tasks=${evidence.tasks.length} runs=${evidence.runs.length} gates=${evidence.gates.length} artifacts=${evidence.artifacts.length}`,
     evidence.pr?.url ? `PR: ${evidence.pr.url}` : null,
     eventLines.length > 0 ? `Recent: ${eventLines.slice(-3).join(" | ")}` : "Recent: no recent events",
+    "",
+    "Review Packet Preview",
+    ...reviewPreview,
   ].filter((line): line is string => line !== null);
   const prompt = [
     `Gate ${gate.gateId}`,
@@ -176,27 +180,32 @@ async function chooseHumanGateAction(
       let selected = 0;
       return {
         render(width: number): string[] {
-          const body = [
-            fg("accent", bold("Conductor Gate Approval Dashboard")),
+          const plainLines = [
+            "Conductor Gate Approval Dashboard",
             "",
             ...review.dashboardLines,
             "",
-            fg("dim", "Decision"),
+            "Decision",
             ...actions.map((item, index) => {
               const prefix = index === selected ? "› " : "  ";
-              const label = index === selected ? fg("accent", item.label) : item.label;
-              return `${prefix}${label} — ${item.description}`;
+              return `${prefix}${item.label} — ${item.description}`;
             }),
             "",
-            fg("dim", "↑↓ navigate • enter choose • esc cancel"),
+            "↑↓ navigate • enter choose • esc cancel",
           ];
-          return body.map((line) => truncatePlainLine(line, width));
+          return plainLines.map((line, index) => {
+            const truncated = truncatePlainLine(line, width);
+            if (index === 0) return fg("accent", bold(truncated));
+            if (truncated === "Decision" || truncated.startsWith("↑↓")) return fg("dim", truncated);
+            if (truncated.startsWith("› ")) return fg("accent", truncated);
+            return truncated;
+          });
         },
         handleInput(data: string): void {
           if (data === "\u001b[A" || data === "k") selected = (selected + actions.length - 1) % actions.length;
           if (data === "\u001b[B" || data === "j") selected = (selected + 1) % actions.length;
           if (data === "\r" || data === "\n") done(actions[selected]?.value ?? "cancel");
-          if (data === "\u001b") done("cancel");
+          if (data === "\u001b" || data === "\u0003") done("cancel");
           tui.requestRender();
         },
         invalidate(): void {},

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -78,10 +78,17 @@ function shouldRegisterLegacyWorkerTools(): boolean {
   return process.env.PI_CONDUCTOR_ENABLE_LEGACY_WORKER_TOOLS === "1";
 }
 
-function buildHumanGatePrompt(cwd: string, gateId: string): string {
+type HumanGateDashboardAction = "packet" | "approve" | "reject" | "cancel";
+
+type HumanGateReview = {
+  prompt: string;
+  dashboardLines: string[];
+};
+
+function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
   const run = getOrCreateRunForRepo(cwd);
   const gate = run.gates.find((entry) => entry.gateId === gateId);
-  if (!gate) return `Gate not found: ${gateId}`;
+  if (!gate) return { prompt: `Gate not found: ${gateId}`, dashboardLines: [`Gate not found: ${gateId}`] };
   const refs = gate.resourceRefs;
   const evidence = buildEvidenceBundleForRepo(cwd, { ...refs, purpose: "handoff", includeEvents: true });
   const timeline = buildResourceTimelineForRepo(cwd, { ...refs, gateId, limit: 10, includeArtifacts: true });
@@ -92,7 +99,22 @@ function buildHumanGatePrompt(cwd: string, gateId: string): string {
       : refs.taskId
         ? checkReadinessForRepo(cwd, { ...refs, purpose: "task_review" })
         : null;
-  return [
+  const readinessText = readiness
+    ? `${readiness.status}: blockers=${readiness.blockers.length} warnings=${readiness.warnings.length}`
+    : "not applicable";
+  const eventLines = timeline.events.slice(-10).map((event) => `#${event.sequence} ${event.type}`);
+  const dashboardLines = [
+    "Conductor Gate Approval",
+    `Gate: ${gate.gateId}`,
+    `Type: ${gate.type}`,
+    `Operation: ${gate.operation}`,
+    `Decision: ${gate.requestedDecision}`,
+    `Readiness: ${readinessText}`,
+    `Evidence: tasks=${evidence.tasks.length} runs=${evidence.runs.length} gates=${evidence.gates.length} artifacts=${evidence.artifacts.length}`,
+    evidence.pr?.url ? `PR: ${evidence.pr.url}` : null,
+    eventLines.length > 0 ? `Recent: ${eventLines.slice(-3).join(" | ")}` : "Recent: no recent events",
+  ].filter((line): line is string => line !== null);
+  const prompt = [
     `Gate ${gate.gateId}`,
     `Type: ${gate.type}`,
     `Status: ${gate.status}`,
@@ -103,25 +125,91 @@ function buildHumanGatePrompt(cwd: string, gateId: string): string {
     gate.expiresAt ? `Expires: ${gate.expiresAt}` : null,
     "",
     "Readiness",
-    readiness
-      ? `${readiness.status}: blockers=${readiness.blockers.length} warnings=${readiness.warnings.length}`
-      : "not applicable",
+    readinessText,
     "",
     "Evidence",
     `tasks=${evidence.tasks.length} runs=${evidence.runs.length} gates=${evidence.gates.length} artifacts=${evidence.artifacts.length}`,
     evidence.pr?.url ? `pr=${evidence.pr.url}` : null,
     "",
     "Timeline",
-    timeline.events
-      .slice(-10)
-      .map((event) => `#${event.sequence} ${event.type}`)
-      .join("\n") || "no recent events",
+    eventLines.join("\n") || "no recent events",
     "",
     "Review Packet",
     review.markdown,
   ]
     .filter((line): line is string => line !== null)
     .join("\n");
+  return { prompt, dashboardLines };
+}
+
+function truncatePlainLine(line: string, width: number): string {
+  if (width <= 0) return "";
+  return line.length > width ? `${line.slice(0, Math.max(0, width - 1))}…` : line;
+}
+
+async function chooseHumanGateAction(
+  ui: {
+    custom?: <T>(
+      factory: (
+        tui: { requestRender: () => void },
+        theme: unknown,
+        keybindings: unknown,
+        done: (value: T) => void,
+      ) => unknown,
+      options?: unknown,
+    ) => Promise<T | undefined> | T | undefined;
+    select?: (message: string, options: string[]) => Promise<string | undefined> | string | undefined;
+  },
+  review: HumanGateReview,
+): Promise<HumanGateDashboardAction | null> {
+  if (ui.custom) {
+    const action = await ui.custom<HumanGateDashboardAction>((tui, theme, _keybindings, done) => {
+      const themeLike = theme as { fg?: (color: string, text: string) => string; bold?: (text: string) => string };
+      const fg = (color: string, text: string) => themeLike.fg?.(color, text) ?? text;
+      const bold = (text: string) => themeLike.bold?.(text) ?? text;
+      const actions: Array<{ value: HumanGateDashboardAction; label: string; description: string }> = [
+        { value: "packet", label: "Open review packet", description: "Inspect the full markdown review packet" },
+        { value: "approve", label: "Approve gate", description: "Allow the gated operation to proceed" },
+        { value: "reject", label: "Reject gate", description: "Block the gated operation" },
+        { value: "cancel", label: "Cancel", description: "Leave the gate open" },
+      ];
+      let selected = 0;
+      return {
+        render(width: number): string[] {
+          const body = [
+            fg("accent", bold("Conductor Gate Approval Dashboard")),
+            "",
+            ...review.dashboardLines,
+            "",
+            fg("dim", "Decision"),
+            ...actions.map((item, index) => {
+              const prefix = index === selected ? "› " : "  ";
+              const label = index === selected ? fg("accent", item.label) : item.label;
+              return `${prefix}${label} — ${item.description}`;
+            }),
+            "",
+            fg("dim", "↑↓ navigate • enter choose • esc cancel"),
+          ];
+          return body.map((line) => truncatePlainLine(line, width));
+        },
+        handleInput(data: string): void {
+          if (data === "\u001b[A" || data === "k") selected = (selected + actions.length - 1) % actions.length;
+          if (data === "\u001b[B" || data === "j") selected = (selected + 1) % actions.length;
+          if (data === "\r" || data === "\n") done(actions[selected]?.value ?? "cancel");
+          if (data === "\u001b") done("cancel");
+          tui.requestRender();
+        },
+        invalidate(): void {},
+      };
+    });
+    return action ?? null;
+  }
+
+  const decision = await ui.select?.(review.prompt, ["Open review packet", "Approve gate", "Reject gate", "Cancel"]);
+  if (decision === "Open review packet") return "packet";
+  if (decision === "Approve gate") return "approve";
+  if (decision === "Reject gate") return "reject";
+  return decision ? "cancel" : null;
 }
 
 function getStatusText(cwd: string): string {
@@ -169,27 +257,32 @@ export default function conductorExtension(pi: ExtensionAPI) {
           ctx.ui.notify(`gate not found: ${gateId}`, "error");
           return;
         }
-        const prompt = buildHumanGatePrompt(ctx.cwd, gateId);
+        const review = buildHumanGateReview(ctx.cwd, gateId);
         const ui = ctx.ui as unknown as {
+          custom?: <T>(
+            factory: (
+              tui: { requestRender: () => void },
+              theme: unknown,
+              keybindings: unknown,
+              done: (value: T) => void,
+            ) => unknown,
+            options?: unknown,
+          ) => Promise<T | undefined> | T | undefined;
           select?: (message: string, options: string[]) => Promise<string | undefined> | string | undefined;
           editor?: (title: string, text: string) => Promise<string | undefined> | string | undefined;
           input?: (message: string, placeholder?: string) => Promise<string | undefined> | string | undefined;
           notify: typeof ctx.ui.notify;
         };
-        let decision = await ui.select?.(prompt, ["Open review packet", "Approve gate", "Reject gate", "Cancel"]);
-        if (decision === "Open review packet") {
-          await ui.editor?.("Conductor gate review packet", prompt);
-          decision = await ui.select?.("Choose a trusted human decision for the conductor gate", [
-            "Approve gate",
-            "Reject gate",
-            "Cancel",
-          ]);
+        let action = await chooseHumanGateAction(ui, review);
+        while (action === "packet") {
+          await ui.editor?.("Conductor gate review packet", review.prompt);
+          action = await chooseHumanGateAction(ui, review);
         }
-        if (!decision || decision === "Cancel") {
+        if (!action || action === "cancel") {
           ctx.ui.notify(`left gate ${gateId} open`, "info");
           return;
         }
-        const status = decision === "Reject gate" ? "rejected" : "approved";
+        const status = action === "reject" ? "rejected" : "approved";
         const defaultReason = status === "approved" ? "Approved from pi conductor UI" : "Rejected from pi conductor UI";
         const reason =
           humanApproval[2]?.trim() ||

--- a/packages/pi-conductor/package.json
+++ b/packages/pi-conductor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-conductor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Long-lived multi-session worker orchestration for pi with git worktrees, resumable sessions, and PR flows",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary
- Adds a keyboard-navigable trusted human approval dashboard for `/conductor human decide gate <gate-id>` when the host supports custom UI components.
- Keeps the existing safe fallback dialog flow for hosts without `ctx.ui.custom`.
- Updates tests and README coverage for the dashboard approval path.

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [x] Documentation
- [ ] Refactor

## Test plan
- [x] `npx vitest run packages/pi-conductor/__tests__/human-approval-ui.test.ts packages/pi-conductor/__tests__/static-safety.test.ts`
- [x] `npx vitest run packages/pi-conductor/__tests__`
- [x] `npm run typecheck`
- [x] `npx biome ci packages/pi-conductor`