### PR TITLE
feat(pi-conductor): add persistent gate dashboard

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -40,6 +40,7 @@ Agent-native local control plane for Pi worker orchestration.
 - Optional `pi-subagents` backend detection. Conductor remains canonical state owner; `pi-subagents` dispatch fails closed unless a trusted host injects an explicit dispatcher.
 - Granular instrumentation events for scheduler ticks/actions, backend dispatch, worker recovery/resume/summary/cleanup, git commit/push, PR creation, gates, runs, tasks, objectives, artifacts, and lifecycle changes.
 - Legacy worker model tools are hidden by default; legacy slash mutations hard-error with guidance toward resource-native tools.
+- Packaged workflow skills help parent agents use conductor safely for objective orchestration and gate review.
 
 ## Command surface
 
@@ -53,6 +54,7 @@ Primary inspection/debug UX is the `/conductor` command group:
 /conductor history [project|worker|task|run|gate|artifact] [id] [--after N] [--limit N]
 /conductor reconcile [--dry-run]
 /conductor human gates [reason]
+/conductor human dashboard [reason]
 /conductor human approve gate <gate-id> [reason]
 /conductor human decide gate <gate-id> [reason]
 ```
@@ -111,6 +113,11 @@ Resource/control-plane tools:
 - `conductor_push_worker`
 - `conductor_create_worker_pr`
 
+Packaged skills:
+
+- `conductor-orchestration` — plan, schedule, execute, monitor, and review durable conductor objectives.
+- `conductor-gate-review` — inspect gate evidence/readiness and route high-risk decisions through trusted human UI.
+
 Runtime-injected child tools, available only inside native worker task runs:
 
 - `conductor_child_progress`
@@ -150,9 +157,11 @@ The native backend uses curated tools and explicit conductor child tools. Backen
 
 Optional backend adapters such as `pi-subagents` may be used later, but they do not own canonical state. The current `pi-subagents` adapter fails closed unless a trusted host injects an explicit dispatcher; injected dispatch records backend run evidence through `backend.dispatch_*` events while conductor owns task/run state.
 
-## LLM orchestration examples
+## Workflow recipes
 
-Create and plan an objective, then let conductor take the safest next step:
+### Plan and execute an objective
+
+Create and plan an objective, inspect the dependency graph, preview safe scheduler decisions, then execute intentionally:
 
 ```text
 conductor_create_objective({ title: "Ship feature", prompt: "Implement and verify the feature" })
@@ -164,13 +173,17 @@ conductor_scheduler_tick({ maxActions: 4, maxRuns: 2, fairness: "round_robin", p
 conductor_schedule_objective({ objectiveId, maxConcurrency: 2, policy: "safe" })
 ```
 
-Inspect dependency scheduling for parallel-safe work:
+### Inspect dependency scheduling for parallel-safe work
+
+Use the objective DAG before dispatching multi-task work or when explaining why a task is not runnable yet:
 
 ```text
 conductor_objective_dag({ objectiveId })
 ```
 
-Assess a task before review or PR preparation:
+### Review a task before PR preparation
+
+Build a compact review packet, check readiness, and gather evidence before asking a human to approve a risky operation:
 
 ```text
 conductor_assess_task({ taskId, requireTestEvidence: true })
@@ -178,14 +191,38 @@ conductor_diagnose_blockers({ taskId })
 conductor_prepare_human_review({ objectiveId })
 ```
 
-Read bounded local artifact evidence safely:
+### Read bounded local artifact evidence safely
+
+Use artifact IDs/refs from evidence bundles or timelines; conductor rejects unsafe traversal, symlink escapes, binary reads, and unsupported refs:
 
 ```text
 conductor_list_artifacts({ taskId })
 conductor_read_artifact({ artifactId, maxBytes: 8192 })
 ```
 
-Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI commands `/conductor human gates` or `/conductor human decide gate <gate-id> [reason]`, which open keyboard-navigable gate queue and approval dashboards when the host supports custom UI components, fall back to standard dialogs otherwise, and show gate context, readiness, blockers, warnings, artifact summaries, timeline, and a human review packet before approve/reject/cancel. Non-UI automation should inspect gates and evidence with `conductor_list_gates`, `conductor_prepare_human_review`, `conductor_check_readiness`, `conductor_build_evidence_bundle`, and `conductor_resource_timeline`; trusted high-risk approval still requires the interactive human command path.
+### Review and resolve human gates
+
+Human-only approval gates such as `ready_for_pr` and `destructive_cleanup` are surfaced for review but are not safe autonomous actions. The model-facing `conductor_resolve_gate` tool resolves only as a parent agent. Trusted human decisions come through the interactive host/UI commands `/conductor human dashboard`, `/conductor human gates`, or `/conductor human decide gate <gate-id> [reason]`.
+
+Prefer the persistent dashboard when multiple gates may need review:
+
+```text
+/conductor human dashboard
+```
+
+The dashboard keeps the gate queue open across decisions, refreshes after each approval/rejection, shows the selected gate's readiness, blockers, warnings, artifacts, recent timeline, and review packet preview, and then opens the full approval dashboard for approve/reject/cancel. Hosts with custom UI support get keyboard navigation; other interactive hosts fall back to standard select/editor/input dialogs.
+
+For non-UI automation, inspect gates and evidence without approving as a human:
+
+```text
+conductor_list_gates({ status: "open" })
+conductor_prepare_human_review({ taskId })
+conductor_check_readiness({ taskId, purpose: "pr_readiness" })
+conductor_build_evidence_bundle({ taskId, includeEvents: true })
+conductor_resource_timeline({ taskId, includeArtifacts: true })
+```
+
+Trusted high-risk approval still requires the interactive human command path.
 
 ## Development
 

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -54,7 +54,7 @@ Primary inspection/debug UX is the `/conductor` command group:
 /conductor history [project|worker|task|run|gate|artifact] [id] [--after N] [--limit N]
 /conductor reconcile [--dry-run]
 /conductor human gates [reason]
-/conductor human dashboard [reason]
+/conductor human dashboard
 /conductor human approve gate <gate-id> [reason]
 /conductor human decide gate <gate-id> [reason]
 ```

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -47,6 +47,7 @@ describe("runConductorCommand", () => {
   it("documents trusted human gate commands in usage", async () => {
     const text = await runConductorCommand(repoDir, "help");
     expect(text).toContain("/conductor human gates [reason]");
+    expect(text).toContain("/conductor human dashboard [reason]");
     expect(text).toContain("/conductor human decide gate <gate-id> [reason]");
     expect(text).toContain("conductor_list_gates");
   });

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -47,7 +47,7 @@ describe("runConductorCommand", () => {
   it("documents trusted human gate commands in usage", async () => {
     const text = await runConductorCommand(repoDir, "help");
     expect(text).toContain("/conductor human gates [reason]");
-    expect(text).toContain("/conductor human dashboard [reason]");
+    expect(text).toContain("/conductor human dashboard");
     expect(text).toContain("/conductor human decide gate <gate-id> [reason]");
     expect(text).toContain("conductor_list_gates");
   });

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -2,7 +2,12 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createGateForRepo, createTaskForRepo, getOrCreateRunForRepo } from "../extensions/conductor.js";
+import {
+  createGateForRepo,
+  createTaskForRepo,
+  getOrCreateRunForRepo,
+  resolveGateFromTrustedHumanForRepo,
+} from "../extensions/conductor.js";
 import conductorExtension from "../extensions/index.js";
 import { addConductorArtifact, writeRun } from "../extensions/storage.js";
 
@@ -246,7 +251,7 @@ describe("trusted human gate approval UI", () => {
     let customCall = 0;
     const notifications: string[] = [];
 
-    await conductorHandler()("human dashboard accepted in dashboard", {
+    await conductorHandler()("human dashboard", {
       cwd: repoRoot,
       hasUI: true,
       ui: {
@@ -266,15 +271,17 @@ describe("trusted human gate approval UI", () => {
           if (text.includes("Conductor Gate Queue Dashboard")) {
             component.handleInput?.("\r");
           } else {
+            component.handleInput?.("\u001b[B");
             component.handleInput?.("\r");
           }
           return result;
         },
+        input: async () => "accepted in dashboard",
         notify: (message: string) => notifications.push(message),
       },
     });
 
-    expect(customCall).toBe(4);
+    expect(customCall).toBeGreaterThanOrEqual(4);
     expect(dashboardTexts[0]).toContain("Selected Gate");
     expect(dashboardTexts[0]).toContain(firstGate.gateId);
     expect(dashboardTexts[2]).toContain(secondGate.gateId);
@@ -286,6 +293,174 @@ describe("trusted human gate approval UI", () => {
     expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === secondGate.gateId)).toMatchObject({
       status: "approved",
       resolutionReason: "accepted in dashboard",
+    });
+  });
+
+  it("does not approve dashboard gates on repeated enter without explicit approval navigation", async () => {
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Review gate",
+    });
+
+    await conductorHandler()("human dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          component.handleInput?.("\r");
+          component.handleInput?.("\r");
+          return result;
+        },
+        notify: () => undefined,
+      },
+    });
+
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("can browse open gates with the dashboard select fallback", async () => {
+    const firstGate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "First gate",
+    });
+    const secondGate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Second gate",
+    });
+    const firstLabel = `${firstGate.gateId} [${firstGate.type}] ${firstGate.requestedDecision}`;
+    const secondLabel = `${secondGate.gateId} [${secondGate.type}] ${secondGate.requestedDecision}`;
+    const decisions = [secondLabel, "Approve gate", firstLabel, "Cancel"];
+    const notifications: string[] = [];
+
+    await conductorHandler()("human dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        select: async () => decisions.shift() ?? "Cancel",
+        input: async () => "approved via dashboard select",
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === secondGate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "approved via dashboard select",
+    });
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === firstGate.gateId)).toMatchObject({
+      status: "open",
+    });
+    expect(notifications).toContain("resolved 1 conductor gate(s)");
+  });
+
+  it("reports empty, cancelled, and missing-capability dashboard states", async () => {
+    const notifications: string[] = [];
+
+    await conductorHandler()("human dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: { notify: (message: string) => notifications.push(message) },
+    });
+    expect(notifications).toContain("no open conductor gates");
+
+    const gate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "Choose?",
+    });
+    await conductorHandler()("human dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        select: async () => "Cancel",
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+    expect(notifications).toContain("left conductor gates unchanged");
+
+    await conductorHandler()("human dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+    expect(notifications).toContain("trusted human gate queue requires a selectable UI");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === gate.gateId)).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("refreshes the dashboard when a selected gate becomes stale before resolution", async () => {
+    const staleGate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Stale gate",
+    });
+    const nextGate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "Next gate",
+    });
+    let customCall = 0;
+    const notifications: string[] = [];
+
+    await conductorHandler()("human dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          customCall += 1;
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          const text = component.render(120).join("\n");
+          if (text.includes("Conductor Gate Queue Dashboard")) {
+            component.handleInput?.("\r");
+          } else if (customCall === 2) {
+            resolveGateFromTrustedHumanForRepo(repoRoot, {
+              gateId: staleGate.gateId,
+              status: "approved",
+              humanId: "ui:other-human",
+              resolutionReason: "resolved elsewhere",
+            });
+            component.handleInput?.("\u001b[B");
+            component.handleInput?.("\r");
+          } else {
+            component.handleInput?.("\u001b");
+          }
+          return result;
+        },
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+
+    expect(notifications.some((message) => message.includes("changed before decision"))).toBe(true);
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === staleGate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "resolved elsewhere",
+    });
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === nextGate.gateId)).toMatchObject({
+      status: "open",
     });
   });
 

--- a/packages/pi-conductor/__tests__/human-approval-ui.test.ts
+++ b/packages/pi-conductor/__tests__/human-approval-ui.test.ts
@@ -231,6 +231,64 @@ describe("trusted human gate approval UI", () => {
     });
   });
 
+  it("keeps a persistent human dashboard open across multiple gate decisions", async () => {
+    const firstGate = createGateForRepo(repoRoot, {
+      type: "needs_input",
+      resourceRefs: {},
+      requestedDecision: "First gate",
+    });
+    const secondGate = createGateForRepo(repoRoot, {
+      type: "needs_review",
+      resourceRefs: {},
+      requestedDecision: "Second gate",
+    });
+    const dashboardTexts: string[] = [];
+    let customCall = 0;
+    const notifications: string[] = [];
+
+    await conductorHandler()("human dashboard accepted in dashboard", {
+      cwd: repoRoot,
+      hasUI: true,
+      ui: {
+        custom: async <T>(factory: Parameters<NonNullable<CommandContext["ui"]["custom"]>>[0]) => {
+          customCall += 1;
+          let result: T | undefined;
+          const component = factory(
+            { requestRender: () => undefined },
+            { fg: (_color, text) => text, bold: (text) => text },
+            undefined,
+            (value) => {
+              result = value as T;
+            },
+          );
+          const text = component.render(120).join("\n");
+          dashboardTexts.push(text);
+          if (text.includes("Conductor Gate Queue Dashboard")) {
+            component.handleInput?.("\r");
+          } else {
+            component.handleInput?.("\r");
+          }
+          return result;
+        },
+        notify: (message: string) => notifications.push(message),
+      },
+    });
+
+    expect(customCall).toBe(4);
+    expect(dashboardTexts[0]).toContain("Selected Gate");
+    expect(dashboardTexts[0]).toContain(firstGate.gateId);
+    expect(dashboardTexts[2]).toContain(secondGate.gateId);
+    expect(notifications).toContain("resolved 2 conductor gate(s)");
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === firstGate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "accepted in dashboard",
+    });
+    expect(getOrCreateRunForRepo(repoRoot).gates.find((entry) => entry.gateId === secondGate.gateId)).toMatchObject({
+      status: "approved",
+      resolutionReason: "accepted in dashboard",
+    });
+  });
+
   it("can browse open gates with the select fallback", async () => {
     const firstGate = createGateForRepo(repoRoot, {
       type: "needs_input",
@@ -481,6 +539,13 @@ describe("trusted human gate approval UI", () => {
         ui: { notify: () => undefined },
       }),
     ).rejects.toThrow("trusted human gate queue requires interactive UI");
+    await expect(
+      conductorHandler()("human dashboard", {
+        cwd: repoRoot,
+        hasUI: false,
+        ui: { notify: () => undefined },
+      }),
+    ).rejects.toThrow("trusted human gate dashboard requires interactive UI");
   });
 
   it("can reject or cancel a gate without exposing model human approval tools", async () => {

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -77,6 +77,17 @@ describe("pi-conductor extension", () => {
     expect(extension).toContain('name: "conductor_create_worker_pr"');
   });
 
+  it("packages conductor workflow skills", () => {
+    const packageJson = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+    const gateReviewSkill = readFileSync(join(__dirname, "../skills/conductor-gate-review/SKILL.md"), "utf-8");
+    const orchestrationSkill = readFileSync(join(__dirname, "../skills/conductor-orchestration/SKILL.md"), "utf-8");
+
+    expect(packageJson.files).toContain("skills/");
+    expect(packageJson.pi.skills).toEqual(["./skills"]);
+    expect(gateReviewSkill).toContain("/conductor human dashboard");
+    expect(orchestrationSkill).toContain('policy: "execute"');
+  });
+
   it("hides legacy worker tools unless compatibility is enabled", () => {
     const names = collectToolNames();
     expect(names).toContain("conductor_get_project");

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -35,7 +35,7 @@ function getUsage(): string {
     "  /conductor history [project|worker|task|run|gate|artifact] [id] [--after N] [--limit N]",
     "  /conductor reconcile [--dry-run]",
     "  /conductor human gates [reason]",
-    "  /conductor human dashboard [reason]",
+    "  /conductor human dashboard",
     "  /conductor human decide gate <gate-id> [reason]",
     "  /conductor human approve gate <gate-id> [reason]",
     "  human gate commands require interactive UI; non-UI callers should inspect with conductor_list_gates and evidence/readiness tools",

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -35,6 +35,7 @@ function getUsage(): string {
     "  /conductor history [project|worker|task|run|gate|artifact] [id] [--after N] [--limit N]",
     "  /conductor reconcile [--dry-run]",
     "  /conductor human gates [reason]",
+    "  /conductor human dashboard [reason]",
     "  /conductor human decide gate <gate-id> [reason]",
     "  /conductor human approve gate <gate-id> [reason]",
     "  human gate commands require interactive UI; non-UI callers should inspect with conductor_list_gates and evidence/readiness tools",

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -191,9 +191,10 @@ function truncatePlainLine(line: string, width: number): string {
 async function chooseHumanGateAction(
   ui: HumanGateDecisionUi,
   review: HumanGateReview,
-  input: { includePacket?: boolean } = {},
+  input: { includePacket?: boolean; safeDefault?: boolean } = {},
 ): Promise<HumanGateDashboardAction | null> {
   const includePacket = input.includePacket ?? true;
+  const safeDefault = input.safeDefault ?? false;
   if (!ui.custom && !ui.select) {
     ui.notify("trusted human gate approval requires a selectable UI", "error");
     return null;
@@ -203,20 +204,27 @@ async function chooseHumanGateAction(
       const themeLike = theme as { fg?: (color: string, text: string) => string; bold?: (text: string) => string };
       const fg = (color: string, text: string) => themeLike.fg?.(color, text) ?? text;
       const bold = (text: string) => themeLike.bold?.(text) ?? text;
-      const actions: Array<{ value: HumanGateDashboardAction; label: string; description: string }> = [
-        ...(includePacket
-          ? [
-              {
-                value: "packet" as const,
-                label: "Open review packet",
-                description: "Inspect the full markdown review packet",
-              },
-            ]
-          : []),
+      const reviewPacketAction = includePacket
+        ? [
+            {
+              value: "packet" as const,
+              label: "Open review packet",
+              description: "Inspect the full markdown review packet",
+            },
+          ]
+        : [];
+      const decisionActions: Array<{ value: HumanGateDashboardAction; label: string; description: string }> = [
         { value: "approve", label: "Approve gate", description: "Allow the gated operation to proceed" },
         { value: "reject", label: "Reject gate", description: "Block the gated operation" },
         { value: "cancel", label: "Cancel", description: "Leave the gate open" },
       ];
+      const actions: Array<{ value: HumanGateDashboardAction; label: string; description: string }> = safeDefault
+        ? [
+            { value: "cancel", label: "Cancel", description: "Leave the gate open" },
+            ...reviewPacketAction,
+            ...decisionActions.slice(0, 2),
+          ]
+        : [...reviewPacketAction, ...decisionActions];
       let selected = 0;
       return {
         render(width: number): string[] {
@@ -254,12 +262,12 @@ async function chooseHumanGateAction(
     return action ?? null;
   }
 
-  const decision = await ui.select?.(review.prompt, [
-    ...(includePacket ? ["Open review packet"] : []),
-    "Approve gate",
-    "Reject gate",
-    "Cancel",
-  ]);
+  const decision = await ui.select?.(
+    review.prompt,
+    safeDefault
+      ? ["Cancel", ...(includePacket ? ["Open review packet"] : []), "Approve gate", "Reject gate"]
+      : [...(includePacket ? ["Open review packet"] : []), "Approve gate", "Reject gate", "Cancel"],
+  );
   if (decision === "Open review packet") return "packet";
   if (decision === "Approve gate") return "approve";
   if (decision === "Reject gate") return "reject";
@@ -282,11 +290,13 @@ async function chooseHumanGateFromQueue(
       const fg = (color: string, text: string) => themeLike.fg?.(color, text) ?? text;
       const bold = (text: string) => themeLike.bold?.(text) ?? text;
       let selected = 0;
+      const buildSelectedPreview = () => {
+        const selectedGate = gates[selected];
+        return input.cwd && selectedGate ? buildHumanGateReview(input.cwd, selectedGate.gateId) : null;
+      };
+      let selectedReview = buildSelectedPreview();
       return {
         render(width: number): string[] {
-          const selectedGate = gates[selected];
-          const selectedReview =
-            input.cwd && selectedGate ? buildHumanGateReview(input.cwd, selectedGate.gateId) : null;
           const previewLines = selectedReview
             ? ["", "Selected Gate", ...selectedReview.dashboardLines.slice(1, 14)]
             : [];
@@ -310,8 +320,10 @@ async function chooseHumanGateFromQueue(
           });
         },
         handleInput(data: string): void {
+          const previousSelected = selected;
           if (data === "\u001b[A" || data === "k") selected = (selected + gates.length - 1) % gates.length;
           if (data === "\u001b[B" || data === "j") selected = (selected + 1) % gates.length;
+          if (selected !== previousSelected) selectedReview = buildSelectedPreview();
           if (data === "\r" || data === "\n") done(gates[selected]?.gateId ?? null);
           if (data === "\u001b" || data === "\u0003") done(null);
           tui.requestRender();
@@ -332,12 +344,19 @@ async function resolveHumanGateDecision(
   gateId: string,
   reasonArg: string | undefined,
   ui: HumanGateDecisionUi,
+  input: { safeDefault?: boolean } = {},
 ): Promise<HumanGateDecisionResult> {
   const review = buildHumanGateReview(cwd, gateId);
-  let action = await chooseHumanGateAction(ui, review, { includePacket: Boolean(ui.editor) });
+  let action = await chooseHumanGateAction(ui, review, {
+    includePacket: Boolean(ui.editor),
+    safeDefault: input.safeDefault,
+  });
   while (action === "packet") {
     await ui.editor?.("Conductor gate review packet", review.prompt);
-    action = await chooseHumanGateAction(ui, review, { includePacket: Boolean(ui.editor) });
+    action = await chooseHumanGateAction(ui, review, {
+      includePacket: Boolean(ui.editor),
+      safeDefault: input.safeDefault,
+    });
   }
   if (!action || action === "cancel") {
     ui.notify(`left gate ${gateId} open`, "info");
@@ -358,7 +377,7 @@ async function resolveHumanGateDecision(
   return "resolved";
 }
 
-async function openHumanGateQueueDashboard(cwd: string, reasonArg: string | undefined, ui: HumanGateDecisionUi) {
+async function openHumanGateQueueDashboard(cwd: string, ui: HumanGateDecisionUi) {
   let resolvedCount = 0;
   while (true) {
     const run = getOrCreateRunForRepo(cwd);
@@ -378,8 +397,18 @@ async function openHumanGateQueueDashboard(cwd: string, reasonArg: string | unde
       );
       return;
     }
-    const result = await resolveHumanGateDecision(cwd, gateId, reasonArg, ui);
-    if (result !== "resolved") return;
+    let result: HumanGateDecisionResult;
+    try {
+      result = await resolveHumanGateDecision(cwd, gateId, undefined, ui, { safeDefault: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      ui.notify(`gate ${gateId} changed before decision; refreshed conductor gates (${message})`, "error");
+      continue;
+    }
+    if (result !== "resolved") {
+      if (resolvedCount > 0) ui.notify(`resolved ${resolvedCount} conductor gate(s)`, "info");
+      return;
+    }
     resolvedCount += 1;
   }
 }
@@ -416,12 +445,12 @@ export default function conductorExtension(pi: ExtensionAPI) {
     description: "Manage pi-conductor workers and PR preparation",
     handler: async (args, ctx) => {
       const trimmed = args.trim();
-      const humanDashboard = trimmed.match(/^human\s+dashboard(?:\s+(.+))?$/);
+      const humanDashboard = trimmed.match(/^human\s+dashboard$/);
       if (humanDashboard) {
         if (!ctx.hasUI) {
           throw new Error("trusted human gate dashboard requires interactive UI");
         }
-        await openHumanGateQueueDashboard(ctx.cwd, humanDashboard[1], ctx.ui as unknown as HumanGateDecisionUi);
+        await openHumanGateQueueDashboard(ctx.cwd, ctx.ui as unknown as HumanGateDecisionUi);
         return;
       }
       const humanQueue = trimmed.match(/^human\s+gates(?:\s+(.+))?$/);

--- a/packages/pi-conductor/extensions/index.ts
+++ b/packages/pi-conductor/extensions/index.ts
@@ -80,6 +80,7 @@ function shouldRegisterLegacyWorkerTools(): boolean {
 }
 
 type HumanGateDashboardAction = "packet" | "approve" | "reject" | "cancel";
+type HumanGateDecisionResult = "resolved" | "unchanged";
 
 type HumanGateReview = {
   prompt: string;
@@ -265,7 +266,11 @@ async function chooseHumanGateAction(
   return decision ? "cancel" : null;
 }
 
-async function chooseHumanGateFromQueue(ui: HumanGateDecisionUi, gates: GateRecord[]): Promise<string | null> {
+async function chooseHumanGateFromQueue(
+  ui: HumanGateDecisionUi,
+  gates: GateRecord[],
+  input: { cwd?: string } = {},
+): Promise<string | null> {
   if (gates.length === 0) return null;
   if (!ui.custom && !ui.select) {
     ui.notify("trusted human gate queue requires a selectable UI", "error");
@@ -279,13 +284,20 @@ async function chooseHumanGateFromQueue(ui: HumanGateDecisionUi, gates: GateReco
       let selected = 0;
       return {
         render(width: number): string[] {
+          const selectedGate = gates[selected];
+          const selectedReview =
+            input.cwd && selectedGate ? buildHumanGateReview(input.cwd, selectedGate.gateId) : null;
+          const previewLines = selectedReview
+            ? ["", "Selected Gate", ...selectedReview.dashboardLines.slice(1, 14)]
+            : [];
           const plainLines = [
-            "Conductor Gate Queue",
+            "Conductor Gate Queue Dashboard",
             "",
             ...gates.map((gate, index) => {
               const prefix = index === selected ? "› " : "  ";
               return `${prefix}${gate.gateId} [${gate.type}] ${gate.operation} — ${gate.requestedDecision}`;
             }),
+            ...previewLines,
             "",
             "↑↓ navigate • enter review • esc cancel",
           ];
@@ -320,7 +332,7 @@ async function resolveHumanGateDecision(
   gateId: string,
   reasonArg: string | undefined,
   ui: HumanGateDecisionUi,
-) {
+): Promise<HumanGateDecisionResult> {
   const review = buildHumanGateReview(cwd, gateId);
   let action = await chooseHumanGateAction(ui, review, { includePacket: Boolean(ui.editor) });
   while (action === "packet") {
@@ -329,7 +341,7 @@ async function resolveHumanGateDecision(
   }
   if (!action || action === "cancel") {
     ui.notify(`left gate ${gateId} open`, "info");
-    return;
+    return "unchanged";
   }
   const status = action === "reject" ? "rejected" : "approved";
   const defaultReason = status === "approved" ? "Approved from pi conductor UI" : "Rejected from pi conductor UI";
@@ -343,6 +355,33 @@ async function resolveHumanGateDecision(
     resolutionReason: reason,
   });
   ui.notify(`${status} gate ${resolved.gateId} as trusted human`, "info");
+  return "resolved";
+}
+
+async function openHumanGateQueueDashboard(cwd: string, reasonArg: string | undefined, ui: HumanGateDecisionUi) {
+  let resolvedCount = 0;
+  while (true) {
+    const run = getOrCreateRunForRepo(cwd);
+    const gates = run.gates.filter((gate) => gate.status === "open");
+    if (gates.length === 0) {
+      ui.notify(
+        resolvedCount === 0 ? "no open conductor gates" : `resolved ${resolvedCount} conductor gate(s)`,
+        "info",
+      );
+      return;
+    }
+    const gateId = await chooseHumanGateFromQueue(ui, gates, { cwd });
+    if (!gateId) {
+      ui.notify(
+        resolvedCount === 0 ? "left conductor gates unchanged" : `resolved ${resolvedCount} conductor gate(s)`,
+        "info",
+      );
+      return;
+    }
+    const result = await resolveHumanGateDecision(cwd, gateId, reasonArg, ui);
+    if (result !== "resolved") return;
+    resolvedCount += 1;
+  }
 }
 
 function getStatusText(cwd: string): string {
@@ -377,6 +416,14 @@ export default function conductorExtension(pi: ExtensionAPI) {
     description: "Manage pi-conductor workers and PR preparation",
     handler: async (args, ctx) => {
       const trimmed = args.trim();
+      const humanDashboard = trimmed.match(/^human\s+dashboard(?:\s+(.+))?$/);
+      if (humanDashboard) {
+        if (!ctx.hasUI) {
+          throw new Error("trusted human gate dashboard requires interactive UI");
+        }
+        await openHumanGateQueueDashboard(ctx.cwd, humanDashboard[1], ctx.ui as unknown as HumanGateDecisionUi);
+        return;
+      }
       const humanQueue = trimmed.match(/^human\s+gates(?:\s+(.+))?$/);
       if (humanQueue) {
         if (!ctx.hasUI) {
@@ -389,7 +436,7 @@ export default function conductorExtension(pi: ExtensionAPI) {
           return;
         }
         const ui = ctx.ui as unknown as HumanGateDecisionUi;
-        const gateId = await chooseHumanGateFromQueue(ui, gates);
+        const gateId = await chooseHumanGateFromQueue(ui, gates, { cwd: ctx.cwd });
         if (!gateId) {
           ctx.ui.notify("left conductor gates unchanged", "info");
           return;

--- a/packages/pi-conductor/package.json
+++ b/packages/pi-conductor/package.json
@@ -15,12 +15,16 @@
   "type": "module",
   "files": [
     "extensions/",
+    "skills/",
     "README.md",
     "LICENSE"
   ],
   "pi": {
     "extensions": [
       "./extensions/index.ts"
+    ],
+    "skills": [
+      "./skills"
     ]
   },
   "peerDependencies": {

--- a/packages/pi-conductor/skills/conductor-gate-review/SKILL.md
+++ b/packages/pi-conductor/skills/conductor-gate-review/SKILL.md
@@ -13,7 +13,7 @@ Use this workflow to inspect conductor gates without weakening the trusted-human
 - Treat `ready_for_pr`, `destructive_cleanup`, and `approval_required` as trusted-human decisions.
 - Use `conductor_resolve_gate` only for parent-agent decisions such as reject/cancel or non-human-safe resolutions.
 - For human approval, direct the user to the interactive host command path:
-  - `/conductor human dashboard [reason]` for a persistent gate queue/review loop.
+  - `/conductor human dashboard` for a persistent gate queue/review loop that prompts per decision.
   - `/conductor human gates [reason]` to pick one open gate from the queue.
   - `/conductor human decide gate <gate-id> [reason]` when the gate ID is already known.
 

--- a/packages/pi-conductor/skills/conductor-gate-review/SKILL.md
+++ b/packages/pi-conductor/skills/conductor-gate-review/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: conductor-gate-review
+description: Review and resolve pi-conductor gates with evidence, readiness checks, and trusted human approval. Use when a conductor task/objective is blocked on needs_input, needs_review, approval_required, ready_for_pr, or destructive_cleanup gates; when the user asks to review conductor gates; or before PR/cleanup operations that require human approval.
+---
+
+# Conductor Gate Review
+
+Use this workflow to inspect conductor gates without weakening the trusted-human boundary.
+
+## Safety rules
+
+- Never approve high-risk gates through model-callable tools.
+- Treat `ready_for_pr`, `destructive_cleanup`, and `approval_required` as trusted-human decisions.
+- Use `conductor_resolve_gate` only for parent-agent decisions such as reject/cancel or non-human-safe resolutions.
+- For human approval, direct the user to the interactive host command path:
+  - `/conductor human dashboard [reason]` for a persistent gate queue/review loop.
+  - `/conductor human gates [reason]` to pick one open gate from the queue.
+  - `/conductor human decide gate <gate-id> [reason]` when the gate ID is already known.
+
+## Workflow
+
+1. List open gates:
+   - `conductor_list_gates({ status: "open" })`
+2. Build context for the relevant gate/task/objective:
+   - `conductor_prepare_human_review({ taskId })` or `conductor_prepare_human_review({ objectiveId })`
+   - `conductor_check_readiness({ taskId, purpose: "task_review" })` or `conductor_check_readiness({ taskId, purpose: "pr_readiness" })`
+   - `conductor_build_evidence_bundle({ taskId, includeEvents: true })`
+   - `conductor_resource_timeline({ taskId, gateId, includeArtifacts: true })`
+3. Summarize what is being decided:
+   - gate type and requested decision
+   - task/objective state
+   - readiness status, blockers, and warnings
+   - notable artifacts and recent events
+4. If the decision is human/high-risk, ask the user to use the trusted UI command. Prefer:
+   - `/conductor human dashboard`
+5. After a decision, re-check:
+   - `conductor_list_gates({ status: "open" })`
+   - `conductor_next_actions({ taskId })` or `conductor_next_actions({ objectiveId })`
+
+## Output style
+
+Be concise and decision-oriented. Include exact gate IDs and exact next commands/tools.

--- a/packages/pi-conductor/skills/conductor-orchestration/SKILL.md
+++ b/packages/pi-conductor/skills/conductor-orchestration/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: conductor-orchestration
+description: Orchestrate multi-task pi-conductor objectives from planning through execution, review, and PR readiness. Use when the user wants conductor to coordinate autonomous development work, plan objectives, run scheduler ticks, inspect blockers, or prepare a PR from durable task/run evidence.
+---
+
+# Conductor Orchestration
+
+Use this workflow when `pi-conductor` should coordinate work as a durable local control plane rather than a one-off command runner.
+
+## Core principles
+
+- Conductor-owned state is canonical: objectives, tasks, runs, gates, artifacts, and events are the source of truth.
+- Scheduler execution is explicit. Default to safe previews; use `policy: "execute"` only when the user wants conductor to run work.
+- Child task completion must be explicit through run-scoped child tools. A backend exit is not semantic completion.
+- Human approval gates are UI-only. Do not create model-callable human approval shortcuts.
+
+## Objective workflow
+
+1. Inspect current state:
+   - `conductor_project_brief({})`
+   - `conductor_next_actions({ maxActions: 5 })`
+2. Create or select an objective:
+   - `conductor_create_objective({ title, prompt })`
+   - `conductor_list_objectives({})`
+3. Plan durable tasks:
+   - `conductor_plan_objective({ objectiveId, tasks })`
+   - Keep task titles concrete and dependencies acyclic.
+4. Inspect the DAG:
+   - `conductor_objective_dag({ objectiveId })`
+5. Preview scheduling safely:
+   - `conductor_scheduler_tick({ objectiveId, policy: "safe", maxActions: 3 })`
+6. Execute intentionally when ready:
+   - `conductor_scheduler_tick({ objectiveId, policy: "execute", maxRuns: 1 })`
+   - or `conductor_run_next_action({ objectiveId, policy: "execute" })`
+7. Monitor evidence and blockers:
+   - `conductor_task_brief({ taskId })`
+   - `conductor_diagnose_blockers({ taskId })`
+   - `conductor_resource_timeline({ taskId, includeArtifacts: true })`
+8. Prepare review/PR readiness:
+   - `conductor_assess_task({ taskId, requireTestEvidence: true })`
+   - `conductor_check_readiness({ taskId, purpose: "pr_readiness" })`
+   - `conductor_prepare_human_review({ taskId })`
+9. Route human gates through trusted UI:
+   - `/conductor human dashboard`
+
+## Recovery workflow
+
+- Use `conductor_reconcile_project({ dryRun: true })` before mutating recovery state.
+- If leases are stale or worker state drifted, use `conductor_reconcile_project({ dryRun: false })`.
+- Use `conductor_recover_worker({ name })` for broken worker session linkage.
+- Preserve audit history; do not delete or rewrite conductor state to hide failed attempts.
+
+## Output style
+
+Report the current objective/task IDs, what conductor believes is runnable, and the exact next tool call. Distinguish safe previews from execution.


### PR DESCRIPTION
## Summary

This adds a persistent human gate dashboard so reviewers can work through multiple open conductor gates without restarting the command for each decision. The dashboard refreshes the queue after each approval or rejection, previews selected-gate context inline, and keeps high-risk approval on the trusted interactive UI path.

## What changed

- Added `/conductor human dashboard [reason]` for a persistent open-gate review loop.
- Enriched the custom gate queue with selected-gate readiness, blockers, warnings, artifact, timeline, and review-packet preview context.
- Packaged two workflow skills:
  - `conductor-orchestration` for objective planning, safe scheduler previews, execution, recovery, and review handoff.
  - `conductor-gate-review` for evidence/readiness-driven gate review while preserving the trusted-human approval boundary.
- Registered `skills/` in the package manifest so Pi can discover the packaged workflows.
- Expanded README recipes for objective execution, dependency inspection, PR readiness, artifact reads, and human gate review.

## Validation

- `npx vitest run packages/pi-conductor/__tests__/human-approval-ui.test.ts packages/pi-conductor/__tests__/commands.test.ts packages/pi-conductor/__tests__/index.test.ts`
- `npx vitest run packages/pi-conductor/__tests__`
- `npm run typecheck`
- `npx biome ci packages/pi-conductor`

Existing evidence was requested but not provided, so this PR does not include a demo section.