### PR TITLE
feat(pi-conductor): infer visible runtime for natural-language work

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -192,6 +192,8 @@ conductor_run_work({
 
 The router is conservative. It splits only when work items are independent, have distinct scopes, and the request implies parallelism. It stays single-worker for small work, overlapping write scopes, or coherent refactors. It uses objective planning when candidate tasks declare dependencies.
 
+Runtime mode selection is also conservative. Explicit `runtimeMode` wins. If omitted, normal work defaults to `headless`, while unambiguous execution requests such as “run these shards in parallel and show/watch/open the workers” infer `iterm-tmux`. Status-only phrases such as “show me current workers” do not infer visible execution; use status/list tools for inspection. Inferred visible runs still fail closed when tmux is unavailable and return runtime summaries with viewer/log/cancel details when runs are created.
+
 `conductor_run_parallel_work` remains the lower-level primitive for callers that already made a parallel-safe decision:
 
 ```text

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -425,6 +425,68 @@ describe("conductor service", () => {
     expect(seenRuntimeModes).toEqual(["tmux", "tmux"]);
   });
 
+  it("infers visible runtime for natural-language visible parallel requests", async () => {
+    const seenRuntimeModes: Array<string | undefined> = [];
+
+    const result = await runWorkForRepo(
+      repoDir,
+      {
+        request: "Run these independent shards in parallel and show me the workers",
+        tasks: [
+          { title: "Inspect README", prompt: "Inspect README.md", writeScope: ["README.md"] },
+          { title: "Inspect package", prompt: "Inspect package metadata", writeScope: ["package.json"] },
+        ],
+      },
+      undefined,
+      async (_root, taskId, _signal, options) => {
+        seenRuntimeModes.push(options?.runtimeMode);
+        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+      },
+    );
+
+    expect(result.decision.mode).toBe("parallel");
+    expect(result.runtimeMode).toBe("iterm-tmux");
+    expect(seenRuntimeModes).toEqual(["iterm-tmux", "iterm-tmux"]);
+  });
+
+  it("does not infer visible runtime for status-only show requests", async () => {
+    let seenRuntimeMode: string | undefined;
+
+    const result = await runWorkForRepo(
+      repoDir,
+      {
+        request: "show me current workers",
+        tasks: [{ title: "Inspect workers", prompt: "Inspect current workers", writeScope: ["README.md"] }],
+      },
+      undefined,
+      async (_root, taskId, _signal, options) => {
+        seenRuntimeMode = options?.runtimeMode;
+        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+      },
+    );
+
+    expect(result.runtimeMode).toBe("headless");
+    expect(seenRuntimeMode).toBe("headless");
+  });
+
+  it("fails inferred visible runtime preflight without creating active runs", async () => {
+    const restorePath = forceTmuxUnavailable();
+    try {
+      await expect(
+        runWorkForRepo(repoDir, {
+          request: "Run this focused task and show me the worker",
+          tasks: [{ title: "Visible focused task", prompt: "Do visible work", writeScope: ["README.md"] }],
+        }),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+
+      const run = getOrCreateRunForRepo(repoDir);
+      expect(run.runs).toHaveLength(0);
+      expect(run.tasks[0]).toMatchObject({ title: "Visible focused task", activeRunId: null });
+    } finally {
+      restorePath();
+    }
+  });
+
   it("passes runtimeMode through single natural-language work runners", async () => {
     let seenRuntimeMode: string | undefined;
 

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -31,10 +31,18 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
 }
 
 function forceTmuxUnavailable(): () => void {
+  return withFakeTmux("exit 127");
+}
+
+function forceTmuxAvailable(): () => void {
+  return withFakeTmux("printf 'tmux 3.4\\n'");
+}
+
+function withFakeTmux(scriptBody: string): () => void {
   const originalPath = process.env.PATH;
   const fakeBin = mkdtempSync(join(tmpdir(), "pi-conductor-fake-bin-"));
   const fakeTmux = join(fakeBin, "tmux");
-  writeFileSync(fakeTmux, "#!/bin/sh\nexit 127\n", "utf-8");
+  writeFileSync(fakeTmux, `#!/bin/sh\n${scriptBody}\n`, "utf-8");
   chmodSync(fakeTmux, 0o755);
   process.env.PATH = `${fakeBin}:${originalPath ?? ""}`;
   return () => {
@@ -403,46 +411,58 @@ describe("conductor service", () => {
   });
 
   it("passes runtimeMode through parallel work runners", async () => {
+    const restorePath = forceTmuxAvailable();
     const seenRuntimeModes: Array<string | undefined> = [];
 
-    await runParallelWorkForRepo(
-      repoDir,
-      {
-        workerPrefix: "parallel",
-        runtimeMode: "tmux",
-        tasks: [
-          { title: "First shard", prompt: "Do first shard" },
-          { title: "Second shard", prompt: "Do second shard" },
-        ],
-      },
-      undefined,
-      async (_root, taskId, _signal, options) => {
-        seenRuntimeModes.push(options?.runtimeMode);
-        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
-      },
-    );
+    try {
+      await runParallelWorkForRepo(
+        repoDir,
+        {
+          workerPrefix: "parallel",
+          runtimeMode: "tmux",
+          tasks: [
+            { title: "First shard", prompt: "Do first shard" },
+            { title: "Second shard", prompt: "Do second shard" },
+          ],
+        },
+        undefined,
+        async (_root, taskId, _signal, options) => {
+          seenRuntimeModes.push(options?.runtimeMode);
+          return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+        },
+      );
+    } finally {
+      restorePath();
+    }
 
     expect(seenRuntimeModes).toEqual(["tmux", "tmux"]);
   });
 
   it("infers visible runtime for natural-language visible parallel requests", async () => {
+    const restorePath = forceTmuxAvailable();
     const seenRuntimeModes: Array<string | undefined> = [];
 
-    const result = await runWorkForRepo(
-      repoDir,
-      {
-        request: "Run these independent shards in parallel and show me the workers",
-        tasks: [
-          { title: "Inspect README", prompt: "Inspect README.md", writeScope: ["README.md"] },
-          { title: "Inspect package", prompt: "Inspect package metadata", writeScope: ["package.json"] },
-        ],
-      },
-      undefined,
-      async (_root, taskId, _signal, options) => {
-        seenRuntimeModes.push(options?.runtimeMode);
-        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
-      },
-    );
+    let result: Awaited<ReturnType<typeof runWorkForRepo>> | null = null;
+    try {
+      result = await runWorkForRepo(
+        repoDir,
+        {
+          request: "Run these independent shards in parallel and show me the workers",
+          tasks: [
+            { title: "Inspect README", prompt: "Inspect README.md", writeScope: ["README.md"] },
+            { title: "Inspect package", prompt: "Inspect package metadata", writeScope: ["package.json"] },
+          ],
+        },
+        undefined,
+        async (_root, taskId, _signal, options) => {
+          seenRuntimeModes.push(options?.runtimeMode);
+          return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+        },
+      );
+    } finally {
+      restorePath();
+    }
+    if (!result) throw new Error("expected runWorkForRepo result");
 
     expect(result.decision.mode).toBe("parallel");
     expect(result.runtimeMode).toBe("iterm-tmux");
@@ -466,7 +486,18 @@ describe("conductor service", () => {
     );
 
     expect(result.runtimeMode).toBe("headless");
-    expect(seenRuntimeMode).toBe("headless");
+    expect(seenRuntimeMode).toBeUndefined();
+  });
+
+  it("rejects status-only work-router requests before mutating conductor state", async () => {
+    await expect(runWorkForRepo(repoDir, { request: "show me current workers" })).rejects.toThrow(
+      /status-only requests/i,
+    );
+
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers).toHaveLength(0);
+    expect(run.tasks).toHaveLength(0);
+    expect(run.runs).toHaveLength(0);
   });
 
   it("fails inferred visible runtime preflight without creating active runs", async () => {
@@ -480,29 +511,116 @@ describe("conductor service", () => {
       ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
 
       const run = getOrCreateRunForRepo(repoDir);
+      expect(run.workers).toHaveLength(0);
+      expect(run.tasks).toHaveLength(0);
       expect(run.runs).toHaveLength(0);
-      expect(run.tasks[0]).toMatchObject({ title: "Visible focused task", activeRunId: null });
     } finally {
       restorePath();
     }
   });
 
+  it("fails inferred visible parallel preflight before creating workers or tasks", async () => {
+    const restorePath = forceTmuxUnavailable();
+    try {
+      await expect(
+        runWorkForRepo(repoDir, {
+          request: "Run these independent shards in parallel and show me the workers",
+          tasks: [
+            { title: "Visible shard one", prompt: "Do visible work one", writeScope: ["README.md"] },
+            { title: "Visible shard two", prompt: "Do visible work two", writeScope: ["package.json"] },
+          ],
+        }),
+      ).rejects.toThrow(/Runtime mode iterm-tmux unavailable/i);
+
+      const run = getOrCreateRunForRepo(repoDir);
+      expect(run.workers).toHaveLength(0);
+      expect(run.tasks).toHaveLength(0);
+      expect(run.runs).toHaveLength(0);
+    } finally {
+      restorePath();
+    }
+  });
+
+  it("returns structured runtime summaries for natural-language visible work", async () => {
+    const restorePath = forceTmuxAvailable();
+    let result: Awaited<ReturnType<typeof runWorkForRepo>> | null = null;
+    try {
+      result = await runWorkForRepo(
+        repoDir,
+        {
+          request: "Run this focused task and show me the worker",
+          tasks: [{ title: "Visible summary", prompt: "Do visible work", writeScope: ["README.md"] }],
+        },
+        undefined,
+        async (root, taskId, _signal, options) => {
+          const started = startTaskRunForRepo(root, { taskId, runtimeMode: options?.runtimeMode });
+          const latest = getOrCreateRunForRepo(root);
+          writeRun({
+            ...latest,
+            tasks: latest.tasks.map((task) =>
+              task.taskId === taskId ? { ...task, latestProgress: "opening viewer" } : task,
+            ),
+            runs: latest.runs.map((run) =>
+              run.runId === started.run.runId
+                ? {
+                    ...run,
+                    runtime: {
+                      ...run.runtime,
+                      mode: "iterm-tmux",
+                      status: "running",
+                      viewerStatus: "opened",
+                      viewerCommand: "tmux attach-session -r -t pi-cond-run",
+                      logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+                      diagnostics: ["iTerm2 viewer opened"],
+                    },
+                  }
+                : run,
+            ),
+          });
+          return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+        },
+      );
+    } finally {
+      restorePath();
+    }
+    if (!result) throw new Error("expected runWorkForRepo result");
+
+    expect(result.runtimeRuns).toHaveLength(1);
+    expect(result.runtimeRuns[0]).toMatchObject({
+      taskId: result.tasks[0]?.taskId,
+      runtimeMode: "iterm-tmux",
+      runtimeStatus: "running",
+      viewerStatus: "opened",
+      viewerCommand: "tmux attach-session -r -t pi-cond-run",
+      logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+      diagnostic: "iTerm2 viewer opened",
+      latestProgress: "opening viewer",
+      cancelTool: { name: "conductor_cancel_task_run", params: { reason: "<reason>" } },
+    });
+    expect(result.runtimeRuns[0]?.cancelCommand).toContain("conductor_cancel_task_run");
+  });
+
   it("passes runtimeMode through single natural-language work runners", async () => {
+    const restorePath = forceTmuxAvailable();
     let seenRuntimeMode: string | undefined;
 
-    await runWorkForRepo(
-      repoDir,
-      {
-        request: "Fix one focused issue",
-        runtimeMode: "iterm-tmux",
-        tasks: [{ title: "Fix one issue", prompt: "Fix it", writeScope: ["README.md"] }],
-      },
-      undefined,
-      async (_root, taskId, _signal, options) => {
-        seenRuntimeMode = options?.runtimeMode;
-        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
-      },
-    );
+    try {
+      await runWorkForRepo(
+        repoDir,
+        {
+          request: "Fix one focused issue",
+          runtimeMode: "iterm-tmux",
+          tasks: [{ title: "Fix one issue", prompt: "Fix it", writeScope: ["README.md"] }],
+        },
+        undefined,
+        async (_root, taskId, _signal, options) => {
+          seenRuntimeMode = options?.runtimeMode;
+          return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+        },
+      );
+    } finally {
+      restorePath();
+    }
 
     expect(seenRuntimeMode).toBe("iterm-tmux");
   });

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../extensions/conductor.js";
 import { deriveProjectKey } from "../extensions/project-key.js";
 import { getRunFile, writeRun } from "../extensions/storage.js";
+import { summarizeRunWorkRuntime } from "../extensions/work-runtime-summary.js";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
   if (value == null) {
@@ -410,6 +411,26 @@ describe("conductor service", () => {
     expect(run.tasks).toHaveLength(1);
   });
 
+  it("passes normalized headless runtimeMode through default natural-language work runners", async () => {
+    let seenRuntimeMode: string | undefined;
+
+    const result = await runWorkForRepo(
+      repoDir,
+      {
+        request: "Fix the typo in README.md",
+        tasks: [{ title: "Fix README typo", prompt: "Fix the typo in README.md", writeScope: ["README.md"] }],
+      },
+      undefined,
+      async (_root, taskId, _signal, options) => {
+        seenRuntimeMode = options?.runtimeMode;
+        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+      },
+    );
+
+    expect(result.runtimeMode).toBe("headless");
+    expect(seenRuntimeMode).toBe("headless");
+  });
+
   it("passes runtimeMode through parallel work runners", async () => {
     const restorePath = forceTmuxAvailable();
     const seenRuntimeModes: Array<string | undefined> = [];
@@ -436,6 +457,29 @@ describe("conductor service", () => {
     }
 
     expect(seenRuntimeModes).toEqual(["tmux", "tmux"]);
+  });
+
+  it("fails direct visible parallel runtime preflight before creating workers or tasks", async () => {
+    const restorePath = forceTmuxUnavailable();
+    try {
+      await expect(
+        runParallelWorkForRepo(repoDir, {
+          workerPrefix: "parallel",
+          runtimeMode: "tmux",
+          tasks: [
+            { title: "First shard", prompt: "Do first shard" },
+            { title: "Second shard", prompt: "Do second shard" },
+          ],
+        }),
+      ).rejects.toThrow(/Runtime mode tmux unavailable/i);
+
+      const run = getOrCreateRunForRepo(repoDir);
+      expect(run.workers).toHaveLength(0);
+      expect(run.tasks).toHaveLength(0);
+      expect(run.runs).toHaveLength(0);
+    } finally {
+      restorePath();
+    }
   });
 
   it("infers visible runtime for natural-language visible parallel requests", async () => {
@@ -469,28 +513,44 @@ describe("conductor service", () => {
     expect(seenRuntimeModes).toEqual(["iterm-tmux", "iterm-tmux"]);
   });
 
-  it("does not infer visible runtime for status-only show requests", async () => {
-    let seenRuntimeMode: string | undefined;
+  it("rejects status-only work-router requests with candidate tasks before mutating conductor state", async () => {
+    await expect(
+      runWorkForRepo(
+        repoDir,
+        {
+          request: "show me current workers",
+          tasks: [{ title: "Inspect workers", prompt: "Inspect current workers", writeScope: ["README.md"] }],
+        },
+        undefined,
+        async (_root, taskId) => ({
+          workerName: taskId,
+          status: "success",
+          finalText: "done",
+          errorMessage: null,
+          sessionId: null,
+        }),
+      ),
+    ).rejects.toThrow(/status-only requests/i);
 
-    const result = await runWorkForRepo(
-      repoDir,
-      {
-        request: "show me current workers",
-        tasks: [{ title: "Inspect workers", prompt: "Inspect current workers", writeScope: ["README.md"] }],
-      },
-      undefined,
-      async (_root, taskId, _signal, options) => {
-        seenRuntimeMode = options?.runtimeMode;
-        return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
-      },
-    );
-
-    expect(result.runtimeMode).toBe("headless");
-    expect(seenRuntimeMode).toBeUndefined();
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers).toHaveLength(0);
+    expect(run.tasks).toHaveLength(0);
+    expect(run.runs).toHaveLength(0);
   });
 
   it("rejects status-only work-router requests before mutating conductor state", async () => {
     await expect(runWorkForRepo(repoDir, { request: "show me current workers" })).rejects.toThrow(
+      /status-only requests/i,
+    );
+
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers).toHaveLength(0);
+    expect(run.tasks).toHaveLength(0);
+    expect(run.runs).toHaveLength(0);
+  });
+
+  it("rejects status-only planning requests before mutating conductor state", async () => {
+    await expect(runWorkForRepo(repoDir, { request: "show run status", execute: false })).rejects.toThrow(
       /status-only requests/i,
     );
 
@@ -595,9 +655,32 @@ describe("conductor service", () => {
       logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
       diagnostic: "iTerm2 viewer opened",
       latestProgress: "opening viewer",
-      cancelTool: { name: "conductor_cancel_task_run", params: { reason: "<reason>" } },
+      cancelTool: { name: "conductor_cancel_task_run", params: { reason: "Parent requested cancellation" } },
     });
-    expect(result.runtimeRuns[0]?.cancelCommand).toContain("conductor_cancel_task_run");
+    expect(result.runtimeRuns[0]?.cancelCommand).toContain("Parent requested cancellation");
+  });
+
+  it("omits runtime cancellation details for terminal run summaries", async () => {
+    const delegated = await delegateTaskForRepo(repoDir, {
+      title: "Terminal summary",
+      prompt: "Summarize terminal runtime",
+      workerName: "terminal-summary",
+      startRun: false,
+    });
+    const started = startTaskRunForRepo(repoDir, {
+      taskId: delegated.task.taskId,
+      workerId: delegated.worker.workerId,
+    });
+    const latest = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...latest,
+      runs: latest.runs.map((run) =>
+        run.runId === started.run.runId ? { ...run, status: "succeeded", finishedAt: new Date().toISOString() } : run,
+      ),
+    });
+
+    const summary = summarizeRunWorkRuntime(repoDir, [delegated.task.taskId]);
+    expect(summary[0]).toMatchObject({ cancelCommand: null, cancelTool: null });
   });
 
   it("passes runtimeMode through single natural-language work runners", async () => {

--- a/packages/pi-conductor/__tests__/planner-quality.test.ts
+++ b/packages/pi-conductor/__tests__/planner-quality.test.ts
@@ -41,6 +41,9 @@ describe("conductor objective planner quality gates", () => {
     expect(selectRuntimeModeForWork({ request: "Run this in tmux so I can watch it" })).toBe("tmux");
     expect(selectRuntimeModeForWork({ request: "show me current workers" })).toBeUndefined();
     expect(selectRuntimeModeForWork({ request: "show tmux sessions" })).toBeUndefined();
+    expect(selectRuntimeModeForWork({ request: "show run status" })).toBeUndefined();
+    expect(selectRuntimeModeForWork({ request: "inspect current run" })).toBeUndefined();
+    expect(selectRuntimeModeForWork({ request: "list active task" })).toBeUndefined();
     expect(selectRuntimeModeForWork({ request: "Run these shards without tmux" })).toBe("headless");
     expect(
       selectRuntimeModeForWork({

--- a/packages/pi-conductor/__tests__/planner-quality.test.ts
+++ b/packages/pi-conductor/__tests__/planner-quality.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createObjectiveForRepo, planObjectiveForRepo } from "../extensions/conductor.js";
+import { createObjectiveForRepo, planObjectiveForRepo, selectRuntimeModeForWork } from "../extensions/conductor.js";
 
 describe("conductor objective planner quality gates", () => {
   let conductorHome: string;
@@ -30,6 +30,22 @@ describe("conductor objective planner quality gates", () => {
         ],
       }),
     ).toThrow(/duplicate task title/i);
+  });
+
+  it("infers visible runtime only for unambiguous execution requests", () => {
+    expect(
+      selectRuntimeModeForWork({
+        request: "Run these independent shards in parallel and show me the workers",
+      }),
+    ).toBe("iterm-tmux");
+    expect(selectRuntimeModeForWork({ request: "Run this in tmux so I can watch it" })).toBe("tmux");
+    expect(selectRuntimeModeForWork({ request: "show me current workers" })).toBeUndefined();
+    expect(
+      selectRuntimeModeForWork({
+        request: "Run this in parallel and show me the workers",
+        explicitRuntimeMode: "headless",
+      }),
+    ).toBe("headless");
   });
 
   it("rejects unresolved dependencies and vague prompts", () => {

--- a/packages/pi-conductor/__tests__/planner-quality.test.ts
+++ b/packages/pi-conductor/__tests__/planner-quality.test.ts
@@ -40,6 +40,8 @@ describe("conductor objective planner quality gates", () => {
     ).toBe("iterm-tmux");
     expect(selectRuntimeModeForWork({ request: "Run this in tmux so I can watch it" })).toBe("tmux");
     expect(selectRuntimeModeForWork({ request: "show me current workers" })).toBeUndefined();
+    expect(selectRuntimeModeForWork({ request: "show tmux sessions" })).toBeUndefined();
+    expect(selectRuntimeModeForWork({ request: "Run these shards without tmux" })).toBe("headless");
     expect(
       selectRuntimeModeForWork({
         request: "Run this in parallel and show me the workers",

--- a/packages/pi-conductor/__tests__/tmux-cancel.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-cancel.test.ts
@@ -276,6 +276,18 @@ describe("tmux durable cancellation", () => {
     expect(getOrCreateRunForRepo(repoDir).runs[0]).toMatchObject({ runtime: { cleanupStatus: "succeeded" } });
   });
 
+  it("cancels visible iterm-tmux active work without caller-supplied run IDs", async () => {
+    await createPersistedTmuxRun("iterm-tmux");
+
+    const canceled = await cancelActiveWorkForRepoWithRuntimeCleanup(repoDir, { reason: "natural-language stop" });
+
+    expect(canceled.canceledRuns).toHaveLength(1);
+    expect(tmuxMocks.cancelTmuxRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: expect.objectContaining({ mode: "iterm-tmux" }) }),
+    );
+    expect(canceled.project.runs[0]).toMatchObject({ status: "aborted", runtime: { cleanupStatus: "succeeded" } });
+  });
+
   it("kills persisted tmux runtime resources during bulk active-work cancellation", async () => {
     await createPersistedTmuxRun();
 

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -69,11 +69,8 @@ import {
   type WorkRoutingDecision,
   type WorkRoutingMode,
 } from "./work-routing.js";
-import {
-  type RunWorkRuntimeSummary,
-  selectRuntimeModeForWork,
-  summarizeRunWorkRuntime,
-} from "./work-runtime-selection.js";
+import { isStatusOnlyWorkRequest, selectRuntimeModeForWork } from "./work-runtime-selection.js";
+import { type RunWorkRuntimeSummary, summarizeRunWorkRuntime } from "./work-runtime-summary.js";
 
 export { buildEvidenceBundleForRepo, checkReadinessForRepo } from "./evidence-service.js";
 export { createGateForRepo, resolveGateForRepo, resolveGateFromTrustedHumanForRepo } from "./gate-service.js";
@@ -102,6 +99,7 @@ export {
 export type { RunWorkItemInput, WorkRoutingDecision, WorkRoutingMode } from "./work-routing.js";
 export { planWorkRouting } from "./work-routing.js";
 export { selectRuntimeModeForWork } from "./work-runtime-selection.js";
+export type { RunWorkRuntimeSummary } from "./work-runtime-summary.js";
 
 export type ParallelWorkItemInput = {
   title: string;
@@ -115,6 +113,15 @@ export type ParallelWorkRunner = (
   signal?: AbortSignal,
   input?: { runtimeMode?: RunRuntimeMode },
 ) => Promise<WorkerRunResult>;
+
+function assertRuntimeModeAvailable(runtimeMode: RunRuntimeMode): void {
+  const runtimeStatus = getConductorRuntimeModeStatus(runtimeMode);
+  if (!runtimeStatus.available) {
+    throw new Error(
+      `Runtime mode ${runtimeMode} unavailable: ${runtimeStatus.diagnostic ?? "not available"}. Use conductor_backend_status to inspect available runtime modes; headless is available.`,
+    );
+  }
+}
 
 type LiveWorkAbortHandle = {
   runId?: string;
@@ -1094,6 +1101,8 @@ export async function runParallelWorkForRepo(
   }>;
   canceledRuns: string[];
   canceledTasks: string[];
+  runtimeMode: RunRuntimeMode;
+  runtimeRuns: RunWorkRuntimeSummary[];
 }> {
   if (input.tasks.length === 0) {
     throw new Error("At least one parallel work item is required");
@@ -1111,6 +1120,10 @@ export async function runParallelWorkForRepo(
       workerName: item.workerName?.trim() || `${workerPrefix}-${index + 1}`,
     };
   });
+  const runtimeMode = input.runtimeMode ?? "headless";
+  if (runtimeMode !== "headless") {
+    assertRuntimeModeAvailable(runtimeMode);
+  }
   const workerNames = new Set<string>();
   for (const item of items) {
     if (workerNames.has(item.workerName)) {
@@ -1211,7 +1224,7 @@ export async function runParallelWorkForRepo(
   try {
     if (signal?.aborted) {
       await Promise.allSettled(pendingCancellations);
-      return { workers, tasks, results: [], canceledRuns, canceledTasks };
+      return { workers, tasks, results: [], canceledRuns, canceledTasks, runtimeMode, runtimeRuns: [] };
     }
     const settled = await Promise.allSettled(
       tasks.map((task, index) =>
@@ -1231,7 +1244,18 @@ export async function runParallelWorkForRepo(
             error: errorMessage(entry.reason),
           },
     );
-    return { workers, tasks, results, canceledRuns, canceledTasks };
+    return {
+      workers,
+      tasks,
+      results,
+      canceledRuns,
+      canceledTasks,
+      runtimeMode,
+      runtimeRuns: summarizeRunWorkRuntime(
+        repoRoot,
+        tasks.map((task) => task.taskId),
+      ),
+    };
   } finally {
     signal?.removeEventListener("abort", onAbort);
     for (const controller of liveControllers) {
@@ -1267,18 +1291,29 @@ export async function runWorkForRepo(
   runtimeMode: RunRuntimeMode;
   runtimeRuns: RunWorkRuntimeSummary[];
 }> {
-  const decision = planWorkRouting(input);
-  const runtimeMode =
-    selectRuntimeModeForWork({ request: input.request, explicitRuntimeMode: input.runtimeMode }) ?? "headless";
-  const workerPrefix = input.workerPrefix?.trim() || "run-work";
   const execute = input.execute ?? true;
+  if (execute && !input.tasks?.length && isStatusOnlyWorkRequest(input.request)) {
+    throw new Error(
+      "conductor_run_work is for executing work; use conductor_get_project, conductor_list_workers, or conductor_list_runs for status-only requests",
+    );
+  }
+  const decision = planWorkRouting(input);
+  const selectedRuntimeMode = selectRuntimeModeForWork({
+    request: input.request,
+    explicitRuntimeMode: input.runtimeMode,
+  });
+  const runtimeMode = selectedRuntimeMode ?? "headless";
+  if (execute && runtimeMode !== "headless") {
+    assertRuntimeModeAvailable(runtimeMode);
+  }
+  const workerPrefix = input.workerPrefix?.trim() || "run-work";
 
   if (decision.mode === "parallel") {
     const parallel = await runParallelWorkForRepo(
       repoRoot,
       {
         workerPrefix,
-        runtimeMode,
+        runtimeMode: selectedRuntimeMode,
         tasks: decision.tasks.map((task) => ({
           title: task.title,
           prompt: task.prompt,
@@ -1330,7 +1365,7 @@ export async function runWorkForRepo(
             objectiveId: objective.objectiveId,
             policy: "execute",
             maxConcurrency: input.maxWorkers,
-            runtimeMode,
+            runtimeMode: selectedRuntimeMode,
           },
           signal,
         )
@@ -1381,7 +1416,9 @@ export async function runWorkForRepo(
       runtimeRuns: summarizeRunWorkRuntime(repoRoot, [delegated.task.taskId]),
     };
   }
-  const result = execute ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode }) : null;
+  const result = execute
+    ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode: selectedRuntimeMode })
+    : null;
   return {
     decision,
     workers: [delegated.worker],

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -46,7 +46,6 @@ import {
   retryTaskForRepo,
   startTaskRunForRepo,
 } from "./task-service.js";
-
 import type {
   ConductorEventType,
   ConductorNextAction,
@@ -63,6 +62,18 @@ import type {
   WorkerRecord,
   WorkerRunResult,
 } from "./types.js";
+import {
+  deriveWorkTitle,
+  planWorkRouting,
+  type RunWorkItemInput,
+  type WorkRoutingDecision,
+  type WorkRoutingMode,
+} from "./work-routing.js";
+import {
+  type RunWorkRuntimeSummary,
+  selectRuntimeModeForWork,
+  summarizeRunWorkRuntime,
+} from "./work-runtime-selection.js";
 
 export { buildEvidenceBundleForRepo, checkReadinessForRepo } from "./evidence-service.js";
 export { createGateForRepo, resolveGateForRepo, resolveGateFromTrustedHumanForRepo } from "./gate-service.js";
@@ -88,6 +99,9 @@ export {
   startTaskRunForRepo,
   updateTaskForRepo,
 } from "./task-service.js";
+export type { RunWorkItemInput, WorkRoutingDecision, WorkRoutingMode } from "./work-routing.js";
+export { planWorkRouting } from "./work-routing.js";
+export { selectRuntimeModeForWork } from "./work-runtime-selection.js";
 
 export type ParallelWorkItemInput = {
   title: string;
@@ -101,21 +115,6 @@ export type ParallelWorkRunner = (
   signal?: AbortSignal,
   input?: { runtimeMode?: RunRuntimeMode },
 ) => Promise<WorkerRunResult>;
-
-export type WorkRoutingMode = "auto" | "single" | "parallel" | "objective";
-
-export type RunWorkItemInput = ParallelWorkItemInput & {
-  writeScope?: string[];
-  dependsOn?: string[];
-};
-
-export type WorkRoutingDecision = {
-  mode: Exclude<WorkRoutingMode, "auto">;
-  confidence: number;
-  reason: string;
-  tasks: RunWorkItemInput[];
-  riskFlags: string[];
-};
 
 type LiveWorkAbortHandle = {
   runId?: string;
@@ -1241,179 +1240,6 @@ export async function runParallelWorkForRepo(
   }
 }
 
-function hasParallelIntent(request: string): boolean {
-  return /\b(parallel|split|many|multiple|workers|fan[- ]?out|deep[- ]?dive|all)\b/i.test(request);
-}
-
-function hasSingleIntent(request: string): boolean {
-  return /\b(single|one worker|do not split|don't split|dont split|same worker|small|typo)\b/i.test(request);
-}
-
-function deriveWorkTitle(request: string): string {
-  const trimmed = request.trim().replace(/\s+/g, " ");
-  if (!trimmed) {
-    return "Conductor work";
-  }
-  return trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed;
-}
-
-function normalizeRunWorkItems(input: { request: string; tasks?: RunWorkItemInput[] }): RunWorkItemInput[] {
-  const candidates = input.tasks?.length
-    ? input.tasks
-    : [{ title: deriveWorkTitle(input.request), prompt: input.request }];
-  return candidates.map((task, index) => ({
-    ...task,
-    title: task.title.trim() || `Work item ${index + 1}`,
-    prompt: task.prompt.trim() || input.request.trim(),
-    workerName: task.workerName?.trim() || undefined,
-    writeScope: task.writeScope?.map((scope) => scope.trim()).filter(Boolean),
-    dependsOn: task.dependsOn?.map((dependency) => dependency.trim()).filter(Boolean),
-  }));
-}
-
-function normalizeWriteScope(scope: string): string {
-  return scope.trim().replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
-}
-
-function writeScopesOverlap(left: string, right: string): boolean {
-  const normalizedLeft = normalizeWriteScope(left);
-  const normalizedRight = normalizeWriteScope(right);
-  if (!normalizedLeft || !normalizedRight) {
-    return false;
-  }
-  return (
-    normalizedLeft === normalizedRight ||
-    normalizedLeft.startsWith(`${normalizedRight}/`) ||
-    normalizedRight.startsWith(`${normalizedLeft}/`)
-  );
-}
-
-function findOverlappingWriteScopes(tasks: RunWorkItemInput[]): boolean {
-  const seen: string[] = [];
-  for (const task of tasks) {
-    for (const scope of task.writeScope ?? []) {
-      if (seen.some((knownScope) => writeScopesOverlap(knownScope, scope))) {
-        return true;
-      }
-      seen.push(scope);
-    }
-  }
-  return false;
-}
-
-function combineWorkItems(tasks: RunWorkItemInput[], request: string): RunWorkItemInput {
-  if (tasks.length === 1 && tasks[0]) {
-    return tasks[0];
-  }
-  return {
-    title: deriveWorkTitle(request),
-    prompt: [
-      request.trim(),
-      "",
-      "Run these work items coherently in one conductor worker because splitting is unsafe:",
-      ...tasks.map((task, index) => `${index + 1}. ${task.title}\n${task.prompt}`),
-    ].join("\n"),
-    writeScope: [...new Set(tasks.flatMap((task) => task.writeScope ?? []))],
-    dependsOn: [...new Set(tasks.flatMap((task) => task.dependsOn ?? []))],
-  };
-}
-
-function capParallelWorkItems(tasks: RunWorkItemInput[], maxWorkers: number): RunWorkItemInput[] {
-  if (tasks.length <= maxWorkers) {
-    return tasks;
-  }
-  const buckets = Array.from({ length: maxWorkers }, () => [] as RunWorkItemInput[]);
-  for (const [index, task] of tasks.entries()) {
-    buckets[index % maxWorkers]?.push(task);
-  }
-  return buckets.map((bucket, index) => ({
-    title: bucket.length === 1 ? (bucket[0]?.title ?? `Work shard ${index + 1}`) : `Work shard ${index + 1}`,
-    prompt:
-      bucket.length === 1
-        ? (bucket[0]?.prompt ?? "")
-        : bucket.map((task, taskIndex) => `${taskIndex + 1}. ${task.title}\n${task.prompt}`).join("\n\n"),
-    workerName: bucket.length === 1 ? bucket[0]?.workerName : undefined,
-    writeScope: [...new Set(bucket.flatMap((task) => task.writeScope ?? []))],
-  }));
-}
-
-export function planWorkRouting(input: {
-  request: string;
-  mode?: WorkRoutingMode;
-  tasks?: RunWorkItemInput[];
-  maxWorkers?: number;
-}): WorkRoutingDecision {
-  const request = input.request.trim();
-  if (!request) {
-    throw new Error("conductor_run_work requires a natural-language request");
-  }
-  const maxWorkers = Math.max(1, Math.floor(input.maxWorkers ?? 4));
-  const tasks = normalizeRunWorkItems({ request, tasks: input.tasks });
-  const riskFlags: string[] = [];
-  const hasDependencies = tasks.some((task) => (task.dependsOn?.length ?? 0) > 0);
-  const hasScopeOverlap = findOverlappingWriteScopes(tasks);
-  if (hasScopeOverlap) {
-    riskFlags.push("overlapping_write_scope");
-  }
-  if (tasks.length > maxWorkers) {
-    riskFlags.push("worker_cap_applied");
-  }
-
-  const requestedMode = input.mode ?? "auto";
-  if (requestedMode === "single") {
-    return {
-      mode: "single",
-      confidence: 1,
-      reason: "Single-worker mode was requested explicitly.",
-      tasks: [combineWorkItems(tasks, request)],
-      riskFlags,
-    };
-  }
-  if (requestedMode === "objective" || hasDependencies) {
-    return {
-      mode: "objective",
-      confidence: requestedMode === "objective" ? 1 : 0.9,
-      reason:
-        requestedMode === "objective"
-          ? "Objective mode was requested explicitly."
-          : "Dependent work requires objective scheduling instead of parallel fan-out.",
-      tasks,
-      riskFlags,
-    };
-  }
-
-  if (tasks.length <= 1 || hasSingleIntent(request) || hasScopeOverlap || maxWorkers === 1) {
-    return {
-      mode: "single",
-      confidence: tasks.length <= 1 ? 0.95 : 0.8,
-      reason:
-        tasks.length <= 1
-          ? "Single coherent work item; splitting would add coordination overhead."
-          : "Work should stay in one worker because parallel splitting is unsafe or was discouraged.",
-      tasks: [combineWorkItems(tasks, request)],
-      riskFlags,
-    };
-  }
-
-  if (requestedMode === "parallel" || hasParallelIntent(request)) {
-    return {
-      mode: "parallel",
-      confidence: requestedMode === "parallel" ? 1 : 0.85,
-      reason: "Independent work items can run in parallel under one foreground cancellation boundary.",
-      tasks: capParallelWorkItems(tasks, maxWorkers),
-      riskFlags,
-    };
-  }
-
-  return {
-    mode: "single",
-    confidence: 0.65,
-    reason: "No explicit parallel intent; defaulting to one coherent worker.",
-    tasks: [combineWorkItems(tasks, request)],
-    riskFlags,
-  };
-}
-
 export async function runWorkForRepo(
   repoRoot: string,
   input: {
@@ -1438,8 +1264,12 @@ export async function runWorkForRepo(
     tasks: TaskRecord[];
     schedule: Awaited<ReturnType<typeof scheduleObjectiveForRepo>> | null;
   } | null;
+  runtimeMode: RunRuntimeMode;
+  runtimeRuns: RunWorkRuntimeSummary[];
 }> {
   const decision = planWorkRouting(input);
+  const runtimeMode =
+    selectRuntimeModeForWork({ request: input.request, explicitRuntimeMode: input.runtimeMode }) ?? "headless";
   const workerPrefix = input.workerPrefix?.trim() || "run-work";
   const execute = input.execute ?? true;
 
@@ -1448,7 +1278,7 @@ export async function runWorkForRepo(
       repoRoot,
       {
         workerPrefix,
-        runtimeMode: input.runtimeMode,
+        runtimeMode,
         tasks: decision.tasks.map((task) => ({
           title: task.title,
           prompt: task.prompt,
@@ -1458,7 +1288,19 @@ export async function runWorkForRepo(
       signal,
       runner,
     );
-    return { decision, workers: parallel.workers, tasks: parallel.tasks, single: null, parallel, objective: null };
+    return {
+      decision,
+      workers: parallel.workers,
+      tasks: parallel.tasks,
+      single: null,
+      parallel,
+      objective: null,
+      runtimeMode,
+      runtimeRuns: summarizeRunWorkRuntime(
+        repoRoot,
+        parallel.tasks.map((task) => task.taskId),
+      ),
+    };
   }
 
   if (decision.mode === "objective") {
@@ -1488,7 +1330,7 @@ export async function runWorkForRepo(
             objectiveId: objective.objectiveId,
             policy: "execute",
             maxConcurrency: input.maxWorkers,
-            runtimeMode: input.runtimeMode,
+            runtimeMode,
           },
           signal,
         )
@@ -1504,6 +1346,11 @@ export async function runWorkForRepo(
       single: null,
       parallel: null,
       objective: { ...planned, schedule },
+      runtimeMode,
+      runtimeRuns: summarizeRunWorkRuntime(
+        repoRoot,
+        planned.tasks.map((task) => task.taskId),
+      ),
     };
   }
 
@@ -1530,11 +1377,11 @@ export async function runWorkForRepo(
       single: { worker: delegated.worker, task: delegated.task, result: null },
       parallel: null,
       objective: null,
+      runtimeMode,
+      runtimeRuns: summarizeRunWorkRuntime(repoRoot, [delegated.task.taskId]),
     };
   }
-  const result = execute
-    ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode: input.runtimeMode })
-    : null;
+  const result = execute ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode }) : null;
   return {
     decision,
     workers: [delegated.worker],
@@ -1542,6 +1389,8 @@ export async function runWorkForRepo(
     single: { worker: delegated.worker, task: delegated.task, result },
     parallel: null,
     objective: null,
+    runtimeMode,
+    runtimeRuns: summarizeRunWorkRuntime(repoRoot, [delegated.task.taskId]),
   };
 }
 

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1228,7 +1228,7 @@ export async function runParallelWorkForRepo(
     }
     const settled = await Promise.allSettled(
       tasks.map((task, index) =>
-        runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode: input.runtimeMode }),
+        runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode }),
       ),
     );
     if (signal?.aborted) await requestCancelOwnedWork();
@@ -1292,9 +1292,9 @@ export async function runWorkForRepo(
   runtimeRuns: RunWorkRuntimeSummary[];
 }> {
   const execute = input.execute ?? true;
-  if (execute && !input.tasks?.length && isStatusOnlyWorkRequest(input.request)) {
+  if (isStatusOnlyWorkRequest(input.request)) {
     throw new Error(
-      "conductor_run_work is for executing work; use conductor_get_project, conductor_list_workers, or conductor_list_runs for status-only requests",
+      "conductor_run_work is for planning or executing work; use conductor_get_project, conductor_list_workers, or conductor_list_runs for status-only requests",
     );
   }
   const decision = planWorkRouting(input);
@@ -1313,7 +1313,7 @@ export async function runWorkForRepo(
       repoRoot,
       {
         workerPrefix,
-        runtimeMode: selectedRuntimeMode,
+        runtimeMode,
         tasks: decision.tasks.map((task) => ({
           title: task.title,
           prompt: task.prompt,
@@ -1331,10 +1331,7 @@ export async function runWorkForRepo(
       parallel,
       objective: null,
       runtimeMode,
-      runtimeRuns: summarizeRunWorkRuntime(
-        repoRoot,
-        parallel.tasks.map((task) => task.taskId),
-      ),
+      runtimeRuns: parallel.runtimeRuns,
     };
   }
 
@@ -1365,7 +1362,7 @@ export async function runWorkForRepo(
             objectiveId: objective.objectiveId,
             policy: "execute",
             maxConcurrency: input.maxWorkers,
-            runtimeMode: selectedRuntimeMode,
+            runtimeMode,
           },
           signal,
         )
@@ -1416,9 +1413,7 @@ export async function runWorkForRepo(
       runtimeRuns: summarizeRunWorkRuntime(repoRoot, [delegated.task.taskId]),
     };
   }
-  const result = execute
-    ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode: selectedRuntimeMode })
-    : null;
+  const result = execute ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode }) : null;
   return {
     decision,
     workers: [delegated.worker],

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -2,7 +2,11 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import * as conductor from "../conductor.js";
 
-const runtimeModeSchema = Type.Union([Type.Literal("headless"), Type.Literal("tmux"), Type.Literal("iterm-tmux")]);
+function runtimeModeSchema(description?: string) {
+  return Type.Union([Type.Literal("headless"), Type.Literal("tmux"), Type.Literal("iterm-tmux")], {
+    ...(description ? { description } : {}),
+  });
+}
 
 export function registerOrchestrationTools(pi: ExtensionAPI): void {
   const workItemSchema = Type.Object({
@@ -36,16 +40,21 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       ),
       maxWorkers: Type.Optional(Type.Number({ description: "Maximum workers conductor may start in this request" })),
       execute: Type.Optional(Type.Boolean({ description: "Whether to execute after planning; defaults to true" })),
-      runtimeMode: Type.Optional(runtimeModeSchema),
+      runtimeMode: Type.Optional(
+        runtimeModeSchema(
+          "Explicit runtime mode. Omit to allow conservative visible-runtime inference from the request.",
+        ),
+      ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await conductor.runWorkForRepo(ctx.cwd, params, signal);
+      const runtimeText = `runtime=${result.runtimeMode}${result.runtimeRuns.length > 0 ? ` runs=${result.runtimeRuns.length}` : ""}`;
       const text =
         result.decision.mode === "parallel"
-          ? `routed work to ${result.tasks.length} parallel conductor worker(s): ${result.decision.reason}`
+          ? `routed work to ${result.tasks.length} parallel conductor worker(s) with ${runtimeText}: ${result.decision.reason}`
           : result.decision.mode === "objective"
-            ? `routed work to an objective with ${result.tasks.length} task(s): ${result.decision.reason}`
-            : `routed work to one conductor worker: ${result.decision.reason}`;
+            ? `routed work to an objective with ${result.tasks.length} task(s) with ${runtimeText}: ${result.decision.reason}`
+            : `routed work to one conductor worker with ${runtimeText}: ${result.decision.reason}`;
       return { content: [{ type: "text", text }], details: result };
     },
   });
@@ -67,7 +76,11 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       workerPrefix: Type.Optional(
         Type.String({ description: "Prefix for generated worker names; defaults to parallel-worker" }),
       ),
-      runtimeMode: Type.Optional(runtimeModeSchema),
+      runtimeMode: Type.Optional(
+        runtimeModeSchema(
+          "Explicit runtime mode for every parallel worker; use iterm-tmux for tmux plus best-effort iTerm2 viewer.",
+        ),
+      ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await conductor.runParallelWorkForRepo(ctx.cwd, params, signal);

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -23,7 +23,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
     name: "conductor_run_work",
     label: "Conductor Run Work",
     description:
-      "Run natural-language pi-conductor work and let conductor decide whether to use one worker, parallel workers, or an objective DAG based on dependencies, write scopes, and user intent",
+      "Run natural-language pi-conductor work and let conductor decide whether to use one worker, parallel workers, or an objective DAG. Omit runtimeMode for conservative visible-runtime inference; use conductor_get_project, conductor_list_workers, or conductor_list_runs for status-only requests. Runtime preflight errors can be investigated with conductor_backend_status, and active runtimeRuns include cancelTool details.",
     parameters: Type.Object({
       request: Type.String({ description: "The user's natural-language work request" }),
       mode: Type.Optional(
@@ -85,9 +85,10 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await conductor.runParallelWorkForRepo(ctx.cwd, params, signal);
       const completed = result.results.filter((entry) => entry.result?.status === "success").length;
+      const runtimeText = `runtime=${result.runtimeMode}${result.runtimeRuns.length > 0 ? ` runs=${result.runtimeRuns.length}` : ""}`;
       const text = signal?.aborted
-        ? `interrupted parallel conductor work; canceled ${result.canceledRuns.length} active run(s) and ${result.canceledTasks.length} task(s)`
-        : `ran ${result.tasks.length} parallel conductor task(s); ${completed} succeeded, ${result.results.length - completed} need follow-up`;
+        ? `interrupted parallel conductor work with ${runtimeText}; canceled ${result.canceledRuns.length} active run(s) and ${result.canceledTasks.length} task(s)`
+        : `ran ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${completed} succeeded, ${result.results.length - completed} need follow-up`;
       return { content: [{ type: "text", text }], details: result };
     },
   });

--- a/packages/pi-conductor/extensions/work-routing.ts
+++ b/packages/pi-conductor/extensions/work-routing.ts
@@ -1,0 +1,190 @@
+export type WorkRoutingMode = "auto" | "single" | "parallel" | "objective";
+
+export type RunWorkItemInput = {
+  title: string;
+  prompt: string;
+  workerName?: string;
+  writeScope?: string[];
+  dependsOn?: string[];
+};
+
+export type WorkRoutingDecision = {
+  mode: Exclude<WorkRoutingMode, "auto">;
+  confidence: number;
+  reason: string;
+  tasks: RunWorkItemInput[];
+  riskFlags: string[];
+};
+
+function hasParallelIntent(request: string): boolean {
+  return /\b(parallel|split|many|multiple|workers|fan[- ]?out|deep[- ]?dive|all)\b/i.test(request);
+}
+
+function hasSingleIntent(request: string): boolean {
+  return /\b(single|one worker|do not split|don't split|dont split|same worker|small|typo)\b/i.test(request);
+}
+
+export function deriveWorkTitle(request: string): string {
+  const trimmed = request.trim().replace(/\s+/g, " ");
+  if (!trimmed) {
+    return "Conductor work";
+  }
+  return trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed;
+}
+
+function normalizeRunWorkItems(input: { request: string; tasks?: RunWorkItemInput[] }): RunWorkItemInput[] {
+  const candidates = input.tasks?.length
+    ? input.tasks
+    : [{ title: deriveWorkTitle(input.request), prompt: input.request }];
+  return candidates.map((task, index) => ({
+    ...task,
+    title: task.title.trim() || `Work item ${index + 1}`,
+    prompt: task.prompt.trim() || input.request.trim(),
+    workerName: task.workerName?.trim() || undefined,
+    writeScope: task.writeScope?.map((scope) => scope.trim()).filter(Boolean),
+    dependsOn: task.dependsOn?.map((dependency) => dependency.trim()).filter(Boolean),
+  }));
+}
+
+function normalizeWriteScope(scope: string): string {
+  return scope.trim().replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
+}
+
+function writeScopesOverlap(left: string, right: string): boolean {
+  const normalizedLeft = normalizeWriteScope(left);
+  const normalizedRight = normalizeWriteScope(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  return (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.startsWith(`${normalizedRight}/`) ||
+    normalizedRight.startsWith(`${normalizedLeft}/`)
+  );
+}
+
+function findOverlappingWriteScopes(tasks: RunWorkItemInput[]): boolean {
+  const seen: string[] = [];
+  for (const task of tasks) {
+    for (const scope of task.writeScope ?? []) {
+      if (seen.some((knownScope) => writeScopesOverlap(knownScope, scope))) {
+        return true;
+      }
+      seen.push(scope);
+    }
+  }
+  return false;
+}
+
+function combineWorkItems(tasks: RunWorkItemInput[], request: string): RunWorkItemInput {
+  if (tasks.length === 1 && tasks[0]) {
+    return tasks[0];
+  }
+  return {
+    title: deriveWorkTitle(request),
+    prompt: [
+      request.trim(),
+      "",
+      "Run these work items coherently in one conductor worker because splitting is unsafe:",
+      ...tasks.map((task, index) => `${index + 1}. ${task.title}\n${task.prompt}`),
+    ].join("\n"),
+    writeScope: [...new Set(tasks.flatMap((task) => task.writeScope ?? []))],
+    dependsOn: [...new Set(tasks.flatMap((task) => task.dependsOn ?? []))],
+  };
+}
+
+function capParallelWorkItems(tasks: RunWorkItemInput[], maxWorkers: number): RunWorkItemInput[] {
+  if (tasks.length <= maxWorkers) {
+    return tasks;
+  }
+  const buckets = Array.from({ length: maxWorkers }, () => [] as RunWorkItemInput[]);
+  for (const [index, task] of tasks.entries()) {
+    buckets[index % maxWorkers]?.push(task);
+  }
+  return buckets.map((bucket, index) => ({
+    title: bucket.length === 1 ? (bucket[0]?.title ?? `Work shard ${index + 1}`) : `Work shard ${index + 1}`,
+    prompt:
+      bucket.length === 1
+        ? (bucket[0]?.prompt ?? "")
+        : bucket.map((task, taskIndex) => `${taskIndex + 1}. ${task.title}\n${task.prompt}`).join("\n\n"),
+    workerName: bucket.length === 1 ? bucket[0]?.workerName : undefined,
+    writeScope: [...new Set(bucket.flatMap((task) => task.writeScope ?? []))],
+  }));
+}
+
+export function planWorkRouting(input: {
+  request: string;
+  mode?: WorkRoutingMode;
+  tasks?: RunWorkItemInput[];
+  maxWorkers?: number;
+}): WorkRoutingDecision {
+  const request = input.request.trim();
+  if (!request) {
+    throw new Error("conductor_run_work requires a natural-language request");
+  }
+  const maxWorkers = Math.max(1, Math.floor(input.maxWorkers ?? 4));
+  const tasks = normalizeRunWorkItems({ request, tasks: input.tasks });
+  const riskFlags: string[] = [];
+  const hasDependencies = tasks.some((task) => (task.dependsOn?.length ?? 0) > 0);
+  const hasScopeOverlap = findOverlappingWriteScopes(tasks);
+  if (hasScopeOverlap) {
+    riskFlags.push("overlapping_write_scope");
+  }
+  if (tasks.length > maxWorkers) {
+    riskFlags.push("worker_cap_applied");
+  }
+
+  const requestedMode = input.mode ?? "auto";
+  if (requestedMode === "single") {
+    return {
+      mode: "single",
+      confidence: 1,
+      reason: "Single-worker mode was requested explicitly.",
+      tasks: [combineWorkItems(tasks, request)],
+      riskFlags,
+    };
+  }
+  if (requestedMode === "objective" || hasDependencies) {
+    return {
+      mode: "objective",
+      confidence: requestedMode === "objective" ? 1 : 0.9,
+      reason:
+        requestedMode === "objective"
+          ? "Objective mode was requested explicitly."
+          : "Dependent work requires objective scheduling instead of parallel fan-out.",
+      tasks,
+      riskFlags,
+    };
+  }
+
+  if (tasks.length <= 1 || hasSingleIntent(request) || hasScopeOverlap || maxWorkers === 1) {
+    return {
+      mode: "single",
+      confidence: tasks.length <= 1 ? 0.95 : 0.8,
+      reason:
+        tasks.length <= 1
+          ? "Single coherent work item; splitting would add coordination overhead."
+          : "Work should stay in one worker because parallel splitting is unsafe or was discouraged.",
+      tasks: [combineWorkItems(tasks, request)],
+      riskFlags,
+    };
+  }
+
+  if (requestedMode === "parallel" || hasParallelIntent(request)) {
+    return {
+      mode: "parallel",
+      confidence: requestedMode === "parallel" ? 1 : 0.85,
+      reason: "Independent work items can run in parallel under one foreground cancellation boundary.",
+      tasks: capParallelWorkItems(tasks, maxWorkers),
+      riskFlags,
+    };
+  }
+
+  return {
+    mode: "single",
+    confidence: 0.65,
+    reason: "No explicit parallel intent; defaulting to one coherent worker.",
+    tasks: [combineWorkItems(tasks, request)],
+    riskFlags,
+  };
+}

--- a/packages/pi-conductor/extensions/work-runtime-selection.ts
+++ b/packages/pi-conductor/extensions/work-runtime-selection.ts
@@ -12,11 +12,10 @@ function hasHeadlessRuntimeIntent(request: string): boolean {
 
 function hasStatusOnlyIntent(request: string): boolean {
   return (
-    /\b(show|list|display|view|inspect|status)\b/i.test(request) &&
-    /\b(current|active|existing|all)?\s*(workers|runs|tasks|project|status|sessions|panes|terminals|tmux|iterm)\b/i.test(
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(show|list|display|view|inspect|status)\b/i.test(request) &&
+    /\b(current|active|existing|all)?\s*(worker|workers|run|runs|task|tasks|project|status|session|sessions|pane|panes|terminal|terminals|tmux|iterm)\b/i.test(
       request,
-    ) &&
-    !hasExecutionIntent(request)
+    )
   );
 }
 

--- a/packages/pi-conductor/extensions/work-runtime-selection.ts
+++ b/packages/pi-conductor/extensions/work-runtime-selection.ts
@@ -1,0 +1,81 @@
+import { getOrCreateRunForRepo } from "./repo-run.js";
+import { isTerminalRunStatus } from "./run-status.js";
+import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode } from "./types.js";
+
+export type RunWorkRuntimeSummary = {
+  taskId: string;
+  runId: string;
+  status: RunAttemptRecord["status"];
+  runtimeMode: RunRuntimeMode;
+  runtimeStatus: RunRuntimeMetadata["status"];
+  viewerStatus: RunRuntimeMetadata["viewerStatus"];
+  viewerCommand: string | null;
+  logPath: string | null;
+  diagnostic: string | null;
+  latestProgress: string | null;
+  cancelCommand: string | null;
+};
+
+function hasExecutionIntent(request: string): boolean {
+  return /\b(run|start|execute|launch|do|implement|fix|build|ship|create|work on)\b/i.test(request);
+}
+
+function hasStatusOnlyIntent(request: string): boolean {
+  return (
+    /\b(show|list|display|view|inspect|status)\b/i.test(request) &&
+    /\b(current|active|existing|all)?\s*(workers|runs|tasks|project|status)\b/i.test(request) &&
+    !hasExecutionIntent(request)
+  );
+}
+
+function hasVisibleSupervisionIntent(request: string): boolean {
+  return (
+    hasExecutionIntent(request) &&
+    /\b(show|open|watch|view|supervise|visible|viewer|terminal|pane)\b/i.test(request) &&
+    /\b(worker|workers|run|runs|session|sessions|pane|panes|terminal|output|progress)\b/i.test(request)
+  );
+}
+
+export function selectRuntimeModeForWork(input: {
+  request: string;
+  explicitRuntimeMode?: RunRuntimeMode;
+}): RunRuntimeMode | undefined {
+  if (input.explicitRuntimeMode) {
+    return input.explicitRuntimeMode;
+  }
+  const request = input.request.trim();
+  if (!request || hasStatusOnlyIntent(request)) {
+    return undefined;
+  }
+  if (/\biterm(?:2)?\b|\biterm-tmux\b/i.test(request)) {
+    return "iterm-tmux";
+  }
+  if (/\btmux\b/i.test(request)) {
+    return "tmux";
+  }
+  return hasVisibleSupervisionIntent(request) ? "iterm-tmux" : undefined;
+}
+
+export function summarizeRunWorkRuntime(repoRoot: string, taskIds: string[]): RunWorkRuntimeSummary[] {
+  const run = getOrCreateRunForRepo(repoRoot);
+  const taskIdSet = new Set(taskIds);
+  return run.runs
+    .filter((attempt) => taskIdSet.has(attempt.taskId))
+    .map((attempt) => {
+      const task = run.tasks.find((entry) => entry.taskId === attempt.taskId);
+      const isActive = !attempt.finishedAt && !isTerminalRunStatus(attempt.status);
+      return {
+        taskId: attempt.taskId,
+        runId: attempt.runId,
+        status: attempt.status,
+        runtimeMode: attempt.runtime.mode,
+        runtimeStatus: attempt.runtime.status,
+        viewerStatus: attempt.runtime.viewerStatus,
+        viewerCommand: attempt.runtime.viewerCommand,
+        logPath: attempt.runtime.logPath,
+        diagnostic: attempt.runtime.diagnostics.at(-1) ?? null,
+        latestProgress: task?.latestProgress ?? null,
+        cancelCommand: isActive ? `conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})` : null,
+      };
+    });
+}

--- a/packages/pi-conductor/extensions/work-runtime-selection.ts
+++ b/packages/pi-conductor/extensions/work-runtime-selection.ts
@@ -1,29 +1,21 @@
-import { getOrCreateRunForRepo } from "./repo-run.js";
-import { isTerminalRunStatus } from "./run-status.js";
-import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode } from "./types.js";
-
-export type RunWorkRuntimeSummary = {
-  taskId: string;
-  runId: string;
-  status: RunAttemptRecord["status"];
-  runtimeMode: RunRuntimeMode;
-  runtimeStatus: RunRuntimeMetadata["status"];
-  viewerStatus: RunRuntimeMetadata["viewerStatus"];
-  viewerCommand: string | null;
-  logPath: string | null;
-  diagnostic: string | null;
-  latestProgress: string | null;
-  cancelCommand: string | null;
-};
+import type { RunRuntimeMode } from "./types.js";
 
 function hasExecutionIntent(request: string): boolean {
   return /\b(run|start|execute|launch|do|implement|fix|build|ship|create|work on)\b/i.test(request);
 }
 
+function hasHeadlessRuntimeIntent(request: string): boolean {
+  return /\b(headless|without tmux|no tmux|do not use tmux|don't use tmux|dont use tmux|not tmux|without iterm|no iterm|do not use iterm|don't use iterm|dont use iterm)\b/i.test(
+    request,
+  );
+}
+
 function hasStatusOnlyIntent(request: string): boolean {
   return (
     /\b(show|list|display|view|inspect|status)\b/i.test(request) &&
-    /\b(current|active|existing|all)?\s*(workers|runs|tasks|project|status)\b/i.test(request) &&
+    /\b(current|active|existing|all)?\s*(workers|runs|tasks|project|status|sessions|panes|terminals|tmux|iterm)\b/i.test(
+      request,
+    ) &&
     !hasExecutionIntent(request)
   );
 }
@@ -34,6 +26,10 @@ function hasVisibleSupervisionIntent(request: string): boolean {
     /\b(show|open|watch|view|supervise|visible|viewer|terminal|pane)\b/i.test(request) &&
     /\b(worker|workers|run|runs|session|sessions|pane|panes|terminal|output|progress)\b/i.test(request)
   );
+}
+
+export function isStatusOnlyWorkRequest(request: string): boolean {
+  return hasStatusOnlyIntent(request.trim());
 }
 
 export function selectRuntimeModeForWork(input: {
@@ -47,6 +43,12 @@ export function selectRuntimeModeForWork(input: {
   if (!request || hasStatusOnlyIntent(request)) {
     return undefined;
   }
+  if (hasHeadlessRuntimeIntent(request)) {
+    return "headless";
+  }
+  if (!hasExecutionIntent(request)) {
+    return undefined;
+  }
   if (/\biterm(?:2)?\b|\biterm-tmux\b/i.test(request)) {
     return "iterm-tmux";
   }
@@ -54,28 +56,4 @@ export function selectRuntimeModeForWork(input: {
     return "tmux";
   }
   return hasVisibleSupervisionIntent(request) ? "iterm-tmux" : undefined;
-}
-
-export function summarizeRunWorkRuntime(repoRoot: string, taskIds: string[]): RunWorkRuntimeSummary[] {
-  const run = getOrCreateRunForRepo(repoRoot);
-  const taskIdSet = new Set(taskIds);
-  return run.runs
-    .filter((attempt) => taskIdSet.has(attempt.taskId))
-    .map((attempt) => {
-      const task = run.tasks.find((entry) => entry.taskId === attempt.taskId);
-      const isActive = !attempt.finishedAt && !isTerminalRunStatus(attempt.status);
-      return {
-        taskId: attempt.taskId,
-        runId: attempt.runId,
-        status: attempt.status,
-        runtimeMode: attempt.runtime.mode,
-        runtimeStatus: attempt.runtime.status,
-        viewerStatus: attempt.runtime.viewerStatus,
-        viewerCommand: attempt.runtime.viewerCommand,
-        logPath: attempt.runtime.logPath,
-        diagnostic: attempt.runtime.diagnostics.at(-1) ?? null,
-        latestProgress: task?.latestProgress ?? null,
-        cancelCommand: isActive ? `conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})` : null,
-      };
-    });
 }

--- a/packages/pi-conductor/extensions/work-runtime-summary.ts
+++ b/packages/pi-conductor/extensions/work-runtime-summary.ts
@@ -39,9 +39,14 @@ export function summarizeRunWorkRuntime(repoRoot: string, taskIds: string[]): Ru
         logPath: attempt.runtime.logPath,
         diagnostic: attempt.runtime.diagnostics.at(-1) ?? null,
         latestProgress: task?.latestProgress ?? null,
-        cancelCommand: isActive ? `conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})` : null,
+        cancelCommand: isActive
+          ? `conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"Parent requested cancellation"})`
+          : null,
         cancelTool: isActive
-          ? { name: "conductor_cancel_task_run", params: { runId: attempt.runId, reason: "<reason>" } }
+          ? {
+              name: "conductor_cancel_task_run",
+              params: { runId: attempt.runId, reason: "Parent requested cancellation" },
+            }
           : null,
       };
     });

--- a/packages/pi-conductor/extensions/work-runtime-summary.ts
+++ b/packages/pi-conductor/extensions/work-runtime-summary.ts
@@ -1,0 +1,48 @@
+import { getOrCreateRunForRepo } from "./repo-run.js";
+import { isTerminalRunStatus } from "./run-status.js";
+import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode } from "./types.js";
+
+export type RunWorkRuntimeSummary = {
+  taskId: string;
+  runId: string;
+  status: RunAttemptRecord["status"];
+  runtimeMode: RunRuntimeMode;
+  runtimeStatus: RunRuntimeMetadata["status"];
+  viewerStatus: RunRuntimeMetadata["viewerStatus"];
+  viewerCommand: string | null;
+  logPath: string | null;
+  diagnostic: string | null;
+  latestProgress: string | null;
+  cancelCommand: string | null;
+  cancelTool: {
+    name: "conductor_cancel_task_run";
+    params: { runId: string; reason: string };
+  } | null;
+};
+
+export function summarizeRunWorkRuntime(repoRoot: string, taskIds: string[]): RunWorkRuntimeSummary[] {
+  const run = getOrCreateRunForRepo(repoRoot);
+  const taskIdSet = new Set(taskIds);
+  return run.runs
+    .filter((attempt) => taskIdSet.has(attempt.taskId))
+    .map((attempt) => {
+      const task = run.tasks.find((entry) => entry.taskId === attempt.taskId);
+      const isActive = !attempt.finishedAt && !isTerminalRunStatus(attempt.status);
+      return {
+        taskId: attempt.taskId,
+        runId: attempt.runId,
+        status: attempt.status,
+        runtimeMode: attempt.runtime.mode,
+        runtimeStatus: attempt.runtime.status,
+        viewerStatus: attempt.runtime.viewerStatus,
+        viewerCommand: attempt.runtime.viewerCommand,
+        logPath: attempt.runtime.logPath,
+        diagnostic: attempt.runtime.diagnostics.at(-1) ?? null,
+        latestProgress: task?.latestProgress ?? null,
+        cancelCommand: isActive ? `conductor_cancel_task_run({"runId":"${attempt.runId}","reason":"<reason>"})` : null,
+        cancelTool: isActive
+          ? { name: "conductor_cancel_task_run", params: { runId: attempt.runId, reason: "<reason>" } }
+          : null,
+      };
+    });
+}


### PR DESCRIPTION
## Summary
- Adds conservative natural-language runtime selection for high-level conductor work: explicit `runtimeMode` still wins, regular work defaults to headless, and unambiguous “run/open/show/watch workers” requests infer `iterm-tmux`.
- Keeps status-only “show current workers/runs/tasks” phrases from selecting visible runtime.
- Returns runtime selection and per-run runtime summaries from `runWorkForRepo`, and includes runtime details in the agent-facing `conductor_run_work` response text/details.
- Splits work routing/runtime-selection helpers out of `conductor.ts` to keep the conductor service under the static safety line-count guard.
- Adds coverage for inferred visible parallel runs, status-only requests, inferred visible preflight failure, and natural-language active-work cancellation for `iterm-tmux`.

## Validation
- `npm run check`
- `npx vitest run packages/pi-conductor/__tests__ --reporter=dot`
- `git diff --check`
- `specdocs_validate`