### PR TITLE
silence session_start auth log that interferes with pi's tui

### DIFF
--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -39,11 +39,6 @@ export { DEFAULT_NUM_RESULTS } from "./web-search.js";
 // =============================================================================
 
 export default function exaExtension(pi: ExtensionAPI) {
-  // SessionStart: check auth and print status
-  pi.on("session_start", async () => {
-    console.log(getAuthStatusMessage(pi));
-  });
-
   // Register CLI flags
   pi.registerFlag("--exa-api-key", {
     description: "Exa AI API key for search operations",

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAuthStatusMessage, getResolvedConfig, isToolEnabledForConfig, resolveAuth } from "./config.js";
+import { getResolvedConfig, isToolEnabledForConfig, resolveAuth } from "./config.js";
 import {
   webAnswerParams,
   webFetchParams,


### PR DESCRIPTION
The `session_start` handler in index.ts prints `[exa] Authenticated via ...` via `console.log` on every session start. This output bleeds into pi's TUI rendering, cluttering the interface.

Removing the `console.log` call keeps the handler registration (minimal diff) while stopping the unwanted stdout noise. Auth resolution and validation already happen at tool execution time, so the startup log is redundant.