### PR TITLE
feat(pi-conductor): add supervised runtime boundary

### DIFF
--- a/docs/adr/ADR-0015-supervised-tmux-visible-runtime.md
+++ b/docs/adr/ADR-0015-supervised-tmux-visible-runtime.md
@@ -1,0 +1,135 @@
+---
+title: "Supervised tmux runtime with optional iTerm2 viewer"
+adr: ADR-0015
+status: Proposed
+date: 2026-04-27
+prd: "PRD-007-pi-conductor-supervised-visible-runtime"
+decision: "Use tmux as the supervised visible runtime backend and treat iTerm2 as an optional read-only viewer over tmux while conductor remains canonical state owner"
+---
+
+# ADR-0015: Supervised tmux runtime with optional iTerm2 viewer
+
+## Status
+
+Proposed
+
+## Date
+
+2026-04-27
+
+## Requirement Source
+
+* **PRD**: `docs/prd/PRD-007-pi-conductor-supervised-visible-runtime.md`
+* **Issue**: <https://github.com/feniix/pi-extensions/issues/63>
+* **Decision Point**: Users need to see and supervise active conductor workers without losing conductor-owned cancellation, gates, persisted state, and recovery semantics.
+
+## Context
+
+`pi-conductor` currently executes native worker runs through an in-process `AgentSession` path. That path is deliberately headless, default-deny, and conductor-owned. It preserves child completion tools and durable task/run state, but it gives humans little live visibility into active worker behavior.
+
+The product direction now requires visible supervision: a human should be able to ask conductor to run parallel work and show the workers. The visible surface must not become an independent source of truth. Conductor still owns workers, tasks, runs, gates, artifacts, events, cancellation, and cleanup.
+
+This creates a runtime design question: what should own the visible worker process, and how should graphical terminal support fit without recreating fire-and-forget terminal automation?
+
+## Decision Drivers
+
+* Conductor must remain the canonical control plane.
+* Cancellation must kill the underlying visible runtime, not just update JSON state.
+* Visible runtime metadata must be persisted so runs can be inspected and reconciled later.
+* The solution should work without requiring a GUI.
+* macOS/iTerm2 polish is valuable but should not become a platform dependency.
+* Existing headless/native execution must remain stable and CI-safe.
+* Child task contracts and explicit completion semantics must continue to apply.
+
+## Considered Options
+
+### Option 1: Keep headless only and improve status output
+
+Conductor would remain in-process/headless and expose richer status/log summaries without opening terminal views.
+
+* Good, because it preserves the current architecture and avoids process supervision.
+* Good, because it is easiest to test in CI.
+* Bad, because it does not satisfy the user need to watch active workers live.
+* Bad, because debugging long-running or parallel work remains opaque.
+
+### Option 2: Launch iTerm2 windows directly as the runtime backend
+
+Conductor would open iTerm2 tabs/windows that run worker commands directly.
+
+* Good, because it is a polished human-facing experience on macOS.
+* Good, because the user can immediately see worker terminals.
+* Bad, because iTerm2 is GUI- and platform-specific.
+* Bad, because GUI windows are harder to supervise, enumerate, cancel, and reconcile reliably.
+* Bad, because it risks making iTerm2 the de facto control plane.
+
+### Option 3: Use tmux as supervised runtime and iTerm2 as optional viewer
+
+Conductor starts a tmux session for each visible run, persists tmux/process/log metadata, and optionally opens iTerm2 attached to that tmux session in read-only mode. Conductor cancellation kills the tmux session/process group and updates durable state.
+
+* Good, because tmux is scriptable, inspectable, cancelable, and GUI-independent.
+* Good, because iTerm2 becomes a viewer layer rather than the runtime owner.
+* Good, because conductor can persist tmux session names, pane IDs, log paths, and cleanup state.
+* Good, because read-only attach supports supervision without encouraging manual state-bypassing input.
+* Bad, because conductor must own process supervision, launch diagnostics, and stale-session reconciliation.
+* Bad, because it introduces an external dependency for visible runs.
+
+### Option 4: Use a custom pseudo-terminal/process supervisor without tmux
+
+Conductor would implement its own process supervision and terminal streaming layer.
+
+* Good, because conductor could control all runtime behavior directly.
+* Good, because it could avoid tmux-specific semantics.
+* Bad, because it duplicates mature terminal/session management behavior.
+* Bad, because it is a much larger implementation than the product need requires.
+* Bad, because it still needs a viewing surface for humans.
+
+## Decision
+
+Chosen option: **Use tmux as supervised runtime and iTerm2 as optional viewer**.
+
+Visible conductor runs should be backed by tmux sessions. Each tmux-backed run records runtime metadata on the conductor run attempt, including tmux session/window/pane identifiers where available, cwd/worktree path, log path, viewer command, launch status, and cleanup status.
+
+On macOS, conductor may open iTerm2 as a viewer by attaching to the tmux session. iTerm2 is not a backend and does not own state. If iTerm2 launch fails, conductor should keep the tmux run active and return a manual attach command plus diagnostics.
+
+The viewer should default to read-only attach semantics where practical. Human direct intervention through a pane is explicitly not part of this first decision; users supervise through view, cancellation, gates, and conductor tools.
+
+The existing in-process native `AgentSession` runtime remains the default headless backend. User-facing naming should distinguish `headless`, `tmux`, and `iterm-tmux`; implementation may keep `native` as an internal compatibility alias for the current runtime.
+
+## Consequences
+
+### Positive
+
+* Humans can see active worker execution without giving up durable conductor control.
+* tmux sessions can be listed, killed, and reconciled independently of a GUI.
+* iTerm2 support can provide a polished local experience while remaining optional.
+* Cancellation semantics can terminate real runtime resources and persist evidence.
+* Future dashboards can consume the same runtime metadata and events.
+
+### Negative
+
+* Conductor must now own a process-supervision adapter and corresponding tests.
+* Visible runs depend on `tmux`; missing `tmux` must be diagnosed clearly.
+* macOS/iTerm2 behavior requires platform-specific adapter code and best-effort handling.
+* Read-only viewer behavior may not fully prevent all local manual intervention unless attach commands are carefully constructed and documented.
+
+### Neutral
+
+* This decision does not remove or deprecate headless/native execution.
+* This decision does not require always-on worker daemons.
+* This decision does not require `pi-subagents`; it is another backend option under the conductor-owned state model from `ADR-0012`.
+
+## Implementation Notes
+
+* Add a runtime backend interface before adding tmux launch code.
+* Persist visible-runtime metadata on run attempts rather than encoding it only in events.
+* Store logs as artifact refs or bounded local file refs, not inline JSON.
+* Route natural-language “show me the workers” requests to visible runtime selection when safe.
+* Make cancellation idempotent: repeated cancellation should not fail because the tmux session is already gone.
+* Reconciliation should classify missing tmux sessions as stale/needs-review/aborted with diagnostics, never success.
+
+## Related
+
+* **PRD**: `docs/prd/PRD-007-pi-conductor-supervised-visible-runtime.md`
+* **Plan**: `docs/plans/2026-04-27-001-feat-conductor-supervised-runtime-plan.md`
+* **ADRs**: Extends `docs/adr/ADR-0006-agent-session-based-foreground-run-execution.md`, `docs/adr/ADR-0011-conductor-run-extension-binding-and-preflight-policy.md`, and `docs/adr/ADR-0012-conductor-owned-state-replaceable-backends.md`
+* **Implementation**: `packages/pi-conductor/extensions/runtime.ts`, `packages/pi-conductor/extensions/conductor.ts`, `packages/pi-conductor/extensions/types.ts`, `packages/pi-conductor/extensions/tools/orchestration-tools.ts`

--- a/docs/plans/2026-04-27-001-feat-conductor-supervised-runtime-plan.md
+++ b/docs/plans/2026-04-27-001-feat-conductor-supervised-runtime-plan.md
@@ -1,0 +1,581 @@
+---
+title: feat: Add supervised visible runtime for pi-conductor
+type: feat
+status: draft
+date: 2026-04-27
+origin: docs/prd/PRD-007-pi-conductor-supervised-visible-runtime.md
+issue: https://github.com/feniix/pi-extensions/issues/63
+---
+
+# feat: Add supervised visible runtime for pi-conductor
+
+## Overview
+
+Add an optional supervised visible runtime to `packages/pi-conductor` so a user can watch active workers while conductor remains the durable control plane. The first visible backend is tmux. iTerm2 support is a viewer layer over tmux on macOS, not a separate backend.
+
+The current headless/native `AgentSession` path remains the default. Visible runs should preserve the same task/run/gate/artifact/event semantics: explicit child completion is authoritative, backend exit without completion creates review, and conductor-driven cancellation stops both persisted state and live runtime resources.
+
+## Requirements Trace
+
+### Defaults and selection
+
+* R1. Keep headless/native execution as default and non-regressed.
+* R2. Add runtime selection for `headless`, `tmux`, and `iterm-tmux` user-facing modes.
+
+### Runtime metadata and execution
+
+* R3. Persist tmux runtime metadata on run attempts: session name, pane/window IDs where available, cwd/worktree, log path, viewer command, launch/cleanup status.
+* R4. Execute tmux-backed work through a conductor-owned runner process that can use the same scoped task contract and child reporting semantics as headless runs.
+
+### Cancellation and reconciliation
+
+* R5. Make cancellation terminate supervised runtime resources and persist terminal run/task/worker state.
+* R8. Reconcile stale or orphaned tmux runtime state without inventing successful completion.
+
+### Viewer and supervision UX
+
+* R6. Treat iTerm2 as optional viewer-only polish; fallback to tmux attach commands when iTerm2 cannot open.
+* R7. Make natural-language visible supervision ergonomic for requests such as “run this in parallel and show me the workers”.
+
+### Logs and test coverage
+
+* R9. Store logs as bounded artifact/local refs, not inline project-state blobs.
+* R10. Cover backend selection, launch metadata, cancellation, iTerm fallback, and reconciliation with tests.
+
+## Supervision Approach Rationale
+
+The first implementation intentionally chooses a tmux-backed visible runtime instead of only improving conductor-native status output.
+
+| Approach | Value | Limitation |
+| --- | --- | --- |
+| Conductor-native visibility only | Lowest runtime risk; can expose project briefs, event streams, log tails, gates, and cancel commands. | Does not let a human watch the live worker terminal/session while tools, model output, and runtime transitions occur. |
+| tmux-backed visible runtime | Gives a durable, scriptable, cancelable live surface for each worker while preserving conductor-owned state. | Adds process supervision, log lifecycle, and reconciliation complexity. |
+| iTerm2 viewer over tmux | Polishes the macOS supervision experience and makes worker panes easy to find. | GUI launch is best-effort and must not own lifecycle or task state. |
+
+Tmux is required for this slice because the user goal is live supervision, not only post-hoc status. Conductor-native surfaces still remain primary: every visible run must expose its conductor task/run state, attach command, log ref, and cancellation affordance through conductor status/tool output so the terminal never becomes the only way to understand or stop work.
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Add a backend boundary before tmux implementation | Prevents tmux-specific code from spreading through task lifecycle logic. |
+| Use tmux as visible runtime owner | tmux is scriptable, inspectable, killable, and independent of GUI availability. |
+| Use iTerm2 only as viewer | Keeps conductor/tmux as the control plane and avoids GUI-owned run state. |
+| Default viewer attach to read-only where possible | Supervision should not bypass conductor state or scoped child tools. |
+| Treat read-only viewing as best-effort affordance, not a security boundary | A user can still manually attach to tmux outside conductor; conductor state remains authoritative either way. |
+| Use a persisted runner contract | A tmux process cannot depend on parent-process memory for task/run scope. |
+| Add a package-owned runner CLI | Tmux launch needs one stable executable boundary across source checkouts, installed packages, and smoke tests. |
+| Keep cancellation idempotent and terminal states monotonic | Cancellation may race with natural process exit, child completion, or prior cleanup. |
+| Prefer explicit runtime selection over keyword inference | Natural-language “show” is ambiguous; explicit params/config must take precedence over inferred visible mode. |
+
+## Resolved Implementation Decisions
+
+* **Runner entrypoint:** add a package-owned CLI entrypoint, `pi-conductor-runner`, in `packages/pi-conductor/package.json`. Because the package is currently source-only TypeScript with no build output, first implementation uses a committed plain-JavaScript shim such as `extensions/runner-cli.mjs` as the `bin` target. The shim resolves the sibling runner module and launches it with the current Node executable and the repository's supported TypeScript-loading strategy; tmux preflight must verify that the resolved command is executable from the worker worktree. If the source-loading strategy is not reliable outside Pi, PR A must add a minimal build/shim strategy before any tmux launch work proceeds. The tmux adapter launches the resolved command from the worker worktree with argv such as `--repo-root`, `--project-key`, `--task-id`, `--run-id`, and `--contract`. The runner reconstructs scope from the persisted contract and current conductor project state; it does not depend on parent-process memory.
+* **Runner command contract:** use argv-based process launch wherever possible. Any tmux command string that must pass through a shell is built by one adapter with centralized quoting tests for spaces, quotes, semicolons, newlines, and command-substitution characters.
+* **Runtime selection:** explicit tool/run parameters win, then conservative natural-language inference. Project/user defaults are deferred; when added later, they should fit between explicit params and inference. Ambiguous phrases such as “show me current workers” must return status rather than launch visible work. Explicit visible runtime requests do not silently fall back to headless when tmux is missing; they return an actionable preflight error. `iterm-tmux` may fall back to `tmux` when only the viewer fails.
+* **View/reopen affordance:** first implementation does not need a separate `conductor_view_run` tool. Status/tool outputs must always include enough attach/reopen detail for active visible runs. Add a dedicated view tool only if manual attach commands prove insufficient.
+* **Real-tmux smoke:** add a skip-when-`tmux`-missing smoke test. It may run in CI when tmux is available, but the feature cannot rely on CI tmux availability.
+
+## State, Race, and Cancellation Model
+
+Visible runtime adds a second process, so terminal-state precedence must be explicit before tmux launch code lands.
+
+| Event / race | Required behavior |
+| --- | --- |
+| Explicit child completion persists before backend exit | Preserve the semantic completion. Backend exit only records runtime evidence unless it contradicts completion and needs review. |
+| Backend exits without explicit completion | Mark the task `needs_review` and create a review gate only if the run is still nonterminal. |
+| Cancellation persists before child completion | Cancellation wins. Late child completion/progress is rejected or audited without changing terminal task/run state. |
+| Child completion and cancellation race | Whichever transition commits first wins through the storage mutation envelope. The losing transition records a rejected/audited event and must not overwrite terminal state. |
+| Reconciliation sees a terminal run | Reconciliation never overwrites terminal success, failure, cancellation, or needs-review state. It may append runtime evidence/diagnostics. |
+| Parent and runner contend on conductor file lock | Runner and parent mutations use bounded retry with jitter/backoff on lock contention and preserve idempotency keys across retries. Expired retries create diagnostics instead of silently dropping completion. |
+| Tmux session already gone during cancel | Cancellation remains idempotent: persist canceled/aborted conductor state if still active, record that runtime cleanup found no live session, and return success with diagnostics. |
+
+Tests must cover cancel-while-complete, cancel-while-runner-blocked, backend-exit-before-completion, late-child-write-after-cancel, reconciliation-after-terminal-run, and file-lock contention between parent and runner writes.
+
+## Liveness and Reconciliation Contract
+
+Tmux session existence is not sufficient proof that a worker run is healthy. A tmux-backed run must persist enough liveness evidence for conductor to distinguish visible terminal state from runner process state.
+
+Minimum runtime metadata:
+
+* runtime mode (`tmux` or `iterm-tmux`)
+* tmux session name and pane/window identifiers where available
+* worker worktree/cwd
+* runner command label and argv shape with secret values omitted
+* runner PID and process group when available
+* last runner heartbeat timestamp
+* log path and log lifecycle status
+* viewer attach command and viewer warning/status
+* launch, cleanup, and reconciliation diagnostics
+
+Reconciliation probes must cover:
+
+* tmux session missing while conductor run is active
+* tmux session alive but runner PID/process group exited
+* tmux session alive but runner heartbeat stale
+* pane command replaced by shell or unknown process when detectable
+* tmux session missing after successful explicit completion
+* log path missing/unreadable
+* cleanup failed or partially completed
+
+Unknown liveness never becomes success. Depending on persisted semantic state, reconciliation records `stale`, `needs_review`, `aborted`, or diagnostic-only evidence.
+
+## Security and Local File Policy
+
+Visible runtime crosses shell, filesystem, terminal, and local process boundaries. The first implementation must include these controls, not defer them to hardening:
+
+* Launch runner processes with argv arrays where possible; isolate unavoidable shell strings in one tmux adapter with escaping tests.
+* Validate and normalize cwd, contract path, log path, and conductor storage path before launching.
+* Create runner contract files under conductor-owned storage with restrictive permissions (`0600` where supported), atomic writes, task/run/revision binding, and no long-lived secrets.
+* Include a per-run nonce or capability value in the runner contract so a stale or tampered process cannot forge progress/completion for a different run. The first implementation treats this as valid for the active run/lease generation rather than as a wall-clock-expiring secret; terminal state, cancellation, cleanup, or lease-generation change invalidates it.
+* Revalidate task ID, run ID, task revision, and nonce before every runner-originated progress/gate/completion mutation.
+* Store logs under conductor-owned storage, outside repository source control, with restrictive permissions.
+* Define per-run log size limits, truncation markers, and rotation behavior. Log write failure must produce runtime diagnostics and must not block conductor cancellation.
+* Treat terminal logs and tmux scrollback as potentially sensitive. Status output may show local log refs/paths, but must not inline unbounded logs, tmux history, or secret environment values.
+* Set an explicit tmux history limit for supervised sessions, avoid persisting tmux history outside the bounded log policy, and kill/clear supervised tmux buffers during cleanup where feasible.
+* Use a conductor-owned tmux namespace: prefer a private tmux socket path under conductor storage with restrictive directory permissions, plus an unguessable per-run/session component. Before attach, cancel, or reconcile acts on an existing session, verify expected metadata such as runner PID/process group, cwd, run ID marker, contract path, and nonce binding where available.
+* Do not expose writable viewer commands as the default. If a debug/writable attach mode is ever added, it must be explicitly labeled as outside normal conductor supervision.
+* Apply the same argv/escaping discipline to iTerm2 viewer launch as to tmux launch. Any AppleScript, shell, URL, or open-handler boundary must have dedicated escaping tests, including AppleScript-specific delimiters.
+
+## Runner Environment and Credential Contract
+
+The visible runner must be equivalent enough to headless `AgentSession` execution to do real work, but it must not blindly inherit the parent process environment.
+
+* Launch with a deny-by-default environment. Start from a small allowlist required for local execution, such as `PATH`, `HOME`, `SHELL` when needed by tools, `TMPDIR`, locale variables, and `PI_CONDUCTOR_HOME`.
+* Do not put secrets in argv, contract files, runtime metadata, status output, tmux titles, or logs.
+* Prefer the same Pi SDK/AuthStorage/config-file lookup path used by headless execution for provider credentials. If a provider is configured only through environment variables, pass only explicitly allowlisted provider variables and redact their names/values in diagnostics according to existing project security conventions.
+* Preflight visible runner environment before task launch: resolved runner command, Node/runtime compatibility, required non-secret env, model/provider availability, worktree cwd, contract path, log path, and conductor storage writability.
+* If visible runtime cannot obtain required config/credentials safely, fail before task execution with actionable diagnostics and no silent headless fallback for explicit visible requests.
+* Add tests proving ambient secrets are not inherited by default, required config absence fails during preflight, and redaction prevents secret values from entering logs/status.
+
+## Heartbeat and Stale Detection Policy
+
+Heartbeat is liveness evidence, not semantic completion and not sufficient by itself to declare a live run dead.
+
+* Prefer a heartbeat mechanism that can continue while the runner awaits model/tool/subprocess work. If the first implementation cannot guarantee that independence, stale heartbeat while runner PID/process group is still alive is a warning/diagnostic, not an automatic terminal transition.
+* Reconciliation may mark a run stale/needs-review only when heartbeat evidence combines with stronger evidence such as missing runner process, exited process, missing tmux session, expired lease with no process evidence, or explicit runtime error.
+* Long-running model/tool/subprocess waits must be tested so healthy work is not falsely moved to stale/needs-review solely because no heartbeat was emitted during a blocking wait.
+* Completion/cancellation monotonicity still wins: a late valid completion can commit only if the run remains nonterminal; a terminal cancel/completion rejects or audits late heartbeat/progress.
+
+## Supervision UX Contract
+
+Visible supervision is not complete just because a terminal opens. Every visible run must be understandable and controllable from conductor output.
+
+Minimum per-run status fields:
+
+* worker name and worker ID
+* task title and task ID
+* run ID and task revision
+* conductor task/run state
+* runtime mode and runtime status
+* viewer state: opened, manual attach available, warning, or unavailable
+* read-only attach command for active tmux sessions
+* log ref/path and whether the log is complete, partial, truncated, or unavailable
+* recommended cancellation command/tool call
+* latest progress or last runtime diagnostic
+
+Multi-worker status should group runs in this order: active with warnings, active healthy, blocked/needs review, canceled/aborted, completed. Project-level briefs show a compact row per visible run; task/run details show full attach/log/runtime metadata.
+
+Visible runtime state table:
+
+| State | User-facing behavior |
+| --- | --- |
+| starting | Show task/run identity, runtime mode, and “starting tmux session”. |
+| running/viewable | Show read-only attach command, log ref, latest heartbeat/progress, and cancel command. |
+| running/no viewer | Show tmux attach command plus iTerm/viewer warning; task remains active. |
+| no visible runs | Status says no visible conductor runs are active; do not imply no conductor tasks exist. |
+| tmux unavailable | Explicit visible request fails with actionable preflight error; no silent headless fallback. |
+| iTerm unavailable | Continue tmux run, show manual attach command and viewer warning. |
+| partial worker launch | Show which workers launched, which failed preflight, and how cancellation affects launched workers. |
+| viewer closed | Run remains active; status shows reopen/attach command. |
+| session missing | Reconcile to stale/needs-review/aborted according to semantic state and diagnostics. |
+| runner exited without completion | Task moves to `needs_review`; status links log ref, runtime diagnostics, and review gate with recovery actions. |
+| canceled | Show terminal conductor state, cleanup result, log ref, and any cleanup warning. |
+| cleanup failed | Show terminal task/run state plus recoverable cleanup diagnostics. |
+
+Log-state behavior:
+
+| Log state | User-facing behavior |
+| --- | --- |
+| complete | Show log ref/path and terminal outcome. |
+| partial | Label the log as partial and point to runtime diagnostics/reconciliation before trusting it as full evidence. |
+| truncated | Show truncation marker, retained byte count, and the fact that older output was rotated or dropped. |
+| missing/unreadable | Show warning/error, recommend reconciliation, and keep task semantics based on run state rather than log availability. |
+| unavailable | Explain that live supervision/log capture did not start; include runtime launch diagnostics and retry/cancel guidance. |
+
+## Needs-Review Recovery Flow
+
+Visible runtime failures that produce `needs_review` must give the user a clear recovery path.
+
+Required status/task-detail content for visible `needs_review`:
+
+* task title, task ID, run ID, worker name, runtime mode, and gate ID
+* completion evidence status: explicit completion missing, backend exited, stale heartbeat, missing tmux session, log unavailable, or contradictory evidence
+* log ref/path and whether it is complete, partial, truncated, missing, or unavailable
+* latest runtime diagnostics and relevant timeline events
+
+Primary recovery actions:
+
+1. **Inspect evidence:** read bounded log/runtime artifacts and recent timeline before deciding.
+2. **Retry visible:** create a new visible run when the worker/runtime is recoverable and the user still wants supervision.
+3. **Retry headless:** rerun through headless/native runtime when tmux/viewer caused the failure.
+4. **Mark failed / keep needs-review:** leave the task unresolved with explanation if evidence is insufficient.
+5. **Cancel/abort cleanup:** terminate any remaining runtime resources if reconciliation shows leftovers.
+
+Approving completion based only on logs should remain a deliberate review decision, not an automatic fallback from backend exit.
+
+## Visible Output Contract
+
+A tmux session must show human-meaningful live activity, not only run a silent wrapper around background state mutations.
+
+Minimum pane output:
+
+* startup banner with worker name, task title, task ID, run ID, cwd, runtime mode, attach/log refs, and cancellation command
+* runtime lifecycle events: starting, running, heartbeat/stale warnings, cancellation requested, cleanup result, terminal state
+* child progress events and gate/blocker requests as they are recorded
+* bounded summaries of tool invocations/results when the SDK/runtime exposes them safely
+* final completion, failure, aborted, or needs-review summary with the log ref and conductor task/run state
+
+The bounded log should capture the same human-readable stream plus stdout/stderr from the runner. If full model-token streaming or full tool transcripts are not available from the current SDK surface, the runner must still print progress/event summaries so the pane is visibly useful. Smoke tests should assert that a visible run produces identity, progress/lifecycle, and terminal-status output in the pane/log; metadata-only success is not enough.
+
+## Multi-Worker Launch Policy
+
+Visible parallel launch should avoid surprising partial execution.
+
+* Preflight global visible-runtime requirements before creating or launching worker runs where possible: tmux availability, runner executable resolution, conductor storage/log/contract writability, and iTerm viewer capability if explicitly requested.
+* Use a two-phase launch barrier for visible parallel requests. Phase 1 may create conductor run reservations and launch tmux sessions into a pre-start state that prints identity/status but does not begin the task `AgentSession` work. Phase 2 starts task execution only after every requested visible session reaches launch acceptance.
+* If any worker fails before the barrier, conductor cancels/cleans up the launched pre-start subset, records diagnostics, and returns a partial-launch failure without claiming side-effect rollback beyond lifecycle cleanup.
+* If any task execution has already crossed the start barrier, later individual run failures are normal per-run outcomes and do not automatically cancel sibling workers.
+* If implementation cannot provide a pre-start barrier in the first tmux slice, the response must explicitly state that side effects may have occurred, list changed worktrees/artifacts/events where known, and avoid wording that implies rollback.
+* Status output for partial launch must show which workers launched, which failed preflight/launch, which were canceled by cleanup, whether task execution had started, and the exact cancellation/retry command.
+
+## Open Questions
+
+### Resolved for this plan
+
+* **Should visible runtime be tmux-first or iTerm-first?** tmux-first; iTerm2 attaches to tmux as a viewer.
+* **Should headless change behavior?** No; it remains the default path.
+* **Should direct human typing into panes be part of this slice?** No; default to read-only supervision and treat read-only as best-effort, not as the correctness boundary.
+* **Should the runner be a CLI or internal module?** Use a package-owned CLI entrypoint, `pi-conductor-runner`, so tmux has one stable executable boundary.
+* **Should visible runtime be opt-in per tool call or configurable?** First implementation uses explicit tool/run params; project/user defaults are deferred.
+* **Should there be a separate `conductor_view_run` tool in the first slice?** No; status/tool output must include attach/reopen commands first.
+
+### Deferred to implementation
+
+* Exact TypeScript names for runtime metadata types and fields in `RunAttemptRecord`.
+* Exact runner CLI flag names and whether the contract path alone can imply repo/project IDs.
+* Exact TypeScript-loading/build details for the `pi-conductor-runner` shim if Node source loading is not reliable in installed packages.
+* Exact heartbeat interval and stale threshold defaults, subject to the rule that stale heartbeat alone cannot terminalize a live runner process.
+* Exact per-run log byte limit, tmux history limit, and retention duration.
+
+## High-Level Design
+
+```mermaid
+flowchart TB
+  Parent[Parent Pi agent]
+  Tools[conductor_run_work / run_task]
+  State[Conductor project state]
+  Headless[Headless native AgentSession]
+  Tmux[tmux supervised session]
+  Runner[pi-conductor-runner process]
+  Iterm[iTerm2 read-only viewer]
+  ChildTools[Scoped progress/gate/complete tools]
+  Cancel[conductor_cancel_active_work]
+
+  Parent --> Tools
+  Tools --> State
+  Tools --> Headless
+  Tools --> Tmux
+  Tmux --> Runner
+  Runner --> ChildTools
+  ChildTools --> State
+  Tmux --> Iterm
+  Cancel --> State
+  Cancel --> Tmux
+```
+
+Runtime ownership boundaries:
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| Conductor state | task/run lifecycle, gates, artifacts, events, cancellation decision | terminal UI rendering |
+| Runtime backend adapter | launch, runtime metadata, process/tmux cleanup, backend diagnostics | semantic task success |
+| Runner process | executing the task contract and reporting scoped progress/completion | durable task state outside scoped tools |
+| tmux session | supervised visible process and terminal buffer | durable orchestration state |
+| iTerm2 viewer | optional human view attached to tmux | process lifecycle or task state |
+
+## Implementation Units
+
+### U1. Introduce runtime backend metadata and selection tests
+
+**Goal:** Define runtime mode names, metadata shape, and selection behavior without changing execution yet.
+
+**Requirements:** R1, R2, R3, R10.
+
+**Files:**
+
+* Modify: `packages/pi-conductor/extensions/types.ts`
+* Modify: `packages/pi-conductor/extensions/backends.ts`
+* Modify: `packages/pi-conductor/extensions/runtime.ts`
+* Modify: `packages/pi-conductor/extensions/task-service.ts`
+* Test: `packages/pi-conductor/__tests__/backends.test.ts`
+* Test: `packages/pi-conductor/__tests__/runtime-run.test.ts`
+* Test: `packages/pi-conductor/__tests__/storage.test.ts`
+
+**Approach:**
+
+* Add user-facing runtime names: `headless`, `tmux`, `iterm-tmux`.
+* Preserve current `native` storage behavior through compatibility mapping if needed.
+* Add a run-level runtime metadata field that can represent headless and visible runtimes.
+* Add metadata fields for runner PID/process group, heartbeat, log lifecycle, viewer command/status, and cleanup diagnostics.
+* Make run details/status include runtime metadata when present.
+* Add tests that current headless runs produce equivalent behavior to today.
+
+**Verification:**
+
+* Typecheck passes.
+* Existing conductor tests still pass.
+* New tests prove runtime selection/metadata can be persisted without tmux installed.
+
+### U2. Extract backend interface around existing headless runtime
+
+**Goal:** Route current headless execution through the same backend interface that tmux will implement.
+
+**Requirements:** R1, R2, R4, R10.
+
+**Files:**
+
+* Modify: `packages/pi-conductor/extensions/runtime.ts`
+* Modify: `packages/pi-conductor/extensions/conductor.ts`
+* Modify: `packages/pi-conductor/extensions/task-service.ts`
+* Test: `packages/pi-conductor/__tests__/run-flow.test.ts`
+* Test: `packages/pi-conductor/__tests__/runtime-run.test.ts`
+
+**Approach:**
+
+* Define an interface that can preflight, start, observe/finalize, cancel, and reconcile runtime work.
+* Implement the current in-process `AgentSession` path behind the interface.
+* Keep child scoped tools and fallback review behavior unchanged.
+* Ensure backend preflight failures happen before misleading active state where possible.
+* Add terminal-state precedence tests before introducing tmux.
+
+**Verification:**
+
+* Existing explicit-completion and fallback-review tests pass through the interface.
+* Cancellation still aborts live in-process work.
+* Terminal-state precedence tests pass for the headless backend before tmux is added.
+
+### U3. Add tmux runner contract and mocked tmux adapter
+
+**Goal:** Implement tmux launch/cancel/reconcile behavior behind an adapter seam, with shell execution mocked in unit tests.
+
+**Requirements:** R3, R4, R5, R8, R9, R10.
+
+**Files:**
+
+* Add: `packages/pi-conductor/extensions/tmux-runtime.ts`
+* Add: `packages/pi-conductor/extensions/runner.ts`
+* Modify: `packages/pi-conductor/package.json`
+* Modify: `packages/pi-conductor/extensions/runtime.ts`
+* Modify: `packages/pi-conductor/extensions/conductor.ts`
+* Test: `packages/pi-conductor/__tests__/tmux-runtime.test.ts`
+* Test: `packages/pi-conductor/__tests__/recovery.test.ts`
+
+**Approach:**
+
+* Add `pi-conductor-runner` as the package runner CLI entrypoint via a committed JavaScript shim and package `bin` entry.
+* Build a tmux command adapter with injectable argv/spawn/exec functions.
+* Preflight `tmux` availability and runner executable resolution before selecting the tmux backend.
+* Generate shell-safe tmux session names from project/run IDs plus an unguessable per-run/session component.
+* Use a conductor-owned private tmux socket/namespace where practical, stored under conductor storage with restrictive permissions.
+* Create conductor-owned contract and log paths under project storage with restrictive permissions.
+* Launch `pi-conductor-runner` in tmux with a persisted task/run contract, worker worktree cwd, and the runner environment/credential contract defined above.
+* Persist tmux metadata, runner PID/process group when available, heartbeat metadata, log ref, viewer command, and launch diagnostics immediately after launch acceptance.
+* Verify expected session metadata before attach, cancel, or reconcile acts on an existing tmux session.
+* Implement cancel as idempotent tmux session/process termination.
+* Implement reconcile probes for missing sessions, exited runner process, stale heartbeat, replaced pane command when detectable, missing logs, and partial cleanup.
+* Test path and argument escaping with spaces, quotes, semicolons, newlines, command-substitution characters, and tmux session/socket collision attempts.
+
+**Verification:**
+
+* Mocked tests cover launch command shape, metadata persistence, cancellation idempotency, missing-session reconciliation, stale heartbeat reconciliation, and shell/path metacharacter escaping.
+* No test requires real tmux yet.
+
+### U4. Wire real runner process to scoped child reporting
+
+**Goal:** Ensure a tmux-launched runner can execute the task contract and mutate conductor state through the same child progress/gate/complete semantics as headless execution.
+
+**Requirements:** R4, R5, R8, R9, R10.
+
+**Files:**
+
+* Modify: `packages/pi-conductor/extensions/runner.ts`
+* Modify: `packages/pi-conductor/extensions/runtime.ts`
+* Modify: `packages/pi-conductor/extensions/storage.ts`
+* Test: `packages/pi-conductor/__tests__/run-flow.test.ts`
+* Test: `packages/pi-conductor/__tests__/runtime-run.test.ts`
+
+**Approach:**
+
+* Persist enough run contract data for `pi-conductor-runner` to reconstruct scope.
+* Reuse `buildTaskContractPrompt` and `buildRunScopedConductorTools` where possible.
+* Include task ID, run ID, task revision, repo/project identity, and an active-run/lease-generation-bound nonce/capability in the contract.
+* Validate task/run/revision/nonce before every runner-originated progress/gate/completion mutation.
+* Ensure runner process writes progress/completion through file-locked conductor mutations with bounded retry, jitter/backoff, and idempotency-key preservation.
+* Implement heartbeat according to the heartbeat/stale policy: stale heartbeat alone is diagnostic while runner PID/process evidence remains healthy.
+* Map runner/AgentSession exits to the same semantic fallback policy as headless runs only when the run is still nonterminal.
+* Reject/audit late runner writes after cancellation or any terminal run state.
+* Record completion reports/log refs as artifacts.
+
+**Verification:**
+
+* Tests simulate a runner process completing, blocking, failing, and exiting without explicit completion.
+* Tests cover completion racing with cancellation, backend exit racing with completion, stale runner write after cancellation, long-running completion after heartbeat renewal/stale-threshold windows, heartbeat-stale-while-PID-alive diagnostics, and lock contention during completion.
+* Project state matches headless semantics for equivalent outcomes.
+
+### U5. Add iTerm2 viewer adapter and viewer/status output
+
+**Goal:** Open iTerm2 as a best-effort read-only tmux viewer on macOS and expose viewer details through status/tools.
+
+**Requirements:** R3, R6, R7, R10.
+
+**Files:**
+
+* Add: `packages/pi-conductor/extensions/iterm-viewer.ts`
+* Modify: `packages/pi-conductor/extensions/status.ts`
+* Modify: `packages/pi-conductor/extensions/tools/orchestration-tools.ts`
+* Modify: `packages/pi-conductor/extensions/commands.ts`
+* Test: `packages/pi-conductor/__tests__/runtime-run.test.ts`
+* Test: `packages/pi-conductor/__tests__/commands.test.ts`
+* Test: `packages/pi-conductor/__tests__/status.test.ts`
+
+**Approach:**
+
+* Detect macOS and iTerm2 availability separately from tmux availability.
+* Open iTerm2 with a read-only tmux attach command when requested.
+* Build iTerm2/AppleScript/open-handler commands through a dedicated adapter with escaping tests equivalent to the tmux adapter.
+* If iTerm2 open fails, return a warning and attach command without failing the tmux run.
+* Treat read-only viewer behavior as an explicit default, but document that it is not a security/correctness boundary because users can manually attach outside conductor.
+* Show worker/task/run identity, conductor state, runtime status, viewer status, attach command, log ref, cancellation command, and latest warning/progress in run/task/project briefs.
+* Implement the visible runtime state table from this plan in status output tests.
+* Do not add `conductor_view_run` in this slice unless manual attach commands are insufficient during smoke testing.
+
+**Verification:**
+
+* Tests mock macOS/iTerm success and failure.
+* Status output includes manual read-only attach commands and cancellation affordances.
+* iTerm failure does not mark the run failed.
+* Status tests cover starting, running/viewable, running/no viewer, no visible runs, missing session, runner exited without completion, canceled, and cleanup failed states.
+
+### U6. Make natural-language visible work ergonomic
+
+**Goal:** Let parent agents select visible runtime naturally for “run this and show me the workers” requests without surprising users who only ask for status.
+
+**Requirements:** R2, R5, R6, R7, R10.
+
+**Files:**
+
+* Modify: `packages/pi-conductor/extensions/tools/orchestration-tools.ts`
+* Modify: `packages/pi-conductor/extensions/conductor.ts`
+* Modify: `packages/pi-conductor/README.md`
+* Test: `packages/pi-conductor/__tests__/conductor.test.ts`
+* Test: `packages/pi-conductor/__tests__/planner-quality.test.ts`
+
+**Approach:**
+
+* Add explicit runtime/viewer params to high-level orchestration tools.
+* Apply runtime selection precedence for the first implementation: explicit params, then conservative natural-language inference.
+* Infer visible runtime only from unambiguous execution requests such as “run this and show/open/watch the workers”.
+* Treat status-only phrases such as “show me current workers” as inspection, not visible-runtime launch.
+* Keep conservative routing: visible runtime can be selected only when work is otherwise safe to run/split.
+* Explicit `tmux` requests fail with actionable tmux preflight errors if tmux is unavailable; they do not silently fall back to headless.
+* Explicit `iterm-tmux` requests may fall back to tmux-only when iTerm2 viewer launch fails.
+* Return structured viewer details and status/warning summaries for all started workers/runs.
+* Ensure cancellation can target all visible runs started by a natural-language orchestration boundary.
+
+**Verification:**
+
+* Natural-language visible parallel requests select visible runtime in tests.
+* Ambiguous “show” status requests do not launch tmux.
+* Visible runtime preflight failure returns actionable diagnostics without creating misleading active runs.
+* Natural-language stop cancels visible active work without user-supplied IDs.
+
+### U7. Add smoke tests and documentation
+
+**Goal:** Provide human-style validation for visible supervision and make cleanup/recovery clear.
+
+**Requirements:** Validates R1-R10; implements documentation/test coverage for R6, R8, R9, and R10.
+
+**Files:**
+
+* Modify: `packages/pi-conductor/README.md`
+* Add or modify: `packages/pi-conductor/__tests__/package-smoke.test.ts`
+* Add optional script/docs note for local real-tmux smoke testing.
+
+**Approach:**
+
+* Add a real-tmux smoke test that skips when `tmux` is unavailable.
+* Smoke: start visible parallel work, inspect tmux sessions/log paths, cancel active work, verify sessions gone and persisted state terminal.
+* Document manual attach, iTerm fallback, cancellation, stale reconciliation, log retention, and cleanup commands.
+* Do not use U7 as a catch-all feature slice. Required cleanup/reconciliation implementation belongs in U3-U6. Defects discovered during smoke testing become focused bug-fix tasks unless they are necessary for the smoke test to pass.
+
+**Verification:**
+
+* `npm run typecheck`
+* `npx vitest run packages/pi-conductor/__tests__`
+* Local smoke with tmux installed proves visible runtime can start, be watched, canceled, and reconciled.
+
+## Suggested PR Slices
+
+1. **PR A — backend boundary and metadata:** U1 + U2 only; no real tmux launch.
+2. **PR B — supervised tmux runtime:** U3 + U4 with mocked tests only; real-tmux smoke belongs to PR E.
+3. **PR C — iTerm viewer and status output:** U5.
+4. **PR D — natural-language visible ergonomics:** U6.
+5. **PR E — docs/smoke hardening:** U7 only; add the real-tmux smoke test and docs, with no open-ended cleanup/reconciliation feature work.
+
+## Test Plan
+
+Run after each slice:
+
+```bash
+npx vitest run packages/pi-conductor/__tests__
+npx tsc --noEmit --project packages/pi-conductor/tsconfig.json
+npx biome ci packages/pi-conductor
+```
+
+Run before final PR:
+
+```bash
+npm run check
+npm run test
+```
+
+Manual smoke for final feature:
+
+1. Start parallel natural-language conductor work with visible runtime intent.
+2. Confirm tmux sessions/log paths exist and viewer details are returned.
+3. Confirm status output maps worker name, task title, run ID, conductor state, runtime state, attach command, log ref, and cancel command.
+4. If on macOS with iTerm2, confirm iTerm attaches as viewer.
+5. Close the viewer and confirm status still exposes a reopen/attach command while the run continues.
+6. Exercise a visible-run `needs_review` path and confirm status shows log/runtime evidence plus retry visible, retry headless, mark failed/keep review, and cleanup actions.
+7. Cancel active conductor work through natural language or `conductor_cancel_active_work`.
+8. Confirm tmux sessions are gone, tasks/runs are terminal, workers are idle/recoverable, logs are retained according to policy, and `PI_CONDUCTOR_HOME` state contains cancellation evidence.
+9. Run reconciliation after cancellation and confirm it does not invent success or resurrect terminal runs.
+
+## Rollback Plan
+
+* Runtime selection should default to headless, so visible runtime can be disabled by config or by not selecting `tmux`/`iterm-tmux`.
+* If tmux behavior proves unstable, keep backend metadata/interface changes but gate tmux launch behind explicit config until fixed.
+* Do not remove or rewrite existing headless runtime paths during this work.
+
+## Done Definition
+
+* A user can request visible conductor work and receive/open tmux/iTerm viewer details.
+* Every visible run can be understood from conductor output without reading the terminal pane.
+* Canceling active visible work terminates the underlying runtime and persists terminal state.
+* Late runner writes after terminal cancellation/completion are rejected or audited without changing terminal state.
+* Reconciliation handles missing/exited/stale tmux sessions and stale runner heartbeat without inventing success.
+* Runtime launch avoids unsafe shell interpolation and validates paths/arguments.
+* Contract and log files use restrictive permissions, bounded retention, and no inline secret values.
+* Existing headless conductor tests continue to pass.
+* README and status/tool outputs explain how to supervise and stop visible workers.

--- a/docs/prd/PRD-007-pi-conductor-supervised-visible-runtime.md
+++ b/docs/prd/PRD-007-pi-conductor-supervised-visible-runtime.md
@@ -1,0 +1,346 @@
+---
+title: "pi-conductor — supervised visible runtime"
+prd: PRD-007
+status: Draft
+owner: "feniix"
+issue: "https://github.com/feniix/pi-extensions/issues/63"
+date: 2026-04-27
+version: "0.1"
+---
+
+# PRD: pi-conductor — supervised visible runtime
+
+## 1. Problem & Context
+
+`pi-conductor` can now route natural-language work, start durable workers/tasks/runs, cancel active conductor-owned work, and persist enough evidence to recover from failed or interrupted orchestration. The current native runtime is intentionally headless: the parent process creates an `AgentSession`, injects scoped child tools, waits for completion, and writes conductor state.
+
+That headless model is good for correctness, but weak for human supervision. When conductor starts multiple workers, the user cannot easily watch what each worker is doing, see live output, or keep a visual sense of which runs are still active. The next product step is to add an optional visible runtime path so a user can say:
+
+> Run this in parallel and show me the workers.
+
+The visible runtime must not turn into fire-and-forget terminal automation. Conductor remains the durable control plane for workers, tasks, runs, gates, artifacts, cancellation, and cleanup. A terminal window is a supervised runtime/viewer, not the source of truth.
+
+This PRD implements issue #63 and builds on:
+
+* `docs/adr/ADR-0006-agent-session-based-foreground-run-execution.md`
+* `docs/adr/ADR-0011-conductor-run-extension-binding-and-preflight-policy.md`
+* `docs/adr/ADR-0012-conductor-owned-state-replaceable-backends.md`
+* `packages/pi-conductor/extensions/runtime.ts`
+* `packages/pi-conductor/extensions/conductor.ts`
+* `packages/pi-conductor/extensions/tools/orchestration-tools.ts`
+
+## 2. Goals & Success Metrics
+
+| Goal                            | Metric                                                                                            | Target                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Make active workers visible** | Conductor can run a task in a tmux-backed visible runtime and return/view attach details          | 100% of tmux-backed runs persist session/log metadata                                        |
+| **Preserve conductor control**  | Natural-language and tool cancellation terminates both conductor state and the supervised runtime | 100% of canceled tmux-backed runs become terminal and release workers                        |
+| **Support human supervision**   | Users can open a read-only tmux/iTerm view for active runs without naming run IDs in common flows | Parallel visible work returns clear viewer commands or opens iTerm when requested/configured |
+| **Keep headless stable**        | Existing native/headless behavior remains the default and passes current tests                    | No regression to existing `native` worker runs                                               |
+| **Fail closed**                 | Missing `tmux`, missing iTerm2, or launch failure leaves no misleading active run                 | Failed visible-runtime preflight records diagnostics and keeps tasks recoverable             |
+
+**Guardrails:**
+
+* Conductor state remains canonical; tmux/iTerm metadata is evidence and control metadata.
+* iTerm2 is a viewer over tmux, not an independent backend.
+* Cancellation must be conductor-driven and work for natural-language “stop all conductor work”.
+* Viewer defaults should be read-only where possible; direct human intervention in a pane is out of scope for the first slice.
+* Existing child completion, progress, gate, and artifact contracts must remain available for visible runs.
+
+## 3. Users & Use Cases
+
+### Primary: human supervising conductor work
+
+> As a Pi user, I want conductor to open visible worker panes when it runs parallel work so that I can watch progress and stop work confidently if it goes wrong.
+
+**Preconditions:** `tmux` is installed for visible runs. On macOS, iTerm2 may be installed for the optional viewer.
+
+### Primary: parent Pi agent orchestrating visible work
+
+> As the parent Pi agent, I want a natural-language path for “run this and show me the workers” so that I can choose visible execution without asking the human for worker IDs, run IDs, or terminal commands.
+
+**Preconditions:** `pi-conductor` tools are loaded in a git repository and at least one usable model/provider is configured.
+
+### Secondary: package maintainer debugging worker behavior
+
+> As a package maintainer, I want persisted runtime metadata, log paths, and cleanup events so that I can inspect stuck, canceled, or failed visible runs after the fact.
+
+## 4. Scope
+
+### In scope
+
+1. Runtime backend boundary that preserves the existing headless/native backend and adds a supervised tmux backend.
+2. Persisted runtime metadata on run attempts: backend name, tmux session/window/pane identifiers where available, process ID or process group where available, log path, viewer command, launch status, and cleanup status.
+3. A tmux-backed runner process that executes the same conductor task contract as headless runs and reports progress/completion through conductor-owned state.
+4. Conductor-driven cancellation that terminates the tmux session/process group and persists aborted run/task state.
+5. iTerm2 viewer support on macOS that opens read-only tmux attach panes/tabs when requested or configured.
+6. Natural-language/tool ergonomics for visible work: visible runtime selection, returned viewer details, and “stop all conductor work” coverage.
+7. Reconciliation for stale visible runtime metadata: missing tmux sessions, exited runner processes, and orphaned active conductor runs.
+8. Tests for backend selection, persisted metadata, launch/preflight failure, cancellation cleanup, stale reconciliation, and iTerm fallback behavior.
+9. README and command/status updates explaining how to supervise visible workers.
+
+### Out of scope / later
+
+| What                                                    | Why                                                                                                        | Tracked in |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------- |
+| Direct interactive human typing into worker agent panes | Risks bypassing conductor state and tool contracts; read-only viewer is enough for first supervision slice | Future PRD |
+| Always-on daemon workers                                | This is per-run supervision, not background worker infrastructure                                          | Future PRD |
+| Remote terminal backends                                | Local tmux/iTerm validates the boundary first                                                              | Future PRD |
+| Full dashboard UI                                       | Viewer + persisted status is enough for this slice                                                         | Future PRD |
+| Replacing native/headless execution                     | Headless remains default and required for CI-safe operation                                                | N/A        |
+
+## 5. Functional Requirements
+
+### FR-1: Select visible runtime without disrupting headless runs
+
+Conductor must support a runtime selection concept for task execution. The existing native `AgentSession` path remains the default headless runtime. A new supervised tmux runtime can be selected explicitly through model-callable tools, natural-language routing, config, or worker/task options.
+
+The public naming should be understandable to users:
+
+* `headless` — existing in-process/native AgentSession behavior.
+* `tmux` — supervised visible runtime with tmux session/log metadata.
+* `iterm-tmux` — tmux runtime plus iTerm2 viewer opening on macOS.
+
+Implementation may keep `native` as an internal compatibility alias for `headless`, but user-facing docs should converge on `headless` vs `tmux`/`iterm-tmux`.
+
+**Acceptance criteria:**
+
+```gherkin
+Given no visible runtime is requested
+When conductor runs a task
+Then it uses the existing headless/native runtime behavior
+  And existing tests for child completion and cancellation still pass
+```
+
+```gherkin
+Given visible runtime "tmux" is requested
+When conductor starts a task run
+Then the run record includes runtime backend "tmux"
+  And the backend launch path is tmux-supervised rather than in-process headless
+```
+
+### FR-2: Persist tmux runtime metadata and logs
+
+A tmux-backed run must persist enough metadata for later inspection, cancellation, and reconciliation. At minimum, conductor records:
+
+* runtime backend: `tmux` or `iterm-tmux`
+* tmux session name
+* tmux window/pane identifiers when available
+* worktree/cwd
+* command line or runner entrypoint label, excluding secrets
+* environment keys relevant to conductor control, excluding secret values
+* log path under conductor-owned storage
+* viewer command, preferably read-only attach
+* launch timestamps and cleanup status
+
+Large logs must live as artifact refs or runtime metadata paths, not inline JSON payloads.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a tmux-backed run starts
+When conductor reads the run detail
+Then the run contains tmux session metadata, worktree path, log path, and a read-only attach command
+  And the log path is under conductor-owned storage
+```
+
+### FR-3: Execute the same task contract in a supervised runner
+
+The tmux backend must execute a conductor-owned runner process that uses the same task contract semantics as headless runs: scoped progress, scoped gates, optional follow-up tasks, explicit child completion, and fallback review if the worker exits without explicit completion.
+
+The runner may be a package-internal CLI/script entrypoint, but it must operate from a persisted run/task contract rather than depending on parent-process memory. This makes the tmux process restartable/reconcilable and prevents a visible pane from becoming an untracked manual session.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a tmux-backed runner starts for task T and run R
+When the child reports progress or completion
+Then conductor records the same task/run events and artifacts as the headless child-tool path
+```
+
+```gherkin
+Given the tmux-backed worker exits without explicit completion
+When conductor finalizes the run
+Then the task becomes needs_review
+  And a review gate explains that semantic completion was not explicitly reported
+```
+
+### FR-4: Cancel visible runs through conductor
+
+Canceling active conductor work must stop the supervised runtime in addition to mutating conductor state. Cancellation applies to:
+
+* `conductor_cancel_active_work`
+* task/run-specific cancellation
+* natural-language stop/cancel requests routed to conductor
+* parent orchestration aborts/interruption
+
+The cancellation order must be safe and auditable:
+
+1. Identify active conductor-owned run/task/worker refs.
+2. Mark or transition conductor state toward cancellation.
+3. Terminate the tmux session/process group.
+4. Persist terminal run/task status and cleanup evidence.
+5. Record cancellation events and diagnostics.
+
+**Acceptance criteria:**
+
+```gherkin
+Given two tmux-backed parallel runs are active
+When the user asks to stop all conductor work
+Then conductor terminates both tmux sessions
+  And both runs become aborted
+  And both tasks become canceled or otherwise terminal according to existing cancellation semantics
+  And both workers return to idle or recoverable with diagnostics
+```
+
+### FR-5: Open iTerm2 as a viewer, not a backend
+
+On macOS, conductor may open iTerm2 windows/tabs that attach to tmux sessions. iTerm2 must be treated as a viewer layer over tmux, not the runtime owner.
+
+The default viewer should attach read-only when possible, for example by using tmux read-only attach semantics. If iTerm2 is unavailable or AppleScript/open fails, the run should continue under tmux and conductor should return a manual attach command plus a warning.
+
+**Acceptance criteria:**
+
+```gherkin
+Given runtime "iterm-tmux" is requested on macOS with iTerm2 available
+When conductor starts a tmux-backed run
+Then conductor opens an iTerm2 viewer attached to the tmux session
+  And the run remains controlled by tmux/conductor metadata
+```
+
+```gherkin
+Given iTerm2 is unavailable
+When runtime "iterm-tmux" is requested
+Then conductor falls back to tmux with a clear viewer warning
+  And does not fail the run solely because the viewer could not open
+```
+
+### FR-6: Make visible supervision natural-language friendly
+
+A parent agent should not ask the user to provide tmux session names, task IDs, run IDs, or worker IDs for common visible-work flows. Natural-language requests such as “run this in parallel and show me the workers” should select a visible runtime when safe and return/open viewer details.
+
+Tool parameters may expose explicit runtime selection for precise calls, but the parent-agent happy path should remain high level.
+
+**Acceptance criteria:**
+
+```gherkin
+Given the user asks "run these in parallel and show me the workers"
+When the parent agent calls conductor_run_work with visible runtime intent
+Then conductor starts visible worker runs when safe
+  And returns worker/run viewer details in the tool result
+```
+
+### FR-7: Reconcile stale or orphaned visible runtime state
+
+Conductor reconciliation must understand tmux-backed run metadata. It should detect:
+
+* conductor run marked active but tmux session is missing
+* tmux process exited but conductor did not record terminal status
+* log path missing or unreadable
+* viewer failed to open while tmux run is healthy
+
+Reconciliation must not invent success. Unknown or missing runtime evidence should produce `needs_review`, `stale`, `aborted`, or recoverable diagnostics according to existing conductor semantics.
+
+**Acceptance criteria:**
+
+```gherkin
+Given conductor state says a tmux-backed run is active
+  And the tmux session no longer exists
+When conductor reconciles the project
+Then the run is marked stale or needs_review with diagnostics
+  And no successful task completion is invented
+```
+
+## 6. Non-Functional Requirements
+
+* **Safety:** visible execution cannot bypass conductor cancellation and cleanup policies.
+* **Portability:** headless remains available everywhere; tmux features fail clearly when `tmux` is missing; iTerm2 is macOS-only and optional.
+* **Observability:** viewer details, logs, runtime metadata, and events are easy to inspect through existing conductor tools.
+* **Testability:** tmux/iTerm shell integration is isolated behind adapters that can be mocked in unit tests; at least one smoke test should exercise real tmux when available.
+* **Security:** do not persist secret environment values, API keys, full prompts beyond existing session behavior, or unbounded terminal logs inline.
+* **Cleanup:** test-created tmux sessions, worktrees, branches, logs, and session files must be removable without manual forensics.
+
+## 7. Risks & Assumptions
+
+| Type       | Item                                                                                         | Mitigation / Validation                                                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Risk       | tmux process continues after conductor cancellation                                          | Track tmux session/process metadata, kill session/process group, and reconcile missing/leftover sessions.                                          |
+| Risk       | iTerm viewer launch flakes on macOS                                                          | Treat iTerm as best-effort viewer; return attach command and warning on failure.                                                                   |
+| Risk       | Child completion tools are unavailable in the runner process                                 | Share the existing task contract/tool wiring through a package runner entrypoint and test it with mocked runtime callbacks before using real tmux. |
+| Risk       | Visible pane invites manual input that bypasses state                                        | Default to read-only attach and document interactive intervention as out of scope.                                                                 |
+| Risk       | Log paths grow without bound                                                                 | Store logs as artifact refs with bounded reads and future retention policy hooks.                                                                  |
+| Assumption | `tmux attach -r` or equivalent read-only viewing is sufficient for first-slice supervision   | Verify during local real-tmux smoke testing and document manual fallback commands.                                                                 |
+| Assumption | A package-owned runner process can reconstruct task/run scope from persisted conductor state | Prove with mocked runner tests before relying on a real tmux process.                                                                              |
+
+## 8. Design Decisions
+
+| Decision                                        | Rationale                                                                                                |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| tmux is the runtime owner for visible runs      | tmux is scriptable, inspectable, cancelable, and independent of GUI availability.                        |
+| iTerm2 is viewer-only                           | Prevents GUI windows from becoming an untracked execution/control plane.                                 |
+| Read-only viewer by default                     | Supervision should not accidentally bypass conductor state or scoped child tools.                        |
+| Headless remains default                        | Existing CI-safe and in-process execution must stay stable.                                              |
+| Visible runner uses persisted task/run contract | Parent-process memory cannot be the only source of truth for a supervised terminal process.              |
+| Runtime metadata lives on run attempts          | Cancellation, status, and reconciliation need direct access to runtime handles, not just event payloads. |
+
+## 9. File Breakdown
+
+| File                                                            | Change type | FR               | Description                                                                                            |
+| --------------------------------------------------------------- | ----------- | ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `packages/pi-conductor/extensions/types.ts`                     | Modify      | FR-1, FR-2       | Add runtime mode names and run-level runtime metadata types.                                           |
+| `packages/pi-conductor/extensions/runtime.ts`                   | Modify      | FR-1, FR-3       | Extract a runtime backend boundary around the existing headless path and shared task-contract helpers. |
+| `packages/pi-conductor/extensions/tmux-runtime.ts`              | Add         | FR-2, FR-4, FR-7 | Add tmux launch, metadata, cancellation, and reconciliation adapter.                                   |
+| `packages/pi-conductor/extensions/runner.ts`                    | Add         | FR-3             | Add package-owned runner entrypoint used by supervised tmux sessions.                                  |
+| `packages/pi-conductor/extensions/iterm-viewer.ts`              | Add         | FR-5             | Add best-effort macOS iTerm2 viewer adapter over tmux attach.                                          |
+| `packages/pi-conductor/extensions/conductor.ts`                 | Modify      | FR-1, FR-4, FR-7 | Route selected runtime modes, persist metadata, and cancel/reconcile visible runs.                     |
+| `packages/pi-conductor/extensions/tools/orchestration-tools.ts` | Modify      | FR-6             | Add visible runtime selection/intent parameters and return viewer details.                             |
+| `packages/pi-conductor/extensions/commands.ts`                  | Modify      | FR-5, FR-6       | Add or update resource commands for viewer/status support.                                             |
+| `packages/pi-conductor/extensions/status.ts`                    | Modify      | FR-2, FR-5       | Display runtime metadata, log paths, viewer commands, and warnings.                                    |
+| `packages/pi-conductor/README.md`                               | Modify      | FR-1-FR-7        | Document supervised runtime usage, requirements, cancellation, and troubleshooting.                    |
+| `packages/pi-conductor/__tests__/runtime-run.test.ts`           | Modify      | FR-1, FR-3, FR-5 | Cover runtime selection, headless compatibility, task contract reuse, and iTerm fallback.              |
+| `packages/pi-conductor/__tests__/tmux-runtime.test.ts`          | Add         | FR-2, FR-4, FR-7 | Cover mocked tmux launch/cancel/reconcile behavior.                                                    |
+| `packages/pi-conductor/__tests__/conductor.test.ts`             | Modify      | FR-4, FR-6       | Cover natural-language visible orchestration and cancellation semantics.                               |
+| `packages/pi-conductor/__tests__/recovery.test.ts`              | Modify      | FR-7             | Cover stale/missing tmux session reconciliation.                                                       |
+
+## 10. Dependencies & Constraints
+
+* `tmux` is required only for visible `tmux` / `iterm-tmux` runtime modes.
+* iTerm2 support is macOS-only and optional; failure to open iTerm2 must not fail a healthy tmux run.
+* Headless/native execution must remain available without `tmux`.
+* Conductor state stays under `PI_CONDUCTOR_HOME` or `~/.pi/agent/conductor/projects`.
+* No secret environment values may be persisted in runtime metadata or logs.
+* Real tmux/iTerm integration must be isolated behind adapters so unit tests can mock shell/platform behavior.
+* Direct human typing into a worker pane is outside this slice; viewer commands should prefer read-only attach.
+
+## 11. Rollout Plan
+
+1. **Backend boundary:** add runtime mode metadata and route existing headless execution through the boundary.
+2. **tmux adapter:** implement mocked tmux launch/cancel/reconcile behavior and persist runtime metadata.
+3. **runner contract:** wire a separate runner process to the existing task contract and child reporting semantics.
+4. **viewer polish:** add iTerm2 viewer fallback and expose viewer details in status/tool results.
+5. **natural-language ergonomics:** route “show/watch/supervise/open terminals” requests to visible runtime selection when safe.
+6. **smoke and docs:** run real-tmux manual smoke, update README, and document cleanup/recovery.
+
+## 12. Open Questions
+
+| # | Question                                                                                             | Default for first implementation                                              | Owner          | Due             | Status |
+| - | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------- | --------------- | ------ |
+| 1 | Should visible runtime be opt-in per tool call only, or also configurable as a project/user default? | Start opt-in/tool-call first; add config only if usage demands it.            | Implementation | Before U6       | Open   |
+| 2 | Should the first implementation expose a separate `conductor_view_run` tool/command?                 | Include viewer details in run/status output first; add reopen tool if needed. | Implementation | Before U5       | Open   |
+| 3 | How much of the runner entrypoint should be public CLI versus internal package seam?                 | Keep it internal unless manual debugging needs a public command.              | Implementation | Before U4       | Open   |
+| 4 | Should real-tmux smoke tests run in CI when `tmux` is available?                                     | Add skip-when-missing smoke; decide CI enablement after local stability.      | Implementation | Before final PR | Open   |
+
+## 13. Related
+
+* Issue: <https://github.com/feniix/pi-extensions/issues/63>
+* ADR: `docs/adr/ADR-0015-supervised-tmux-visible-runtime.md`
+* Prior ADR: `docs/adr/ADR-0006-agent-session-based-foreground-run-execution.md`
+* Prior ADR: `docs/adr/ADR-0011-conductor-run-extension-binding-and-preflight-policy.md`
+* Prior ADR: `docs/adr/ADR-0012-conductor-owned-state-replaceable-backends.md`
+* Plan: `docs/plans/2026-04-27-001-feat-conductor-supervised-runtime-plan.md`
+
+## 14. Changelog
+
+| Date       | Version | Author | Change                                                   |
+| ---------- | ------- | ------ | -------------------------------------------------------- |
+| 2026-04-27 | 0.1     | pi     | Initial draft for supervised tmux/iTerm visible runtime. |

--- a/packages/pi-conductor/__tests__/backends.test.ts
+++ b/packages/pi-conductor/__tests__/backends.test.ts
@@ -52,11 +52,12 @@ describe("conductor backend inspection", () => {
       available: false,
       capabilities: { canStartRun: false, canSuperviseLiveOutput: true, requiresExternalRunner: true },
     });
-    expect(status.itermTmux).toMatchObject({
+    expect(status["iterm-tmux"]).toMatchObject({
       mode: "iterm-tmux",
       available: false,
       capabilities: { viewerOnly: true },
     });
+    expect(status.itermTmux).toBe(status["iterm-tmux"]);
     expect(getConductorRuntimeModeStatus("headless").available).toBe(true);
     expect(getConductorRuntimeModeStatus("tmux").diagnostic).toMatch(/not implemented yet/i);
   });

--- a/packages/pi-conductor/__tests__/backends.test.ts
+++ b/packages/pi-conductor/__tests__/backends.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getConductorBackendAdapter, inspectConductorBackends } from "../extensions/backends.js";
+import {
+  getConductorBackendAdapter,
+  getConductorRuntimeModeStatus,
+  inspectConductorBackends,
+  inspectConductorRuntimeModes,
+} from "../extensions/backends.js";
 
 describe("conductor backend inspection", () => {
   it("always reports the native backend as available", () => {
@@ -31,6 +36,29 @@ describe("conductor backend inspection", () => {
     const piSubagents = getConductorBackendAdapter("pi-subagents", { resolvePackage: () => null });
     expect(piSubagents.preflight()).toMatchObject({ available: false, capabilities: { canStartRun: false } });
     expect(piSubagents.dispatch()).toMatchObject({ ok: false });
+  });
+
+  it("reports runtime mode availability without requiring tmux", () => {
+    const status = inspectConductorRuntimeModes();
+
+    expect(status.headless).toMatchObject({
+      mode: "headless",
+      available: true,
+      canonicalStateOwner: "conductor",
+      capabilities: { canStartRun: true, canSuperviseLiveOutput: false },
+    });
+    expect(status.tmux).toMatchObject({
+      mode: "tmux",
+      available: false,
+      capabilities: { canStartRun: false, canSuperviseLiveOutput: true, requiresExternalRunner: true },
+    });
+    expect(status.itermTmux).toMatchObject({
+      mode: "iterm-tmux",
+      available: false,
+      capabilities: { viewerOnly: true },
+    });
+    expect(getConductorRuntimeModeStatus("headless").available).toBe(true);
+    expect(getConductorRuntimeModeStatus("tmux").diagnostic).toMatch(/not implemented yet/i);
   });
 
   it("reports pi-subagents available when an explicit dispatcher is injected", async () => {

--- a/packages/pi-conductor/__tests__/brief.test.ts
+++ b/packages/pi-conductor/__tests__/brief.test.ts
@@ -10,8 +10,10 @@ import {
   createObjectiveForRepo,
   createTaskForRepo,
   createWorkerForRepo,
+  getOrCreateRunForRepo,
   startTaskRunForRepo,
 } from "../extensions/conductor.js";
+import { writeRun } from "../extensions/storage.js";
 
 describe("conductor project brief", () => {
   let repoDir: string;
@@ -64,5 +66,24 @@ describe("conductor project brief", () => {
     expect(brief.markdown).toContain("runtimeMode=headless runtimeStatus=running");
     expect(brief.nextActions.length).toBeGreaterThan(0);
     expect(brief.recentEvents.length).toBeLessThanOrEqual(5);
+  });
+
+  it("does not surface terminal-status runs with missing finishedAt as active", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Corrupt terminal", prompt: "Summarize state" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId ? { ...entry, status: "failed", finishedAt: null } : entry,
+      ),
+    });
+
+    const brief = buildProjectBriefForRepo(repoDir, { maxActions: 3, recentEventLimit: 5 });
+
+    expect(brief.markdown).toContain("## Active Runs\n- none");
+    expect(brief.markdown).not.toContain(`cancel=conductor_cancel_task_run({"runId":"${started.run.runId}"`);
   });
 });

--- a/packages/pi-conductor/__tests__/brief.test.ts
+++ b/packages/pi-conductor/__tests__/brief.test.ts
@@ -4,11 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  assignTaskForRepo,
   buildProjectBriefForRepo,
   createGateForRepo,
   createObjectiveForRepo,
   createTaskForRepo,
   createWorkerForRepo,
+  startTaskRunForRepo,
 } from "../extensions/conductor.js";
 
 describe("conductor project brief", () => {
@@ -34,13 +36,15 @@ describe("conductor project brief", () => {
   });
 
   it("builds an LLM-oriented project brief with counts, blockers, and next actions", async () => {
-    await createWorkerForRepo(repoDir, "backend");
+    const worker = await createWorkerForRepo(repoDir, "backend");
     const objective = createObjectiveForRepo(repoDir, { title: "Autonomous MVP", prompt: "Ship conductor autonomy" });
     const task = createTaskForRepo(repoDir, {
       title: "Build brief",
       prompt: "Summarize state",
       objectiveId: objective.objectiveId,
     });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
     createGateForRepo(repoDir, {
       type: "needs_input",
       resourceRefs: { objectiveId: objective.objectiveId, taskId: task.taskId },
@@ -56,6 +60,8 @@ describe("conductor project brief", () => {
       type: "needs_input",
       requestedDecision: "Which next action should run?",
     });
+    expect(brief.markdown).toContain(`- ${started.run.runId} task=${task.taskId}`);
+    expect(brief.markdown).toContain("runtimeMode=headless runtimeStatus=running");
     expect(brief.nextActions.length).toBeGreaterThan(0);
     expect(brief.recentEvents.length).toBeLessThanOrEqual(5);
   });

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -20,6 +20,7 @@ import {
   startTaskRunForRepo,
   updateTaskForRepo,
 } from "../extensions/conductor.js";
+import { writeRun } from "../extensions/storage.js";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
   if (value == null) {
@@ -211,6 +212,22 @@ describe("conductor service", () => {
     expect(run.runs).toHaveLength(1);
   });
 
+  it("fails closed when a delegated start requests an unavailable runtime mode", async () => {
+    await expect(
+      delegateTaskForRepo(repoDir, {
+        title: "Visible delegated work",
+        prompt: "Run visibly",
+        workerName: "visible-worker",
+        startRun: true,
+        runtimeMode: "tmux",
+      }),
+    ).rejects.toThrow(/Runtime mode tmux unavailable/i);
+
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+    expect(run.runs).toHaveLength(0);
+  });
+
   it("cancels active conductor work without requiring run IDs", async () => {
     const worker = await createWorkerForRepo(repoDir, "backend");
     const task = createTaskForRepo(repoDir, { title: "Cancelable", prompt: "Do it" });
@@ -366,6 +383,49 @@ describe("conductor service", () => {
     expect(run.tasks).toHaveLength(1);
   });
 
+  it("passes runtimeMode through parallel work runners", async () => {
+    const seenRuntimeModes: Array<string | undefined> = [];
+
+    await runParallelWorkForRepo(
+      repoDir,
+      {
+        workerPrefix: "parallel",
+        runtimeMode: "tmux",
+        tasks: [
+          { title: "First shard", prompt: "Do first shard" },
+          { title: "Second shard", prompt: "Do second shard" },
+        ],
+      },
+      undefined,
+      async (_root, taskId, _signal, options) => {
+        seenRuntimeModes.push(options?.runtimeMode);
+        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+      },
+    );
+
+    expect(seenRuntimeModes).toEqual(["tmux", "tmux"]);
+  });
+
+  it("passes runtimeMode through single natural-language work runners", async () => {
+    let seenRuntimeMode: string | undefined;
+
+    await runWorkForRepo(
+      repoDir,
+      {
+        request: "Fix one focused issue",
+        runtimeMode: "iterm-tmux",
+        tasks: [{ title: "Fix one issue", prompt: "Fix it", writeScope: ["README.md"] }],
+      },
+      undefined,
+      async (_root, taskId, _signal, options) => {
+        seenRuntimeMode = options?.runtimeMode;
+        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+      },
+    );
+
+    expect(seenRuntimeMode).toBe("iterm-tmux");
+  });
+
   it("routes independent scoped work items to parallel workers", async () => {
     const result = await runWorkForRepo(
       repoDir,
@@ -480,6 +540,28 @@ describe("conductor service", () => {
     expect(getOrCreateRunForRepo(repoDir).events.map((event) => event.type)).toContain("task.updated");
   });
 
+  it("rejects canceling terminal-status runs even if finishedAt is missing", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Corrupt terminal", prompt: "Do it" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, workerId: worker.workerId });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      tasks: run.tasks.map((entry) =>
+        entry.taskId === task.taskId ? { ...entry, state: "failed", activeRunId: started.run.runId } : entry,
+      ),
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId ? { ...entry, status: "failed", finishedAt: null } : entry,
+      ),
+    });
+
+    const canceled = cancelTaskRunForRepo(repoDir, { runId: started.run.runId, reason: "stop" });
+
+    expect(canceled.runs[0]).toMatchObject({ status: "failed", finishedAt: null });
+    expect(canceled.events.at(-1)).toMatchObject({ type: "run.cancel_rejected" });
+  });
+
   it("cancels and retries task runs through conductor service helpers", async () => {
     const worker = await createWorkerForRepo(repoDir, "backend");
     const task = createTaskForRepo(repoDir, { title: "Retry task", prompt: "Do it" });
@@ -492,6 +574,11 @@ describe("conductor service", () => {
     });
     expect(canceled.runs[0]).toMatchObject({ status: "aborted" });
     expect(canceled.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
+
+    expect(() => retryTaskForRepo(repoDir, { taskId: task.taskId, runtimeMode: "tmux" })).toThrow(
+      /Runtime mode tmux unavailable/i,
+    );
+    expect(getOrCreateRunForRepo(repoDir).tasks[0]?.runIds).toHaveLength(1);
 
     const retried = retryTaskForRepo(repoDir, { taskId: task.taskId, leaseSeconds: 300 });
     expect(retried.run.runId).not.toBe(started.run.runId);

--- a/packages/pi-conductor/__tests__/dispatch.test.ts
+++ b/packages/pi-conductor/__tests__/dispatch.test.ts
@@ -50,6 +50,28 @@ describe("conductor backend dispatch wrapper", () => {
     });
   }
 
+  it("marks a started pi-subagents run failed when dispatcher throws", async () => {
+    addWorker();
+    const task = createTaskForRepo(repoRoot, { title: "Dispatch failure", prompt: "Run externally" });
+    assignTaskForRepo(repoRoot, task.taskId, "worker-1");
+
+    await expect(
+      dispatchTaskRunForRepo(repoRoot, {
+        taskId: task.taskId,
+        backend: "pi-subagents",
+        resolvePackage: () => "/tmp/pi-subagents/package.json",
+        dispatcher: async () => {
+          throw new Error("transport exploded");
+        },
+      }),
+    ).rejects.toThrow(/transport exploded/i);
+
+    const persisted = getOrCreateRunForRepo(repoRoot);
+    expect(persisted.tasks[0]).toMatchObject({ state: "failed", activeRunId: null });
+    expect(persisted.runs[0]).toMatchObject({ status: "failed", completionSummary: "transport exploded" });
+    expect(persisted.events.map((event) => event.type)).toContain("backend.dispatch_failed");
+  });
+
   it("dispatches pi-subagents runs through an injected dispatcher", async () => {
     addWorker();
     const task = createTaskForRepo(repoRoot, { title: "Dispatch", prompt: "Run externally" });

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -28,6 +28,7 @@ vi.mock("../extensions/runtime.js", async (importOriginal) => {
 
 import {
   assignTaskForRepo,
+  cancelTaskRunForRepo,
   createTaskForRepo,
   createWorkerForRepo,
   getOrCreateRunForRepo,
@@ -159,12 +160,40 @@ describe("durable task run flows", () => {
     assignTaskForRepo(repoDir, task.taskId, worker.workerId);
 
     await expect(runTaskForRepo(repoDir, task.taskId, undefined, { runtimeMode: "tmux" })).rejects.toThrow(
-      /tmux runtime is not implemented/i,
+      /Runtime mode tmux unavailable/i,
     );
 
     const persisted = getOrCreateRunForRepo(repoDir);
     expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
     expect(persisted.runs).toHaveLength(0);
+  });
+
+  it("aborts live worker runtime when canceling a specific active run", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Cancelable run", prompt: "Do cancellable work" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    let runtimeSignal: AbortSignal | undefined;
+    runtimeMocks.runWorkerPromptRuntime.mockImplementationOnce(async (input) => {
+      runtimeSignal = input.signal;
+      expect(runtimeSignal?.aborted).toBe(false);
+      cancelTaskRunForRepo(repoDir, { runId: input.taskContract.runId, reason: "human canceled run" });
+      expect(runtimeSignal?.aborted).toBe(true);
+      return {
+        status: "aborted",
+        finalText: null,
+        errorMessage: "human canceled run",
+        sessionId: "run-session-aborted",
+      };
+    });
+
+    const result = await runTaskForRepo(repoDir, task.taskId);
+
+    expect(result.status).toBe("aborted");
+    expect(runtimeSignal?.aborted).toBe(true);
+    const persisted = getOrCreateRunForRepo(repoDir);
+    expect(persisted.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
+    expect(persisted.runs[0]).toMatchObject({ status: "aborted", errorMessage: "human canceled run" });
   });
 
   it("forwards cancellation signals from tool callers into the worker runtime", async () => {

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -15,6 +15,14 @@ vi.mock("../extensions/runtime.js", async (importOriginal) => {
     ...actual,
     preflightWorkerRunRuntime: runtimeMocks.preflightWorkerRunRuntime,
     runWorkerPromptRuntime: runtimeMocks.runWorkerPromptRuntime,
+    getWorkerRunRuntimeBackend: vi.fn((mode = "headless") => {
+      if (mode !== "headless") throw new Error(`${mode} runtime is not implemented yet`);
+      return {
+        mode,
+        preflight: runtimeMocks.preflightWorkerRunRuntime,
+        run: runtimeMocks.runWorkerPromptRuntime,
+      };
+    }),
   };
 });
 

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -32,6 +32,7 @@ import {
   createWorkerForRepo,
   getOrCreateRunForRepo,
   runTaskForRepo,
+  startTaskRunForRepo,
 } from "../extensions/conductor.js";
 
 describe("durable task run flows", () => {
@@ -122,6 +123,48 @@ describe("durable task run flows", () => {
     expect(persisted.tasks[0]).toMatchObject({ state: "needs_review", activeRunId: null });
     expect(persisted.runs[0]).toMatchObject({ status: "partial", completionSummary: "I think it is done" });
     expect(persisted.gates[0]).toMatchObject({ type: "needs_review", status: "open" });
+  });
+
+  it("does not create an active run when runtime preflight fails", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Preflight task", prompt: "Do work" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    runtimeMocks.preflightWorkerRunRuntime.mockRejectedValueOnce(new Error("preflight failed"));
+
+    await expect(runTaskForRepo(repoDir, task.taskId)).rejects.toThrow(/preflight failed/i);
+
+    const persisted = getOrCreateRunForRepo(repoDir);
+    expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+    expect(persisted.runs).toHaveLength(0);
+    expect(persisted.workers[0]).toMatchObject({ lifecycle: "idle" });
+  });
+
+  it("fails closed for explicit visible runtime start before creating a run", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Visible start", prompt: "Start visible work" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    expect(() => startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "tmux" })).toThrow(
+      /Runtime mode tmux unavailable/i,
+    );
+
+    const persisted = getOrCreateRunForRepo(repoDir);
+    expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+    expect(persisted.runs).toHaveLength(0);
+  });
+
+  it("fails closed for explicit visible runtime execution before creating a run", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Visible task", prompt: "Do visible work" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    await expect(runTaskForRepo(repoDir, task.taskId, undefined, { runtimeMode: "tmux" })).rejects.toThrow(
+      /tmux runtime is not implemented/i,
+    );
+
+    const persisted = getOrCreateRunForRepo(repoDir);
+    expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+    expect(persisted.runs).toHaveLength(0);
   });
 
   it("forwards cancellation signals from tool callers into the worker runtime", async () => {

--- a/packages/pi-conductor/__tests__/runtime-run.test.ts
+++ b/packages/pi-conductor/__tests__/runtime-run.test.ts
@@ -30,6 +30,7 @@ import {
   preflightWorkerRunRuntime,
   runWorkerPromptRuntime,
 } from "../extensions/runtime.js";
+import { mapRunStatusToRuntimeStatus } from "../extensions/runtime-metadata.js";
 
 describe("worker run runtime helpers", () => {
   afterEach(() => {
@@ -368,6 +369,20 @@ describe("worker run runtime helpers", () => {
     const result = await backend.run({ worktreePath, sessionFile, task: "do work" });
 
     expect(result).toMatchObject({ status: "success", finalText: "done", sessionId: "run-session-backend" });
+  });
+
+  it("maps conductor run statuses to runtime statuses", () => {
+    expect(mapRunStatusToRuntimeStatus("queued")).toBe("running");
+    expect(mapRunStatusToRuntimeStatus("dispatch_pending")).toBe("running");
+    expect(mapRunStatusToRuntimeStatus("succeeded")).toBe("exited_success");
+    expect(mapRunStatusToRuntimeStatus("partial")).toBe("exited_success");
+    expect(mapRunStatusToRuntimeStatus("blocked")).toBe("exited_success");
+    expect(mapRunStatusToRuntimeStatus("failed")).toBe("exited_error");
+    expect(mapRunStatusToRuntimeStatus("stale")).toBe("exited_error");
+    expect(mapRunStatusToRuntimeStatus("unknown_dispatch")).toBe("exited_error");
+    expect(mapRunStatusToRuntimeStatus("aborted")).toBe("aborted");
+    expect(mapRunStatusToRuntimeStatus("interrupted")).toBe("aborted");
+    expect(mapRunStatusToRuntimeStatus(undefined)).toBe("unknown");
   });
 
   it("fails closed for visible runtime modes until their adapters are implemented", () => {

--- a/packages/pi-conductor/__tests__/runtime-run.test.ts
+++ b/packages/pi-conductor/__tests__/runtime-run.test.ts
@@ -25,6 +25,7 @@ import {
   buildRunScopedConductorTools,
   buildTaskContractPrompt,
   extractFinalAssistantText,
+  getWorkerRunRuntimeBackend,
   mapStopReasonToRunOutcome,
   preflightWorkerRunRuntime,
   runWorkerPromptRuntime,
@@ -342,6 +343,36 @@ describe("worker run runtime helpers", () => {
     await expect(preflightWorkerRunRuntime({ worktreePath, sessionFile })).rejects.toThrow(
       /No usable model or provider configuration/,
     );
+  });
+
+  it("routes headless execution through a runtime backend interface", async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), "pi-conductor-runtime-"));
+    const sessionFile = join(worktreePath, "session.jsonl");
+    writeFileSync(sessionFile, "{}\n", "utf-8");
+    codingAgentMocks.openSession.mockReturnValue({} as never);
+
+    const session = {
+      sessionId: "run-session-backend",
+      messages: [] as unknown[],
+      bindExtensions: vi.fn(async () => {}),
+      prompt: vi.fn(async () => {
+        session.messages.push({ role: "assistant", stopReason: "stop", content: [{ type: "text", text: "done" }] });
+      }),
+      abort: vi.fn(async () => {}),
+      dispose: vi.fn(),
+    };
+    codingAgentMocks.createAgentSession.mockResolvedValue({ session });
+
+    const backend = getWorkerRunRuntimeBackend("headless");
+    expect(backend.mode).toBe("headless");
+    const result = await backend.run({ worktreePath, sessionFile, task: "do work" });
+
+    expect(result).toMatchObject({ status: "success", finalText: "done", sessionId: "run-session-backend" });
+  });
+
+  it("fails closed for visible runtime modes until their adapters are implemented", () => {
+    expect(() => getWorkerRunRuntimeBackend("tmux")).toThrow(/tmux runtime is not implemented/i);
+    expect(() => getWorkerRunRuntimeBackend("iterm-tmux")).toThrow(/iterm-tmux runtime is not implemented/i);
   });
 
   it("returns successful outcome from assistant final state and text extraction", async () => {

--- a/packages/pi-conductor/__tests__/scheduler.test.ts
+++ b/packages/pi-conductor/__tests__/scheduler.test.ts
@@ -18,19 +18,29 @@ const runtimeTracking = vi.hoisted(() => ({
 
 vi.mock("../extensions/runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../extensions/runtime.js")>();
+  const preflightWorkerRunRuntime = vi.fn(() => undefined);
+  const runWorkerPromptRuntime = vi.fn(async (input) => {
+    runtimeTracking.runWorkerPromptInputs.push(input);
+    await input.onConductorComplete?.({
+      runId: input.taskContract?.runId ?? "run-unknown",
+      taskId: input.taskContract?.taskId ?? "task-unknown",
+      status: "succeeded",
+      completionSummary: "done by scheduler",
+      artifact: { type: "completion_report", ref: "completion://scheduler" },
+    });
+    return { status: "success", finalText: "done", errorMessage: null, sessionId: "session-1" };
+  });
   return {
     ...actual,
-    preflightWorkerRunRuntime: vi.fn(() => undefined),
-    runWorkerPromptRuntime: vi.fn(async (input) => {
-      runtimeTracking.runWorkerPromptInputs.push(input);
-      await input.onConductorComplete?.({
-        runId: input.taskContract?.runId ?? "run-unknown",
-        taskId: input.taskContract?.taskId ?? "task-unknown",
-        status: "succeeded",
-        completionSummary: "done by scheduler",
-        artifact: { type: "completion_report", ref: "completion://scheduler" },
-      });
-      return { status: "success", finalText: "done", errorMessage: null, sessionId: "session-1" };
+    preflightWorkerRunRuntime,
+    runWorkerPromptRuntime,
+    getWorkerRunRuntimeBackend: vi.fn((mode = "headless") => {
+      if (mode !== "headless") throw new Error(`${mode} runtime is not implemented yet`);
+      return {
+        mode,
+        preflight: preflightWorkerRunRuntime,
+        run: runWorkerPromptRuntime,
+      };
     }),
   };
 });

--- a/packages/pi-conductor/__tests__/static-safety.test.ts
+++ b/packages/pi-conductor/__tests__/static-safety.test.ts
@@ -191,6 +191,25 @@ describe("pi-conductor static safety guards", () => {
     expect(gateSource.split("\n").length).toBeLessThan(120);
   });
 
+  it("exposes runtimeMode on agent-facing run entrypoints", () => {
+    const tools = collectTools();
+    const runtimeAwareToolNames = [
+      "conductor_delegate_task",
+      "conductor_start_task_run",
+      "conductor_run_task",
+      "conductor_retry_task",
+      "conductor_run_work",
+      "conductor_run_parallel_work",
+      "conductor_schedule_objective",
+    ];
+
+    for (const name of runtimeAwareToolNames) {
+      const tool = tools.find((entry) => entry.name === name);
+      expect(JSON.stringify(tool?.parameters)).toContain("runtimeMode");
+      expect(JSON.stringify(tool?.parameters)).toContain("iterm-tmux");
+    }
+  });
+
   it("does not expose trusted-human gate approval as a model tool", () => {
     const tools = collectTools();
     const toolNames = tools.map((tool) => tool.name).sort();

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -7,6 +7,7 @@ import {
   createEmptyRun,
   createTaskRecord,
   createWorkerRecord,
+  startTaskRun,
 } from "../extensions/storage.js";
 
 describe("formatRunStatus", () => {
@@ -39,6 +40,33 @@ describe("formatRunStatus", () => {
     expect(text).toContain(
       "- task Add ledger [task-1] state=assigned assignedWorker=worker-1 activeRun=none latestProgress=none",
     );
+  });
+
+  it("includes run runtime metadata", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    const task = createTaskRecord({ taskId: "task-1", title: "Add ledger", prompt: "Implement tasks" });
+    const withRun = startTaskRun(
+      assignTaskToWorker(addTask(addWorker(run, worker), task), task.taskId, worker.workerId),
+      {
+        runId: "run-1",
+        taskId: task.taskId,
+        workerId: worker.workerId,
+        backend: "native",
+        leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+      },
+    );
+
+    const text = formatRunStatus(withRun);
+
+    expect(text).toContain("- run run-1 task=task-1 worker=worker-1 status=running backend=native");
+    expect(text).toContain("runtimeMode=headless runtimeStatus=running viewer=not_applicable cleanup=not_required");
   });
 
   it("includes worker runtime and PR state", () => {

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -740,7 +740,9 @@ describe("storage helpers", () => {
       ],
     };
 
-    writeRun(legacy as never);
+    const projectDir = getConductorProjectDir("abc");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, "run.json"), `${JSON.stringify(legacy, null, 2)}\n`, "utf-8");
 
     const persisted = readRun("abc");
     expect(persisted?.runs[0]?.runtime).toMatchObject({
@@ -750,6 +752,115 @@ describe("storage helpers", () => {
       startedAt: "2026-01-01T00:00:00.000Z",
       cleanupStatus: "not_required",
     });
+  });
+
+  it("rejects malformed runtime metadata", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
+    const task = createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" });
+    const running = startTaskRun(
+      assignTaskToWorker(addTask(addWorker(run, worker), task), task.taskId, worker.workerId),
+      {
+        runId: "run-1",
+        taskId: task.taskId,
+        workerId: worker.workerId,
+        backend: "native",
+        leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+      },
+    );
+    const runtime = running.runs[0]?.runtime;
+    if (!runtime) throw new Error("expected runtime");
+
+    expect(() =>
+      validateRunRecord({
+        ...running,
+        runs: [{ ...running.runs[0], runtime: { ...runtime, mode: "bogus" } } as never],
+      }),
+    ).toThrow(/runtime\.mode has invalid value/i);
+    expect(() =>
+      validateRunRecord({
+        ...running,
+        runs: [{ ...running.runs[0], runtime: { ...runtime, diagnostics: "not-an-array" } } as never],
+      }),
+    ).toThrow(/runtime\.diagnostics must be an array of strings/i);
+    const { diagnostics: _diagnostics, ...partialRuntime } = runtime;
+    expect(() =>
+      validateRunRecord({
+        ...running,
+        runs: [{ ...running.runs[0], runtime: partialRuntime } as never],
+      }),
+    ).toThrow(/runtime missing required field diagnostics/i);
+    expect(() =>
+      validateRunRecord({
+        ...running,
+        runs: [
+          {
+            ...running.runs[0],
+            runtime: { ...runtime, mode: "tmux", tmux: { socketPath: "/tmp/socket", sessionName: "s" } },
+          } as never,
+        ],
+      }),
+    ).toThrow(/runtime\.tmux missing required field windowId/i);
+    expect(() =>
+      validateRunRecord({
+        ...running,
+        runs: [
+          {
+            ...running.runs[0],
+            runtime: {
+              ...runtime,
+              mode: "tmux",
+              tmux: { socketPath: "/tmp/socket", sessionName: "s", windowId: "w", paneId: "%1" },
+              viewerStatus: "pending",
+              cleanupStatus: "pending",
+            },
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("lets canonical terminal run state win over stale runtime metadata", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
+    const task = createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" });
+    const running = startTaskRun(
+      assignTaskToWorker(addTask(addWorker(run, worker), task), task.taskId, worker.workerId),
+      {
+        runId: "run-1",
+        taskId: task.taskId,
+        workerId: worker.workerId,
+        backend: "native",
+        leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+      },
+    );
+    const canceled = cancelTaskRun(running, { runId: "run-1", reason: "stop" });
+    const corrupted = {
+      ...canceled,
+      runs: canceled.runs.map((attempt) =>
+        attempt.runId === "run-1"
+          ? { ...attempt, runtime: { ...attempt.runtime, status: "running", finishedAt: null } }
+          : attempt,
+      ),
+    };
+    const projectDir = getConductorProjectDir("abc");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, "run.json"), `${JSON.stringify(corrupted, null, 2)}\n`, "utf-8");
+
+    const persisted = readRun("abc");
+    expect(persisted?.runs[0]?.runtime).toMatchObject({ status: "aborted", finishedAt: canceled.runs[0]?.finishedAt });
   });
 
   it("validates resource identity and reference invariants", () => {

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -187,7 +187,17 @@ describe("storage helpers", () => {
     });
 
     expect(running.tasks[0]).toMatchObject({ state: "running", activeRunId: "run-1", runIds: ["run-1"] });
-    expect(running.runs[0]).toMatchObject({ runId: "run-1", status: "running", taskRevision: 1 });
+    expect(running.runs[0]).toMatchObject({
+      runId: "run-1",
+      status: "running",
+      taskRevision: 1,
+      runtime: {
+        mode: "headless",
+        status: "running",
+        sessionId: null,
+        cleanupStatus: "not_required",
+      },
+    });
     expect(running.workers[0]?.lifecycle).toBe("running");
 
     const completed = completeTaskRun(running, {
@@ -200,6 +210,7 @@ describe("storage helpers", () => {
     expect(completed.runs[0]).toMatchObject({
       status: "succeeded",
       completionSummary: "Implemented durable task runs",
+      runtime: { status: "exited_success", cleanupStatus: "not_required" },
     });
     expect(completed.workers[0]?.lifecycle).toBe("idle");
     expect(completed.events.map((event) => event.type)).toContain("run.completed");
@@ -235,10 +246,15 @@ describe("storage helpers", () => {
     });
     expect(heartbeat.runs[0]).toMatchObject({ leaseExpiresAt: "2026-04-24T02:00:00.000Z" });
     expect(heartbeat.runs[0]?.lastHeartbeatAt).toBeTruthy();
+    expect(heartbeat.runs[0]?.runtime.heartbeatAt).toBeTruthy();
     expect(heartbeat.events.map((event) => event.type)).toContain("run.heartbeat");
 
     const reconciled = reconcileRunLeases(heartbeat, { now: "2026-04-24T02:00:01.000Z" });
-    expect(reconciled.runs[0]).toMatchObject({ status: "stale", finishedAt: "2026-04-24T02:00:01.000Z" });
+    expect(reconciled.runs[0]).toMatchObject({
+      status: "stale",
+      finishedAt: "2026-04-24T02:00:01.000Z",
+      runtime: { status: "exited_error", finishedAt: "2026-04-24T02:00:01.000Z" },
+    });
     expect(reconciled.tasks[0]).toMatchObject({ state: "needs_review", activeRunId: null });
     expect(reconciled.workers[0]?.lifecycle).toBe("idle");
     expect(reconciled.events.map((event) => event.type)).toContain("run.lease_expired");
@@ -383,7 +399,11 @@ describe("storage helpers", () => {
 
     const canceled = cancelTaskRun(run, { runId: "run-1", reason: "Parent agent stopped superseded work" });
 
-    expect(canceled.runs[0]).toMatchObject({ status: "aborted", errorMessage: "Parent agent stopped superseded work" });
+    expect(canceled.runs[0]).toMatchObject({
+      status: "aborted",
+      errorMessage: "Parent agent stopped superseded work",
+      runtime: { status: "aborted", cleanupStatus: "not_required" },
+    });
     expect(canceled.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
     expect(canceled.workers[0]?.lifecycle).toBe("idle");
     expect(canceled.events.map((event) => event.type)).toContain("run.canceled");
@@ -682,6 +702,56 @@ describe("storage helpers", () => {
     expect(() => readRun("abc")).toThrow(/Failed to read conductor state for project abc/i);
   });
 
+  it("normalizes legacy run attempts without runtime metadata", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: null,
+    });
+    const task = createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" });
+    const legacy = {
+      ...run,
+      workers: [worker],
+      tasks: [{ ...task, assignedWorkerId: worker.workerId, activeRunId: "run-1", runIds: ["run-1"] }],
+      runs: [
+        {
+          runId: "run-1",
+          taskId: task.taskId,
+          workerId: worker.workerId,
+          taskRevision: 1,
+          status: "running",
+          backend: "native",
+          backendRunId: null,
+          sessionId: "session-1",
+          leaseGeneration: 1,
+          leaseStartedAt: null,
+          leaseExpiresAt: null,
+          lastHeartbeatAt: null,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: null,
+          completionSummary: null,
+          errorMessage: null,
+          artifactIds: [],
+          gateIds: [],
+        },
+      ],
+    };
+
+    writeRun(legacy as never);
+
+    const persisted = readRun("abc");
+    expect(persisted?.runs[0]?.runtime).toMatchObject({
+      mode: "headless",
+      status: "running",
+      sessionId: "session-1",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      cleanupStatus: "not_required",
+    });
+  });
+
   it("validates resource identity and reference invariants", () => {
     const run = createEmptyRun("abc", "/tmp/repo");
     const worker = createWorkerRecord({
@@ -712,6 +782,24 @@ describe("storage helpers", () => {
             backend: "native",
             backendRunId: null,
             sessionId: null,
+            runtime: {
+              mode: "headless",
+              status: "running",
+              sessionId: null,
+              cwd: null,
+              command: null,
+              runnerPid: null,
+              processGroupId: null,
+              tmux: null,
+              logPath: null,
+              viewerCommand: null,
+              viewerStatus: "not_applicable",
+              diagnostics: [],
+              heartbeatAt: null,
+              cleanupStatus: "not_required",
+              startedAt: null,
+              finishedAt: null,
+            },
             leaseGeneration: 1,
             leaseStartedAt: null,
             leaseExpiresAt: null,

--- a/packages/pi-conductor/__tests__/task-brief.test.ts
+++ b/packages/pi-conductor/__tests__/task-brief.test.ts
@@ -9,6 +9,7 @@ import {
   createObjectiveForRepo,
   createTaskForRepo,
   createWorkerForRepo,
+  startTaskRunForRepo,
 } from "../extensions/conductor.js";
 
 describe("conductor task brief", () => {
@@ -42,6 +43,7 @@ describe("conductor task brief", () => {
       objectiveId: objective.objectiveId,
     });
     assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
 
     const brief = buildTaskBriefForRepo(repoDir, { taskId: task.taskId });
 
@@ -49,6 +51,8 @@ describe("conductor task brief", () => {
     expect(brief.task.taskId).toBe(task.taskId);
     expect(brief.objective?.objectiveId).toBe(objective.objectiveId);
     expect(brief.worker?.workerId).toBe(worker.workerId);
-    expect(brief.suggestedNextTool).toMatchObject({ name: "conductor_run_task", params: { taskId: task.taskId } });
+    expect(brief.markdown).toContain(`- ${started.run.runId} status=running`);
+    expect(brief.markdown).toContain("runtimeMode=headless runtimeStatus=running");
+    expect(brief.suggestedNextTool).toBeNull();
   });
 });

--- a/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
+++ b/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
@@ -1,0 +1,154 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assignTaskForRepo,
+  cancelTaskRunForRepo,
+  createTaskForRepo,
+  createWorkerForRepo,
+  getOrCreateRunForRepo,
+  startTaskRunForRepo,
+} from "../extensions/conductor.js";
+import conductorExtension from "../extensions/index.js";
+
+type RegisteredTool = {
+  name: string;
+  parameters?: unknown;
+  execute?: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: { cwd: string },
+  ) => Promise<unknown> | unknown;
+};
+
+function collectTools(): RegisteredTool[] {
+  const tools: RegisteredTool[] = [];
+  const fakePi = {
+    registerCommand: () => undefined,
+    registerTool: (tool: RegisteredTool) => tools.push(tool),
+  };
+  conductorExtension(fakePi as never);
+  return tools;
+}
+
+function getTool(tools: RegisteredTool[], name: string): RegisteredTool {
+  const tool = tools.find((entry) => entry.name === name);
+  if (!tool?.execute) {
+    throw new Error(`Tool ${name} not registered with an execute handler`);
+  }
+  return tool;
+}
+
+describe("conductor runtime-mode tool contracts", () => {
+  let repoDir: string;
+  let conductorHome: string;
+
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
+
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) rmSync(repoDir, { recursive: true, force: true });
+    if (existsSync(conductorHome)) rmSync(conductorHome, { recursive: true, force: true });
+  });
+
+  it("forwards runtimeMode through registered start, run, retry, and delegate tools", async () => {
+    const tools = collectTools();
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Visible tool task", prompt: "Run visibly" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    await expect(
+      getTool(tools, "conductor_start_task_run").execute?.(
+        "tool-call-1",
+        { taskId: task.taskId, runtimeMode: "tmux" },
+        undefined,
+        undefined,
+        { cwd: repoDir },
+      ),
+    ).rejects.toThrow(/Runtime mode tmux unavailable/i);
+    expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(0);
+
+    await expect(
+      getTool(tools, "conductor_run_task").execute?.(
+        "tool-call-2",
+        { taskId: task.taskId, runtimeMode: "tmux" },
+        undefined,
+        undefined,
+        { cwd: repoDir },
+      ),
+    ).rejects.toThrow(/Runtime mode tmux unavailable/i);
+    expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(0);
+
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
+    cancelTaskRunForRepo(repoDir, { runId: started.run.runId, reason: "prepare retry" });
+    await expect(
+      getTool(tools, "conductor_retry_task").execute?.(
+        "tool-call-3",
+        { taskId: task.taskId, runtimeMode: "tmux" },
+        undefined,
+        undefined,
+        { cwd: repoDir },
+      ),
+    ).rejects.toThrow(/Runtime mode tmux unavailable/i);
+    expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(1);
+
+    await expect(
+      getTool(tools, "conductor_delegate_task").execute?.(
+        "tool-call-4",
+        {
+          title: "Visible delegate",
+          prompt: "Run visibly",
+          workerName: "delegate-visible",
+          startRun: true,
+          runtimeMode: "tmux",
+        },
+        undefined,
+        undefined,
+        { cwd: repoDir },
+      ),
+    ).rejects.toThrow(/Runtime mode tmux unavailable/i);
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.tasks.at(-1)).toMatchObject({ title: "Visible delegate", state: "assigned", activeRunId: null });
+  });
+
+  it("surfaces runtime status through registered list-runs and backend-status tools", async () => {
+    const tools = collectTools();
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Visible status", prompt: "Report status" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
+
+    const listRuns = (await getTool(tools, "conductor_list_runs").execute?.("tool-call-5", {}, undefined, undefined, {
+      cwd: repoDir,
+    })) as { content: Array<{ text: string }>; details: { runs: Array<{ runtime?: unknown }> } };
+    expect(listRuns.content[0]?.text).toContain(`${started.run.runId} task=${task.taskId}`);
+    expect(listRuns.content[0]?.text).toContain("runtimeMode=headless runtimeStatus=running");
+    expect(listRuns.details.runs[0]?.runtime).toMatchObject({ mode: "headless", status: "running" });
+
+    const backendStatus = (await getTool(tools, "conductor_backend_status").execute?.(
+      "tool-call-6",
+      {},
+      undefined,
+      undefined,
+      { cwd: repoDir },
+    )) as { content: Array<{ text: string }>; details: { runtimes: Record<string, { available: boolean }> } };
+    expect(backendStatus.content[0]?.text).toContain("runtime headless: available=true");
+    expect(backendStatus.content[0]?.text).toContain("runtime tmux: available=false");
+    expect(backendStatus.details.runtimes.headless).toMatchObject({ available: true });
+    expect(backendStatus.details.runtimes.tmux).toMatchObject({ available: false });
+  });
+});

--- a/packages/pi-conductor/extensions/backends.ts
+++ b/packages/pi-conductor/extensions/backends.ts
@@ -38,11 +38,10 @@ export interface ConductorRuntimeModeStatus {
   diagnostic: string | null;
 }
 
-export interface ConductorRuntimeModesStatus {
-  headless: ConductorRuntimeModeStatus;
-  tmux: ConductorRuntimeModeStatus;
+export type ConductorRuntimeModesStatus = Record<RunRuntimeMode, ConductorRuntimeModeStatus> & {
+  /** @deprecated Use the runtime mode literal key `iterm-tmux`. */
   itermTmux: ConductorRuntimeModeStatus;
-}
+};
 
 export interface ConductorBackendDispatchResult {
   ok: boolean;
@@ -136,6 +135,13 @@ export function inspectConductorBackends(
 }
 
 export function inspectConductorRuntimeModes(): ConductorRuntimeModesStatus {
+  const itermTmux: ConductorRuntimeModeStatus = {
+    mode: "iterm-tmux",
+    available: false,
+    canonicalStateOwner: "conductor",
+    capabilities: unavailableItermViewerCapabilities,
+    diagnostic: "iTerm2 viewer depends on the tmux supervised runtime adapter, which is not implemented yet",
+  };
   return {
     headless: {
       mode: "headless",
@@ -151,26 +157,14 @@ export function inspectConductorRuntimeModes(): ConductorRuntimeModesStatus {
       capabilities: unavailableVisibleRuntimeCapabilities,
       diagnostic: "tmux supervised runtime adapter is not implemented yet",
     },
-    itermTmux: {
-      mode: "iterm-tmux",
-      available: false,
-      canonicalStateOwner: "conductor",
-      capabilities: unavailableItermViewerCapabilities,
-      diagnostic: "iTerm2 viewer depends on the tmux supervised runtime adapter, which is not implemented yet",
-    },
+    "iterm-tmux": itermTmux,
+    itermTmux,
   };
 }
 
 export function getConductorRuntimeModeStatus(mode: RunRuntimeMode): ConductorRuntimeModeStatus {
   const status = inspectConductorRuntimeModes();
-  switch (mode) {
-    case "headless":
-      return status.headless;
-    case "tmux":
-      return status.tmux;
-    case "iterm-tmux":
-      return status.itermTmux;
-  }
+  return status[mode];
 }
 
 export function getConductorBackendAdapter(

--- a/packages/pi-conductor/extensions/backends.ts
+++ b/packages/pi-conductor/extensions/backends.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import type { RunRuntimeMode } from "./types.js";
 
 export type ConductorBackendKind = "native" | "pi-subagents";
 
@@ -20,6 +21,27 @@ export interface ConductorBackendStatus {
 export interface ConductorBackendsStatus {
   native: ConductorBackendStatus;
   piSubagents: ConductorBackendStatus;
+}
+
+export interface ConductorRuntimeModeCapabilities {
+  canStartRun: boolean;
+  canSuperviseLiveOutput: boolean;
+  requiresExternalRunner: boolean;
+  viewerOnly: boolean;
+}
+
+export interface ConductorRuntimeModeStatus {
+  mode: RunRuntimeMode;
+  available: boolean;
+  canonicalStateOwner: "conductor";
+  capabilities: ConductorRuntimeModeCapabilities;
+  diagnostic: string | null;
+}
+
+export interface ConductorRuntimeModesStatus {
+  headless: ConductorRuntimeModeStatus;
+  tmux: ConductorRuntimeModeStatus;
+  itermTmux: ConductorRuntimeModeStatus;
 }
 
 export interface ConductorBackendDispatchResult {
@@ -50,6 +72,27 @@ const unavailablePiSubagentsCapabilities: ConductorBackendCapabilities = {
   canRunForeground: false,
   supportsScopedChildTools: false,
   requiresReviewOnExit: true,
+};
+
+const headlessRuntimeCapabilities: ConductorRuntimeModeCapabilities = {
+  canStartRun: true,
+  canSuperviseLiveOutput: false,
+  requiresExternalRunner: false,
+  viewerOnly: false,
+};
+
+const unavailableVisibleRuntimeCapabilities: ConductorRuntimeModeCapabilities = {
+  canStartRun: false,
+  canSuperviseLiveOutput: true,
+  requiresExternalRunner: true,
+  viewerOnly: false,
+};
+
+const unavailableItermViewerCapabilities: ConductorRuntimeModeCapabilities = {
+  canStartRun: false,
+  canSuperviseLiveOutput: true,
+  requiresExternalRunner: true,
+  viewerOnly: true,
 };
 
 function resolvePiSubagents(input: { resolvePackage?: (specifier: string) => string | null } = {}): string | null {
@@ -90,6 +133,44 @@ export function inspectConductorBackends(
           : "Optional pi-subagents adapter is not installed or not resolvable from pi-conductor",
     },
   };
+}
+
+export function inspectConductorRuntimeModes(): ConductorRuntimeModesStatus {
+  return {
+    headless: {
+      mode: "headless",
+      available: true,
+      canonicalStateOwner: "conductor",
+      capabilities: headlessRuntimeCapabilities,
+      diagnostic: null,
+    },
+    tmux: {
+      mode: "tmux",
+      available: false,
+      canonicalStateOwner: "conductor",
+      capabilities: unavailableVisibleRuntimeCapabilities,
+      diagnostic: "tmux supervised runtime adapter is not implemented yet",
+    },
+    itermTmux: {
+      mode: "iterm-tmux",
+      available: false,
+      canonicalStateOwner: "conductor",
+      capabilities: unavailableItermViewerCapabilities,
+      diagnostic: "iTerm2 viewer depends on the tmux supervised runtime adapter, which is not implemented yet",
+    },
+  };
+}
+
+export function getConductorRuntimeModeStatus(mode: RunRuntimeMode): ConductorRuntimeModeStatus {
+  const status = inspectConductorRuntimeModes();
+  switch (mode) {
+    case "headless":
+      return status.headless;
+    case "tmux":
+      return status.tmux;
+    case "iterm-tmux":
+      return status.itermTmux;
+  }
 }
 
 export function getConductorBackendAdapter(

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -13,6 +13,7 @@ import { computeNextActions } from "./next-actions.js";
 import { createObjectiveForRepo, planObjectiveForRepo, refreshObjectiveStatusForRepo } from "./objective-service.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
 import { createWorkerSessionRuntime, getWorkerRunRuntimeBackend, recoverWorkerSessionRuntime } from "./runtime.js";
+import { formatRunRuntimeSummary } from "./runtime-metadata.js";
 import { type SchedulerFairness, type SchedulerPolicyName, selectSchedulerActions } from "./scheduler-selection.js";
 import {
   addConductorArtifact,
@@ -45,6 +46,7 @@ import type {
   ConductorTaskBrief,
   RunAttemptRecord,
   RunRecord,
+  RunRuntimeMode,
   TaskContractInput,
   TaskRecord,
   WorkerRecord,
@@ -431,6 +433,16 @@ export function buildTaskBriefForRepo(repoRoot: string, input: { taskId: string 
     `Gates: ${gates.length}`,
     `Artifacts: ${artifacts.length}`,
     "",
+    "## Runs",
+    runs.length === 0
+      ? "- none"
+      : runs
+          .map(
+            (attempt) =>
+              `- ${attempt.runId} status=${attempt.status} taskRevision=${attempt.taskRevision} ${formatRunRuntimeSummary(attempt.runtime)}`,
+          )
+          .join("\n"),
+    "",
     "## Dependencies",
     dependencies.length === 0
       ? "- none"
@@ -464,6 +476,7 @@ export function buildProjectBriefForRepo(
   });
   const recentEventLimit = Math.max(1, Math.min(input.recentEventLimit ?? 10, 50));
   const recentEvents = run.events.slice(-recentEventLimit);
+  const activeRuns = run.runs.filter((attempt) => !attempt.finishedAt);
   const lines = [
     "# Conductor Project Brief",
     "",
@@ -486,6 +499,16 @@ export function buildProjectBriefForRepo(
       ? "- none"
       : blockers
           .map((gate) => `- ${gate.type} [${gate.gateId}] ${gate.requestedDecision} operation=${gate.operation}`)
+          .join("\n"),
+    "",
+    "## Active Runs",
+    activeRuns.length === 0
+      ? "- none"
+      : activeRuns
+          .map(
+            (attempt) =>
+              `- ${attempt.runId} task=${attempt.taskId} worker=${attempt.workerId} status=${attempt.status} ${formatRunRuntimeSummary(attempt.runtime)} cancel=conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})`,
+          )
           .join("\n"),
     "",
     "## Recommended Next Actions",
@@ -799,6 +822,7 @@ export async function dispatchTaskRunForRepo(
     leaseSeconds?: number;
     runId?: string;
     backend?: RunAttemptRecord["backend"];
+    runtimeMode?: RunRuntimeMode;
     allowFollowUpTasks?: boolean;
     dispatcher?: ConductorBackendDispatcher;
     resolvePackage?: (specifier: string) => string | null;
@@ -1838,11 +1862,18 @@ function mapWorkerRunStatusToRunStatus(status: WorkerRunResult["status"]): "succ
   }
 }
 
-export async function runTaskForRepo(repoRoot: string, taskId: string, signal?: AbortSignal): Promise<WorkerRunResult> {
-  const started = startTaskRunForRepo(repoRoot, { taskId });
+export async function runTaskForRepo(
+  repoRoot: string,
+  taskId: string,
+  signal?: AbortSignal,
+  input: { runtimeMode?: RunRuntimeMode } = {},
+): Promise<WorkerRunResult> {
+  const runtimeMode = input.runtimeMode ?? "headless";
+  const runtimeBackend = getWorkerRunRuntimeBackend(runtimeMode);
   const currentRun = getOrCreateRunForRepo(repoRoot);
-  const worker = currentRun.workers.find((entry) => entry.workerId === started.run.workerId);
   const task = currentRun.tasks.find((entry) => entry.taskId === taskId);
+  const workerId = task?.assignedWorkerId;
+  const worker = workerId ? currentRun.workers.find((entry) => entry.workerId === workerId) : null;
   if (!worker || !task) {
     throw new Error(`Task ${taskId} has invalid worker/run references`);
   }
@@ -1852,10 +1883,9 @@ export async function runTaskForRepo(repoRoot: string, taskId: string, signal?: 
   if (!worker.worktreePath || !existsSync(worker.worktreePath)) {
     throw new Error(`Worker ${worker.name} is missing its worktree; recover the worker first`);
   }
-
-  const runtimeBackend = getWorkerRunRuntimeBackend("headless");
   await runtimeBackend.preflight({ worktreePath: worker.worktreePath, sessionFile: worker.sessionFile });
 
+  const started = startTaskRunForRepo(repoRoot, { taskId, workerId: worker.workerId, runtimeMode });
   const linkedSignal = createLinkedAbortController(signal);
   const unregisterLiveRun = registerLiveWorkAbortHandle({
     runId: started.run.runId,

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -12,12 +12,7 @@ import {
 import { computeNextActions } from "./next-actions.js";
 import { createObjectiveForRepo, planObjectiveForRepo, refreshObjectiveStatusForRepo } from "./objective-service.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
-import {
-  createWorkerSessionRuntime,
-  preflightWorkerRunRuntime,
-  recoverWorkerSessionRuntime,
-  runWorkerPromptRuntime,
-} from "./runtime.js";
+import { createWorkerSessionRuntime, getWorkerRunRuntimeBackend, recoverWorkerSessionRuntime } from "./runtime.js";
 import { type SchedulerFairness, type SchedulerPolicyName, selectSchedulerActions } from "./scheduler-selection.js";
 import {
   addConductorArtifact,
@@ -1858,7 +1853,8 @@ export async function runTaskForRepo(repoRoot: string, taskId: string, signal?: 
     throw new Error(`Worker ${worker.name} is missing its worktree; recover the worker first`);
   }
 
-  await preflightWorkerRunRuntime({ worktreePath: worker.worktreePath, sessionFile: worker.sessionFile });
+  const runtimeBackend = getWorkerRunRuntimeBackend("headless");
+  await runtimeBackend.preflight({ worktreePath: worker.worktreePath, sessionFile: worker.sessionFile });
 
   const linkedSignal = createLinkedAbortController(signal);
   const unregisterLiveRun = registerLiveWorkAbortHandle({
@@ -1869,7 +1865,7 @@ export async function runTaskForRepo(repoRoot: string, taskId: string, signal?: 
   });
 
   try {
-    const runtimeResult = await runWorkerPromptRuntime({
+    const runtimeResult = await runtimeBackend.run({
       worktreePath: worker.worktreePath,
       sessionFile: worker.sessionFile,
       task: task.prompt,

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1,6 +1,11 @@
 import { existsSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
-import { type ConductorBackendDispatcher, getConductorBackendAdapter, inspectConductorBackends } from "./backends.js";
+import {
+  type ConductorBackendDispatcher,
+  getConductorBackendAdapter,
+  getConductorRuntimeModeStatus,
+  inspectConductorBackends,
+} from "./backends.js";
 import { createGateForRepo } from "./gate-service.js";
 import {
   commitAllChanges,
@@ -28,7 +33,7 @@ import {
 } from "./storage.js";
 import {
   assignTaskForRepo,
-  cancelTaskRunForRepo,
+  cancelTaskRunForRepo as cancelTaskRunStateForRepo,
   createFollowUpTaskForRepo,
   createTaskForRepo,
   recordTaskCompletionForRepo,
@@ -68,7 +73,6 @@ export { buildBlockingDiagnosisForRepo, prepareHumanReviewForRepo } from "./revi
 export type { SchedulerFairness, SchedulerPolicyName } from "./scheduler-selection.js";
 export {
   assignTaskForRepo,
-  cancelTaskRunForRepo,
   createFollowUpTaskForRepo,
   createTaskForRepo,
   recordTaskCompletionForRepo,
@@ -84,7 +88,12 @@ export type ParallelWorkItemInput = {
   workerName?: string;
 };
 
-export type ParallelWorkRunner = (repoRoot: string, taskId: string, signal?: AbortSignal) => Promise<WorkerRunResult>;
+export type ParallelWorkRunner = (
+  repoRoot: string,
+  taskId: string,
+  signal?: AbortSignal,
+  input?: { runtimeMode?: RunRuntimeMode },
+) => Promise<WorkerRunResult>;
 
 export type WorkRoutingMode = "auto" | "single" | "parallel" | "objective";
 
@@ -476,7 +485,7 @@ export function buildProjectBriefForRepo(
   });
   const recentEventLimit = Math.max(1, Math.min(input.recentEventLimit ?? 10, 50));
   const recentEvents = run.events.slice(-recentEventLimit);
-  const activeRuns = run.runs.filter((attempt) => !attempt.finishedAt);
+  const activeRuns = run.runs.filter(isActiveRunAttempt);
   const lines = [
     "# Conductor Project Brief",
     "",
@@ -634,6 +643,7 @@ export async function scheduleObjectiveForRepo(
     maxConcurrency?: number;
     executeRuns?: boolean;
     policy?: SchedulerPolicyName;
+    runtimeMode?: RunRuntimeMode;
   },
   signal?: AbortSignal,
 ): Promise<{
@@ -675,7 +685,7 @@ export async function scheduleObjectiveForRepo(
       assigned.push(schedulableTask);
     }
     if (schedulerPolicy.executeRuns) {
-      const result = await runTaskForRepo(repoRoot, schedulableTask.taskId, signal);
+      const result = await runTaskForRepo(repoRoot, schedulableTask.taskId, signal, { runtimeMode: input.runtimeMode });
       executed.push({ taskId: schedulableTask.taskId, result });
     }
   }
@@ -854,11 +864,33 @@ export async function dispatchTaskRunForRepo(
     });
   }
   const started = startTaskRunForRepo(repoRoot, { ...input, backend: "native" });
-  const result = await adapter.dispatch({
-    cwd: resolve(repoRoot),
-    taskContract: started.taskContract,
-    run: started.run,
-  });
+  let result: { ok: boolean; diagnostic: string | null; backendRunId?: string | null };
+  try {
+    result = await adapter.dispatch({
+      cwd: resolve(repoRoot),
+      taskContract: started.taskContract,
+      run: started.run,
+    });
+  } catch (error) {
+    const diagnostic = errorMessage(error);
+    recordTaskCompletionForRepo(repoRoot, {
+      runId: started.run.runId,
+      taskId: input.taskId,
+      status: "failed",
+      completionSummary: diagnostic,
+    });
+    recordExternalOperationEvent(repoRoot, {
+      status: "failed",
+      resourceRefs: { taskId: input.taskId, workerId: started.run.workerId, runId: started.run.runId },
+      payload: {
+        operation: "dispatch_task_run",
+        backend: "pi-subagents",
+        diagnostic,
+        errorMessage: diagnostic,
+      },
+    });
+    throw error;
+  }
   if (!result.ok) {
     recordTaskCompletionForRepo(repoRoot, {
       runId: started.run.runId,
@@ -909,7 +941,14 @@ export async function dispatchTaskRunForRepo(
 
 export async function delegateTaskForRepo(
   repoRoot: string,
-  input: { title: string; prompt: string; workerName: string; startRun?: boolean; leaseSeconds?: number },
+  input: {
+    title: string;
+    prompt: string;
+    workerName: string;
+    startRun?: boolean;
+    leaseSeconds?: number;
+    runtimeMode?: RunRuntimeMode;
+  },
 ): Promise<{
   worker: WorkerRecord;
   task: TaskRecord;
@@ -931,6 +970,7 @@ export async function delegateTaskForRepo(
     taskId: assigned.taskId,
     workerId: worker.workerId,
     leaseSeconds: input.leaseSeconds,
+    runtimeMode: input.runtimeMode,
   });
   const current = getOrCreateRunForRepo(repoRoot);
   return {
@@ -939,6 +979,15 @@ export async function delegateTaskForRepo(
     run: started.run,
     taskContract: started.taskContract,
   };
+}
+
+export function cancelTaskRunForRepo(repoRoot: string, input: { runId: string; reason: string }): RunRecord {
+  const project = cancelTaskRunStateForRepo(repoRoot, input);
+  const run = project.runs.find((entry) => entry.runId === input.runId);
+  if (run?.status === "aborted") {
+    abortLiveWorkForFilter({ runIds: new Set([input.runId]) });
+  }
+  return project;
 }
 
 export function cancelActiveWorkForRepo(
@@ -955,7 +1004,7 @@ export function cancelActiveWorkForRepo(
   const workerIds = new Set(input.workerIds ?? []);
   const activeRuns = project.runs.filter(
     (run) =>
-      !run.finishedAt &&
+      isActiveRunAttempt(run) &&
       (taskIds.size === 0 || taskIds.has(run.taskId)) &&
       (workerIds.size === 0 || workerIds.has(run.workerId)),
   );
@@ -988,6 +1037,7 @@ export async function runParallelWorkForRepo(
   input: {
     tasks: ParallelWorkItemInput[];
     workerPrefix?: string;
+    runtimeMode?: RunRuntimeMode;
   },
   signal?: AbortSignal,
   runner: ParallelWorkRunner = runTaskForRepo,
@@ -1109,7 +1159,9 @@ export async function runParallelWorkForRepo(
       return { workers, tasks, results: [], canceledRuns, canceledTasks };
     }
     const settled = await Promise.allSettled(
-      tasks.map((task, index) => runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal)),
+      tasks.map((task, index) =>
+        runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode: input.runtimeMode }),
+      ),
     );
     if (signal?.aborted) onAbort();
     collectOwnedCanceledWork();
@@ -1314,6 +1366,7 @@ export async function runWorkForRepo(
     workerPrefix?: string;
     maxWorkers?: number;
     execute?: boolean;
+    runtimeMode?: RunRuntimeMode;
   },
   signal?: AbortSignal,
   runner: ParallelWorkRunner = runTaskForRepo,
@@ -1338,6 +1391,7 @@ export async function runWorkForRepo(
       repoRoot,
       {
         workerPrefix,
+        runtimeMode: input.runtimeMode,
         tasks: decision.tasks.map((task) => ({
           title: task.title,
           prompt: task.prompt,
@@ -1373,7 +1427,12 @@ export async function runWorkForRepo(
     const schedule = execute
       ? await scheduleObjectiveForRepo(
           repoRoot,
-          { objectiveId: objective.objectiveId, policy: "execute", maxConcurrency: input.maxWorkers },
+          {
+            objectiveId: objective.objectiveId,
+            policy: "execute",
+            maxConcurrency: input.maxWorkers,
+            runtimeMode: input.runtimeMode,
+          },
           signal,
         )
       : null;
@@ -1416,7 +1475,9 @@ export async function runWorkForRepo(
       objective: null,
     };
   }
-  const result = execute ? await runner(repoRoot, delegated.task.taskId, signal) : null;
+  const result = execute
+    ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode: input.runtimeMode })
+    : null;
   return {
     decision,
     workers: [delegated.worker],
@@ -1851,6 +1912,16 @@ export function createWorkerPrForRepo(
   }
 }
 
+function isTerminalRunAttemptStatus(status: RunAttemptRecord["status"]): boolean {
+  return ["succeeded", "partial", "blocked", "failed", "aborted", "stale", "interrupted", "unknown_dispatch"].includes(
+    status,
+  );
+}
+
+function isActiveRunAttempt(attempt: RunAttemptRecord): boolean {
+  return !attempt.finishedAt && !isTerminalRunAttemptStatus(attempt.status);
+}
+
 function mapWorkerRunStatusToRunStatus(status: WorkerRunResult["status"]): "succeeded" | "failed" | "aborted" {
   switch (status) {
     case "success":
@@ -1869,6 +1940,12 @@ export async function runTaskForRepo(
   input: { runtimeMode?: RunRuntimeMode } = {},
 ): Promise<WorkerRunResult> {
   const runtimeMode = input.runtimeMode ?? "headless";
+  const runtimeStatus = getConductorRuntimeModeStatus(runtimeMode);
+  if (!runtimeStatus.available) {
+    throw new Error(
+      `Runtime mode ${runtimeMode} unavailable: ${runtimeStatus.diagnostic ?? "not available"}. Use conductor_backend_status to inspect available runtime modes; headless is available.`,
+    );
+  }
   const runtimeBackend = getWorkerRunRuntimeBackend(runtimeMode);
   const currentRun = getOrCreateRunForRepo(repoRoot);
   const task = currentRun.tasks.find((entry) => entry.taskId === taskId);

--- a/packages/pi-conductor/extensions/runtime-metadata.ts
+++ b/packages/pi-conductor/extensions/runtime-metadata.ts
@@ -1,0 +1,90 @@
+import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode, RunRuntimeStatus } from "./types.js";
+
+export function createRunRuntimeMetadata(input: {
+  mode: RunRuntimeMode;
+  status?: RunRuntimeStatus;
+  sessionId?: string | null;
+  cwd?: string | null;
+  command?: string | null;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  diagnostics?: string[];
+}): RunRuntimeMetadata {
+  return {
+    mode: input.mode,
+    status: input.status ?? "unknown",
+    sessionId: input.sessionId ?? null,
+    cwd: input.cwd ?? null,
+    command: input.command ?? null,
+    runnerPid: null,
+    processGroupId: null,
+    tmux: null,
+    logPath: null,
+    viewerCommand: null,
+    viewerStatus: input.mode === "headless" ? "not_applicable" : "pending",
+    diagnostics: input.diagnostics ?? [],
+    heartbeatAt: null,
+    cleanupStatus: input.mode === "headless" ? "not_required" : "pending",
+    startedAt: input.startedAt ?? null,
+    finishedAt: input.finishedAt ?? null,
+  };
+}
+
+function mapLegacyBackendToRuntimeMode(_backend: RunAttemptRecord["backend"] | undefined): RunRuntimeMode {
+  return "headless";
+}
+
+export function mapRunStatusToRuntimeStatus(status: RunAttemptRecord["status"] | undefined): RunRuntimeStatus {
+  switch (status) {
+    case "running":
+    case "starting":
+    case "queued":
+    case "dispatch_pending":
+    case "completing":
+      return "running";
+    case "succeeded":
+    case "partial":
+    case "blocked":
+      return "exited_success";
+    case "aborted":
+    case "interrupted":
+      return "aborted";
+    case "failed":
+    case "stale":
+    case "unknown_dispatch":
+      return "exited_error";
+    default:
+      return "unknown";
+  }
+}
+
+export function normalizeRunRuntimeMetadata(run: RunAttemptRecord): RunRuntimeMetadata {
+  if (run.runtime) {
+    return {
+      mode: run.runtime.mode,
+      status: run.runtime.status,
+      sessionId: run.runtime.sessionId ?? run.sessionId ?? null,
+      cwd: run.runtime.cwd ?? null,
+      command: run.runtime.command ?? null,
+      runnerPid: run.runtime.runnerPid ?? null,
+      processGroupId: run.runtime.processGroupId ?? null,
+      tmux: run.runtime.tmux ?? null,
+      logPath: run.runtime.logPath ?? null,
+      viewerCommand: run.runtime.viewerCommand ?? null,
+      viewerStatus: run.runtime.viewerStatus ?? (run.runtime.mode === "headless" ? "not_applicable" : "pending"),
+      diagnostics: run.runtime.diagnostics ?? [],
+      heartbeatAt: run.runtime.heartbeatAt ?? run.lastHeartbeatAt ?? null,
+      cleanupStatus: run.runtime.cleanupStatus ?? (run.runtime.mode === "headless" ? "not_required" : "pending"),
+      startedAt: run.runtime.startedAt ?? run.startedAt ?? null,
+      finishedAt: run.runtime.finishedAt ?? run.finishedAt ?? null,
+    };
+  }
+
+  return createRunRuntimeMetadata({
+    mode: mapLegacyBackendToRuntimeMode(run.backend),
+    status: mapRunStatusToRuntimeStatus(run.status),
+    sessionId: run.sessionId ?? null,
+    startedAt: run.startedAt ?? null,
+    finishedAt: run.finishedAt ?? null,
+  });
+}

--- a/packages/pi-conductor/extensions/runtime-metadata.ts
+++ b/packages/pi-conductor/extensions/runtime-metadata.ts
@@ -1,4 +1,10 @@
-import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode, RunRuntimeStatus } from "./types.js";
+import type {
+  PersistedRunAttemptRecord,
+  RunAttemptRecord,
+  RunRuntimeMetadata,
+  RunRuntimeMode,
+  RunRuntimeStatus,
+} from "./types.js";
 
 export function createRunRuntimeMetadata(input: {
   mode: RunRuntimeMode;
@@ -64,7 +70,7 @@ function isTerminalRunStatus(status: RunAttemptRecord["status"] | undefined): bo
   );
 }
 
-export function normalizeRunRuntimeMetadata(run: RunAttemptRecord): RunRuntimeMetadata {
+export function normalizeRunRuntimeMetadata(run: PersistedRunAttemptRecord): RunRuntimeMetadata {
   const runtime = run.runtime
     ? {
         mode: run.runtime.mode,

--- a/packages/pi-conductor/extensions/runtime-metadata.ts
+++ b/packages/pi-conductor/extensions/runtime-metadata.ts
@@ -58,33 +58,63 @@ export function mapRunStatusToRuntimeStatus(status: RunAttemptRecord["status"] |
   }
 }
 
+function isTerminalRunStatus(status: RunAttemptRecord["status"] | undefined): boolean {
+  return ["succeeded", "partial", "blocked", "failed", "aborted", "stale", "interrupted", "unknown_dispatch"].includes(
+    status ?? "",
+  );
+}
+
 export function normalizeRunRuntimeMetadata(run: RunAttemptRecord): RunRuntimeMetadata {
-  if (run.runtime) {
+  const runtime = run.runtime
+    ? {
+        mode: run.runtime.mode,
+        status: run.runtime.status,
+        sessionId: run.runtime.sessionId ?? run.sessionId ?? null,
+        cwd: run.runtime.cwd ?? null,
+        command: run.runtime.command ?? null,
+        runnerPid: run.runtime.runnerPid ?? null,
+        processGroupId: run.runtime.processGroupId ?? null,
+        tmux: run.runtime.tmux ?? null,
+        logPath: run.runtime.logPath ?? null,
+        viewerCommand: run.runtime.viewerCommand ?? null,
+        viewerStatus: run.runtime.viewerStatus ?? (run.runtime.mode === "headless" ? "not_applicable" : "pending"),
+        diagnostics: run.runtime.diagnostics ?? [],
+        heartbeatAt: run.runtime.heartbeatAt ?? run.lastHeartbeatAt ?? null,
+        cleanupStatus: run.runtime.cleanupStatus ?? (run.runtime.mode === "headless" ? "not_required" : "pending"),
+        startedAt: run.runtime.startedAt ?? run.startedAt ?? null,
+        finishedAt: run.runtime.finishedAt ?? run.finishedAt ?? null,
+      }
+    : createRunRuntimeMetadata({
+        mode: mapLegacyBackendToRuntimeMode(run.backend),
+        status: mapRunStatusToRuntimeStatus(run.status),
+        sessionId: run.sessionId ?? null,
+        startedAt: run.startedAt ?? null,
+        finishedAt: run.finishedAt ?? null,
+      });
+
+  if (isTerminalRunStatus(run.status)) {
     return {
-      mode: run.runtime.mode,
-      status: run.runtime.status,
-      sessionId: run.runtime.sessionId ?? run.sessionId ?? null,
-      cwd: run.runtime.cwd ?? null,
-      command: run.runtime.command ?? null,
-      runnerPid: run.runtime.runnerPid ?? null,
-      processGroupId: run.runtime.processGroupId ?? null,
-      tmux: run.runtime.tmux ?? null,
-      logPath: run.runtime.logPath ?? null,
-      viewerCommand: run.runtime.viewerCommand ?? null,
-      viewerStatus: run.runtime.viewerStatus ?? (run.runtime.mode === "headless" ? "not_applicable" : "pending"),
-      diagnostics: run.runtime.diagnostics ?? [],
-      heartbeatAt: run.runtime.heartbeatAt ?? run.lastHeartbeatAt ?? null,
-      cleanupStatus: run.runtime.cleanupStatus ?? (run.runtime.mode === "headless" ? "not_required" : "pending"),
-      startedAt: run.runtime.startedAt ?? run.startedAt ?? null,
-      finishedAt: run.runtime.finishedAt ?? run.finishedAt ?? null,
+      ...runtime,
+      status: mapRunStatusToRuntimeStatus(run.status),
+      finishedAt: run.finishedAt ?? runtime.finishedAt,
+      cleanupStatus: runtime.mode === "headless" ? "not_required" : runtime.cleanupStatus,
     };
   }
 
-  return createRunRuntimeMetadata({
-    mode: mapLegacyBackendToRuntimeMode(run.backend),
-    status: mapRunStatusToRuntimeStatus(run.status),
-    sessionId: run.sessionId ?? null,
-    startedAt: run.startedAt ?? null,
-    finishedAt: run.finishedAt ?? null,
-  });
+  return runtime;
+}
+
+export function formatRunRuntimeSummary(runtime: RunRuntimeMetadata): string {
+  const diagnostics = runtime.diagnostics.at(-1);
+  return [
+    `runtimeMode=${runtime.mode}`,
+    `runtimeStatus=${runtime.status}`,
+    `viewer=${runtime.viewerStatus}`,
+    `cleanup=${runtime.cleanupStatus}`,
+    `log=${runtime.logPath ?? "none"}`,
+    `heartbeat=${runtime.heartbeatAt ?? "none"}`,
+    diagnostics ? `diagnostic=${diagnostics}` : null,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
 }

--- a/packages/pi-conductor/extensions/runtime.ts
+++ b/packages/pi-conductor/extensions/runtime.ts
@@ -15,6 +15,7 @@ import type {
   ConductorFollowUpTaskInput,
   ConductorGateReportInput,
   ConductorProgressReportInput,
+  RunRuntimeMode,
   RuntimeRunContext,
   RuntimeRunPreflightContext,
   RuntimeRunResult,
@@ -25,6 +26,23 @@ import type {
 
 export interface WorkerRuntimeHandle extends WorkerRuntimeState {
   sessionFile: string | null;
+}
+
+export interface WorkerRunRuntimeBackend {
+  mode: RunRuntimeMode;
+  preflight(input: RuntimeRunPreflightContext): Promise<void>;
+  run(input: RuntimeRunContext): Promise<RuntimeRunResult>;
+}
+
+export function getWorkerRunRuntimeBackend(mode: RunRuntimeMode = "headless"): WorkerRunRuntimeBackend {
+  if (mode === "headless") {
+    return {
+      mode,
+      preflight: preflightWorkerRunRuntime,
+      run: runWorkerPromptRuntime,
+    };
+  }
+  throw new Error(`${mode} runtime is not implemented yet`);
 }
 
 function persistSessionFile(sessionManager: SessionManager, sessionFile: string): void {

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -1,3 +1,4 @@
+import { formatRunRuntimeSummary } from "./runtime-metadata.js";
 import { getConductorProjectDir } from "./storage.js";
 import type { RunRecord, WorkerRecord } from "./types.js";
 
@@ -28,6 +29,17 @@ export function formatRunStatus(run: RunRecord): string {
         `assignedWorker=${task.assignedWorkerId ?? "none"} ` +
         `activeRun=${task.activeRunId ?? "none"} ` +
         `latestProgress=${task.latestProgress ?? "none"}`,
+    );
+  }
+
+  for (const attempt of run.runs) {
+    lines.push(
+      `- run ${attempt.runId} ` +
+        `task=${attempt.taskId} ` +
+        `worker=${attempt.workerId} ` +
+        `status=${attempt.status} ` +
+        `backend=${attempt.backend} ` +
+        formatRunRuntimeSummary(attempt.runtime),
     );
   }
 

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -1,12 +1,32 @@
 import { formatRunRuntimeSummary } from "./runtime-metadata.js";
 import { getConductorProjectDir } from "./storage.js";
-import type { RunRecord, WorkerRecord } from "./types.js";
+import type { RunAttemptRecord, RunRecord, WorkerRecord } from "./types.js";
 
 function getWorkerHealth(worker: WorkerRecord): "healthy" | "broken" {
   if (worker.lifecycle === "broken") {
     return "broken";
   }
   return "healthy";
+}
+
+function isTerminalRunStatus(status: RunAttemptRecord["status"]): boolean {
+  return ["succeeded", "partial", "blocked", "failed", "aborted", "stale", "interrupted", "unknown_dispatch"].includes(
+    status,
+  );
+}
+
+function isActiveRun(attempt: RunAttemptRecord): boolean {
+  return !attempt.finishedAt && !isTerminalRunStatus(attempt.status);
+}
+
+function runsForStatusOutput(runs: RunAttemptRecord[]): { visible: RunAttemptRecord[]; omittedCount: number } {
+  const activeRuns = runs.filter(isActiveRun);
+  const recentTerminalRuns = runs.filter((attempt) => !isActiveRun(attempt)).slice(-10);
+  const visibleRunIds = new Set([...activeRuns, ...recentTerminalRuns].map((attempt) => attempt.runId));
+  return {
+    visible: runs.filter((attempt) => visibleRunIds.has(attempt.runId)),
+    omittedCount: runs.length - visibleRunIds.size,
+  };
 }
 
 export function formatRunStatus(run: RunRecord): string {
@@ -32,7 +52,8 @@ export function formatRunStatus(run: RunRecord): string {
     );
   }
 
-  for (const attempt of run.runs) {
+  const runStatusOutput = runsForStatusOutput(run.runs);
+  for (const attempt of runStatusOutput.visible) {
     lines.push(
       `- run ${attempt.runId} ` +
         `task=${attempt.taskId} ` +
@@ -40,6 +61,11 @@ export function formatRunStatus(run: RunRecord): string {
         `status=${attempt.status} ` +
         `backend=${attempt.backend} ` +
         formatRunRuntimeSummary(attempt.runtime),
+    );
+  }
+  if (runStatusOutput.omittedCount > 0) {
+    lines.push(
+      `- runs omitted: ${runStatusOutput.omittedCount} older terminal run(s); use conductor_list_runs for full history`,
     );
   }
 

--- a/packages/pi-conductor/extensions/storage-normalize.ts
+++ b/packages/pi-conductor/extensions/storage-normalize.ts
@@ -1,4 +1,5 @@
-import type { GateOperation, GateRecord, RunRecord, TaskRecord, WorkerRecord } from "./types.js";
+import { normalizeRunRuntimeMetadata } from "./runtime-metadata.js";
+import type { GateOperation, GateRecord, RunAttemptRecord, RunRecord, TaskRecord, WorkerRecord } from "./types.js";
 
 export function normalizeProjectRecord(run: RunRecord): RunRecord {
   return {
@@ -9,7 +10,7 @@ export function normalizeProjectRecord(run: RunRecord): RunRecord {
     archivedWorkers: run.archivedWorkers.map(normalizeWorkerRecord),
     objectives: run.objectives,
     tasks: run.tasks.map(normalizeTaskRecord),
-    runs: run.runs,
+    runs: run.runs.map(normalizeRunAttemptRecord),
     gates: run.gates.map(normalizeGateRecord),
     artifacts: run.artifacts,
     events: run.events,
@@ -46,6 +47,13 @@ function normalizeTaskRecord(task: TaskRecord): TaskRecord {
     ...task,
     objectiveId: task.objectiveId,
     dependsOnTaskIds: task.dependsOnTaskIds,
+  };
+}
+
+function normalizeRunAttemptRecord(run: RunAttemptRecord): RunAttemptRecord {
+  return {
+    ...run,
+    runtime: normalizeRunRuntimeMetadata(run),
   };
 }
 

--- a/packages/pi-conductor/extensions/storage-normalize.ts
+++ b/packages/pi-conductor/extensions/storage-normalize.ts
@@ -1,7 +1,16 @@
 import { normalizeRunRuntimeMetadata } from "./runtime-metadata.js";
-import type { GateOperation, GateRecord, RunAttemptRecord, RunRecord, TaskRecord, WorkerRecord } from "./types.js";
+import type {
+  GateOperation,
+  GateRecord,
+  PersistedRunAttemptRecord,
+  PersistedRunRecord,
+  RunAttemptRecord,
+  RunRecord,
+  TaskRecord,
+  WorkerRecord,
+} from "./types.js";
 
-export function normalizeProjectRecord(run: RunRecord): RunRecord {
+export function normalizeProjectRecord(run: RunRecord | PersistedRunRecord): RunRecord {
   return {
     ...run,
     schemaVersion: run.schemaVersion,
@@ -50,7 +59,7 @@ function normalizeTaskRecord(task: TaskRecord): TaskRecord {
   };
 }
 
-function normalizeRunAttemptRecord(run: RunAttemptRecord): RunAttemptRecord {
+function normalizeRunAttemptRecord(run: RunAttemptRecord | PersistedRunAttemptRecord): RunAttemptRecord {
   return {
     ...run,
     runtime: normalizeRunRuntimeMetadata(run),

--- a/packages/pi-conductor/extensions/storage-runtime-validation.ts
+++ b/packages/pi-conductor/extensions/storage-runtime-validation.ts
@@ -1,0 +1,117 @@
+import type { RunRuntimeCleanupStatus, RunRuntimeMode, RunRuntimeStatus, RunRuntimeViewerStatus } from "./types.js";
+
+const runRuntimeModes = new Set<RunRuntimeMode>(["headless", "tmux", "iterm-tmux"]);
+const runRuntimeStatuses = new Set<RunRuntimeStatus>([
+  "unavailable",
+  "starting",
+  "running",
+  "exited_success",
+  "exited_error",
+  "aborted",
+  "unknown",
+]);
+const runRuntimeViewerStatuses = new Set<RunRuntimeViewerStatus>([
+  "not_applicable",
+  "pending",
+  "opened",
+  "warning",
+  "unavailable",
+]);
+const runRuntimeCleanupStatuses = new Set<RunRuntimeCleanupStatus>(["not_required", "pending", "succeeded", "failed"]);
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertRequiredKeys(value: unknown, keys: readonly string[], context: string): void {
+  if (!isPlainRecord(value)) {
+    throw new Error(`${context} is not an object`);
+  }
+  for (const key of keys) {
+    if (!Object.hasOwn(value, key)) {
+      throw new Error(`${context} missing required field ${key}`);
+    }
+  }
+}
+
+function assertStringEnum<T extends string>(
+  value: unknown,
+  allowed: ReadonlySet<T>,
+  context: string,
+): asserts value is T {
+  if (typeof value !== "string" || !allowed.has(value as T)) {
+    throw new Error(`${context} has invalid value ${String(value)}`);
+  }
+}
+
+function assertNullableString(value: unknown, context: string): void {
+  if (value !== null && typeof value !== "string") {
+    throw new Error(`${context} must be a string or null`);
+  }
+}
+
+function assertNullableNumber(value: unknown, context: string): void {
+  if (value !== null && (typeof value !== "number" || !Number.isFinite(value))) {
+    throw new Error(`${context} must be a finite number or null`);
+  }
+}
+
+function assertStringArray(value: unknown, context: string): void {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`${context} must be an array of strings`);
+  }
+}
+
+export function assertRunRuntimeMetadata(runtime: unknown, context: string): void {
+  assertRequiredKeys(
+    runtime,
+    [
+      "mode",
+      "status",
+      "sessionId",
+      "cwd",
+      "command",
+      "runnerPid",
+      "processGroupId",
+      "tmux",
+      "logPath",
+      "viewerCommand",
+      "viewerStatus",
+      "diagnostics",
+      "heartbeatAt",
+      "cleanupStatus",
+      "startedAt",
+      "finishedAt",
+    ],
+    context,
+  );
+  if (!isPlainRecord(runtime)) {
+    throw new Error(`${context} is not an object`);
+  }
+  assertStringEnum(runtime.mode, runRuntimeModes, `${context}.mode`);
+  assertStringEnum(runtime.status, runRuntimeStatuses, `${context}.status`);
+  assertStringEnum(runtime.viewerStatus, runRuntimeViewerStatuses, `${context}.viewerStatus`);
+  assertStringEnum(runtime.cleanupStatus, runRuntimeCleanupStatuses, `${context}.cleanupStatus`);
+  assertNullableString(runtime.sessionId, `${context}.sessionId`);
+  assertNullableString(runtime.cwd, `${context}.cwd`);
+  assertNullableString(runtime.command, `${context}.command`);
+  assertNullableNumber(runtime.runnerPid, `${context}.runnerPid`);
+  assertNullableNumber(runtime.processGroupId, `${context}.processGroupId`);
+  assertNullableString(runtime.logPath, `${context}.logPath`);
+  assertNullableString(runtime.viewerCommand, `${context}.viewerCommand`);
+  assertStringArray(runtime.diagnostics, `${context}.diagnostics`);
+  assertNullableString(runtime.heartbeatAt, `${context}.heartbeatAt`);
+  assertNullableString(runtime.startedAt, `${context}.startedAt`);
+  assertNullableString(runtime.finishedAt, `${context}.finishedAt`);
+
+  if (runtime.tmux !== null) {
+    assertRequiredKeys(runtime.tmux, ["socketPath", "sessionName", "windowId", "paneId"], `${context}.tmux`);
+    if (!isPlainRecord(runtime.tmux)) {
+      throw new Error(`${context}.tmux is not an object`);
+    }
+    assertNullableString(runtime.tmux.socketPath, `${context}.tmux.socketPath`);
+    assertNullableString(runtime.tmux.sessionName, `${context}.tmux.sessionName`);
+    assertNullableString(runtime.tmux.windowId, `${context}.tmux.windowId`);
+    assertNullableString(runtime.tmux.paneId, `${context}.tmux.paneId`);
+  }
+}

--- a/packages/pi-conductor/extensions/storage-validation.ts
+++ b/packages/pi-conductor/extensions/storage-validation.ts
@@ -295,6 +295,53 @@ export function validateRunRecord(run: RunRecord): void {
     }
   }
   for (const attempt of normalized.runs) {
+    assertRequiredKeys(
+      attempt,
+      [
+        "runId",
+        "taskId",
+        "workerId",
+        "taskRevision",
+        "status",
+        "backend",
+        "backendRunId",
+        "sessionId",
+        "runtime",
+        "leaseGeneration",
+        "leaseStartedAt",
+        "leaseExpiresAt",
+        "lastHeartbeatAt",
+        "startedAt",
+        "finishedAt",
+        "completionSummary",
+        "errorMessage",
+        "artifactIds",
+        "gateIds",
+      ],
+      `Run ${attempt.runId ?? "<unknown>"}`,
+    );
+    assertRequiredKeys(
+      attempt.runtime,
+      [
+        "mode",
+        "status",
+        "sessionId",
+        "cwd",
+        "command",
+        "runnerPid",
+        "processGroupId",
+        "tmux",
+        "logPath",
+        "viewerCommand",
+        "viewerStatus",
+        "diagnostics",
+        "heartbeatAt",
+        "cleanupStatus",
+        "startedAt",
+        "finishedAt",
+      ],
+      `Run ${attempt.runId} runtime`,
+    );
     if (!indexes.taskIds.has(attempt.taskId)) {
       throw new Error(`Run ${attempt.runId} references missing task ${attempt.taskId}`);
     }

--- a/packages/pi-conductor/extensions/storage-validation.ts
+++ b/packages/pi-conductor/extensions/storage-validation.ts
@@ -1,4 +1,5 @@
 import { normalizeProjectRecord } from "./storage-normalize.js";
+import { assertRunRuntimeMetadata } from "./storage-runtime-validation.js";
 import type { ConductorActor, ConductorEventType, ConductorResourceRefs, RunRecord } from "./types.js";
 import { CONDUCTOR_SCHEMA_VERSION } from "./types.js";
 
@@ -222,6 +223,11 @@ export function validateRunRecord(run: RunRecord): void {
       `Gate ${gate.gateId ?? "<unknown>"}`,
     );
   }
+  for (const attempt of run.runs) {
+    if (Object.hasOwn(attempt, "runtime")) {
+      assertRunRuntimeMetadata(attempt.runtime, `Run ${attempt.runId ?? "<unknown>"} runtime`);
+    }
+  }
   const normalized = normalizeProjectRecord(run);
   if (normalized.schemaVersion !== CONDUCTOR_SCHEMA_VERSION) {
     throw new Error(`Unsupported conductor schemaVersion ${normalized.schemaVersion}`);
@@ -320,28 +326,7 @@ export function validateRunRecord(run: RunRecord): void {
       ],
       `Run ${attempt.runId ?? "<unknown>"}`,
     );
-    assertRequiredKeys(
-      attempt.runtime,
-      [
-        "mode",
-        "status",
-        "sessionId",
-        "cwd",
-        "command",
-        "runnerPid",
-        "processGroupId",
-        "tmux",
-        "logPath",
-        "viewerCommand",
-        "viewerStatus",
-        "diagnostics",
-        "heartbeatAt",
-        "cleanupStatus",
-        "startedAt",
-        "finishedAt",
-      ],
-      `Run ${attempt.runId} runtime`,
-    );
+    assertRunRuntimeMetadata(attempt.runtime, `Run ${attempt.runId} runtime`);
     if (!indexes.taskIds.has(attempt.taskId)) {
       throw new Error(`Run ${attempt.runId} references missing task ${attempt.taskId}`);
     }

--- a/packages/pi-conductor/extensions/storage-validation.ts
+++ b/packages/pi-conductor/extensions/storage-validation.ts
@@ -1,6 +1,12 @@
 import { normalizeProjectRecord } from "./storage-normalize.js";
 import { assertRunRuntimeMetadata } from "./storage-runtime-validation.js";
-import type { ConductorActor, ConductorEventType, ConductorResourceRefs, RunRecord } from "./types.js";
+import type {
+  ConductorActor,
+  ConductorEventType,
+  ConductorResourceRefs,
+  PersistedRunRecord,
+  RunRecord,
+} from "./types.js";
 import { CONDUCTOR_SCHEMA_VERSION } from "./types.js";
 
 const conductorEventTypes = new Set<ConductorEventType>([
@@ -138,7 +144,7 @@ function assertRefsExist(
   }
 }
 
-export function validateRunRecord(run: RunRecord): void {
+export function validateRunRecord(run: RunRecord | PersistedRunRecord): void {
   const workerRecordKeys = [
     "workerId",
     "name",

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -33,6 +33,7 @@ import type {
   GateStatus,
   ObjectiveRecord,
   ObjectiveStatus,
+  PersistedRunRecord,
   RunAttemptRecord,
   RunRecord,
   RunRuntimeMode,
@@ -78,7 +79,7 @@ export function readRun(projectKey: string): RunRecord | null {
     return null;
   }
   try {
-    const run = JSON.parse(readFileSync(path, "utf-8")) as RunRecord;
+    const run = JSON.parse(readFileSync(path, "utf-8")) as PersistedRunRecord;
     validateRunRecord(run);
     return normalizeProjectRecord(run);
   } catch (error) {
@@ -586,7 +587,7 @@ export function cancelTaskRun(run: RunRecord, input: { runId: string; reason: st
   if (!runAttempt) {
     throw new Error(`Run ${input.runId} not found`);
   }
-  if (runAttempt.finishedAt) {
+  if (runAttempt.finishedAt || isTerminalRunStatus(runAttempt.status)) {
     return appendConductorEvent(normalized, {
       actor: { type: "parent_agent", id: "conductor" },
       type: "run.cancel_rejected",
@@ -658,7 +659,7 @@ export function recordRunHeartbeat(
   if (!runAttempt) {
     throw new Error(`Run ${input.runId} not found`);
   }
-  if (runAttempt.finishedAt) {
+  if (runAttempt.finishedAt || isTerminalRunStatus(runAttempt.status)) {
     throw new Error(`Run ${input.runId} is already terminal`);
   }
   const updated = {
@@ -1064,7 +1065,7 @@ function getActiveRunForTask(normalized: RunRecord, input: { runId: string; task
   if (runAttempt.taskId !== input.taskId) {
     throw new Error(`Run ${input.runId} is not scoped to task ${input.taskId}`);
   }
-  if (runAttempt.finishedAt) {
+  if (runAttempt.finishedAt || isTerminalRunStatus(runAttempt.status)) {
     throw new Error(`Run ${input.runId} is already terminal`);
   }
   const task = normalized.tasks.find((entry) => entry.taskId === input.taskId);
@@ -1093,7 +1094,7 @@ export function recordTaskProgress(
     return normalized;
   }
   const existingRun = normalized.runs.find((entry) => entry.runId === input.runId);
-  if (existingRun?.taskId === input.taskId && existingRun.finishedAt) {
+  if (existingRun?.taskId === input.taskId && (existingRun.finishedAt || isTerminalRunStatus(existingRun.status))) {
     return appendConductorEvent(normalized, {
       actor: { type: "child_run", id: input.runId },
       type: "task.progress_rejected",
@@ -1171,7 +1172,7 @@ export function recordTaskCompletion(
     return normalized;
   }
   const existingRun = normalized.runs.find((entry) => entry.runId === input.runId);
-  if (existingRun?.taskId === input.taskId && existingRun.finishedAt) {
+  if (existingRun?.taskId === input.taskId && (existingRun.finishedAt || isTerminalRunStatus(existingRun.status))) {
     return appendConductorEvent(normalized, {
       actor: { type: "child_run", id: input.runId },
       type: "task.completion_rejected",
@@ -1233,7 +1234,7 @@ export function completeTaskRun(
   if (!runAttempt) {
     throw new Error(`Run ${input.runId} not found`);
   }
-  if (runAttempt.finishedAt) {
+  if (runAttempt.finishedAt || isTerminalRunStatus(runAttempt.status)) {
     throw new Error(`Run ${input.runId} is already terminal`);
   }
 

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -35,6 +35,7 @@ import type {
   ObjectiveStatus,
   RunAttemptRecord,
   RunRecord,
+  RunRuntimeMode,
   RunStatus,
   TaskRecord,
   WorkerPrState,
@@ -489,6 +490,7 @@ export function startTaskRun(
     taskId: string;
     workerId: string;
     backend: RunAttemptRecord["backend"];
+    runtimeMode?: RunRuntimeMode;
     leaseExpiresAt: string;
   },
 ): RunRecord {
@@ -525,7 +527,7 @@ export function startTaskRun(
     backendRunId: null,
     sessionId: worker.runtime.sessionId,
     runtime: createRunRuntimeMetadata({
-      mode: "headless",
+      mode: input.runtimeMode ?? "headless",
       status: "running",
       sessionId: worker.runtime.sessionId,
       cwd: worker.worktreePath,

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -14,6 +14,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
+import { createRunRuntimeMetadata, mapRunStatusToRuntimeStatus } from "./runtime-metadata.js";
 import { defaultOperationForGate, normalizeProjectRecord } from "./storage-normalize.js";
 import { validateRunRecord } from "./storage-validation.js";
 
@@ -523,6 +524,13 @@ export function startTaskRun(
     backend: input.backend,
     backendRunId: null,
     sessionId: worker.runtime.sessionId,
+    runtime: createRunRuntimeMetadata({
+      mode: "headless",
+      status: "running",
+      sessionId: worker.runtime.sessionId,
+      cwd: worker.worktreePath,
+      startedAt: now,
+    }),
     leaseGeneration: 1,
     leaseStartedAt: now,
     leaseExpiresAt: input.leaseExpiresAt,
@@ -597,6 +605,12 @@ export function cancelTaskRun(run: RunRecord, input: { runId: string; reason: st
         ? {
             ...entry,
             status: "aborted" as const,
+            runtime: {
+              ...entry.runtime,
+              status: "aborted" as const,
+              finishedAt: now,
+              cleanupStatus: entry.runtime.mode === "headless" ? "not_required" : entry.runtime.cleanupStatus,
+            },
             finishedAt: now,
             leaseExpiresAt: null,
             errorMessage: input.reason,
@@ -652,6 +666,7 @@ export function recordRunHeartbeat(
         ? {
             ...entry,
             lastHeartbeatAt: now,
+            runtime: { ...entry.runtime, heartbeatAt: now },
             leaseExpiresAt: input.leaseExpiresAt === undefined ? entry.leaseExpiresAt : input.leaseExpiresAt,
           }
         : entry,
@@ -694,7 +709,14 @@ export function reconcileRunLeases(run: RunRecord, input: { now?: string } = {})
       ...current,
       runs: current.runs.map((entry) =>
         entry.runId === expired.runId
-          ? { ...entry, status: "stale" as const, finishedAt: now, leaseExpiresAt: null, errorMessage: "Lease expired" }
+          ? {
+              ...entry,
+              status: "stale" as const,
+              runtime: { ...entry.runtime, status: "exited_error" as const, finishedAt: now },
+              finishedAt: now,
+              leaseExpiresAt: null,
+              errorMessage: "Lease expired",
+            }
           : entry,
       ),
       tasks: current.tasks.map((entry) =>
@@ -1106,7 +1128,12 @@ export function recordTaskProgress(
     ),
     runs: normalized.runs.map((entry) =>
       entry.runId === input.runId
-        ? { ...entry, lastHeartbeatAt: now, artifactIds: [...entry.artifactIds, ...artifactIds] }
+        ? {
+            ...entry,
+            lastHeartbeatAt: now,
+            runtime: { ...entry.runtime, heartbeatAt: now },
+            artifactIds: [...entry.artifactIds, ...artifactIds],
+          }
         : entry,
     ),
     artifacts: artifact ? [...normalized.artifacts, artifact] : normalized.artifacts,
@@ -1222,6 +1249,12 @@ export function completeTaskRun(
         ? {
             ...entry,
             status: input.status,
+            runtime: {
+              ...entry.runtime,
+              status: mapRunStatusToRuntimeStatus(input.status),
+              finishedAt: now,
+              cleanupStatus: entry.runtime.mode === "headless" ? "not_required" : entry.runtime.cleanupStatus,
+            },
             finishedAt: now,
             leaseExpiresAt: null,
             completionSummary: input.completionSummary ?? null,

--- a/packages/pi-conductor/extensions/task-service.ts
+++ b/packages/pi-conductor/extensions/task-service.ts
@@ -1,4 +1,4 @@
-import { type ConductorBackendsStatus, inspectConductorBackends } from "./backends.js";
+import { type ConductorBackendsStatus, getConductorRuntimeModeStatus, inspectConductorBackends } from "./backends.js";
 import { refreshObjectiveStatusForRepo } from "./objective-service.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
 import {
@@ -13,7 +13,7 @@ import {
   startTaskRun,
   updateTask,
 } from "./storage.js";
-import type { RunAttemptRecord, RunRecord, TaskContractInput, TaskRecord } from "./types.js";
+import type { RunAttemptRecord, RunRecord, RunRuntimeMode, TaskContractInput, TaskRecord } from "./types.js";
 
 function createTaskId(): string {
   return `task-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
@@ -131,6 +131,7 @@ export function startTaskRunForRepo(
     leaseSeconds?: number;
     runId?: string;
     backend?: RunAttemptRecord["backend"];
+    runtimeMode?: RunRuntimeMode;
     allowFollowUpTasks?: boolean;
     inspectBackends?: () => ConductorBackendsStatus;
   },
@@ -164,6 +165,11 @@ export function startTaskRunForRepo(
       `pi-subagents backend unavailable: ${status.available ? "dispatch adapter is not implemented yet" : (status.diagnostic ?? "not available")}`,
     );
   }
+  const runtimeMode = input.runtimeMode ?? "headless";
+  const runtimeStatus = getConductorRuntimeModeStatus(runtimeMode);
+  if (!runtimeStatus.available) {
+    throw new Error(`Runtime mode ${runtimeMode} unavailable: ${runtimeStatus.diagnostic ?? "not available"}`);
+  }
   const runId = input.runId ?? createRunId();
   const updatedRun = mutateRepoRunSync(repoRoot, (latest) =>
     startTaskRun(latest, {
@@ -171,6 +177,7 @@ export function startTaskRunForRepo(
       taskId: input.taskId,
       workerId,
       backend,
+      runtimeMode,
       leaseExpiresAt: leaseExpiryFromNow(input.leaseSeconds ?? 900),
     }),
   );
@@ -205,7 +212,7 @@ export function cancelTaskRunForRepo(repoRoot: string, input: { runId: string; r
 
 export function retryTaskForRepo(
   repoRoot: string,
-  input: { taskId: string; workerId?: string; leaseSeconds?: number },
+  input: { taskId: string; workerId?: string; leaseSeconds?: number; runtimeMode?: RunRuntimeMode },
 ): { run: RunAttemptRecord; taskContract: TaskContractInput } {
   const run = getOrCreateRunForRepo(repoRoot);
   const task = run.tasks.find((entry) => entry.taskId === input.taskId);

--- a/packages/pi-conductor/extensions/tools/gate-tools.ts
+++ b/packages/pi-conductor/extensions/tools/gate-tools.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import * as conductor from "../conductor.js";
+import { formatRunRuntimeSummary } from "../runtime-metadata.js";
 
 const gateTypeSchema = Type.Union([
   Type.Literal("needs_input"),
@@ -36,7 +37,12 @@ export function registerGateTools(pi: ExtensionAPI): void {
       const text =
         runs.length === 0
           ? "no conductor runs"
-          : runs.map((attempt) => `${attempt.runId} task=${attempt.taskId} status=${attempt.status}`).join("\n");
+          : runs
+              .map(
+                (attempt) =>
+                  `${attempt.runId} task=${attempt.taskId} status=${attempt.status} ${formatRunRuntimeSummary(attempt.runtime)}`,
+              )
+              .join("\n");
       return { content: [{ type: "text", text }], details: { runs } };
     },
   });

--- a/packages/pi-conductor/extensions/tools/objective-tools.ts
+++ b/packages/pi-conductor/extensions/tools/objective-tools.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import * as conductor from "../conductor.js";
 
 const schedulerPolicySchema = Type.Union([Type.Literal("safe"), Type.Literal("execute")]);
+const runtimeModeSchema = Type.Union([Type.Literal("headless"), Type.Literal("tmux"), Type.Literal("iterm-tmux")]);
 export function registerObjectiveTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "conductor_list_objectives",
@@ -179,6 +180,7 @@ export function registerObjectiveTools(pi: ExtensionAPI): void {
       maxConcurrency: Type.Optional(Type.Number({ description: "Maximum runnable tasks to schedule; defaults to 1" })),
       policy: Type.Optional(schedulerPolicySchema),
       executeRuns: Type.Optional(Type.Boolean({ description: "Also execute assigned runnable tasks" })),
+      runtimeMode: Type.Optional(runtimeModeSchema),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const result = await conductor.scheduleObjectiveForRepo(ctx.cwd, params, _signal);

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -2,6 +2,8 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import * as conductor from "../conductor.js";
 
+const runtimeModeSchema = Type.Union([Type.Literal("headless"), Type.Literal("tmux"), Type.Literal("iterm-tmux")]);
+
 export function registerOrchestrationTools(pi: ExtensionAPI): void {
   const workItemSchema = Type.Object({
     title: Type.String({ description: "Short title for this work item" }),
@@ -34,6 +36,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       ),
       maxWorkers: Type.Optional(Type.Number({ description: "Maximum workers conductor may start in this request" })),
       execute: Type.Optional(Type.Boolean({ description: "Whether to execute after planning; defaults to true" })),
+      runtimeMode: Type.Optional(runtimeModeSchema),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await conductor.runWorkForRepo(ctx.cwd, params, signal);
@@ -64,6 +67,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       workerPrefix: Type.Optional(
         Type.String({ description: "Prefix for generated worker names; defaults to parallel-worker" }),
       ),
+      runtimeMode: Type.Optional(runtimeModeSchema),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await conductor.runParallelWorkForRepo(ctx.cwd, params, signal);

--- a/packages/pi-conductor/extensions/tools/project-tools.ts
+++ b/packages/pi-conductor/extensions/tools/project-tools.ts
@@ -164,7 +164,7 @@ export function registerProjectTools(pi: ExtensionAPI, findRepoRoot: (cwd: strin
         `pi-subagents: available=${backendStatus.piSubagents.available}${backendStatus.piSubagents.diagnostic ? ` (${backendStatus.piSubagents.diagnostic})` : ""}`,
         `runtime headless: available=${runtimeStatus.headless.available}`,
         `runtime tmux: available=${runtimeStatus.tmux.available}${runtimeStatus.tmux.diagnostic ? ` (${runtimeStatus.tmux.diagnostic})` : ""}`,
-        `runtime iterm-tmux: available=${runtimeStatus.itermTmux.available}${runtimeStatus.itermTmux.diagnostic ? ` (${runtimeStatus.itermTmux.diagnostic})` : ""}`,
+        `runtime iterm-tmux: available=${runtimeStatus["iterm-tmux"].available}${runtimeStatus["iterm-tmux"].diagnostic ? ` (${runtimeStatus["iterm-tmux"].diagnostic})` : ""}`,
       ].join("\n");
       return { content: [{ type: "text", text }], details: { ...backendStatus, runtimes: runtimeStatus } };
     },

--- a/packages/pi-conductor/extensions/tools/project-tools.ts
+++ b/packages/pi-conductor/extensions/tools/project-tools.ts
@@ -154,15 +154,19 @@ export function registerProjectTools(pi: ExtensionAPI, findRepoRoot: (cwd: strin
   pi.registerTool({
     name: "conductor_backend_status",
     label: "Conductor Backend Status",
-    description: "Inspect native and optional pi-subagents backend adapter availability",
+    description: "Inspect native/pi-subagents backend and worker runtime mode availability",
     parameters: Type.Object({}),
     async execute() {
       const backendStatus = backends.inspectConductorBackends();
+      const runtimeStatus = backends.inspectConductorRuntimeModes();
       const text = [
         `native: available=${backendStatus.native.available}`,
         `pi-subagents: available=${backendStatus.piSubagents.available}${backendStatus.piSubagents.diagnostic ? ` (${backendStatus.piSubagents.diagnostic})` : ""}`,
+        `runtime headless: available=${runtimeStatus.headless.available}`,
+        `runtime tmux: available=${runtimeStatus.tmux.available}${runtimeStatus.tmux.diagnostic ? ` (${runtimeStatus.tmux.diagnostic})` : ""}`,
+        `runtime iterm-tmux: available=${runtimeStatus.itermTmux.available}${runtimeStatus.itermTmux.diagnostic ? ` (${runtimeStatus.itermTmux.diagnostic})` : ""}`,
       ].join("\n");
-      return { content: [{ type: "text", text }], details: backendStatus };
+      return { content: [{ type: "text", text }], details: { ...backendStatus, runtimes: runtimeStatus } };
     },
   });
 }

--- a/packages/pi-conductor/extensions/tools/task-tools.ts
+++ b/packages/pi-conductor/extensions/tools/task-tools.ts
@@ -139,6 +139,7 @@ export function registerTaskTools(pi: ExtensionAPI): void {
       workerName: Type.String({ description: "Worker name to use or create" }),
       startRun: Type.Optional(Type.Boolean({ description: "Start a durable run immediately; defaults to true" })),
       leaseSeconds: Type.Optional(Type.Number({ description: "Run lease duration in seconds; defaults to 900" })),
+      runtimeMode: Type.Optional(runtimeModeSchema),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const delegated = await conductor.delegateTaskForRepo(ctx.cwd, {
@@ -147,6 +148,7 @@ export function registerTaskTools(pi: ExtensionAPI): void {
         workerName: params.workerName,
         startRun: params.startRun ?? true,
         leaseSeconds: params.leaseSeconds,
+        runtimeMode: params.runtimeMode,
       });
       const runText = delegated.run ? ` and started run ${delegated.run.runId}` : "";
       return {

--- a/packages/pi-conductor/extensions/tools/task-tools.ts
+++ b/packages/pi-conductor/extensions/tools/task-tools.ts
@@ -1,6 +1,9 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import * as conductor from "../conductor.js";
+
+const runtimeModeSchema = Type.Union([Type.Literal("headless"), Type.Literal("tmux"), Type.Literal("iterm-tmux")]);
+
 export function registerTaskTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "conductor_assess_task",
@@ -167,6 +170,7 @@ export function registerTaskTools(pi: ExtensionAPI): void {
       workerId: Type.Optional(Type.String({ description: "Worker ID; defaults to the task's assigned worker" })),
       leaseSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds; defaults to 900" })),
       backend: Type.Optional(Type.Union([Type.Literal("native"), Type.Literal("pi-subagents")])),
+      runtimeMode: Type.Optional(runtimeModeSchema),
       allowFollowUpTasks: Type.Optional(
         Type.Boolean({ description: "Allow the child run to create scoped follow-up tasks" }),
       ),
@@ -191,9 +195,12 @@ export function registerTaskTools(pi: ExtensionAPI): void {
     description: "Run an assigned durable task through its worker using scoped child completion tools",
     parameters: Type.Object({
       taskId: Type.String({ description: "Task ID to run" }),
+      runtimeMode: Type.Optional(runtimeModeSchema),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await conductor.runTaskForRepo(ctx.cwd, params.taskId, _signal);
+      const result = await conductor.runTaskForRepo(ctx.cwd, params.taskId, _signal, {
+        runtimeMode: params.runtimeMode,
+      });
       const summary = result.finalText ?? result.errorMessage ?? "Run completed without a final assistant summary";
       return {
         content: [{ type: "text", text: `ran task ${params.taskId}: outcome=${result.status} result=${summary}` }],
@@ -228,6 +235,7 @@ export function registerTaskTools(pi: ExtensionAPI): void {
       taskId: Type.String({ description: "Task ID to retry" }),
       workerId: Type.Optional(Type.String({ description: "Worker ID; defaults to assigned worker" })),
       leaseSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds; defaults to 900" })),
+      runtimeMode: Type.Optional(runtimeModeSchema),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const retried = conductor.retryTaskForRepo(ctx.cwd, params);

--- a/packages/pi-conductor/extensions/types.ts
+++ b/packages/pi-conductor/extensions/types.ts
@@ -431,6 +431,9 @@ export interface RunRecord {
   updatedAt: string;
 }
 
+export type PersistedRunAttemptRecord = Omit<RunAttemptRecord, "runtime"> & { runtime?: RunRuntimeMetadata };
+export type PersistedRunRecord = Omit<RunRecord, "runs"> & { runs: PersistedRunAttemptRecord[] };
+
 export interface WorkerRunResult {
   workerName: string;
   status: WorkerRunStatus;

--- a/packages/pi-conductor/extensions/types.ts
+++ b/packages/pi-conductor/extensions/types.ts
@@ -3,6 +3,17 @@ export const CONDUCTOR_SCHEMA_VERSION = 1;
 export type WorkerLifecycleState = "idle" | "running" | "broken" | "archived";
 export type ObjectiveStatus = "draft" | "active" | "blocked" | "needs_review" | "completed" | "canceled";
 export type WorkerRunStatus = "success" | "error" | "aborted";
+export type RunRuntimeMode = "headless" | "tmux" | "iterm-tmux";
+export type RunRuntimeStatus =
+  | "unavailable"
+  | "starting"
+  | "running"
+  | "exited_success"
+  | "exited_error"
+  | "aborted"
+  | "unknown";
+export type RunRuntimeViewerStatus = "not_applicable" | "pending" | "opened" | "warning" | "unavailable";
+export type RunRuntimeCleanupStatus = "not_required" | "pending" | "succeeded" | "failed";
 
 export type TaskState =
   | "draft"
@@ -301,6 +312,30 @@ export interface TaskRecord {
   updatedAt: string;
 }
 
+export interface RunRuntimeMetadata {
+  mode: RunRuntimeMode;
+  status: RunRuntimeStatus;
+  sessionId: string | null;
+  cwd: string | null;
+  command: string | null;
+  runnerPid: number | null;
+  processGroupId: number | null;
+  tmux: {
+    socketPath: string | null;
+    sessionName: string | null;
+    windowId: string | null;
+    paneId: string | null;
+  } | null;
+  logPath: string | null;
+  viewerCommand: string | null;
+  viewerStatus: RunRuntimeViewerStatus;
+  diagnostics: string[];
+  heartbeatAt: string | null;
+  cleanupStatus: RunRuntimeCleanupStatus;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
 export interface RunAttemptRecord {
   runId: string;
   taskId: string;
@@ -310,6 +345,7 @@ export interface RunAttemptRecord {
   backend: "native" | "pi-subagents";
   backendRunId: string | null;
   sessionId: string | null;
+  runtime: RunRuntimeMetadata;
   leaseGeneration: number;
   leaseStartedAt: string | null;
   leaseExpiresAt: string | null;


### PR DESCRIPTION
## Summary

Adds the first supervised visible runtime slice for `pi-conductor`: a durable runtime metadata boundary and headless runtime adapter seam that keeps conductor canonical while preparing for tmux/iTerm supervision.

## What changed

- Added PRD/ADR/implementation plan for tmux-backed visible supervision with iTerm as viewer-only polish.
- Persisted per-run runtime metadata for headless runs, including runtime status, viewer/cleanup state, heartbeat/log fields, and diagnostics.
- Routed current headless `AgentSession` execution through a runtime backend interface, while `tmux` and `iterm-tmux` fail closed until implemented.
- Added `runtimeMode` parameters to conductor start/run/retry paths so agents can request visible runtime modes and get actionable unavailable errors without silently falling back.
- Surfaced runtime summaries in conductor status, project brief, task brief, and `conductor_list_runs` output.
- Hardened storage normalization/validation so malformed runtime metadata is rejected and canonical terminal run state wins over stale runtime state.

## Review notes

This is PR A only. It intentionally does **not** launch tmux sessions or add the runner contract yet; that belongs to the next slice.

Refs #63

## Validation

- `npx vitest run packages/pi-conductor/__tests__ --reporter=dot`
- `npm run check`
- `specdocs_validate`
- `git diff --check`