### PR TITLE
fix(pi-devtools): use gh subject flag for squash merge title

### DIFF
--- a/packages/pi-devtools/__tests__/command-contract.test.ts
+++ b/packages/pi-devtools/__tests__/command-contract.test.ts
@@ -138,6 +138,17 @@ describe("pi-devtools generated CLI command contract", () => {
       draft: true,
       prerelease: true,
     });
+    await executeTool("devtools_create_release", { tag: "v1.2.4", title: "Version 1.2.4" });
+
+    expect(generatedCommands.some((command) => command.startsWith("gh pr create") && command.includes("--head"))).toBe(
+      true,
+    );
+    expect(generatedCommands.some((command) => command.startsWith("gh pr create") && command.includes("--body"))).toBe(
+      true,
+    );
+    expect(
+      generatedCommands.some((command) => command.startsWith("gh release create") && command.includes("--notes")),
+    ).toBe(true);
 
     const helpByCommand = new Map<(typeof HELP_COMMANDS)[number], string>();
     for (const command of generatedCommands) {

--- a/packages/pi-devtools/__tests__/command-contract.test.ts
+++ b/packages/pi-devtools/__tests__/command-contract.test.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { checkCiTool, createPrTool, createReleaseTool, mergePrTool } from "../extensions/index.js";
+
+vi.mock("../extensions/git.js", () => ({
+  execGit: vi.fn(),
+  execGh: vi.fn(),
+  getDefaultBranch: vi.fn().mockReturnValue("main"),
+}));
+
+import { execGh, execGit } from "../extensions/git.js";
+
+const HELP_COMMANDS = [
+  "gh pr create",
+  "gh pr list",
+  "gh pr view",
+  "gh pr merge",
+  "gh pr checks",
+  "gh run list",
+  "gh release create",
+] as const;
+
+function hasGhCli(): boolean {
+  try {
+    execFileSync("gh", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ghHelp(command: (typeof HELP_COMMANDS)[number]): string {
+  const args = command.split(" ").slice(1).concat("--help");
+  return execFileSync("gh", args, { encoding: "utf-8" });
+}
+
+function helpCommandFor(ghCommand: string): (typeof HELP_COMMANDS)[number] {
+  const match = HELP_COMMANDS.find((command) => ghCommand.startsWith(command));
+  if (!match) {
+    throw new Error(`No help command mapped for generated command: ${ghCommand}`);
+  }
+  return match;
+}
+
+function longFlags(command: string): string[] {
+  return Array.from(new Set(command.match(/--[a-z][a-z-]*/g) ?? []));
+}
+
+describe("pi-devtools generated GitHub CLI command contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(execGit).mockReset();
+    vi.mocked(execGh).mockReset();
+  });
+
+  it.skipIf(!hasGhCli())("uses only long flags supported by the installed gh CLI", () => {
+    const generatedCommands: string[] = [];
+    vi.mocked(execGh).mockImplementation((command: string) => {
+      generatedCommands.push(command);
+      if (command.startsWith("gh pr list")) return JSON.stringify([{ number: 123 }]);
+      if (command.startsWith("gh pr view")) {
+        return JSON.stringify({ title: "Test PR", url: "https://github.com/owner/repo/pull/123", state: "OPEN" });
+      }
+      if (command.startsWith("gh pr create")) return "https://github.com/owner/repo/pull/124";
+      if (command.startsWith("gh release create")) return "https://github.com/owner/repo/releases/tag/v1.2.3";
+      if (command.startsWith("gh pr checks")) return JSON.stringify([]);
+      if (command.startsWith("gh run list")) return JSON.stringify([]);
+      return "";
+    });
+    vi.mocked(execGit).mockReturnValue("feature/devtools-command-contract");
+
+    createPrTool("Validate CLI flags", "Body", "main", true, ["user1"]);
+    mergePrTool(123, false, true);
+    mergePrTool(123, true, true, "Squash title", "Squash body");
+    mergePrTool(undefined, true, false, "Detected PR title");
+    checkCiTool(123);
+    checkCiTool(undefined, "feature/devtools-command-contract");
+    createReleaseTool("v1.2.3", "Version 1.2.3", "Release notes", true, true);
+
+    const helpByCommand = new Map<(typeof HELP_COMMANDS)[number], string>();
+    for (const command of generatedCommands) {
+      const helpCommand = helpCommandFor(command);
+      const help = helpByCommand.get(helpCommand) ?? ghHelp(helpCommand);
+      helpByCommand.set(helpCommand, help);
+      for (const flag of longFlags(command)) {
+        expect(help, `${helpCommand} should support ${flag} used by ${command}`).toContain(flag);
+      }
+    }
+  });
+});

--- a/packages/pi-devtools/__tests__/command-contract.test.ts
+++ b/packages/pi-devtools/__tests__/command-contract.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { checkCiTool, createPrTool, createReleaseTool, mergePrTool } from "../extensions/index.js";
+import { toolDefinitions } from "../extensions/index.js";
 
 vi.mock("../extensions/git.js", () => ({
   execGit: vi.fn(),
@@ -19,6 +19,21 @@ const HELP_COMMANDS = [
   "gh run list",
   "gh release create",
 ] as const;
+
+const TOOL_COVERAGE = {
+  devtools_create_branch: "git-integration",
+  devtools_commit: "git-integration",
+  devtools_push: "git-integration",
+  devtools_create_pr: "gh-contract",
+  devtools_merge_pr: "gh-contract",
+  devtools_squash_merge_pr: "gh-contract",
+  devtools_check_ci: "gh-contract",
+  devtools_get_repo_info: "git-integration",
+  devtools_get_latest_tag: "git-integration",
+  devtools_analyze_commits: "git-integration",
+  devtools_bump_version: "local-file",
+  devtools_create_release: "gh-contract",
+} as const satisfies Record<(typeof toolDefinitions)[number]["name"], string>;
 
 function hasGhCli(): boolean {
   try {
@@ -46,14 +61,45 @@ function longFlags(command: string): string[] {
   return Array.from(new Set(command.match(/--[a-z][a-z-]*/g) ?? []));
 }
 
-describe("pi-devtools generated GitHub CLI command contract", () => {
+function requestedJsonFields(command: string): string[] {
+  const match = command.match(/--json\s+([A-Za-z0-9_,]+)/);
+  return match ? match[1].split(",").filter(Boolean) : [];
+}
+
+function supportedJsonFields(help: string): Set<string> {
+  const jsonSection = help.split("JSON FIELDS")[1]?.split(/\n\s*\n/)[0] ?? "";
+  return new Set(jsonSection.match(/[A-Za-z][A-Za-z0-9_]*/g) ?? []);
+}
+
+function toolByName(name: (typeof toolDefinitions)[number]["name"]): (typeof toolDefinitions)[number] {
+  const tool = toolDefinitions.find((entry) => entry.name === name);
+  if (!tool) throw new Error(`Tool not found: ${name}`);
+  return tool;
+}
+
+async function executeTool(name: (typeof toolDefinitions)[number]["name"], params: Record<string, unknown> = {}) {
+  return toolByName(name).execute("contract-test", params);
+}
+
+describe("pi-devtools generated CLI command contract", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(execGit).mockReset();
     vi.mocked(execGh).mockReset();
   });
 
-  it.skipIf(!hasGhCli())("uses only long flags supported by the installed gh CLI", () => {
+  it("classifies every registered tool for command-contract coverage", () => {
+    expect(new Set(Object.keys(TOOL_COVERAGE))).toEqual(new Set(toolDefinitions.map((tool) => tool.name)));
+  });
+
+  it("uses only gh flags and JSON fields supported by the installed gh CLI", async () => {
+    if (!hasGhCli()) {
+      if (process.env.CI) {
+        throw new Error("GitHub CLI (`gh`) is required in CI to validate pi-devtools generated command contracts");
+      }
+      return;
+    }
+
     const generatedCommands: string[] = [];
     vi.mocked(execGh).mockImplementation((command: string) => {
       generatedCommands.push(command);
@@ -69,13 +115,29 @@ describe("pi-devtools generated GitHub CLI command contract", () => {
     });
     vi.mocked(execGit).mockReturnValue("feature/devtools-command-contract");
 
-    createPrTool("Validate CLI flags", "Body", "main", true, ["user1"]);
-    mergePrTool(123, false, true);
-    mergePrTool(123, true, true, "Squash title", "Squash body");
-    mergePrTool(undefined, true, false, "Detected PR title");
-    checkCiTool(123);
-    checkCiTool(undefined, "feature/devtools-command-contract");
-    createReleaseTool("v1.2.3", "Version 1.2.3", "Release notes", true, true);
+    await executeTool("devtools_create_pr", {
+      title: "Validate CLI flags",
+      base: "main",
+      draft: true,
+      assignees: ["user1"],
+    });
+    await executeTool("devtools_merge_pr", { prNumber: 123, deleteBranch: true });
+    await executeTool("devtools_merge_pr", {
+      prNumber: 123,
+      squash: true,
+      commitTitle: "Squash title",
+      commitMessage: "Squash body",
+    });
+    await executeTool("devtools_squash_merge_pr", { commitTitle: "Detected PR title", deleteBranch: false });
+    await executeTool("devtools_check_ci", { prNumber: 123 });
+    await executeTool("devtools_check_ci", { branch: "feature/devtools-command-contract" });
+    await executeTool("devtools_create_release", {
+      tag: "v1.2.3",
+      title: "Version 1.2.3",
+      body: "Release notes",
+      draft: true,
+      prerelease: true,
+    });
 
     const helpByCommand = new Map<(typeof HELP_COMMANDS)[number], string>();
     for (const command of generatedCommands) {
@@ -84,6 +146,16 @@ describe("pi-devtools generated GitHub CLI command contract", () => {
       helpByCommand.set(helpCommand, help);
       for (const flag of longFlags(command)) {
         expect(help, `${helpCommand} should support ${flag} used by ${command}`).toContain(flag);
+      }
+
+      const jsonFields = requestedJsonFields(command);
+      if (jsonFields.length > 0) {
+        const supportedFields = supportedJsonFields(help);
+        for (const field of jsonFields) {
+          expect(supportedFields, `${helpCommand} should support JSON field ${field} used by ${command}`).toContain(
+            field,
+          );
+        }
       }
     }
   });

--- a/packages/pi-devtools/__tests__/git.integration.test.ts
+++ b/packages/pi-devtools/__tests__/git.integration.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { execGh, execGit, getDefaultBranch } from "../extensions/git.js";
+import { execGh, execGit, getDefaultBranch, getGitContext } from "../extensions/git.js";
 
 describe("pi-devtools git integration", () => {
   let tempDir: string;
@@ -52,6 +52,18 @@ describe("pi-devtools git integration", () => {
 
     it("handles error in command execution", () => {
       expect(() => execGit(`git -C ${tempDir} log --invalid-flag`)).toThrow();
+    });
+  });
+
+  describe("session git context", () => {
+    it("builds context inside a git repository", () => {
+      const originalCwd = process.cwd();
+      process.chdir(tempDir);
+      try {
+        expect(getGitContext()).toContain("Branch: main");
+      } finally {
+        process.chdir(originalCwd);
+      }
     });
   });
 

--- a/packages/pi-devtools/__tests__/tools.test.ts
+++ b/packages/pi-devtools/__tests__/tools.test.ts
@@ -245,7 +245,7 @@ describe("pi-devtools", () => {
       expect(result.details.mergeType).toBe("squash-merged");
     });
 
-    it("squash merges with commit title", () => {
+    it("squash merges with commit title using GitHub CLI subject flag", () => {
       vi.mocked(execGh)
         .mockReturnValueOnce(JSON.stringify({ title: "Test PR", url: "https://github.com/123", state: "OPEN" }))
         .mockReturnValueOnce("");
@@ -253,7 +253,8 @@ describe("pi-devtools", () => {
       mergePrTool(123, true, true, "Custom Title");
 
       const mergeCall = vi.mocked(execGh).mock.calls[1][0] as string;
-      expect(mergeCall).toContain("--title");
+      expect(mergeCall).toContain("--subject 'Custom Title'");
+      expect(mergeCall).not.toContain("--title");
     });
 
     it("squash merges with commit message", () => {

--- a/packages/pi-devtools/__tests__/tools.test.ts
+++ b/packages/pi-devtools/__tests__/tools.test.ts
@@ -179,13 +179,15 @@ describe("pi-devtools", () => {
       expect(result.details.prUrl).toContain("github.com");
     });
 
-    it("creates PR without body", () => {
+    it("creates PR with an explicit empty body when body is omitted", () => {
       vi.mocked(execGit).mockReturnValue("main");
       vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
 
       const result = createPrTool("Test PR");
 
       expect(result.content[0].text).toContain("Created PR");
+      const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
+      expect(ghCall).toContain("--body ''");
     });
 
     it("creates draft PR", () => {

--- a/packages/pi-devtools/__tests__/tools.test.ts
+++ b/packages/pi-devtools/__tests__/tools.test.ts
@@ -169,14 +169,16 @@ describe("pi-devtools", () => {
   });
 
   describe("createPrTool", () => {
-    it("creates PR successfully", () => {
-      vi.mocked(execGit).mockReturnValue("main");
+    it("creates PR successfully with an explicit head branch", () => {
+      vi.mocked(execGit).mockReturnValue("feature-branch");
       vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/pull/123");
 
       const result = createPrTool("Add new feature", "Description");
 
       expect(result.content[0].text).toContain("Created PR");
       expect(result.details.prUrl).toContain("github.com");
+      const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
+      expect(ghCall).toContain("--head 'feature-branch'");
     });
 
     it("creates PR with an explicit empty body when body is omitted", () => {
@@ -534,6 +536,18 @@ describe("pi-devtools", () => {
 
       expect(result.content[0].text).toContain("Created release");
       expect(result.details.tag).toBe("v1.0.0");
+      const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
+      expect(ghCall).toContain("--notes 'Release notes'");
+    });
+
+    it("creates release with explicit empty notes when body is omitted", () => {
+      vi.mocked(execGh).mockReturnValue("https://github.com/owner/repo/releases/tag/v1.0.0");
+
+      const result = createReleaseTool("v1.0.0", "Version 1.0.0");
+
+      expect(result.content[0].text).toContain("Created release");
+      const ghCall = vi.mocked(execGh).mock.calls[0][0] as string;
+      expect(ghCall).toContain("--notes ''");
     });
 
     it("handles release creation error", () => {

--- a/packages/pi-devtools/extensions/git.ts
+++ b/packages/pi-devtools/extensions/git.ts
@@ -10,21 +10,21 @@ import { execSync } from "node:child_process";
 
 export function isGitRepo(): boolean {
   try {
-    return execGit("rev-parse --is-inside-work-tree") === "true";
+    return execGit("git rev-parse --is-inside-work-tree") === "true";
   } catch {
     return false;
   }
 }
 
 export function getCurrentBranch(): string {
-  const branch = execGit("branch --show-current");
+  const branch = execGit("git branch --show-current");
   if (branch) return branch;
-  const sha = execGit("rev-parse --short HEAD");
+  const sha = execGit("git rev-parse --short HEAD");
   return sha ? `Detached HEAD at ${sha}` : "unknown";
 }
 
 export function getWorkingTreeStatus(): string {
-  const output = execGit("status --porcelain");
+  const output = execGit("git status --porcelain");
   if (!output) return "clean";
 
   const lines = output.split("\n").filter(Boolean);
@@ -54,7 +54,7 @@ export function compareVersions(a: number[], b: number[]): number {
 }
 
 export function getTagInfo(): string {
-  const output = execGit('tag -l "v*"');
+  const output = execGit('git tag -l "v*"');
   if (!output) return "No version tags found";
 
   const tags = output.split("\n").filter(Boolean);
@@ -64,7 +64,7 @@ export function getTagInfo(): string {
   const latest = tags.at(-1) ?? tags[0];
 
   try {
-    const count = execGit(`rev-list ${latest}..HEAD --count`);
+    const count = execGit(`git rev-list ${latest}..HEAD --count`);
     if (count !== null) return `Tag: ${latest} (${count} unreleased commits)`;
   } catch {
     // Fall through

--- a/packages/pi-devtools/extensions/pull-request-tools.ts
+++ b/packages/pi-devtools/extensions/pull-request-tools.ts
@@ -78,7 +78,7 @@ function buildMergeCommand(
   const commandParts = [`gh pr merge ${prNumber}`, squash ? "--squash" : "--merge"];
 
   if (squash && commitTitle) {
-    commandParts.push(`--title ${shellQuote(commitTitle)}`);
+    commandParts.push(`--subject ${shellQuote(commitTitle)}`);
   }
   if (squash && commitMessage) {
     commandParts.push(`--body ${shellQuote(commitMessage)}`);

--- a/packages/pi-devtools/extensions/pull-request-tools.ts
+++ b/packages/pi-devtools/extensions/pull-request-tools.ts
@@ -29,7 +29,7 @@ export function createPrTool(
     const targetBase = base || getDefaultBranch();
     const headBranch = execGit("git branch --show-current");
 
-    let command = `gh pr create --title ${shellQuote(title)} --base ${shellQuote(targetBase)}`;
+    let command = `gh pr create --title ${shellQuote(title)} --base ${shellQuote(targetBase)} --head ${shellQuote(headBranch)}`;
     command += ` --body ${shellQuote(body ?? "")}`;
     if (draft) {
       command += " --draft";

--- a/packages/pi-devtools/extensions/pull-request-tools.ts
+++ b/packages/pi-devtools/extensions/pull-request-tools.ts
@@ -30,9 +30,7 @@ export function createPrTool(
     const headBranch = execGit("git branch --show-current");
 
     let command = `gh pr create --title ${shellQuote(title)} --base ${shellQuote(targetBase)}`;
-    if (body) {
-      command += ` --body ${shellQuote(body)}`;
-    }
+    command += ` --body ${shellQuote(body ?? "")}`;
     if (draft) {
       command += " --draft";
     }

--- a/packages/pi-devtools/extensions/release-tools.ts
+++ b/packages/pi-devtools/extensions/release-tools.ts
@@ -146,9 +146,7 @@ export function createReleaseTool(
 ): ToolResult {
   try {
     let command = `gh release create ${shellQuote(tag)} --title ${shellQuote(title)}`;
-    if (body) {
-      command += ` --notes ${shellQuote(body)}`;
-    }
+    command += ` --notes ${shellQuote(body ?? "")}`;
     if (draft) {
       command += " --draft";
     }


### PR DESCRIPTION
## Summary
- Replace the invalid `gh pr merge --title` flag with the supported `--subject` flag when setting squash merge commit titles.
- Add a generated GitHub CLI command-contract test that drives gh-backed registered `devtools_*` tools through `toolDefinitions` and verifies generated long flags plus `--json` fields against the installed `gh --help` output.
- Make the contract fail in CI when `gh` is unavailable, while keeping local runs portable.
- Avoid interactive prompt traps by passing explicit `--head`/`--body` for PR creation and explicit `--notes` for release creation.
- Add integration coverage for session-start git context and fix helper commands that were missing the `git` executable prefix.

## Validation
- `npx vitest run packages/pi-devtools/__tests__/tools.test.ts --reporter=dot`
- `npx vitest run packages/pi-devtools/__tests__/git.integration.test.ts packages/pi-devtools/__tests__/git.unit.test.ts packages/pi-devtools/__tests__/command-contract.test.ts --reporter=dot`
- `npx vitest run packages/pi-devtools/__tests__/command-contract.test.ts packages/pi-devtools/__tests__/tools.test.ts --reporter=dot`
- `npx vitest run packages/pi-devtools/__tests__ --reporter=dot`
- `npx vitest run packages/pi-devtools/__tests__ --coverage.enabled --coverage.reportsDirectory=coverage/pi-devtools --coverage.include=packages/pi-devtools/extensions/**/*.ts --coverage.thresholds.lines=70 --coverage.thresholds.statements=70 --coverage.thresholds.functions=70 --coverage.thresholds.branches=60 --reporter=dot`
- `npx tsc --noEmit --project packages/pi-devtools/tsconfig.json`
- `npx biome ci packages/pi-devtools`
- `npm run check`
