### PR TITLE
feat(pi-conductor): add iterm tmux viewer runtime

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -146,6 +146,18 @@ The native backend uses curated tools and explicit conductor child tools. Backen
 
 Optional backend adapters such as `pi-subagents` may be used later, but they do not own canonical state. The current `pi-subagents` adapter fails closed unless a trusted host injects an explicit dispatcher; injected dispatch records backend run evidence through `backend.dispatch_*` events while conductor owns task/run state.
 
+### Supervised visible runtime
+
+Run tools accept `runtimeMode: "headless" | "tmux" | "iterm-tmux"`. `headless` remains the default. `tmux` launches the conductor runner in a private tmux session and records the attach command, runtime log path, heartbeat, diagnostics, and cleanup state on the durable run. `iterm-tmux` uses the same tmux control plane and best-effort opens iTerm2 as a viewer on macOS; if iTerm2 is unavailable or launch fails, the tmux run remains active and status output shows a warning plus the manual read-only attach command.
+
+Use conductor status tools rather than typing into worker panes to supervise work. Active visible runs include:
+
+- `viewer=<opened|warning|unavailable|pending>` and `viewerCommand=tmux ... attach-session -r ...`
+- `log=<path-or-ref>` and the latest runtime diagnostic/heartbeat
+- `cancel=conductor_cancel_task_run({"runId":"...","reason":"<reason>"})`
+
+`conductor_backend_status` reports tmux startability separately from iTerm2 viewer availability. Explicit visible runtime requests fail closed when tmux is unavailable; iTerm2 viewer failures degrade to tmux-only supervision.
+
 ## Workflow recipes
 
 ### Plan and execute an objective

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -152,7 +152,7 @@ Run tools accept `runtimeMode: "headless" | "tmux" | "iterm-tmux"`. `headless` r
 
 Use conductor status tools rather than typing into worker panes to supervise work. Active visible runs include:
 
-- `viewer=<opened|warning|unavailable|pending>` and `viewerCommand=tmux ... attach-session -r ...`
+- `viewer=<opened|warning|unavailable|pending>` and `viewerCommand="tmux ... attach-session -r ..."`
 - `log=<path-or-ref>` and the latest runtime diagnostic/heartbeat
 - `cancel=conductor_cancel_task_run({"runId":"...","reason":"<reason>"})`
 

--- a/packages/pi-conductor/__tests__/backends.test.ts
+++ b/packages/pi-conductor/__tests__/backends.test.ts
@@ -54,12 +54,34 @@ describe("conductor backend inspection", () => {
     expect(status.tmux.capabilities.canStartRun).toBe(status.tmux.available);
     expect(status["iterm-tmux"]).toMatchObject({
       mode: "iterm-tmux",
-      available: false,
       capabilities: { viewerOnly: true },
     });
+    expect(status["iterm-tmux"].available).toBe(status.tmux.available);
     expect(status.itermTmux).toBe(status["iterm-tmux"]);
     expect(getConductorRuntimeModeStatus("headless").available).toBe(true);
     expect(getConductorRuntimeModeStatus("tmux")).toMatchObject({ mode: "tmux" });
+  });
+
+  it("treats iterm-tmux availability as tmux startability plus viewer diagnostics", () => {
+    const tmuxReadyItermMissing = inspectConductorRuntimeModes({
+      tmuxAvailability: { available: true, diagnostic: null },
+      itermViewerAvailability: { available: false, diagnostic: "iTerm2 is not installed" },
+    });
+    expect(tmuxReadyItermMissing["iterm-tmux"]).toMatchObject({
+      available: true,
+      capabilities: { canStartRun: true, viewerOnly: true },
+      diagnostic: "iTerm2 is not installed",
+    });
+
+    const tmuxMissing = inspectConductorRuntimeModes({
+      tmuxAvailability: { available: false, diagnostic: "tmux missing" },
+      itermViewerAvailability: { available: true, diagnostic: null },
+    });
+    expect(tmuxMissing["iterm-tmux"]).toMatchObject({
+      available: false,
+      capabilities: { canStartRun: false, viewerOnly: true },
+      diagnostic: "tmux missing",
+    });
   });
 
   it("reports pi-subagents available when an explicit dispatcher is injected", async () => {

--- a/packages/pi-conductor/__tests__/brief.test.ts
+++ b/packages/pi-conductor/__tests__/brief.test.ts
@@ -13,6 +13,7 @@ import {
   getOrCreateRunForRepo,
   startTaskRunForRepo,
 } from "../extensions/conductor.js";
+import { createRunRuntimeMetadata } from "../extensions/runtime-metadata.js";
 import { writeRun } from "../extensions/storage.js";
 
 describe("conductor project brief", () => {
@@ -66,6 +67,46 @@ describe("conductor project brief", () => {
     expect(brief.markdown).toContain("runtimeMode=headless runtimeStatus=running");
     expect(brief.nextActions.length).toBeGreaterThan(0);
     expect(brief.recentEvents.length).toBeLessThanOrEqual(5);
+  });
+
+  it("surfaces visible runtime supervision details in active project briefs", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Visible brief", prompt: "Summarize visible state" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      tasks: run.tasks.map((entry) =>
+        entry.taskId === task.taskId ? { ...entry, latestProgress: "opening viewer" } : entry,
+      ),
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId
+          ? {
+              ...entry,
+              runtime: {
+                ...createRunRuntimeMetadata({ mode: "iterm-tmux", status: "running" }),
+                viewerStatus: "opened" as const,
+                viewerCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+                logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+                diagnostics: ["iTerm2 viewer opened"],
+              },
+            }
+          : entry,
+      ),
+    });
+
+    const brief = buildProjectBriefForRepo(repoDir, { maxActions: 3, recentEventLimit: 5 });
+
+    expect(brief.markdown).toContain("## Active Runs");
+    expect(brief.markdown).toContain(`- ${started.run.runId} task=${task.taskId}`);
+    expect(brief.markdown).toContain("runtimeMode=iterm-tmux runtimeStatus=running viewer=opened");
+    expect(brief.markdown).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(brief.markdown).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
+    expect(brief.markdown).toContain("progress=opening viewer");
+    expect(brief.markdown).toContain(
+      `cancel=conductor_cancel_task_run({"runId":"${started.run.runId}","reason":"<reason>"})`,
+    );
   });
 
   it("does not surface terminal-status runs with missing finishedAt as active", async () => {

--- a/packages/pi-conductor/__tests__/brief.test.ts
+++ b/packages/pi-conductor/__tests__/brief.test.ts
@@ -101,7 +101,7 @@ describe("conductor project brief", () => {
     expect(brief.markdown).toContain("## Active Runs");
     expect(brief.markdown).toContain(`- ${started.run.runId} task=${task.taskId}`);
     expect(brief.markdown).toContain("runtimeMode=iterm-tmux runtimeStatus=running viewer=opened");
-    expect(brief.markdown).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(brief.markdown).toContain("viewerCommand=\"tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'\"");
     expect(brief.markdown).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
     expect(brief.markdown).toContain("progress=opening viewer");
     expect(brief.markdown).toContain(

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -11,6 +11,8 @@ import {
   resolveGateForRepo,
   startTaskRunForRepo,
 } from "../extensions/conductor.js";
+import { createRunRuntimeMetadata } from "../extensions/runtime-metadata.js";
+import { writeRun } from "../extensions/storage.js";
 
 describe("runConductorCommand", () => {
   let repoDir: string;
@@ -82,6 +84,51 @@ describe("runConductorCommand", () => {
     await expect(runConductorCommand(repoDir, `get worker ${worker.name}`)).resolves.toContain(worker.workerId);
     await expect(runConductorCommand(repoDir, `get task ${task.taskId}`)).resolves.toContain("state=running");
     await expect(runConductorCommand(repoDir, `get run ${started.run.runId}`)).resolves.toContain("status=running");
+  });
+
+  it("shows visible runtime details for run inspection commands", async () => {
+    await runConductorCommand(repoDir, "create worker backend");
+    await runConductorCommand(repoDir, "create task Build Implement it");
+    const run = getOrCreateRunForRepo(repoDir);
+    const worker = run.workers[0];
+    const task = run.tasks[0];
+    if (!worker || !task) {
+      throw new Error("test resources missing");
+    }
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, {
+      taskId: task.taskId,
+      workerId: worker.workerId,
+      runtimeMode: "iterm-tmux",
+    });
+    writeRun({
+      ...getOrCreateRunForRepo(repoDir),
+      runs: getOrCreateRunForRepo(repoDir).runs.map((entry) =>
+        entry.runId === started.run.runId
+          ? {
+              ...entry,
+              runtime: {
+                ...createRunRuntimeMetadata({ mode: "iterm-tmux", status: "running" }),
+                viewerStatus: "opened" as const,
+                viewerCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+                logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+                diagnostics: ["iTerm2 viewer opened"],
+              },
+            }
+          : entry,
+      ),
+    });
+
+    const runs = await runConductorCommand(repoDir, "get runs");
+    const oneRun = await runConductorCommand(repoDir, `get run ${started.run.runId}`);
+
+    for (const text of [runs, oneRun]) {
+      expect(text).toContain(`task=${task.taskId}`);
+      expect(text).toContain("runtimeMode=iterm-tmux runtimeStatus=running viewer=opened");
+      expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+      expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
+      expect(text).toContain(`cancel=conductor_cancel_task_run({"runId":"${started.run.runId}","reason":"<reason>"})`);
+    }
   });
 
   it("shows resource-shaped run, gate, event, and artifact inspection commands", async () => {

--- a/packages/pi-conductor/__tests__/commands.test.ts
+++ b/packages/pi-conductor/__tests__/commands.test.ts
@@ -125,7 +125,7 @@ describe("runConductorCommand", () => {
     for (const text of [runs, oneRun]) {
       expect(text).toContain(`task=${task.taskId}`);
       expect(text).toContain("runtimeMode=iterm-tmux runtimeStatus=running viewer=opened");
-      expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+      expect(text).toContain("viewerCommand=\"tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'\"");
       expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
       expect(text).toContain(`cancel=conductor_cancel_task_run({"runId":"${started.run.runId}","reason":"<reason>"})`);
     }

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -28,6 +28,19 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
     throw new Error(message);
   }
   return value;
+}
+
+function forceTmuxUnavailable(): () => void {
+  const originalPath = process.env.PATH;
+  const fakeBin = mkdtempSync(join(tmpdir(), "pi-conductor-fake-bin-"));
+  const fakeTmux = join(fakeBin, "tmux");
+  writeFileSync(fakeTmux, "#!/bin/sh\nexit 127\n", "utf-8");
+  chmodSync(fakeTmux, 0o755);
+  process.env.PATH = `${fakeBin}:${originalPath ?? ""}`;
+  return () => {
+    process.env.PATH = originalPath;
+    rmSync(fakeBin, { recursive: true, force: true });
+  };
 }
 
 describe("conductor service", () => {
@@ -214,19 +227,24 @@ describe("conductor service", () => {
   });
 
   it("fails closed when a delegated start requests an unavailable runtime mode", async () => {
-    await expect(
-      delegateTaskForRepo(repoDir, {
-        title: "Visible delegated work",
-        prompt: "Run visibly",
-        workerName: "visible-worker",
-        startRun: true,
-        runtimeMode: "iterm-tmux",
-      }),
-    ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+    const restorePath = forceTmuxUnavailable();
+    try {
+      await expect(
+        delegateTaskForRepo(repoDir, {
+          title: "Visible delegated work",
+          prompt: "Run visibly",
+          workerName: "visible-worker",
+          startRun: true,
+          runtimeMode: "iterm-tmux",
+        }),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
 
-    const run = getOrCreateRunForRepo(repoDir);
-    expect(run.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
-    expect(run.runs).toHaveLength(0);
+      const run = getOrCreateRunForRepo(repoDir);
+      expect(run.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+      expect(run.runs).toHaveLength(0);
+    } finally {
+      restorePath();
+    }
   });
 
   it("cancels active conductor work without requiring run IDs", async () => {
@@ -576,10 +594,15 @@ describe("conductor service", () => {
     expect(canceled.runs[0]).toMatchObject({ status: "aborted" });
     expect(canceled.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
 
-    expect(() => retryTaskForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" })).toThrow(
-      /Runtime mode iterm-tmux unavailable/i,
-    );
-    expect(getOrCreateRunForRepo(repoDir).tasks[0]?.runIds).toHaveLength(1);
+    const restorePath = forceTmuxUnavailable();
+    try {
+      expect(() => retryTaskForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" })).toThrow(
+        /Runtime mode iterm-tmux unavailable/i,
+      );
+      expect(getOrCreateRunForRepo(repoDir).tasks[0]?.runIds).toHaveLength(1);
+    } finally {
+      restorePath();
+    }
 
     const retried = retryTaskForRepo(repoDir, { taskId: task.taskId, leaseSeconds: 300 });
     expect(retried.run.runId).not.toBe(started.run.runId);

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -715,6 +715,39 @@ case "$*" in *has-session*) exit 1 ;; *) exit 0 ;; esac
     expect(reconciled.runs[0]).toMatchObject({ status: "stale", errorMessage: expect.stringContaining("tmux") });
   });
 
+  it("reconciles missing iterm-tmux runtime sessions through project reconciliation", async () => {
+    const worker = await createWorkerForRepo(repoDir, "iterm-tmux-worker");
+    const task = createTaskForRepo(repoDir, { title: "Visible viewer lease task", prompt: "Do it visibly" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, workerId: worker.workerId });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      runs: run.runs.map((attempt) =>
+        attempt.runId === started.run.runId
+          ? {
+              ...attempt,
+              runtime: {
+                ...attempt.runtime,
+                mode: "iterm-tmux",
+                tmux: {
+                  socketPath: "/tmp/missing-iterm-tmux.sock",
+                  sessionName: "missing",
+                  windowId: "@1",
+                  paneId: "%2",
+                },
+              },
+            }
+          : attempt,
+      ),
+    });
+
+    const reconciled = reconcileProjectForRepo(repoDir, { now: "2026-04-27T00:00:00.000Z" });
+
+    expect(reconciled.tasks[0]).toMatchObject({ state: "needs_review", activeRunId: null });
+    expect(reconciled.runs[0]).toMatchObject({ status: "stale", errorMessage: expect.stringContaining("tmux") });
+  });
+
   it("does not expire active tmux runs while their tmux session is still present", async () => {
     const originalPath = process.env.PATH;
     const binDir = mkdtempSync(join(tmpdir(), "fake-tmux-bin-"));

--- a/packages/pi-conductor/__tests__/iterm-viewer.test.ts
+++ b/packages/pi-conductor/__tests__/iterm-viewer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildItermViewerScript,
+  type ItermViewerCommandAdapter,
+  openItermTmuxViewer,
+} from "../extensions/iterm-viewer.js";
+
+describe("iTerm2 tmux viewer", () => {
+  it("escapes AppleScript strings when opening a read-only tmux viewer", async () => {
+    const adapter: ItermViewerCommandAdapter = { execFile: vi.fn(async () => ({ stdout: "", stderr: "" })) };
+    const attachCommand = "tmux -S '/tmp/socket with space' attach-session -r -t 'pi-cond-\"run'";
+
+    const result = await openItermTmuxViewer({
+      attachCommand,
+      title: 'Run "A"',
+      platform: "darwin",
+      adapter,
+    });
+
+    expect(result).toMatchObject({ status: "opened", diagnostic: null, command: attachCommand });
+    expect(adapter.execFile).toHaveBeenCalledWith(
+      "osascript",
+      ["-e", expect.stringContaining('write text "tmux -S')],
+      undefined,
+    );
+    const script = (adapter.execFile as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.[1] as string;
+    expect(script).toContain('set name to "Run \\"A\\""');
+    expect(script).toContain("attach-session -r -t 'pi-cond-\\\"run'");
+  });
+
+  it("reports unavailable instead of launching outside macOS", async () => {
+    const adapter: ItermViewerCommandAdapter = { execFile: vi.fn(async () => ({ stdout: "", stderr: "" })) };
+
+    const result = await openItermTmuxViewer({
+      attachCommand: "tmux attach -r",
+      platform: "linux",
+      adapter,
+    });
+
+    expect(result).toMatchObject({ status: "unavailable", diagnostic: expect.stringContaining("macOS") });
+    expect(adapter.execFile).not.toHaveBeenCalled();
+  });
+
+  it("returns a warning when iTerm2 launch fails", async () => {
+    const adapter: ItermViewerCommandAdapter = {
+      execFile: vi.fn(async () => {
+        throw new Error("iTerm2 not found");
+      }),
+    };
+
+    const result = await openItermTmuxViewer({
+      attachCommand: "tmux attach -r",
+      platform: "darwin",
+      adapter,
+    });
+
+    expect(result).toMatchObject({ status: "warning", diagnostic: expect.stringContaining("iTerm2 not found") });
+  });
+
+  it("builds a script that activates iTerm2 and writes the attach command", () => {
+    expect(buildItermViewerScript({ attachCommand: "tmux attach -r", title: "Conductor" })).toContain(
+      'tell application "iTerm"',
+    );
+  });
+});

--- a/packages/pi-conductor/__tests__/iterm-viewer.test.ts
+++ b/packages/pi-conductor/__tests__/iterm-viewer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildItermViewerScript,
   type ItermViewerCommandAdapter,
+  inspectItermViewerAvailability,
   openItermTmuxViewer,
 } from "../extensions/iterm-viewer.js";
 
@@ -61,5 +62,30 @@ describe("iTerm2 tmux viewer", () => {
     expect(buildItermViewerScript({ attachCommand: "tmux attach -r", title: "Conductor" })).toContain(
       'tell application "iTerm"',
     );
+  });
+
+  it("detects iTerm2 viewer availability without probing on non-macOS platforms", () => {
+    const probe = vi.fn();
+
+    expect(inspectItermViewerAvailability({ platform: "linux", probe })).toMatchObject({
+      available: false,
+      diagnostic: expect.stringContaining("macOS"),
+    });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("reports macOS iTerm2 probe success and failure", () => {
+    expect(inspectItermViewerAvailability({ platform: "darwin", probe: () => undefined })).toMatchObject({
+      available: true,
+      diagnostic: null,
+    });
+    expect(
+      inspectItermViewerAvailability({
+        platform: "darwin",
+        probe: () => {
+          throw new Error("iTerm is missing");
+        },
+      }),
+    ).toMatchObject({ available: false, diagnostic: expect.stringContaining("iTerm is missing") });
   });
 });

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,7 +16,9 @@ vi.mock("../extensions/runtime.js", async (importOriginal) => {
     preflightWorkerRunRuntime: runtimeMocks.preflightWorkerRunRuntime,
     runWorkerPromptRuntime: runtimeMocks.runWorkerPromptRuntime,
     getWorkerRunRuntimeBackend: vi.fn((mode = "headless") => {
-      if (mode !== "headless" && mode !== "tmux") throw new Error(`${mode} runtime is not implemented yet`);
+      if (mode !== "headless" && mode !== "tmux" && mode !== "iterm-tmux") {
+        throw new Error(`${mode} runtime is not implemented yet`);
+      }
       return {
         mode,
         preflight: runtimeMocks.preflightWorkerRunRuntime,
@@ -38,6 +40,19 @@ import {
 import { deriveProjectKey } from "../extensions/project-key.js";
 import { getRunLockFile, readArtifactContentForRepo } from "../extensions/storage.js";
 import { createTmuxRuntimePaths } from "../extensions/tmux-runtime.js";
+
+function forceTmuxUnavailable(): () => void {
+  const originalPath = process.env.PATH;
+  const fakeBin = mkdtempSync(join(tmpdir(), "pi-conductor-fake-bin-"));
+  const fakeTmux = join(fakeBin, "tmux");
+  writeFileSync(fakeTmux, "#!/bin/sh\nexit 127\n", "utf-8");
+  chmodSync(fakeTmux, 0o755);
+  process.env.PATH = `${fakeBin}:${originalPath ?? ""}`;
+  return () => {
+    process.env.PATH = originalPath;
+    rmSync(fakeBin, { recursive: true, force: true });
+  };
+}
 
 describe("durable task run flows", () => {
   let repoDir: string;
@@ -337,13 +352,18 @@ describe("durable task run flows", () => {
     const task = createTaskForRepo(repoDir, { title: "Visible start", prompt: "Start visible work" });
     assignTaskForRepo(repoDir, task.taskId, worker.workerId);
 
-    expect(() => startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" })).toThrow(
-      /Runtime mode iterm-tmux unavailable/i,
-    );
+    const restorePath = forceTmuxUnavailable();
+    try {
+      expect(() => startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" })).toThrow(
+        /Runtime mode iterm-tmux unavailable/i,
+      );
 
-    const persisted = getOrCreateRunForRepo(repoDir);
-    expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
-    expect(persisted.runs).toHaveLength(0);
+      const persisted = getOrCreateRunForRepo(repoDir);
+      expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+      expect(persisted.runs).toHaveLength(0);
+    } finally {
+      restorePath();
+    }
   });
 
   it("fails closed for explicit unavailable viewer runtime execution before creating a run", async () => {
@@ -351,13 +371,18 @@ describe("durable task run flows", () => {
     const task = createTaskForRepo(repoDir, { title: "Visible task", prompt: "Do visible work" });
     assignTaskForRepo(repoDir, task.taskId, worker.workerId);
 
-    await expect(runTaskForRepo(repoDir, task.taskId, undefined, { runtimeMode: "iterm-tmux" })).rejects.toThrow(
-      /Runtime mode iterm-tmux unavailable/i,
-    );
+    const restorePath = forceTmuxUnavailable();
+    try {
+      await expect(runTaskForRepo(repoDir, task.taskId, undefined, { runtimeMode: "iterm-tmux" })).rejects.toThrow(
+        /Runtime mode iterm-tmux unavailable/i,
+      );
 
-    const persisted = getOrCreateRunForRepo(repoDir);
-    expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
-    expect(persisted.runs).toHaveLength(0);
+      const persisted = getOrCreateRunForRepo(repoDir);
+      expect(persisted.tasks[0]).toMatchObject({ state: "assigned", activeRunId: null, runIds: [] });
+      expect(persisted.runs).toHaveLength(0);
+    } finally {
+      restorePath();
+    }
   });
 
   it("aborts live worker runtime when canceling a specific active run", async () => {

--- a/packages/pi-conductor/__tests__/runtime-run.test.ts
+++ b/packages/pi-conductor/__tests__/runtime-run.test.ts
@@ -385,9 +385,9 @@ describe("worker run runtime helpers", () => {
     expect(mapRunStatusToRuntimeStatus(undefined)).toBe("unknown");
   });
 
-  it("selects the tmux backend while keeping the iTerm viewer mode fail-closed", () => {
+  it("selects supervised tmux backends including the iTerm2 viewer mode", () => {
     expect(getWorkerRunRuntimeBackend("tmux")).toMatchObject({ mode: "tmux" });
-    expect(() => getWorkerRunRuntimeBackend("iterm-tmux")).toThrow(/iterm-tmux runtime is not implemented/i);
+    expect(getWorkerRunRuntimeBackend("iterm-tmux")).toMatchObject({ mode: "iterm-tmux" });
   });
 
   it("returns successful outcome from assistant final state and text extraction", async () => {

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -10,6 +10,67 @@ import {
   createWorkerRecord,
   startTaskRun,
 } from "../extensions/storage.js";
+import type {
+  RunRecord,
+  RunRuntimeCleanupStatus,
+  RunRuntimeStatus,
+  RunRuntimeViewerStatus,
+  RunStatus,
+} from "../extensions/types.js";
+
+function createVisibleStatusRun(input: {
+  runStatus: RunStatus;
+  runtimeStatus: RunRuntimeStatus;
+  viewerStatus: RunRuntimeViewerStatus;
+  cleanupStatus?: RunRuntimeCleanupStatus;
+  diagnostic: string;
+  finished?: boolean;
+}): RunRecord {
+  const run = createEmptyRun("abc", "/tmp/repo");
+  const worker = createWorkerRecord({
+    workerId: "worker-1",
+    name: "backend",
+    branch: "conductor/backend",
+    worktreePath: "/tmp/repo/.worktrees/backend",
+    sessionFile: "/tmp/session.jsonl",
+  });
+  const task = createTaskRecord({ taskId: "task-1", title: "Add ledger", prompt: "Implement tasks" });
+  const withRun = startTaskRun(
+    assignTaskToWorker(addTask(addWorker(run, worker), task), task.taskId, worker.workerId),
+    {
+      runId: "run-1",
+      taskId: task.taskId,
+      workerId: worker.workerId,
+      backend: "native",
+      runtimeMode: "iterm-tmux",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    },
+  );
+  return {
+    ...withRun,
+    tasks: withRun.tasks.map((entry) =>
+      entry.taskId === task.taskId ? { ...entry, latestProgress: "editing files" } : entry,
+    ),
+    runs: withRun.runs.map((entry) =>
+      entry.runId === "run-1"
+        ? {
+            ...entry,
+            status: input.runStatus,
+            finishedAt: input.finished ? "2026-04-24T00:01:00.000Z" : null,
+            runtime: {
+              ...createRunRuntimeMetadata({ mode: "iterm-tmux", status: input.runtimeStatus }),
+              viewerStatus: input.viewerStatus,
+              viewerCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+              logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+              heartbeatAt: "2026-04-24T00:00:00.000Z",
+              cleanupStatus: input.cleanupStatus ?? "pending",
+              diagnostics: [input.diagnostic],
+            },
+          }
+        : entry,
+    ),
+  };
+}
 
 describe("formatRunStatus", () => {
   it("formats an empty run", () => {
@@ -122,6 +183,98 @@ describe("formatRunStatus", () => {
     expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
     expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
     expect(text).toContain('cancel=conductor_cancel_task_run({"runId":"run-1","reason":"<reason>"})');
+  });
+
+  it.each([
+    {
+      name: "starting",
+      runStatus: "starting" as const,
+      runtimeStatus: "starting" as const,
+      viewerStatus: "pending" as const,
+      diagnostic: "tmux session pi-cond-run prepared",
+      visibleRuns: "visibleRuns: 1 active",
+      cancel: true,
+    },
+    {
+      name: "running/viewable",
+      runStatus: "running" as const,
+      runtimeStatus: "running" as const,
+      viewerStatus: "opened" as const,
+      diagnostic: "iTerm2 viewer opened",
+      visibleRuns: "visibleRuns: 1 active",
+      cancel: true,
+    },
+    {
+      name: "running/no viewer",
+      runStatus: "running" as const,
+      runtimeStatus: "running" as const,
+      viewerStatus: "warning" as const,
+      diagnostic: "iTerm2 viewer launch failed; attach manually with the tmux command",
+      visibleRuns: "visibleRuns: 1 active",
+      cancel: true,
+    },
+    {
+      name: "missing session",
+      runStatus: "stale" as const,
+      runtimeStatus: "exited_error" as const,
+      viewerStatus: "warning" as const,
+      diagnostic: "tmux session missing during reconciliation: can't find session",
+      visibleRuns: "visibleRuns: none active",
+      finished: true,
+      cancel: false,
+    },
+    {
+      name: "runner exited without completion",
+      runStatus: "partial" as const,
+      runtimeStatus: "exited_success" as const,
+      viewerStatus: "opened" as const,
+      diagnostic: "tmux runner exited after fallback completion",
+      visibleRuns: "visibleRuns: none active",
+      finished: true,
+      cancel: false,
+    },
+    {
+      name: "canceled",
+      runStatus: "aborted" as const,
+      runtimeStatus: "aborted" as const,
+      viewerStatus: "opened" as const,
+      cleanupStatus: "succeeded" as const,
+      diagnostic: "tmux session cleanup succeeded",
+      visibleRuns: "visibleRuns: none active",
+      finished: true,
+      cancel: false,
+    },
+    {
+      name: "cleanup failed",
+      runStatus: "aborted" as const,
+      runtimeStatus: "aborted" as const,
+      viewerStatus: "opened" as const,
+      cleanupStatus: "failed" as const,
+      diagnostic: "tmux pane command verification failed before cancel: zsh",
+      visibleRuns: "visibleRuns: none active",
+      finished: true,
+      cancel: false,
+    },
+  ])("covers visible runtime status table state: $name", (state) => {
+    const text = formatRunStatus(createVisibleStatusRun(state));
+
+    expect(text).toContain(state.visibleRuns);
+    expect(text).toContain(`status=${state.runStatus}`);
+    expect(text).toContain(`runtimeStatus=${state.runtimeStatus}`);
+    expect(text).toContain(`viewer=${state.viewerStatus}`);
+    expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
+    expect(text).toContain("latestProgress=editing files");
+    expect(text).toContain(`diagnostic=${state.diagnostic}`);
+    if (state.cleanupStatus) {
+      expect(text).toContain(`cleanup=${state.cleanupStatus}`);
+    }
+    const cancelCommand = 'cancel=conductor_cancel_task_run({"runId":"run-1","reason":"<reason>"})';
+    if (state.cancel) {
+      expect(text).toContain(cancelCommand);
+    } else {
+      expect(text).not.toContain(cancelCommand);
+    }
   });
 
   it("includes worker runtime and PR state", () => {

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -81,7 +81,7 @@ describe("formatRunStatus", () => {
     expect(text).toContain("tasks: 0");
     expect(text).toContain("runs: 0");
     expect(text).toContain("events: 0");
-    expect(text).toContain("visibleRuns: none active");
+    expect(text).toContain("activeVisibleRuns: none");
   });
 
   it("includes concise durable task resource status", () => {
@@ -177,10 +177,10 @@ describe("formatRunStatus", () => {
 
     const text = formatRunStatus(withRuntime);
 
-    expect(text).toContain("visibleRuns: 1 active");
+    expect(text).toContain("activeVisibleRuns: 1");
     expect(text).toContain("latestProgress=editing files");
     expect(text).toContain("viewer=warning");
-    expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(text).toContain("viewerCommand=\"tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'\"");
     expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
     expect(text).toContain('cancel=conductor_cancel_task_run({"runId":"run-1","reason":"<reason>"})');
   });
@@ -192,7 +192,7 @@ describe("formatRunStatus", () => {
       runtimeStatus: "starting" as const,
       viewerStatus: "pending" as const,
       diagnostic: "tmux session pi-cond-run prepared",
-      visibleRuns: "visibleRuns: 1 active",
+      visibleRuns: "activeVisibleRuns: 1",
       cancel: true,
     },
     {
@@ -201,7 +201,7 @@ describe("formatRunStatus", () => {
       runtimeStatus: "running" as const,
       viewerStatus: "opened" as const,
       diagnostic: "iTerm2 viewer opened",
-      visibleRuns: "visibleRuns: 1 active",
+      visibleRuns: "activeVisibleRuns: 1",
       cancel: true,
     },
     {
@@ -210,7 +210,7 @@ describe("formatRunStatus", () => {
       runtimeStatus: "running" as const,
       viewerStatus: "warning" as const,
       diagnostic: "iTerm2 viewer launch failed; attach manually with the tmux command",
-      visibleRuns: "visibleRuns: 1 active",
+      visibleRuns: "activeVisibleRuns: 1",
       cancel: true,
     },
     {
@@ -219,7 +219,7 @@ describe("formatRunStatus", () => {
       runtimeStatus: "exited_error" as const,
       viewerStatus: "warning" as const,
       diagnostic: "tmux session missing during reconciliation: can't find session",
-      visibleRuns: "visibleRuns: none active",
+      visibleRuns: "activeVisibleRuns: none",
       finished: true,
       cancel: false,
     },
@@ -229,7 +229,7 @@ describe("formatRunStatus", () => {
       runtimeStatus: "exited_success" as const,
       viewerStatus: "opened" as const,
       diagnostic: "tmux runner exited after fallback completion",
-      visibleRuns: "visibleRuns: none active",
+      visibleRuns: "activeVisibleRuns: none",
       finished: true,
       cancel: false,
     },
@@ -240,7 +240,7 @@ describe("formatRunStatus", () => {
       viewerStatus: "opened" as const,
       cleanupStatus: "succeeded" as const,
       diagnostic: "tmux session cleanup succeeded",
-      visibleRuns: "visibleRuns: none active",
+      visibleRuns: "activeVisibleRuns: none",
       finished: true,
       cancel: false,
     },
@@ -251,7 +251,7 @@ describe("formatRunStatus", () => {
       viewerStatus: "opened" as const,
       cleanupStatus: "failed" as const,
       diagnostic: "tmux pane command verification failed before cancel: zsh",
-      visibleRuns: "visibleRuns: none active",
+      visibleRuns: "activeVisibleRuns: none",
       finished: true,
       cancel: false,
     },
@@ -262,7 +262,7 @@ describe("formatRunStatus", () => {
     expect(text).toContain(`status=${state.runStatus}`);
     expect(text).toContain(`runtimeStatus=${state.runtimeStatus}`);
     expect(text).toContain(`viewer=${state.viewerStatus}`);
-    expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(text).toContain("viewerCommand=\"tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'\"");
     expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
     expect(text).toContain("latestProgress=editing files");
     expect(text).toContain(`diagnostic=${state.diagnostic}`);

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createRunRuntimeMetadata } from "../extensions/runtime-metadata.js";
 import { formatRunStatus } from "../extensions/status.js";
 import {
   addTask,
@@ -19,6 +20,7 @@ describe("formatRunStatus", () => {
     expect(text).toContain("tasks: 0");
     expect(text).toContain("runs: 0");
     expect(text).toContain("events: 0");
+    expect(text).toContain("visibleRuns: none active");
   });
 
   it("includes concise durable task resource status", () => {
@@ -67,6 +69,59 @@ describe("formatRunStatus", () => {
 
     expect(text).toContain("- run run-1 task=task-1 worker=worker-1 status=running backend=native");
     expect(text).toContain("runtimeMode=headless runtimeStatus=running viewer=not_applicable cleanup=not_required");
+  });
+
+  it("surfaces supervised runtime viewer and cancellation guidance", () => {
+    const run = createEmptyRun("abc", "/tmp/repo");
+    const worker = createWorkerRecord({
+      workerId: "worker-1",
+      name: "backend",
+      branch: "conductor/backend",
+      worktreePath: "/tmp/repo/.worktrees/backend",
+      sessionFile: "/tmp/session.jsonl",
+    });
+    const task = createTaskRecord({ taskId: "task-1", title: "Add ledger", prompt: "Implement tasks" });
+    const withRun = startTaskRun(
+      assignTaskToWorker(addTask(addWorker(run, worker), task), task.taskId, worker.workerId),
+      {
+        runId: "run-1",
+        taskId: task.taskId,
+        workerId: worker.workerId,
+        backend: "native",
+        runtimeMode: "iterm-tmux",
+        leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+      },
+    );
+    const withRuntime = {
+      ...withRun,
+      tasks: withRun.tasks.map((entry) =>
+        entry.taskId === task.taskId ? { ...entry, latestProgress: "editing files" } : entry,
+      ),
+      runs: withRun.runs.map((entry) =>
+        entry.runId === "run-1"
+          ? {
+              ...entry,
+              runtime: {
+                ...createRunRuntimeMetadata({ mode: "iterm-tmux", status: "running" }),
+                viewerStatus: "warning" as const,
+                viewerCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+                logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+                heartbeatAt: "2026-04-24T00:00:00.000Z",
+                diagnostics: ["iTerm2 viewer launch failed; attach manually with the tmux command"],
+              },
+            }
+          : entry,
+      ),
+    };
+
+    const text = formatRunStatus(withRuntime);
+
+    expect(text).toContain("visibleRuns: 1 active");
+    expect(text).toContain("latestProgress=editing files");
+    expect(text).toContain("viewer=warning");
+    expect(text).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(text).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
+    expect(text).toContain('cancel=conductor_cancel_task_run({"runId":"run-1","reason":"<reason>"})');
   });
 
   it("includes worker runtime and PR state", () => {

--- a/packages/pi-conductor/__tests__/task-brief.test.ts
+++ b/packages/pi-conductor/__tests__/task-brief.test.ts
@@ -91,7 +91,7 @@ describe("conductor task brief", () => {
     expect(brief.markdown).toContain("Latest progress: opening viewer");
     expect(brief.markdown).toContain(`- ${started.run.runId} status=running`);
     expect(brief.markdown).toContain("runtimeMode=iterm-tmux runtimeStatus=running viewer=opened");
-    expect(brief.markdown).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(brief.markdown).toContain("viewerCommand=\"tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'\"");
     expect(brief.markdown).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
     expect(brief.markdown).toContain(
       `cancel=conductor_cancel_task_run({"runId":"${started.run.runId}","reason":"<reason>"})`,

--- a/packages/pi-conductor/__tests__/task-brief.test.ts
+++ b/packages/pi-conductor/__tests__/task-brief.test.ts
@@ -9,8 +9,11 @@ import {
   createObjectiveForRepo,
   createTaskForRepo,
   createWorkerForRepo,
+  getOrCreateRunForRepo,
   startTaskRunForRepo,
 } from "../extensions/conductor.js";
+import { createRunRuntimeMetadata } from "../extensions/runtime-metadata.js";
+import { writeRun } from "../extensions/storage.js";
 
 describe("conductor task brief", () => {
   let repoDir: string;
@@ -54,5 +57,44 @@ describe("conductor task brief", () => {
     expect(brief.markdown).toContain(`- ${started.run.runId} status=running`);
     expect(brief.markdown).toContain("runtimeMode=headless runtimeStatus=running");
     expect(brief.suggestedNextTool).toBeNull();
+  });
+
+  it("surfaces visible runtime supervision details in task briefs", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const task = createTaskForRepo(repoDir, { title: "Visible task brief", prompt: "Create visible context" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      tasks: run.tasks.map((entry) =>
+        entry.taskId === task.taskId ? { ...entry, latestProgress: "opening viewer" } : entry,
+      ),
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId
+          ? {
+              ...entry,
+              runtime: {
+                ...createRunRuntimeMetadata({ mode: "iterm-tmux", status: "running" }),
+                viewerStatus: "opened" as const,
+                viewerCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+                logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+                diagnostics: ["iTerm2 viewer opened"],
+              },
+            }
+          : entry,
+      ),
+    });
+
+    const brief = buildTaskBriefForRepo(repoDir, { taskId: task.taskId });
+
+    expect(brief.markdown).toContain("Latest progress: opening viewer");
+    expect(brief.markdown).toContain(`- ${started.run.runId} status=running`);
+    expect(brief.markdown).toContain("runtimeMode=iterm-tmux runtimeStatus=running viewer=opened");
+    expect(brief.markdown).toContain("viewerCommand=tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'");
+    expect(brief.markdown).toContain("log=/tmp/pi-conductor/runtime/run-1/runner.log");
+    expect(brief.markdown).toContain(
+      `cancel=conductor_cancel_task_run({"runId":"${started.run.runId}","reason":"<reason>"})`,
+    );
   });
 });

--- a/packages/pi-conductor/__tests__/tmux-cancel.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-cancel.test.ts
@@ -59,7 +59,7 @@ describe("tmux durable cancellation", () => {
     }
   });
 
-  async function createPersistedTmuxRun() {
+  async function createPersistedTmuxRun(runtimeMode: "tmux" | "iterm-tmux" = "tmux") {
     const worker = await createWorkerForRepo(repoDir, "tmux-worker");
     const task = createTaskForRepo(repoDir, { title: "Detached tmux", prompt: "Run visibly" });
     assignTaskForRepo(repoDir, task.taskId, worker.workerId);
@@ -73,7 +73,7 @@ describe("tmux durable cancellation", () => {
               ...run,
               runtime: {
                 ...run.runtime,
-                mode: "tmux",
+                mode: runtimeMode,
                 cleanupStatus: "pending",
                 tmux: { socketPath: "/tmp/tmux.sock", sessionName: "detached", windowId: "@1", paneId: "%2" },
               },
@@ -148,6 +148,21 @@ describe("tmux durable cancellation", () => {
       status: "aborted",
       runtime: { cleanupStatus: "succeeded", diagnostics: expect.arrayContaining(["killed detached tmux"]) },
     });
+    expect(canceled.workers[0]).toMatchObject({ lifecycle: "idle", recoverable: false });
+  });
+
+  it("kills persisted iterm-tmux runtime resources when no live abort handle exists", async () => {
+    const started = await createPersistedTmuxRun("iterm-tmux");
+
+    const canceled = await cancelTaskRunForRepoWithRuntimeCleanup(repoDir, {
+      runId: started.run.runId,
+      reason: "stop detached viewer run",
+    });
+
+    expect(tmuxMocks.cancelTmuxRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: expect.objectContaining({ mode: "iterm-tmux" }) }),
+    );
+    expect(canceled.runs[0]).toMatchObject({ status: "aborted", runtime: { cleanupStatus: "succeeded" } });
     expect(canceled.workers[0]).toMatchObject({ lifecycle: "idle", recoverable: false });
   });
 

--- a/packages/pi-conductor/__tests__/tmux-runtime.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   getOrCreateRunForRepo,
   startTaskRunForRepo,
 } from "../extensions/conductor.js";
+import type { ItermViewerCommandAdapter } from "../extensions/iterm-viewer.js";
 import {
   buildTmuxLaunch,
   cancelTmuxRuntime,
@@ -168,6 +169,134 @@ describe("tmux conductor runtime", () => {
     expect(contractContent).not.toContain("abc123def4567890abc123def4567890");
     expect(existsSync(persisted?.runtime.logPath ?? "")).toBe(true);
     expect(statSync(persisted?.runtime.logPath ?? "").mode & 0o777).toBe(0o600);
+  });
+
+  it("opens iTerm2 as a viewer over an iterm-tmux run", async () => {
+    const { worker, started } = await createStartedTask();
+    const adapter = new FakeTmuxAdapter();
+    const itermViewerAdapter: ItermViewerCommandAdapter = { execFile: async () => ({ stdout: "", stderr: "" }) };
+    const backend = createTmuxWorkerRunRuntimeBackend({
+      mode: "iterm-tmux",
+      commandAdapter: adapter,
+      runnerCommand: ["node", "/tmp/pi-conductor-runner", "run"],
+      itermViewerAdapter,
+      itermPlatform: "darwin",
+      waitForCompletion: false,
+      randomHex: () => "feedfacefeedfacefeedfacefeedface",
+      now: () => "2026-04-27T00:00:00.000Z",
+    });
+
+    await backend.run({
+      repoRoot: repoDir,
+      worktreePath: worker.worktreePath ?? repoDir,
+      sessionFile: worker.sessionFile ?? join(repoDir, "session.jsonl"),
+      task: "Run in tmux",
+      taskContract: started.taskContract,
+      onRuntimeMetadata: async (metadata) => {
+        const latest = getOrCreateRunForRepo(repoDir);
+        const { writeRun } = await import("../extensions/storage.js");
+        writeRun({
+          ...latest,
+          runs: latest.runs.map((entry) =>
+            entry.runId === started.run.runId ? { ...entry, runtime: { ...entry.runtime, ...metadata } } : entry,
+          ),
+        });
+      },
+    });
+
+    const persisted = getOrCreateRunForRepo(repoDir).runs[0];
+    expect(persisted?.runtime).toMatchObject({
+      mode: "iterm-tmux",
+      status: "running",
+      viewerStatus: "opened",
+      viewerCommand: expect.stringContaining("attach-session -r"),
+    });
+    expect(persisted?.runtime.diagnostics.join("\n")).toContain("iTerm2 viewer opened");
+  });
+
+  it("does not tear down tmux when best-effort viewer metadata cannot be persisted", async () => {
+    const { worker, started } = await createStartedTask();
+    const adapter = new FakeTmuxAdapter();
+    const itermViewerAdapter: ItermViewerCommandAdapter = { execFile: async () => ({ stdout: "", stderr: "" }) };
+    const backend = createTmuxWorkerRunRuntimeBackend({
+      mode: "iterm-tmux",
+      commandAdapter: adapter,
+      runnerCommand: ["node", "/tmp/pi-conductor-runner", "run"],
+      itermViewerAdapter,
+      itermPlatform: "darwin",
+      waitForCompletion: false,
+      randomHex: () => "ba5eba11ba5eba11ba5eba11ba5eba11",
+    });
+
+    const result = await backend.run({
+      repoRoot: repoDir,
+      worktreePath: worker.worktreePath ?? repoDir,
+      sessionFile: worker.sessionFile ?? join(repoDir, "session.jsonl"),
+      task: "Run in tmux",
+      taskContract: started.taskContract,
+      onRuntimeMetadata: async (metadata) => {
+        if (metadata.viewerStatus === "opened") throw new Error("viewer state lock unavailable");
+        const latest = getOrCreateRunForRepo(repoDir);
+        const { writeRun } = await import("../extensions/storage.js");
+        writeRun({
+          ...latest,
+          runs: latest.runs.map((entry) =>
+            entry.runId === started.run.runId ? { ...entry, runtime: { ...entry.runtime, ...metadata } } : entry,
+          ),
+        });
+      },
+    });
+
+    expect(result).toMatchObject({ status: "success" });
+    expect(adapter.calls.some((call) => call.args.includes("kill-session"))).toBe(false);
+    expect(getOrCreateRunForRepo(repoDir).runs[0]?.runtime).toMatchObject({
+      mode: "iterm-tmux",
+      status: "running",
+      viewerStatus: "pending",
+    });
+  });
+
+  it("keeps an iterm-tmux run active when the iTerm2 viewer cannot open", async () => {
+    const { worker, started } = await createStartedTask();
+    const adapter = new FakeTmuxAdapter();
+    const itermViewerAdapter: ItermViewerCommandAdapter = {
+      execFile: async () => {
+        throw new Error("osascript unavailable");
+      },
+    };
+    const backend = createTmuxWorkerRunRuntimeBackend({
+      mode: "iterm-tmux",
+      commandAdapter: adapter,
+      runnerCommand: ["node", "/tmp/pi-conductor-runner", "run"],
+      itermViewerAdapter,
+      itermPlatform: "darwin",
+      waitForCompletion: false,
+      randomHex: () => "cafebabecafebabecafebabecafebabe",
+    });
+
+    const result = await backend.run({
+      repoRoot: repoDir,
+      worktreePath: worker.worktreePath ?? repoDir,
+      sessionFile: worker.sessionFile ?? join(repoDir, "session.jsonl"),
+      task: "Run in tmux",
+      taskContract: started.taskContract,
+      onRuntimeMetadata: async (metadata) => {
+        const latest = getOrCreateRunForRepo(repoDir);
+        const { writeRun } = await import("../extensions/storage.js");
+        writeRun({
+          ...latest,
+          runs: latest.runs.map((entry) =>
+            entry.runId === started.run.runId ? { ...entry, runtime: { ...entry.runtime, ...metadata } } : entry,
+          ),
+        });
+      },
+    });
+
+    const persisted = getOrCreateRunForRepo(repoDir).runs[0];
+    expect(result).toMatchObject({ status: "success" });
+    expect(persisted?.runtime).toMatchObject({ mode: "iterm-tmux", status: "running", viewerStatus: "warning" });
+    expect(persisted?.runtime.diagnostics.join("\n")).toContain("osascript unavailable");
+    expect(adapter.calls.some((call) => call.args.includes("kill-session"))).toBe(false);
   });
 
   it("does not launch tmux when cancellation is already requested", async () => {

--- a/packages/pi-conductor/__tests__/tmux-runtime.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-runtime.test.ts
@@ -2,9 +2,10 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assignTaskForRepo,
+  cancelTaskRunForRepo,
   createTaskForRepo,
   createWorkerForRepo,
   getOrCreateRunForRepo,
@@ -69,6 +70,7 @@ describe("tmux conductor runtime", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     delete process.env.PI_CONDUCTOR_HOME;
     for (const dir of [repoDir, conductorHome]) {
       if (dir && existsSync(dir)) rmSync(dir, { recursive: true, force: true });
@@ -215,6 +217,7 @@ describe("tmux conductor runtime", () => {
   });
 
   it("does not tear down tmux when best-effort viewer metadata cannot be persisted", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { worker, started } = await createStartedTask();
     const adapter = new FakeTmuxAdapter();
     const itermViewerAdapter: ItermViewerCommandAdapter = { execFile: async () => ({ stdout: "", stderr: "" }) };
@@ -249,10 +252,60 @@ describe("tmux conductor runtime", () => {
 
     expect(result).toMatchObject({ status: "success" });
     expect(adapter.calls.some((call) => call.args.includes("kill-session"))).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("viewer metadata persistence failed"));
     expect(getOrCreateRunForRepo(repoDir).runs[0]?.runtime).toMatchObject({
       mode: "iterm-tmux",
       status: "running",
       viewerStatus: "pending",
+    });
+    consoleError.mockRestore();
+  });
+
+  it("does not open an iTerm2 viewer after durable cancellation wins the launch race", async () => {
+    const { worker, started } = await createStartedTask();
+    const adapter = new FakeTmuxAdapter();
+    let viewerLaunchCount = 0;
+    const itermViewerAdapter: ItermViewerCommandAdapter = {
+      execFile: async () => {
+        viewerLaunchCount += 1;
+        return { stdout: "", stderr: "" };
+      },
+    };
+    const backend = createTmuxWorkerRunRuntimeBackend({
+      mode: "iterm-tmux",
+      commandAdapter: adapter,
+      runnerCommand: ["node", "/tmp/pi-conductor-runner", "run"],
+      itermViewerAdapter,
+      itermPlatform: "darwin",
+      waitForCompletion: false,
+      randomHex: () => "decafbaddecafbaddecafbaddecafbad",
+    });
+
+    await backend.run({
+      repoRoot: repoDir,
+      worktreePath: worker.worktreePath ?? repoDir,
+      sessionFile: worker.sessionFile ?? join(repoDir, "session.jsonl"),
+      task: "Run in tmux",
+      taskContract: started.taskContract,
+      onRuntimeMetadata: async (metadata) => {
+        const latest = getOrCreateRunForRepo(repoDir);
+        const { writeRun } = await import("../extensions/storage.js");
+        writeRun({
+          ...latest,
+          runs: latest.runs.map((entry) =>
+            entry.runId === started.run.runId ? { ...entry, runtime: { ...entry.runtime, ...metadata } } : entry,
+          ),
+        });
+        if (metadata.status === "running") {
+          cancelTaskRunForRepo(repoDir, { runId: started.run.runId, reason: "human canceled before viewer" });
+        }
+      },
+    });
+
+    expect(viewerLaunchCount).toBe(0);
+    expect(getOrCreateRunForRepo(repoDir).runs[0]).toMatchObject({
+      status: "aborted",
+      runtime: { mode: "iterm-tmux", viewerStatus: "pending" },
     });
   });
 

--- a/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
+++ b/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -66,63 +66,74 @@ describe("conductor runtime-mode tool contracts", () => {
   });
 
   it("forwards runtimeMode through registered start, run, retry, and delegate tools", async () => {
+    const originalPath = process.env.PATH;
     const tools = collectTools();
     const worker = await createWorkerForRepo(repoDir, "backend");
     const task = createTaskForRepo(repoDir, { title: "Visible tool task", prompt: "Run visibly" });
     assignTaskForRepo(repoDir, task.taskId, worker.workerId);
 
-    await expect(
-      getTool(tools, "conductor_start_task_run").execute?.(
-        "tool-call-1",
-        { taskId: task.taskId, runtimeMode: "iterm-tmux" },
-        undefined,
-        undefined,
-        { cwd: repoDir },
-      ),
-    ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
-    expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(0);
+    const fakeBin = mkdtempSync(join(tmpdir(), "pi-conductor-fake-bin-"));
+    const fakeTmux = join(fakeBin, "tmux");
+    writeFileSync(fakeTmux, "#!/bin/sh\nexit 127\n", "utf-8");
+    chmodSync(fakeTmux, 0o755);
+    process.env.PATH = `${fakeBin}:${originalPath ?? ""}`;
+    try {
+      await expect(
+        getTool(tools, "conductor_start_task_run").execute?.(
+          "tool-call-1",
+          { taskId: task.taskId, runtimeMode: "iterm-tmux" },
+          undefined,
+          undefined,
+          { cwd: repoDir },
+        ),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+      expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(0);
 
-    await expect(
-      getTool(tools, "conductor_run_task").execute?.(
-        "tool-call-2",
-        { taskId: task.taskId, runtimeMode: "iterm-tmux" },
-        undefined,
-        undefined,
-        { cwd: repoDir },
-      ),
-    ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
-    expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(0);
+      await expect(
+        getTool(tools, "conductor_run_task").execute?.(
+          "tool-call-2",
+          { taskId: task.taskId, runtimeMode: "iterm-tmux" },
+          undefined,
+          undefined,
+          { cwd: repoDir },
+        ),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+      expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(0);
 
-    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
-    await cancelTaskRunForRepo(repoDir, { runId: started.run.runId, reason: "prepare retry" });
-    await expect(
-      getTool(tools, "conductor_retry_task").execute?.(
-        "tool-call-3",
-        { taskId: task.taskId, runtimeMode: "iterm-tmux" },
-        undefined,
-        undefined,
-        { cwd: repoDir },
-      ),
-    ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
-    expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(1);
+      const started = startTaskRunForRepo(repoDir, { taskId: task.taskId });
+      await cancelTaskRunForRepo(repoDir, { runId: started.run.runId, reason: "prepare retry" });
+      await expect(
+        getTool(tools, "conductor_retry_task").execute?.(
+          "tool-call-3",
+          { taskId: task.taskId, runtimeMode: "iterm-tmux" },
+          undefined,
+          undefined,
+          { cwd: repoDir },
+        ),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+      expect(getOrCreateRunForRepo(repoDir).runs).toHaveLength(1);
 
-    await expect(
-      getTool(tools, "conductor_delegate_task").execute?.(
-        "tool-call-4",
-        {
-          title: "Visible delegate",
-          prompt: "Run visibly",
-          workerName: "delegate-visible",
-          startRun: true,
-          runtimeMode: "iterm-tmux",
-        },
-        undefined,
-        undefined,
-        { cwd: repoDir },
-      ),
-    ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
-    const run = getOrCreateRunForRepo(repoDir);
-    expect(run.tasks.at(-1)).toMatchObject({ title: "Visible delegate", state: "assigned", activeRunId: null });
+      await expect(
+        getTool(tools, "conductor_delegate_task").execute?.(
+          "tool-call-4",
+          {
+            title: "Visible delegate",
+            prompt: "Run visibly",
+            workerName: "delegate-visible",
+            startRun: true,
+            runtimeMode: "iterm-tmux",
+          },
+          undefined,
+          undefined,
+          { cwd: repoDir },
+        ),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+      const run = getOrCreateRunForRepo(repoDir);
+      expect(run.tasks.at(-1)).toMatchObject({ title: "Visible delegate", state: "assigned", activeRunId: null });
+    } finally {
+      process.env.PATH = originalPath;
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
   });
 
   it("surfaces runtime status through registered list-runs and backend-status tools", async () => {

--- a/packages/pi-conductor/extensions/backends.ts
+++ b/packages/pi-conductor/extensions/backends.ts
@@ -150,6 +150,48 @@ export function inspectConductorBackends(
   };
 }
 
+function getHeadlessRuntimeStatus(): ConductorRuntimeModeStatus {
+  return {
+    mode: "headless",
+    available: true,
+    canonicalStateOwner: "conductor",
+    capabilities: headlessRuntimeCapabilities,
+    diagnostic: null,
+  };
+}
+
+function getTmuxRuntimeStatus(
+  input: { tmuxAvailability?: { available: boolean; diagnostic: string | null } } = {},
+): ConductorRuntimeModeStatus {
+  const tmuxAvailability = input.tmuxAvailability ?? inspectTmuxRuntimeAvailability();
+  return {
+    mode: "tmux",
+    available: tmuxAvailability.available,
+    canonicalStateOwner: "conductor",
+    capabilities: tmuxAvailability.available ? tmuxRuntimeCapabilities : unavailableVisibleRuntimeCapabilities,
+    diagnostic: tmuxAvailability.diagnostic,
+  };
+}
+
+function getItermTmuxRuntimeStatus(
+  input: {
+    tmuxAvailability?: { available: boolean; diagnostic: string | null };
+    itermViewerAvailability?: ItermViewerAvailability;
+  } = {},
+): ConductorRuntimeModeStatus {
+  const tmuxAvailability = input.tmuxAvailability ?? inspectTmuxRuntimeAvailability();
+  const itermViewerAvailability =
+    input.itermViewerAvailability ??
+    (tmuxAvailability.available ? inspectItermViewerAvailability() : { available: false, diagnostic: null });
+  return {
+    mode: "iterm-tmux",
+    available: tmuxAvailability.available,
+    canonicalStateOwner: "conductor",
+    capabilities: tmuxAvailability.available ? itermViewerRuntimeCapabilities : unavailableItermViewerCapabilities,
+    diagnostic: tmuxAvailability.available ? itermViewerAvailability.diagnostic : tmuxAvailability.diagnostic,
+  };
+}
+
 export function inspectConductorRuntimeModes(
   input: {
     tmuxAvailability?: { available: boolean; diagnostic: string | null };
@@ -157,37 +199,25 @@ export function inspectConductorRuntimeModes(
   } = {},
 ): ConductorRuntimeModesStatus {
   const tmuxAvailability = input.tmuxAvailability ?? inspectTmuxRuntimeAvailability();
-  const itermViewerAvailability = input.itermViewerAvailability ?? inspectItermViewerAvailability();
-  const itermTmux: ConductorRuntimeModeStatus = {
-    mode: "iterm-tmux",
-    available: tmuxAvailability.available,
-    canonicalStateOwner: "conductor",
-    capabilities: tmuxAvailability.available ? itermViewerRuntimeCapabilities : unavailableItermViewerCapabilities,
-    diagnostic: tmuxAvailability.available ? itermViewerAvailability.diagnostic : tmuxAvailability.diagnostic,
-  };
+  const headless = getHeadlessRuntimeStatus();
+  const tmux = getTmuxRuntimeStatus({ tmuxAvailability });
+  const itermTmux = getItermTmuxRuntimeStatus({ ...input, tmuxAvailability });
   return {
-    headless: {
-      mode: "headless",
-      available: true,
-      canonicalStateOwner: "conductor",
-      capabilities: headlessRuntimeCapabilities,
-      diagnostic: null,
-    },
-    tmux: {
-      mode: "tmux",
-      available: tmuxAvailability.available,
-      canonicalStateOwner: "conductor",
-      capabilities: tmuxAvailability.available ? tmuxRuntimeCapabilities : unavailableVisibleRuntimeCapabilities,
-      diagnostic: tmuxAvailability.diagnostic,
-    },
+    headless,
+    tmux,
     "iterm-tmux": itermTmux,
     itermTmux,
   };
 }
 
 export function getConductorRuntimeModeStatus(mode: RunRuntimeMode): ConductorRuntimeModeStatus {
-  const status = inspectConductorRuntimeModes();
-  return status[mode];
+  if (mode === "headless") {
+    return getHeadlessRuntimeStatus();
+  }
+  if (mode === "tmux") {
+    return getTmuxRuntimeStatus();
+  }
+  return getItermTmuxRuntimeStatus();
 }
 
 export function getConductorBackendAdapter(

--- a/packages/pi-conductor/extensions/backends.ts
+++ b/packages/pi-conductor/extensions/backends.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { type ItermViewerAvailability, inspectItermViewerAvailability } from "./iterm-viewer.js";
 import { inspectTmuxRuntimeAvailability } from "./tmux-runtime.js";
 import type { RunRuntimeMode } from "./types.js";
 
@@ -95,6 +96,13 @@ const unavailableVisibleRuntimeCapabilities: ConductorRuntimeModeCapabilities = 
   viewerOnly: false,
 };
 
+const itermViewerRuntimeCapabilities: ConductorRuntimeModeCapabilities = {
+  canStartRun: true,
+  canSuperviseLiveOutput: true,
+  requiresExternalRunner: true,
+  viewerOnly: true,
+};
+
 const unavailableItermViewerCapabilities: ConductorRuntimeModeCapabilities = {
   canStartRun: false,
   canSuperviseLiveOutput: true,
@@ -142,14 +150,20 @@ export function inspectConductorBackends(
   };
 }
 
-export function inspectConductorRuntimeModes(): ConductorRuntimeModesStatus {
-  const tmuxAvailability = inspectTmuxRuntimeAvailability();
+export function inspectConductorRuntimeModes(
+  input: {
+    tmuxAvailability?: { available: boolean; diagnostic: string | null };
+    itermViewerAvailability?: ItermViewerAvailability;
+  } = {},
+): ConductorRuntimeModesStatus {
+  const tmuxAvailability = input.tmuxAvailability ?? inspectTmuxRuntimeAvailability();
+  const itermViewerAvailability = input.itermViewerAvailability ?? inspectItermViewerAvailability();
   const itermTmux: ConductorRuntimeModeStatus = {
     mode: "iterm-tmux",
-    available: false,
+    available: tmuxAvailability.available,
     canonicalStateOwner: "conductor",
-    capabilities: unavailableItermViewerCapabilities,
-    diagnostic: "iTerm2 viewer depends on the tmux supervised runtime adapter, which is not implemented yet",
+    capabilities: tmuxAvailability.available ? itermViewerRuntimeCapabilities : unavailableItermViewerCapabilities,
+    diagnostic: tmuxAvailability.available ? itermViewerAvailability.diagnostic : tmuxAvailability.diagnostic,
   };
   return {
     headless: {

--- a/packages/pi-conductor/extensions/commands.ts
+++ b/packages/pi-conductor/extensions/commands.ts
@@ -5,8 +5,25 @@ import {
   reconcileProjectForRepo,
   reconcileWorkerHealth,
 } from "./conductor.js";
+import { isTerminalRunStatus } from "./run-status.js";
+import { formatRunRuntimeSummary } from "./runtime-metadata.js";
 import { formatRunStatus } from "./status.js";
 import { queryConductorEvents } from "./storage.js";
+import type { RunAttemptRecord } from "./types.js";
+
+function isActiveRun(attempt: RunAttemptRecord): boolean {
+  return !attempt.finishedAt && !isTerminalRunStatus(attempt.status);
+}
+
+function formatRunInspection(attempt: RunAttemptRecord): string {
+  const cancelCommand = isActiveRun(attempt)
+    ? ` cancel=conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})`
+    : "";
+  return (
+    `${attempt.runId} task=${attempt.taskId} worker=${attempt.workerId} status=${attempt.status} ` +
+    `backend=${attempt.backend} ${formatRunRuntimeSummary(attempt.runtime)}${cancelCommand}`
+  );
+}
 
 function getUsage(): string {
   return [
@@ -70,20 +87,11 @@ export async function runConductorCommand(cwd: string, args: string): Promise<st
         : `task not found: ${idOrName ?? ""}`;
     }
     if (resource === "runs") {
-      return run.runs.length === 0
-        ? "runs: none"
-        : run.runs
-            .map(
-              (attempt) =>
-                `${attempt.runId} task=${attempt.taskId} worker=${attempt.workerId} status=${attempt.status}`,
-            )
-            .join("\n");
+      return run.runs.length === 0 ? "runs: none" : run.runs.map(formatRunInspection).join("\n");
     }
     if (resource === "run") {
       const attempt = run.runs.find((entry) => entry.runId === idOrName);
-      return attempt
-        ? `${attempt.runId} task=${attempt.taskId} worker=${attempt.workerId} status=${attempt.status} backend=${attempt.backend}`
-        : `run not found: ${idOrName ?? ""}`;
+      return attempt ? formatRunInspection(attempt) : `run not found: ${idOrName ?? ""}`;
     }
     if (resource === "gates") {
       return run.gates.length === 0

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -19,7 +19,7 @@ import { createObjectiveForRepo, planObjectiveForRepo, refreshObjectiveStatusFor
 import { reconcileProjectForRepo } from "./project-reconcile.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
 import { mutateRepoRunWithLockRetry } from "./repo-run-retry.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { createWorkerSessionRuntime, getWorkerRunRuntimeBackend, recoverWorkerSessionRuntime } from "./runtime.js";
 import { recordRuntimeMetadataForRun } from "./runtime-artifacts.js";
 import { cleanupCanceledTmuxRunForRepo } from "./runtime-cancel.js";
@@ -1009,7 +1009,7 @@ export async function cancelTaskRunForRepoWithRuntimeCleanup(
 ): Promise<RunRecord> {
   let project = cancelTaskRunForRepo(repoRoot, input);
   const run = project.runs.find((entry) => entry.runId === input.runId);
-  if (run?.status === "aborted" && run.runtime.mode === "tmux") {
+  if (run?.status === "aborted" && isTmuxRuntimeMode(run.runtime.mode)) {
     project = await cleanupCanceledTmuxRunForRepo({ repoRoot, runId: input.runId, run });
   }
   return project;
@@ -1065,7 +1065,7 @@ export async function cancelActiveWorkForRepoWithRuntimeCleanup(
   let project = canceled.project;
   for (const runId of canceled.canceledRuns) {
     const run = project.runs.find((entry) => entry.runId === runId);
-    if (run?.status === "aborted" && run.runtime.mode === "tmux") {
+    if (run?.status === "aborted" && isTmuxRuntimeMode(run.runtime.mode)) {
       project = await cleanupCanceledTmuxRunForRepo({ repoRoot, runId, run });
     }
   }
@@ -2044,7 +2044,7 @@ export async function runTaskForRepo(
         errorMessage: runtimeResult.errorMessage,
       });
     });
-    if (createdFallbackCompletion && runtimeMode === "tmux") {
+    if (createdFallbackCompletion && isTmuxRuntimeMode(runtimeMode)) {
       releaseTerminalTmuxWorkerForRepo({
         repoRoot,
         runId: started.run.runId,
@@ -2080,7 +2080,7 @@ export async function runTaskForRepo(
         errorMessage: message,
       });
     });
-    if (runtimeMode === "tmux") {
+    if (isTmuxRuntimeMode(runtimeMode)) {
       const cleanupStatus = runtimeCleanupStatus(error);
       releaseTerminalTmuxWorkerForRepo({
         repoRoot,

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -446,6 +446,7 @@ export function buildTaskBriefForRepo(repoRoot: string, input: { taskId: string 
     `State: ${task.state}`,
     objective ? `Objective: ${objective.title} [${objective.objectiveId}]` : "Objective: none",
     worker ? `Worker: ${worker.name} [${worker.workerId}] lifecycle=${worker.lifecycle}` : "Worker: unassigned",
+    `Latest progress: ${task.latestProgress ?? "none"}`,
     "",
     "## Prompt",
     task.prompt,
@@ -459,10 +460,12 @@ export function buildTaskBriefForRepo(repoRoot: string, input: { taskId: string 
     runs.length === 0
       ? "- none"
       : runs
-          .map(
-            (attempt) =>
-              `- ${attempt.runId} status=${attempt.status} taskRevision=${attempt.taskRevision} ${formatRunRuntimeSummary(attempt.runtime)}`,
-          )
+          .map((attempt) => {
+            const cancelCommand = isActiveRunAttempt(attempt)
+              ? ` cancel=conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})`
+              : "";
+            return `- ${attempt.runId} status=${attempt.status} taskRevision=${attempt.taskRevision} ${formatRunRuntimeSummary(attempt.runtime)}${cancelCommand}`;
+          })
           .join("\n"),
     "",
     "## Dependencies",
@@ -527,10 +530,10 @@ export function buildProjectBriefForRepo(
     activeRuns.length === 0
       ? "- none"
       : activeRuns
-          .map(
-            (attempt) =>
-              `- ${attempt.runId} task=${attempt.taskId} worker=${attempt.workerId} status=${attempt.status} ${formatRunRuntimeSummary(attempt.runtime)} cancel=conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})`,
-          )
+          .map((attempt) => {
+            const task = run.tasks.find((entry) => entry.taskId === attempt.taskId);
+            return `- ${attempt.runId} task=${attempt.taskId} worker=${attempt.workerId} status=${attempt.status} ${formatRunRuntimeSummary(attempt.runtime)} progress=${task?.latestProgress ?? "none"} cancel=conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})`;
+          })
           .join("\n"),
     "",
     "## Recommended Next Actions",

--- a/packages/pi-conductor/extensions/iterm-viewer.ts
+++ b/packages/pi-conductor/extensions/iterm-viewer.ts
@@ -1,0 +1,111 @@
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const ITERM_VIEWER_TIMEOUT_MS = 10_000;
+
+export interface ItermViewerCommandAdapter {
+  execFile(
+    command: string,
+    args: string[],
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+  ): Promise<{ stdout: string; stderr: string }>;
+}
+
+export type ItermViewerStatus = "opened" | "warning" | "unavailable";
+
+export interface ItermViewerOpenResult {
+  status: ItermViewerStatus;
+  command: string;
+  diagnostic: string | null;
+}
+
+export interface ItermViewerAvailability {
+  available: boolean;
+  diagnostic: string | null;
+}
+
+const defaultCommandAdapter: ItermViewerCommandAdapter = {
+  async execFile(command, args, options) {
+    const result = await execFileAsync(command, args, {
+      cwd: options?.cwd,
+      env: options?.env,
+      timeout: ITERM_VIEWER_TIMEOUT_MS,
+    });
+    return { stdout: result.stdout, stderr: result.stderr };
+  },
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function inspectItermViewerAvailability(
+  input: { platform?: NodeJS.Platform | string; probe?: () => void } = {},
+): ItermViewerAvailability {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "darwin") {
+    return { available: false, diagnostic: "iTerm2 viewer is only available on macOS" };
+  }
+  const probe =
+    input.probe ??
+    (() =>
+      execFileSync("osascript", ["-e", 'id of application "iTerm"'], {
+        stdio: "ignore",
+        timeout: ITERM_VIEWER_TIMEOUT_MS,
+      }));
+  try {
+    probe();
+    return { available: true, diagnostic: null };
+  } catch (error) {
+    return { available: false, diagnostic: `iTerm2 viewer is not available: ${errorMessage(error)}` };
+  }
+}
+
+export function escapeAppleScriptString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r?\n/g, "\\n");
+}
+
+export function buildItermViewerScript(input: { attachCommand: string; title?: string | null }): string {
+  const escapedCommand = escapeAppleScriptString(input.attachCommand);
+  const escapedTitle = escapeAppleScriptString(input.title?.trim() || "pi-conductor worker");
+  return [
+    'tell application "iTerm"',
+    "activate",
+    "set conductorWindow to (create window with default profile)",
+    "tell current session of conductorWindow",
+    `set name to "${escapedTitle}"`,
+    `write text "${escapedCommand}"`,
+    "end tell",
+    "end tell",
+  ].join("\n");
+}
+
+export async function openItermTmuxViewer(input: {
+  attachCommand: string;
+  title?: string | null;
+  platform?: NodeJS.Platform | string;
+  adapter?: ItermViewerCommandAdapter;
+}): Promise<ItermViewerOpenResult> {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "darwin") {
+    return {
+      status: "unavailable",
+      command: input.attachCommand,
+      diagnostic: "iTerm2 viewer is only available on macOS; attach manually with the tmux command",
+    };
+  }
+
+  const adapter = input.adapter ?? defaultCommandAdapter;
+  const script = buildItermViewerScript({ attachCommand: input.attachCommand, title: input.title });
+  try {
+    await adapter.execFile("osascript", ["-e", script], undefined);
+    return { status: "opened", command: input.attachCommand, diagnostic: null };
+  } catch (error) {
+    return {
+      status: "warning",
+      command: input.attachCommand,
+      diagnostic: `iTerm2 viewer launch failed; attach manually with the tmux command: ${errorMessage(error)}`,
+    };
+  }
+}

--- a/packages/pi-conductor/extensions/project-reconcile.ts
+++ b/packages/pi-conductor/extensions/project-reconcile.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { reconcileRunLeases } from "./storage.js";
 import { applyTmuxReconciliationState, tmuxHeartbeatIsStale } from "./tmux-reconcile-policy.js";
 import type { RunAttemptRecord, RunRecord } from "./types.js";
@@ -30,7 +30,7 @@ export function reconcileTmuxRuntimeState(run: RunRecord, input: { now?: string 
   let current = run;
   const now = input.now ?? new Date().toISOString();
   for (const attempt of current.runs.filter(
-    (entry) => isActiveRunAttempt(entry) && entry.runtime.mode === "tmux" && entry.runtime.tmux?.socketPath,
+    (entry) => isActiveRunAttempt(entry) && isTmuxRuntimeMode(entry.runtime.mode) && entry.runtime.tmux?.socketPath,
   )) {
     if (
       attempt.runtime.status === "starting" &&
@@ -98,7 +98,7 @@ function cleanupPersistedStaleTmuxSessions(repoRoot: string, persisted: RunRecor
   for (const attempt of persisted.runs) {
     if (
       attempt.status !== "stale" ||
-      attempt.runtime.mode !== "tmux" ||
+      !isTmuxRuntimeMode(attempt.runtime.mode) ||
       !attempt.errorMessage?.includes("heartbeat") ||
       attempt.runtime.cleanupStatus === "succeeded" ||
       !attempt.runtime.tmux?.socketPath ||

--- a/packages/pi-conductor/extensions/run-status.ts
+++ b/packages/pi-conductor/extensions/run-status.ts
@@ -1,4 +1,4 @@
-import type { RunAttemptRecord } from "./types.js";
+import type { RunAttemptRecord, RunRuntimeMode } from "./types.js";
 
 export const TERMINAL_RUN_STATUSES = [
   "succeeded",
@@ -13,4 +13,10 @@ export const TERMINAL_RUN_STATUSES = [
 
 export function isTerminalRunStatus(status: string | undefined): status is RunAttemptRecord["status"] {
   return TERMINAL_RUN_STATUSES.includes(status as (typeof TERMINAL_RUN_STATUSES)[number]);
+}
+
+export function isTmuxRuntimeMode(
+  mode: RunRuntimeMode | string | undefined,
+): mode is Extract<RunRuntimeMode, "tmux" | "iterm-tmux"> {
+  return mode === "tmux" || mode === "iterm-tmux";
 }

--- a/packages/pi-conductor/extensions/runner.ts
+++ b/packages/pi-conductor/extensions/runner.ts
@@ -2,7 +2,7 @@ import { readFileSync, rmSync } from "node:fs";
 import { createGateForRepo } from "./gate-service.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
 import { withStateLockRetry } from "./repo-run-retry.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import {
   createRunnerContract,
   RUNNER_CONTRACT_SCHEMA_VERSION,
@@ -97,7 +97,7 @@ export function finalizeRunnerExitForRepo(input: {
     return;
   }
   if (runAttempt.finishedAt || isTerminalRunStatus(runAttempt.status)) {
-    if (runAttempt.runtime.mode === "tmux") {
+    if (isTmuxRuntimeMode(runAttempt.runtime.mode)) {
       releaseTerminalTmuxWorkerForRepo({
         repoRoot: input.repoRoot,
         runId: input.contract.taskContract.runId,

--- a/packages/pi-conductor/extensions/runtime-cancel.ts
+++ b/packages/pi-conductor/extensions/runtime-cancel.ts
@@ -1,5 +1,5 @@
 import { mutateRepoRunSync } from "./repo-run.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { cancelTmuxRuntime } from "./tmux-runtime.js";
 import type { RunAttemptRecord, RunRecord } from "./types.js";
 
@@ -19,7 +19,7 @@ export async function cleanupCanceledTmuxRunForRepo(input: {
     );
     const mayReleaseWorker =
       latestRun?.status === "aborted" &&
-      latestRun.runtime.mode === "tmux" &&
+      isTmuxRuntimeMode(latestRun.runtime.mode) &&
       !hasNewerActiveRun &&
       (!hasLaunchMetadata || cleanupOnlyProvedAbsent || cleanup.cleanupStatus === "succeeded");
     return {

--- a/packages/pi-conductor/extensions/runtime-metadata.ts
+++ b/packages/pi-conductor/extensions/runtime-metadata.ts
@@ -115,6 +115,7 @@ export function formatRunRuntimeSummary(runtime: RunRuntimeMetadata): string {
     `runtimeMode=${runtime.mode}`,
     `runtimeStatus=${runtime.status}`,
     `viewer=${runtime.viewerStatus}`,
+    runtime.viewerCommand ? `viewerCommand=${runtime.viewerCommand}` : null,
     `cleanup=${runtime.cleanupStatus}`,
     `log=${runtime.logPath ?? "none"}`,
     `heartbeat=${runtime.heartbeatAt ?? "none"}`,

--- a/packages/pi-conductor/extensions/runtime-metadata.ts
+++ b/packages/pi-conductor/extensions/runtime-metadata.ts
@@ -115,7 +115,7 @@ export function formatRunRuntimeSummary(runtime: RunRuntimeMetadata): string {
     `runtimeMode=${runtime.mode}`,
     `runtimeStatus=${runtime.status}`,
     `viewer=${runtime.viewerStatus}`,
-    runtime.viewerCommand ? `viewerCommand=${runtime.viewerCommand}` : null,
+    runtime.viewerCommand ? `viewerCommand=${JSON.stringify(runtime.viewerCommand)}` : null,
     `cleanup=${runtime.cleanupStatus}`,
     `log=${runtime.logPath ?? "none"}`,
     `heartbeat=${runtime.heartbeatAt ?? "none"}`,

--- a/packages/pi-conductor/extensions/runtime-worker-release.ts
+++ b/packages/pi-conductor/extensions/runtime-worker-release.ts
@@ -1,5 +1,5 @@
 import { mutateRepoRunSync } from "./repo-run.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import type { RunRecord, WorkerLifecycleState } from "./types.js";
 
 export function releaseTerminalTmuxWorkerForRepo(input: {
@@ -13,7 +13,11 @@ export function releaseTerminalTmuxWorkerForRepo(input: {
   const now = new Date().toISOString();
   return mutateRepoRunSync(input.repoRoot, (latest) => {
     const attempt = latest.runs.find((entry) => entry.runId === input.runId);
-    if (!attempt || attempt.runtime.mode !== "tmux" || (!attempt.finishedAt && !isTerminalRunStatus(attempt.status))) {
+    if (
+      !attempt ||
+      !isTmuxRuntimeMode(attempt.runtime.mode) ||
+      (!attempt.finishedAt && !isTerminalRunStatus(attempt.status))
+    ) {
       return latest;
     }
     const effectiveCleanupStatus = input.cleanupStatus ?? attempt.runtime.cleanupStatus;

--- a/packages/pi-conductor/extensions/runtime.ts
+++ b/packages/pi-conductor/extensions/runtime.ts
@@ -43,8 +43,8 @@ export function getWorkerRunRuntimeBackend(mode: RunRuntimeMode = "headless"): W
       run: runWorkerPromptRuntime,
     };
   }
-  if (mode === "tmux") {
-    return createTmuxWorkerRunRuntimeBackend();
+  if (mode === "tmux" || mode === "iterm-tmux") {
+    return createTmuxWorkerRunRuntimeBackend({ mode });
   }
   throw new Error(`${mode} runtime is not implemented yet`);
 }

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -38,7 +38,7 @@ export function formatRunStatus(run: RunRecord): string {
     `gates: ${run.gates.length}`,
     `artifacts: ${run.artifacts.length}`,
     `events: ${run.events.length}`,
-    `visibleRuns: ${activeVisibleRuns.length === 0 ? "none active" : `${activeVisibleRuns.length} active`}`,
+    `activeVisibleRuns: ${activeVisibleRuns.length === 0 ? "none" : activeVisibleRuns.length}`,
   ];
 
   for (const task of run.tasks) {

--- a/packages/pi-conductor/extensions/status.ts
+++ b/packages/pi-conductor/extensions/status.ts
@@ -1,4 +1,4 @@
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { formatRunRuntimeSummary } from "./runtime-metadata.js";
 import { getConductorProjectDir } from "./storage.js";
 import type { RunAttemptRecord, RunRecord, WorkerRecord } from "./types.js";
@@ -25,6 +25,9 @@ function runsForStatusOutput(runs: RunAttemptRecord[]): { visible: RunAttemptRec
 }
 
 export function formatRunStatus(run: RunRecord): string {
+  const activeVisibleRuns = run.runs.filter(
+    (attempt) => isActiveRun(attempt) && isTmuxRuntimeMode(attempt.runtime.mode),
+  );
   const lines = [
     `projectKey: ${run.projectKey}`,
     `repoRoot: ${run.repoRoot}`,
@@ -35,6 +38,7 @@ export function formatRunStatus(run: RunRecord): string {
     `gates: ${run.gates.length}`,
     `artifacts: ${run.artifacts.length}`,
     `events: ${run.events.length}`,
+    `visibleRuns: ${activeVisibleRuns.length === 0 ? "none active" : `${activeVisibleRuns.length} active`}`,
   ];
 
   for (const task of run.tasks) {
@@ -49,13 +53,17 @@ export function formatRunStatus(run: RunRecord): string {
 
   const runStatusOutput = runsForStatusOutput(run.runs);
   for (const attempt of runStatusOutput.visible) {
+    const cancelCommand = isActiveRun(attempt)
+      ? ` cancel=conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})`
+      : "";
     lines.push(
       `- run ${attempt.runId} ` +
         `task=${attempt.taskId} ` +
         `worker=${attempt.workerId} ` +
         `status=${attempt.status} ` +
         `backend=${attempt.backend} ` +
-        formatRunRuntimeSummary(attempt.runtime),
+        formatRunRuntimeSummary(attempt.runtime) +
+        cancelCommand,
     );
   }
   if (runStatusOutput.omittedCount > 0) {

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -14,7 +14,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
 import { deriveProjectKey } from "./project-key.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { createRunRuntimeMetadata, mapRunStatusToRuntimeStatus } from "./runtime-metadata.js";
 import { markRunAttemptStale } from "./runtime-stale.js";
 import { defaultOperationForGate, normalizeProjectRecord } from "./storage-normalize.js";
@@ -1235,7 +1235,7 @@ export function completeTaskRun(
       entry.workerId === runAttempt.workerId
         ? {
             ...entry,
-            lifecycle: runAttempt.runtime.mode === "tmux" ? ("running" as const) : ("idle" as const),
+            lifecycle: isTmuxRuntimeMode(runAttempt.runtime.mode) ? ("running" as const) : ("idle" as const),
             updatedAt: now,
           }
         : entry,

--- a/packages/pi-conductor/extensions/tmux-runtime.ts
+++ b/packages/pi-conductor/extensions/tmux-runtime.ts
@@ -161,6 +161,11 @@ function mapTerminalRunToRuntimeResult(run: RunAttemptRecord): RuntimeRunResult 
   };
 }
 
+function durableRunIsActive(input: { repoRoot: string; runId: string }): boolean {
+  const latest = getOrCreateRunForRepo(input.repoRoot).runs.find((entry) => entry.runId === input.runId);
+  return Boolean(latest && !latest.finishedAt && !isTerminalRunStatus(latest.status));
+}
+
 export function shellQuote(value: string): string {
   if (value.length === 0) {
     return "''";
@@ -716,7 +721,11 @@ export function createTmuxWorkerRunRuntimeBackend(options: TmuxRuntimeOptions = 
           diagnostics: runningDiagnostics,
           heartbeatAt: now(),
         });
-        if (mode === "iterm-tmux") {
+        if (
+          mode === "iterm-tmux" &&
+          !input.signal?.aborted &&
+          durableRunIsActive({ repoRoot: input.repoRoot, runId: input.taskContract.runId })
+        ) {
           try {
             const viewer = await openItermTmuxViewer({
               attachCommand: launch.attachCommand,
@@ -724,19 +733,31 @@ export function createTmuxWorkerRunRuntimeBackend(options: TmuxRuntimeOptions = 
               adapter: options.itermViewerAdapter,
               platform: options.itermPlatform,
             });
-            await input.onRuntimeMetadata?.({
-              viewerCommand: viewer.command,
-              viewerStatus: viewer.status,
-              diagnostics: [
-                ...runningDiagnostics,
-                viewer.status === "opened"
-                  ? "iTerm2 viewer opened"
-                  : (viewer.diagnostic ?? "iTerm2 viewer unavailable"),
-              ],
-            });
-          } catch {
-            // iTerm is a best-effort viewer over the already-launched tmux control plane.
-            // Viewer telemetry persistence must not tear down active worker execution.
+            if (
+              !input.signal?.aborted &&
+              durableRunIsActive({ repoRoot: input.repoRoot, runId: input.taskContract.runId })
+            ) {
+              try {
+                await input.onRuntimeMetadata?.({
+                  viewerCommand: viewer.command,
+                  viewerStatus: viewer.status,
+                  diagnostics: [
+                    ...runningDiagnostics,
+                    viewer.status === "opened"
+                      ? "iTerm2 viewer opened"
+                      : (viewer.diagnostic ?? "iTerm2 viewer unavailable"),
+                  ],
+                });
+              } catch (error) {
+                console.error(
+                  `pi-conductor viewer metadata persistence failed for ${input.taskContract.runId}: ${errorMessage(error)}`,
+                );
+              }
+            }
+          } catch (error) {
+            console.error(
+              `pi-conductor iTerm2 viewer launch failed for ${input.taskContract.runId}: ${errorMessage(error)}`,
+            );
           }
         }
       } catch (error) {

--- a/packages/pi-conductor/extensions/tmux-runtime.ts
+++ b/packages/pi-conductor/extensions/tmux-runtime.ts
@@ -4,9 +4,10 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { type ItermViewerCommandAdapter, openItermTmuxViewer } from "./iterm-viewer.js";
 import { deriveProjectKey } from "./project-key.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
-import { isTerminalRunStatus } from "./run-status.js";
+import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { createRunnerContract, hashRunnerNonce, writeRunnerContract } from "./runner-contract.js";
 import { markRunAttemptStale } from "./runtime-stale.js";
 import { releaseTerminalTmuxWorkerForRepo } from "./runtime-worker-release.js";
@@ -58,6 +59,8 @@ export interface TmuxRuntimeOptions {
   runnerHeartbeatIntervalMs?: number;
   now?: () => string;
   randomHex?: (bytes: number) => string;
+  itermViewerAdapter?: ItermViewerCommandAdapter;
+  itermPlatform?: NodeJS.Platform | string;
 }
 
 type TmuxRuntimePaths = {
@@ -310,7 +313,7 @@ async function waitForTerminalRun(input: {
       return { status: "error", finalText: null, errorMessage: `Run ${input.runId} disappeared`, sessionId: null };
     }
     if (attempt.finishedAt || isTerminalRunStatus(attempt.status)) {
-      if (attempt.runtime.mode === "tmux" && input.adapter && attempt.runtime.cleanupStatus === "pending") {
+      if (isTmuxRuntimeMode(attempt.runtime.mode) && input.adapter && attempt.runtime.cleanupStatus === "pending") {
         const cleanup = await cancelTmuxRuntime({ adapter: input.adapter, runtime: attempt.runtime });
         releaseTerminalTmuxWorkerForRepo({
           repoRoot: input.repoRoot,
@@ -325,7 +328,7 @@ async function waitForTerminalRun(input: {
         getOrCreateRunForRepo(input.repoRoot).runs.find((entry) => entry.runId === input.runId) ?? attempt,
       );
     }
-    if (attempt.runtime.mode === "tmux" && input.adapter) {
+    if (isTmuxRuntimeMode(attempt.runtime.mode) && input.adapter) {
       const reconciled = await reconcileTmuxRuntimeForRepo({
         repoRoot: input.repoRoot,
         runId: input.runId,
@@ -695,6 +698,10 @@ export function createTmuxWorkerRunRuntimeBackend(options: TmuxRuntimeOptions = 
           return mapTerminalRunToRuntimeResult(durableRun);
         }
         const paneMetadata = await inspectTmuxPaneMetadata({ adapter, socketPath: paths.socketPath, sessionName });
+        const runningDiagnostics = [
+          `tmux session ${sessionName} launched`,
+          ...(paneMetadata.diagnostic ? [paneMetadata.diagnostic] : []),
+        ];
         await input.onRuntimeMetadata?.({
           ...baseRuntime,
           status: "running",
@@ -706,12 +713,32 @@ export function createTmuxWorkerRunRuntimeBackend(options: TmuxRuntimeOptions = 
             windowId: paneMetadata.windowId,
             paneId: paneMetadata.paneId,
           },
-          diagnostics: [
-            `tmux session ${sessionName} launched`,
-            ...(paneMetadata.diagnostic ? [paneMetadata.diagnostic] : []),
-          ],
+          diagnostics: runningDiagnostics,
           heartbeatAt: now(),
         });
+        if (mode === "iterm-tmux") {
+          try {
+            const viewer = await openItermTmuxViewer({
+              attachCommand: launch.attachCommand,
+              title: `pi-conductor ${input.taskContract.runId}`,
+              adapter: options.itermViewerAdapter,
+              platform: options.itermPlatform,
+            });
+            await input.onRuntimeMetadata?.({
+              viewerCommand: viewer.command,
+              viewerStatus: viewer.status,
+              diagnostics: [
+                ...runningDiagnostics,
+                viewer.status === "opened"
+                  ? "iTerm2 viewer opened"
+                  : (viewer.diagnostic ?? "iTerm2 viewer unavailable"),
+              ],
+            });
+          } catch {
+            // iTerm is a best-effort viewer over the already-launched tmux control plane.
+            // Viewer telemetry persistence must not tear down active worker execution.
+          }
+        }
       } catch (error) {
         const cleanup = await cancelTmuxRuntime({ adapter, runtime: buildCancellationRuntime() });
         throw errorWithCleanupStatus(error, cleanup.cleanupStatus);


### PR DESCRIPTION
## Summary
- Adds the optional iTerm2 viewer layer for `runtimeMode: "iterm-tmux"` over the existing tmux supervised runner control plane.
- Keeps iTerm2 best-effort: viewer launch or viewer metadata failures do not tear down the active tmux run, and manual read-only attach commands remain available.
- Treats `iterm-tmux` as tmux-managed for cancellation, reconciliation, runner finalization, and worker release paths.
- Improves status output/README with visible-run counts, viewer attach commands, log/heartbeat diagnostics, and cancellation guidance.

## Validation
- `npm run check`
- `npx vitest run packages/pi-conductor/__tests__ --reporter=dot`
- `git diff --check`
- `specdocs_validate`