### PR TITLE
feat(pi-conductor): add human gate queue browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7659,7 +7659,7 @@
     },
     "packages/pi-conductor": {
       "name": "@feniix/pi-conductor",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@feniix/worktrees-core": "^1.1.0"

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -52,6 +52,7 @@ Primary inspection/debug UX is the `/conductor` command group:
 /conductor status
 /conductor history [project|worker|task|run|gate|artifact] [id] [--after N] [--limit N]
 /conductor reconcile [--dry-run]
+/conductor human gates [reason]
 /conductor human approve gate <gate-id> [reason]
 /conductor human decide gate <gate-id> [reason]
 ```
@@ -184,7 +185,7 @@ conductor_list_artifacts({ taskId })
 conductor_read_artifact({ artifactId, maxBytes: 8192 })
 ```
 
-Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI command `/conductor human decide gate <gate-id> [reason]`, which opens a keyboard-navigable approval dashboard when the host supports custom UI components, falls back to standard dialogs otherwise, and shows gate context, readiness, evidence, timeline, and a human review packet before approve/reject/cancel.
+Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI commands `/conductor human gates` or `/conductor human decide gate <gate-id> [reason]`, which open keyboard-navigable gate queue and approval dashboards when the host supports custom UI components, fall back to standard dialogs otherwise, and show gate context, readiness, blockers, warnings, artifact summaries, timeline, and a human review packet before approve/reject/cancel.
 
 ## Development
 

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -185,7 +185,7 @@ conductor_list_artifacts({ taskId })
 conductor_read_artifact({ artifactId, maxBytes: 8192 })
 ```
 
-Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI commands `/conductor human gates` or `/conductor human decide gate <gate-id> [reason]`, which open keyboard-navigable gate queue and approval dashboards when the host supports custom UI components, fall back to standard dialogs otherwise, and show gate context, readiness, blockers, warnings, artifact summaries, timeline, and a human review packet before approve/reject/cancel.
+Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI commands `/conductor human gates` or `/conductor human decide gate <gate-id> [reason]`, which open keyboard-navigable gate queue and approval dashboards when the host supports custom UI components, fall back to standard dialogs otherwise, and show gate context, readiness, blockers, warnings, artifact summaries, timeline, and a human review packet before approve/reject/cancel. Non-UI automation should inspect gates and evidence with `conductor_list_gates`, `conductor_prepare_human_review`, `conductor_check_readiness`, `conductor_build_evidence_bundle`, and `conductor_resource_timeline`; trusted high-risk approval still requires the interactive human command path.
 
 ## Development
 

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -44,6 +44,13 @@ describe("runConductorCommand", () => {
     expect(text).toContain("workers: 0");
   });
 
+  it("documents trusted human gate commands in usage", async () => {
+    const text = await runConductorCommand(repoDir, "help");
+    expect(text).toContain("/conductor human gates [reason]");
+    expect(text).toContain("/conductor human decide gate <gate-id> [reason]");
+    expect(text).toContain("conductor_list_gates");
+  });
+
   it("supports resource-shaped worker and task inspection commands", async () => {
     const workerText = await runConductorCommand(repoDir, "create worker backend");
     expect(workerText).toContain("created worker backend");

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -18,7 +18,7 @@ type CommandContext = {
         done: (value: T) => void,
       ) => { render: (width: number) => string[]; handleInput?: (data: string) => void },
     ) => Promise<T | undefined> | T | undefined;
-    select?: (message: string) => Promise<string> | string;
+    select?: (message: string, options?: string[]) => Promise<string> | string;
     editor?: (title: string, text: string) => Promise<string | undefined> | string | undefined;
     input?: (message: string, placeholder?: string) => Promise<string | undefined> | string | undefined;
     notify: (message: string, level?: string) => void;
@@ -154,7 +154,6 @@ describe("trusted human gate approval UI", () => {
             },
           );
           dashboardText = component.render(100).join("\n");
-          component.handleInput?.("\u001b[B");
           component.handleInput?.("\r");
           return result;
         },
@@ -211,7 +210,6 @@ describe("trusted human gate approval UI", () => {
             component.handleInput?.("\r");
           } else {
             dashboardText = component.render(100).join("\n");
-            component.handleInput?.("\u001b[B");
             component.handleInput?.("\r");
           }
           return result;
@@ -265,6 +263,36 @@ describe("trusted human gate approval UI", () => {
     });
   });
 
+  it("reports empty and cancelled gate queues without changing gates", async () => {
+    const notifications: string[] = [];
+
+    await conductorHandler()("human gates", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: { notify: (message: string) => notifications.push(message) },
+    });
+    expect(notifications).toContain("no open conductor gates");
+
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "Choose?",
+    });
+    await conductorHandler()("human gates", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        select: async () => "Cancel",
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+
+    expect(notifications).toContain("left conductor gates unchanged");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
+      status: "open",
+    });
+  });
+
   it("reports missing UI capabilities instead of silently no-oping", async () => {
     const gate = createGateForRepo(repoRoot, {
       type: "needs_input",
@@ -284,6 +312,44 @@ describe("trusted human gate approval UI", () => {
     expect(notifications).toContain("trusted human gate approval requires a selectable UI");
     expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
       status: "open",
+    });
+  });
+
+  it("does not offer packet action when editor support is unavailable", async () => {
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Review before merge",
+    });
+    let dashboardText = "";
+
+    await conductorHandler()(`human decide gate ${gate.gateId}`, {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          dashboardText = component.render(100).join("\n");
+          component.handleInput?.("\r");
+          return result;
+        },
+        input: async () => "approved without packet action",
+        notify: () => undefined,
+      },
+    });
+
+    expect(dashboardText).not.toContain("Open review packet");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "approved without packet action",
     });
   });
 
@@ -392,6 +458,29 @@ describe("trusted human gate approval UI", () => {
       status: "approved",
       resolutionReason: "reviewed full packet",
     });
+  });
+
+  it("rejects non-UI human gate commands with machine-detectable failures", async () => {
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "Needs UI",
+    });
+
+    await expect(
+      conductorHandler()(`human decide gate ${gate.gateId}`, {
+        cwd: repoRoot,
+        hasUI: false,
+        ui: { notify: () => undefined },
+      }),
+    ).rejects.toThrow("trusted human gate approval requires interactive UI");
+    await expect(
+      conductorHandler()("human gates", {
+        cwd: repoRoot,
+        hasUI: false,
+        ui: { notify: () => undefined },
+      }),
+    ).rejects.toThrow("trusted human gate queue requires interactive UI");
   });
 
   it("can reject or cancel a gate without exposing model human approval tools", async () => {

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -118,12 +118,71 @@ describe("trusted human gate approval UI", () => {
 
     expect(dashboardText).toContain("Conductor Gate Approval Dashboard");
     expect(dashboardText).toContain("Evidence:");
+    expect(dashboardText).toContain("Artifacts: none");
     expect(dashboardText).toContain("Review Packet Preview");
     expect(dashboardText).toContain("Conductor Human Review Packet");
     expect(dashboardText).toContain("Approve gate");
     expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
       status: "approved",
       resolutionReason: "approved from dashboard",
+    });
+  });
+
+  it("can browse open gates before opening the approval dashboard", async () => {
+    const firstGate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "First gate",
+    });
+    const secondGate = createGateForRepo(repoRoot, {
+      type: "destructive_cleanup",
+      resourceRefs: {},
+      requestedDecision: "Second gate",
+    });
+    let queueText = "";
+    let dashboardText = "";
+    let customCall = 0;
+
+    await conductorHandler()("human gates approved from queue", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          customCall += 1;
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          if (customCall === 1) {
+            queueText = component.render(100).join("\n");
+            component.handleInput?.("\u001b[B");
+            component.handleInput?.("\r");
+          } else {
+            dashboardText = component.render(100).join("\n");
+            component.handleInput?.("\u001b[B");
+            component.handleInput?.("\r");
+          }
+          return result;
+        },
+        notify: () => undefined,
+      },
+    });
+
+    expect(queueText).toContain("Conductor Gate Queue");
+    expect(queueText).toContain(firstGate.gateId);
+    expect(queueText).toContain(secondGate.gateId);
+    expect(dashboardText).toContain("Conductor Gate Approval Dashboard");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === secondGate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "approved from queue",
+    });
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === firstGate.gateId)).toMatchObject({
+      status: "open",
     });
   });
 

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -2,8 +2,9 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createGateForRepo, getOrCreateRunForRepo } from "../extensions/conductor.js";
+import { createGateForRepo, createTaskForRepo, getOrCreateRunForRepo } from "../extensions/conductor.js";
 import conductorExtension from "../extensions/index.js";
+import { addConductorArtifact, writeRun } from "../extensions/storage.js";
 
 type CommandContext = {
   cwd: string;
@@ -82,6 +83,52 @@ describe("trusted human gate approval UI", () => {
     expect(prompt).toContain("Review Packet");
     const resolved = getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId);
     expect(resolved).toMatchObject({ status: "approved", resolvedBy: { type: "human" } });
+  });
+
+  it("shows concrete artifact and blocker details in the approval dashboard", async () => {
+    const task = createTaskForRepo(repoRoot, { title: "Review me", prompt: "Needs review" });
+    writeRun(
+      addConductorArtifact(getOrCreateRunForRepo(repoRoot), {
+        artifactId: "artifact-dashboard-test",
+        type: "test_result",
+        ref: "test://dashboard",
+        resourceRefs: { taskId: task.taskId },
+        producer: { type: "test", id: "test" },
+      }),
+    );
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: { taskId: task.taskId },
+      requestedDecision: "Review task?",
+    });
+    let dashboardText = "";
+
+    await conductorHandler()(`human decide gate ${gate.gateId}`, {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          dashboardText = component.render(120).join("\n");
+          component.handleInput?.("\u001b");
+          return result;
+        },
+        notify: () => undefined,
+      },
+    });
+
+    expect(dashboardText).toContain("artifact-dashboard-test");
+    expect(dashboardText).toContain("test://dashboard");
+    expect(dashboardText).toContain("Blockers:");
+    expect(dashboardText).toContain("Task is ready");
   });
 
   it("prefers a custom approval dashboard when the host supports it", async () => {
@@ -182,6 +229,60 @@ describe("trusted human gate approval UI", () => {
       resolutionReason: "approved from queue",
     });
     expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === firstGate.gateId)).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("can browse open gates with the select fallback", async () => {
+    const firstGate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "First gate",
+    });
+    const secondGate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Second gate",
+    });
+    const secondLabel = `${secondGate.gateId} [${secondGate.type}] ${secondGate.requestedDecision}`;
+    const decisions = [secondLabel, "Approve gate"];
+
+    await conductorHandler()("human gates approved via select", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        select: async () => decisions.shift() ?? "Cancel",
+        notify: () => undefined,
+      },
+    });
+
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === secondGate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "approved via select",
+    });
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === firstGate.gateId)).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("reports missing UI capabilities instead of silently no-oping", async () => {
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "Needs UI",
+    });
+    const notifications: string[] = [];
+
+    await conductorHandler()(`human decide gate ${gate.gateId}`, {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+
+    expect(notifications).toContain("trusted human gate approval requires a selectable UI");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
       status: "open",
     });
   });

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -34,6 +34,10 @@ function getUsage(): string {
     "  /conductor status",
     "  /conductor history [project|worker|task|run|gate|artifact] [id] [--after N] [--limit N]",
     "  /conductor reconcile [--dry-run]",
+    "  /conductor human gates [reason]",
+    "  /conductor human decide gate <gate-id> [reason]",
+    "  /conductor human approve gate <gate-id> [reason]",
+    "  human gate commands require interactive UI; non-UI callers should inspect with conductor_list_gates and evidence/readiness tools",
   ].join("\n");
 }
 

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -191,6 +191,10 @@ async function chooseHumanGateAction(
   ui: HumanGateDecisionUi,
   review: HumanGateReview,
 ): Promise<HumanGateDashboardAction | null> {
+  if (!ui.custom && !ui.select) {
+    ui.notify("trusted human gate approval requires a selectable UI", "error");
+    return null;
+  }
   if (ui.custom) {
     const action = await ui.custom<HumanGateDashboardAction>((tui, theme, _keybindings, done) => {
       const themeLike = theme as { fg?: (color: string, text: string) => string; bold?: (text: string) => string };
@@ -248,6 +252,10 @@ async function chooseHumanGateAction(
 
 async function chooseHumanGateFromQueue(ui: HumanGateDecisionUi, gates: GateRecord[]): Promise<string | null> {
   if (gates.length === 0) return null;
+  if (!ui.custom && !ui.select) {
+    ui.notify("trusted human gate queue requires a selectable UI", "error");
+    return null;
+  }
   if (ui.custom) {
     const gateId = await ui.custom<string | null>((tui, theme, _keybindings, done) => {
       const themeLike = theme as { fg?: (color: string, text: string) => string; bold?: (text: string) => string };
@@ -301,7 +309,11 @@ async function resolveHumanGateDecision(
   const review = buildHumanGateReview(cwd, gateId);
   let action = await chooseHumanGateAction(ui, review);
   while (action === "packet") {
-    await ui.editor?.("Conductor gate review packet", review.prompt);
+    if (!ui.editor) {
+      ui.notify("opening the conductor review packet requires editor UI support", "error");
+      return;
+    }
+    await ui.editor("Conductor gate review packet", review.prompt);
     action = await chooseHumanGateAction(ui, review);
   }
   if (!action || action === "cancel") {
@@ -357,7 +369,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
       const humanQueue = trimmed.match(/^human\s+gates(?:\s+(.+))?$/);
       if (humanQueue) {
         if (!ctx.hasUI) {
-          console.log("error: trusted human gate queue requires interactive UI");
+          console.error("error: trusted human gate queue requires interactive UI");
           return;
         }
         const run = getOrCreateRunForRepo(ctx.cwd);
@@ -379,7 +391,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
       if (humanApproval) {
         const gateId = humanApproval[1];
         if (!ctx.hasUI) {
-          console.log("error: trusted human gate approval requires interactive UI");
+          console.error("error: trusted human gate approval requires interactive UI");
           return;
         }
         const run = getOrCreateRunForRepo(ctx.cwd);

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -59,6 +59,7 @@ import {
   readRun,
   writeRun,
 } from "./storage.js";
+import type { ArtifactRecord, GateRecord } from "./types.js";
 
 function findRepoRoot(cwd: string): string | null {
   try {
@@ -85,6 +86,26 @@ type HumanGateReview = {
   dashboardLines: string[];
 };
 
+type HumanGateDecisionUi = {
+  custom?: <T>(
+    factory: (
+      tui: { requestRender: () => void },
+      theme: unknown,
+      keybindings: unknown,
+      done: (value: T) => void,
+    ) => unknown,
+    options?: unknown,
+  ) => Promise<T | undefined> | T | undefined;
+  select?: (message: string, options: string[]) => Promise<string | undefined> | string | undefined;
+  editor?: (title: string, text: string) => Promise<string | undefined> | string | undefined;
+  input?: (message: string, placeholder?: string) => Promise<string | undefined> | string | undefined;
+  notify: (message: string, level?: string) => void;
+};
+
+function summarizeArtifact(artifact: ArtifactRecord): string {
+  return `${artifact.artifactId} [${artifact.type}] ${artifact.ref}`;
+}
+
 function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
   const run = getOrCreateRunForRepo(cwd);
   const gate = run.gates.find((entry) => entry.gateId === gateId);
@@ -93,6 +114,7 @@ function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
   const evidence = buildEvidenceBundleForRepo(cwd, { ...refs, purpose: "handoff", includeEvents: true });
   const timeline = buildResourceTimelineForRepo(cwd, { ...refs, gateId, limit: 10, includeArtifacts: true });
   const review = prepareHumanReviewForRepo(cwd, { objectiveId: refs.objectiveId, taskId: refs.taskId });
+  const artifacts = evidence.artifacts.slice(-5).map(summarizeArtifact);
   const readiness =
     gate.operation === "create_worker_pr" || gate.type === "ready_for_pr"
       ? checkReadinessForRepo(cwd, { ...refs, purpose: "pr_readiness" })
@@ -102,6 +124,8 @@ function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
   const readinessText = readiness
     ? `${readiness.status}: blockers=${readiness.blockers.length} warnings=${readiness.warnings.length}`
     : "not applicable";
+  const blockerLines = readiness?.blockers.map((blocker) => `- ${blocker.message}`) ?? [];
+  const warningLines = readiness?.warnings.map((warning) => `- ${warning.message}`) ?? [];
   const eventLines = timeline.events.slice(-10).map((event) => `#${event.sequence} ${event.type}`);
   const reviewPreview = review.markdown.split("\n").slice(0, 8);
   const dashboardLines = [
@@ -114,6 +138,9 @@ function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
     `Evidence: tasks=${evidence.tasks.length} runs=${evidence.runs.length} gates=${evidence.gates.length} artifacts=${evidence.artifacts.length}`,
     evidence.pr?.url ? `PR: ${evidence.pr.url}` : null,
     eventLines.length > 0 ? `Recent: ${eventLines.slice(-3).join(" | ")}` : "Recent: no recent events",
+    artifacts.length > 0 ? `Artifacts: ${artifacts.slice(0, 3).join(" | ")}` : "Artifacts: none",
+    blockerLines.length > 0 ? `Blockers: ${blockerLines.slice(0, 2).join(" | ")}` : null,
+    warningLines.length > 0 ? `Warnings: ${warningLines.slice(0, 2).join(" | ")}` : null,
     "",
     "Review Packet Preview",
     ...reviewPreview,
@@ -138,6 +165,15 @@ function buildHumanGateReview(cwd: string, gateId: string): HumanGateReview {
     "Timeline",
     eventLines.join("\n") || "no recent events",
     "",
+    "Artifacts",
+    artifacts.join("\n") || "none",
+    "",
+    "Blockers",
+    blockerLines.join("\n") || "none",
+    "",
+    "Warnings",
+    warningLines.join("\n") || "none",
+    "",
     "Review Packet",
     review.markdown,
   ]
@@ -152,18 +188,7 @@ function truncatePlainLine(line: string, width: number): string {
 }
 
 async function chooseHumanGateAction(
-  ui: {
-    custom?: <T>(
-      factory: (
-        tui: { requestRender: () => void },
-        theme: unknown,
-        keybindings: unknown,
-        done: (value: T) => void,
-      ) => unknown,
-      options?: unknown,
-    ) => Promise<T | undefined> | T | undefined;
-    select?: (message: string, options: string[]) => Promise<string | undefined> | string | undefined;
-  },
+  ui: HumanGateDecisionUi,
   review: HumanGateReview,
 ): Promise<HumanGateDashboardAction | null> {
   if (ui.custom) {
@@ -221,6 +246,82 @@ async function chooseHumanGateAction(
   return decision ? "cancel" : null;
 }
 
+async function chooseHumanGateFromQueue(ui: HumanGateDecisionUi, gates: GateRecord[]): Promise<string | null> {
+  if (gates.length === 0) return null;
+  if (ui.custom) {
+    const gateId = await ui.custom<string | null>((tui, theme, _keybindings, done) => {
+      const themeLike = theme as { fg?: (color: string, text: string) => string; bold?: (text: string) => string };
+      const fg = (color: string, text: string) => themeLike.fg?.(color, text) ?? text;
+      const bold = (text: string) => themeLike.bold?.(text) ?? text;
+      let selected = 0;
+      return {
+        render(width: number): string[] {
+          const plainLines = [
+            "Conductor Gate Queue",
+            "",
+            ...gates.map((gate, index) => {
+              const prefix = index === selected ? "› " : "  ";
+              return `${prefix}${gate.gateId} [${gate.type}] ${gate.operation} — ${gate.requestedDecision}`;
+            }),
+            "",
+            "↑↓ navigate • enter review • esc cancel",
+          ];
+          return plainLines.map((line, index) => {
+            const truncated = truncatePlainLine(line, width);
+            if (index === 0) return fg("accent", bold(truncated));
+            if (truncated.startsWith("› ")) return fg("accent", truncated);
+            if (truncated.startsWith("↑↓")) return fg("dim", truncated);
+            return truncated;
+          });
+        },
+        handleInput(data: string): void {
+          if (data === "\u001b[A" || data === "k") selected = (selected + gates.length - 1) % gates.length;
+          if (data === "\u001b[B" || data === "j") selected = (selected + 1) % gates.length;
+          if (data === "\r" || data === "\n") done(gates[selected]?.gateId ?? null);
+          if (data === "\u001b" || data === "\u0003") done(null);
+          tui.requestRender();
+        },
+        invalidate(): void {},
+      };
+    });
+    return gateId ?? null;
+  }
+  const labels = gates.map((gate) => `${gate.gateId} [${gate.type}] ${gate.requestedDecision}`);
+  const selected = await ui.select?.("Select a conductor gate to review", [...labels, "Cancel"]);
+  if (!selected || selected === "Cancel") return null;
+  return gates[labels.indexOf(selected)]?.gateId ?? null;
+}
+
+async function resolveHumanGateDecision(
+  cwd: string,
+  gateId: string,
+  reasonArg: string | undefined,
+  ui: HumanGateDecisionUi,
+) {
+  const review = buildHumanGateReview(cwd, gateId);
+  let action = await chooseHumanGateAction(ui, review);
+  while (action === "packet") {
+    await ui.editor?.("Conductor gate review packet", review.prompt);
+    action = await chooseHumanGateAction(ui, review);
+  }
+  if (!action || action === "cancel") {
+    ui.notify(`left gate ${gateId} open`, "info");
+    return;
+  }
+  const status = action === "reject" ? "rejected" : "approved";
+  const defaultReason = status === "approved" ? "Approved from pi conductor UI" : "Rejected from pi conductor UI";
+  const reason =
+    reasonArg?.trim() || (await ui.input?.("Reason for this gate decision", defaultReason)) || defaultReason;
+  const humanId = `ui:${process.env.USER ?? "local-human"}`;
+  const resolved = resolveGateFromTrustedHumanForRepo(cwd, {
+    gateId,
+    status,
+    humanId,
+    resolutionReason: reason,
+  });
+  ui.notify(`${status} gate ${resolved.gateId} as trusted human`, "info");
+}
+
 function getStatusText(cwd: string): string {
   const repoRoot = findRepoRoot(cwd);
   if (!repoRoot) {
@@ -253,6 +354,27 @@ export default function conductorExtension(pi: ExtensionAPI) {
     description: "Manage pi-conductor workers and PR preparation",
     handler: async (args, ctx) => {
       const trimmed = args.trim();
+      const humanQueue = trimmed.match(/^human\s+gates(?:\s+(.+))?$/);
+      if (humanQueue) {
+        if (!ctx.hasUI) {
+          console.log("error: trusted human gate queue requires interactive UI");
+          return;
+        }
+        const run = getOrCreateRunForRepo(ctx.cwd);
+        const gates = run.gates.filter((gate) => gate.status === "open");
+        if (gates.length === 0) {
+          ctx.ui.notify("no open conductor gates", "info");
+          return;
+        }
+        const ui = ctx.ui as unknown as HumanGateDecisionUi;
+        const gateId = await chooseHumanGateFromQueue(ui, gates);
+        if (!gateId) {
+          ctx.ui.notify("left conductor gates unchanged", "info");
+          return;
+        }
+        await resolveHumanGateDecision(ctx.cwd, gateId, humanQueue[1], ui);
+        return;
+      }
       const humanApproval = trimmed.match(/^human\s+(?:approve|decide)\s+gate\s+(\S+)(?:\s+(.+))?$/);
       if (humanApproval) {
         const gateId = humanApproval[1];
@@ -266,45 +388,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
           ctx.ui.notify(`gate not found: ${gateId}`, "error");
           return;
         }
-        const review = buildHumanGateReview(ctx.cwd, gateId);
-        const ui = ctx.ui as unknown as {
-          custom?: <T>(
-            factory: (
-              tui: { requestRender: () => void },
-              theme: unknown,
-              keybindings: unknown,
-              done: (value: T) => void,
-            ) => unknown,
-            options?: unknown,
-          ) => Promise<T | undefined> | T | undefined;
-          select?: (message: string, options: string[]) => Promise<string | undefined> | string | undefined;
-          editor?: (title: string, text: string) => Promise<string | undefined> | string | undefined;
-          input?: (message: string, placeholder?: string) => Promise<string | undefined> | string | undefined;
-          notify: typeof ctx.ui.notify;
-        };
-        let action = await chooseHumanGateAction(ui, review);
-        while (action === "packet") {
-          await ui.editor?.("Conductor gate review packet", review.prompt);
-          action = await chooseHumanGateAction(ui, review);
-        }
-        if (!action || action === "cancel") {
-          ctx.ui.notify(`left gate ${gateId} open`, "info");
-          return;
-        }
-        const status = action === "reject" ? "rejected" : "approved";
-        const defaultReason = status === "approved" ? "Approved from pi conductor UI" : "Rejected from pi conductor UI";
-        const reason =
-          humanApproval[2]?.trim() ||
-          (await ui.input?.("Reason for this gate decision", defaultReason)) ||
-          defaultReason;
-        const humanId = `ui:${process.env.USER ?? "local-human"}`;
-        const resolved = resolveGateFromTrustedHumanForRepo(ctx.cwd, {
-          gateId,
-          status,
-          humanId,
-          resolutionReason: reason,
-        });
-        ctx.ui.notify(`${status} gate ${resolved.gateId} as trusted human`, "info");
+        await resolveHumanGateDecision(ctx.cwd, gateId, humanApproval[2], ctx.ui as unknown as HumanGateDecisionUi);
         return;
       }
       const text = await runConductorCommand(ctx.cwd, args);

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -190,7 +190,9 @@ function truncatePlainLine(line: string, width: number): string {
 async function chooseHumanGateAction(
   ui: HumanGateDecisionUi,
   review: HumanGateReview,
+  input: { includePacket?: boolean } = {},
 ): Promise<HumanGateDashboardAction | null> {
+  const includePacket = input.includePacket ?? true;
   if (!ui.custom && !ui.select) {
     ui.notify("trusted human gate approval requires a selectable UI", "error");
     return null;
@@ -201,7 +203,15 @@ async function chooseHumanGateAction(
       const fg = (color: string, text: string) => themeLike.fg?.(color, text) ?? text;
       const bold = (text: string) => themeLike.bold?.(text) ?? text;
       const actions: Array<{ value: HumanGateDashboardAction; label: string; description: string }> = [
-        { value: "packet", label: "Open review packet", description: "Inspect the full markdown review packet" },
+        ...(includePacket
+          ? [
+              {
+                value: "packet" as const,
+                label: "Open review packet",
+                description: "Inspect the full markdown review packet",
+              },
+            ]
+          : []),
         { value: "approve", label: "Approve gate", description: "Allow the gated operation to proceed" },
         { value: "reject", label: "Reject gate", description: "Block the gated operation" },
         { value: "cancel", label: "Cancel", description: "Leave the gate open" },
@@ -243,7 +253,12 @@ async function chooseHumanGateAction(
     return action ?? null;
   }
 
-  const decision = await ui.select?.(review.prompt, ["Open review packet", "Approve gate", "Reject gate", "Cancel"]);
+  const decision = await ui.select?.(review.prompt, [
+    ...(includePacket ? ["Open review packet"] : []),
+    "Approve gate",
+    "Reject gate",
+    "Cancel",
+  ]);
   if (decision === "Open review packet") return "packet";
   if (decision === "Approve gate") return "approve";
   if (decision === "Reject gate") return "reject";
@@ -307,14 +322,10 @@ async function resolveHumanGateDecision(
   ui: HumanGateDecisionUi,
 ) {
   const review = buildHumanGateReview(cwd, gateId);
-  let action = await chooseHumanGateAction(ui, review);
+  let action = await chooseHumanGateAction(ui, review, { includePacket: Boolean(ui.editor) });
   while (action === "packet") {
-    if (!ui.editor) {
-      ui.notify("opening the conductor review packet requires editor UI support", "error");
-      return;
-    }
-    await ui.editor("Conductor gate review packet", review.prompt);
-    action = await chooseHumanGateAction(ui, review);
+    await ui.editor?.("Conductor gate review packet", review.prompt);
+    action = await chooseHumanGateAction(ui, review, { includePacket: Boolean(ui.editor) });
   }
   if (!action || action === "cancel") {
     ui.notify(`left gate ${gateId} open`, "info");
@@ -369,8 +380,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
       const humanQueue = trimmed.match(/^human\s+gates(?:\s+(.+))?$/);
       if (humanQueue) {
         if (!ctx.hasUI) {
-          console.error("error: trusted human gate queue requires interactive UI");
-          return;
+          throw new Error("trusted human gate queue requires interactive UI");
         }
         const run = getOrCreateRunForRepo(ctx.cwd);
         const gates = run.gates.filter((gate) => gate.status === "open");
@@ -391,8 +401,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
       if (humanApproval) {
         const gateId = humanApproval[1];
         if (!ctx.hasUI) {
-          console.error("error: trusted human gate approval requires interactive UI");
-          return;
+          throw new Error("trusted human gate approval requires interactive UI");
         }
         const run = getOrCreateRunForRepo(ctx.cwd);
         const gate = run.gates.find((entry) => entry.gateId === gateId);

--- a/packages/pi-conductor/package.json
+++ b/packages/pi-conductor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-conductor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Long-lived multi-session worker orchestration for pi with git worktrees, resumable sessions, and PR flows",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary
- Adds `/conductor human gates` for browsing open conductor gates before launching the trusted approval dashboard.
- Deepens the approval dashboard with artifact summaries, readiness blockers/warnings, timeline context, and review packet preview.
- Hardens UI fallback behavior and documents automation-safe non-UI inspection tools.

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [x] Documentation
- [ ] Refactor

## Test plan
- [x] `npx vitest run packages/pi-conductor/__tests__/human-approval-ui.test.ts packages/pi-conductor/__tests__/static-safety.test.ts`
- [x] `npx vitest run packages/pi-conductor/__tests__`
- [x] `npm run typecheck`
- [x] `npx biome ci packages/pi-conductor`