### PR TITLE
test(pi-conductor): add visible runtime smoke hardening

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -158,7 +158,7 @@ Use conductor status tools rather than typing into worker panes to supervise wor
 
 `conductor_backend_status` reports tmux startability separately from iTerm2 viewer availability. Explicit visible runtime requests fail closed when tmux is unavailable; iTerm2 viewer failures degrade to tmux-only supervision.
 
-For inspection-only requests, call status/list tools instead of `conductor_run_work`. Phrases such as “show current workers”, “show run status”, “inspect current run”, “open current run output”, and “watch current worker status” are treated as status-only guidance, not as permission to launch visible worker execution. If a user actually wants new visible work, make the execution intent explicit, for example “run these shards in parallel and show me the workers” or pass `runtimeMode: "tmux" | "iterm-tmux"` directly.
+For inspection-only requests, call status/list tools instead of `conductor_run_work`. Phrases such as “show current workers”, “show run status”, “inspect current run”, “open current run output”, and “watch current worker status” are treated as status-only guidance, not as permission to launch visible worker execution. Passing `runtimeMode` only selects a runtime after the request is clearly execution/planning work; it does not turn status-only text into new work. If a user actually wants new visible work, make the execution intent explicit, for example “run these shards in parallel and show me the workers” with `runtimeMode: "tmux" | "iterm-tmux"` when direct runtime selection is needed.
 
 ## Workflow recipes
 

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -158,6 +158,8 @@ Use conductor status tools rather than typing into worker panes to supervise wor
 
 `conductor_backend_status` reports tmux startability separately from iTerm2 viewer availability. Explicit visible runtime requests fail closed when tmux is unavailable; iTerm2 viewer failures degrade to tmux-only supervision.
 
+For inspection-only requests, call status/list tools instead of `conductor_run_work`. Phrases such as “show current workers”, “show run status”, “inspect current run”, “open current run output”, and “watch current worker status” are treated as status-only guidance, not as permission to launch visible worker execution. If a user actually wants new visible work, make the execution intent explicit, for example “run these shards in parallel and show me the workers” or pass `runtimeMode: "tmux" | "iterm-tmux"` directly.
+
 ## Workflow recipes
 
 ### Plan and execute an objective
@@ -206,6 +208,22 @@ conductor_run_parallel_work({
 ```
 
 If the user interrupts or asks in natural language to stop conductor work, use `conductor_cancel_active_work({ reason: "user requested stop" })`. It cancels active runs and conductor-owned queued tasks without requiring run IDs.
+
+### Local visible-runtime smoke
+
+The package test suite includes a real-tmux lifecycle smoke that skips when `tmux` is not installed. To exercise the full visible supervision flow manually on a machine with tmux, run:
+
+```bash
+npx vitest run packages/pi-conductor/__tests__/package-smoke.test.ts packages/pi-conductor/__tests__/work-runtime-selection.test.ts
+```
+
+Then perform a conductor-level smoke in an isolated `PI_CONDUCTOR_HOME`:
+
+1. Start visible parallel work with an explicit or inferred visible runtime request.
+2. Confirm the tool details include `runtimeMode`, `runtimeRuns`, `viewerCommand`, `logPath`, diagnostics/progress, and a cancellation affordance.
+3. Attach read-only with the reported tmux command, or confirm iTerm2 opens as a best-effort viewer on macOS.
+4. Cancel with `conductor_cancel_active_work({ reason: "smoke cleanup" })` or the returned `cancelTool` for a specific active run.
+5. Verify tmux sessions are gone, run/task state is terminal, logs remain under conductor storage, and reconciliation does not resurrect terminal runs or invent success.
 
 ### Inspect dependency scheduling for parallel-safe work
 

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -211,7 +211,7 @@ If the user interrupts or asks in natural language to stop conductor work, use `
 
 ### Local visible-runtime smoke
 
-The package test suite includes a real-tmux lifecycle smoke that skips when `tmux` is not installed. To exercise the full visible supervision flow manually on a machine with tmux, run:
+The package test suite includes a low-level real-tmux lifecycle smoke that skips when `tmux` is not installed. It verifies the terminal primitive used by visible supervision; the full conductor-visible runtime checklist remains the manual smoke below. On a machine with tmux, run:
 
 ```bash
 npx vitest run packages/pi-conductor/__tests__/package-smoke.test.ts packages/pi-conductor/__tests__/work-runtime-selection.test.ts

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -1080,7 +1080,7 @@ case "$*" in *has-session*) exit 1 ;; *) exit 0 ;; esac
     const binDir = mkdtempSync(join(tmpdir(), "fake-tmux-bin-"));
     writeFileSync(
       join(binDir, "tmux"),
-      "#!/bin/sh\ncase \"$*\" in *display-message*) printf 'zsh\\n' ;; *) exit 0 ;; esac\n",
+      "#!/bin/sh\ncase \"$*\" in *display-message*) printf 'vim\\n' ;; *) exit 0 ;; esac\n",
       { mode: 0o755 },
     );
     process.env.PATH = `${binDir}:${originalPath ?? ""}`;

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -542,6 +542,10 @@ describe("conductor service", () => {
     "show me current workers",
     "watch current worker status",
     "open current run output",
+    "open run output",
+    "tail run log",
+    "watch worker status",
+    "open logs",
     "what's running?",
     "are any workers active?",
     "current worker status",
@@ -558,6 +562,21 @@ describe("conductor service", () => {
     await expect(runWorkForRepo(repoDir, { request: "show run status", execute: false })).rejects.toThrow(
       /status-only requests/i,
     );
+
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.workers).toHaveLength(0);
+    expect(run.tasks).toHaveLength(0);
+    expect(run.runs).toHaveLength(0);
+  });
+
+  it("rejects status-only requests with explicit runtime before mutating conductor state", async () => {
+    await expect(
+      runWorkForRepo(repoDir, {
+        request: "show me current workers",
+        runtimeMode: "iterm-tmux",
+        tasks: [{ title: "Inspect workers", prompt: "Inspect current workers", writeScope: ["README.md"] }],
+      }),
+    ).rejects.toThrow(/status-only requests/i);
 
     const run = getOrCreateRunForRepo(repoDir);
     expect(run.workers).toHaveLength(0);

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -538,10 +538,15 @@ describe("conductor service", () => {
     expect(run.runs).toHaveLength(0);
   });
 
-  it("rejects status-only work-router requests before mutating conductor state", async () => {
-    await expect(runWorkForRepo(repoDir, { request: "show me current workers" })).rejects.toThrow(
-      /status-only requests/i,
-    );
+  it.each([
+    "show me current workers",
+    "watch current worker status",
+    "open current run output",
+    "what's running?",
+    "are any workers active?",
+    "current worker status",
+  ])("rejects status-only work-router requests before mutating conductor state: %s", async (request) => {
+    await expect(runWorkForRepo(repoDir, { request })).rejects.toThrow(/status-only requests/i);
 
     const run = getOrCreateRunForRepo(repoDir);
     expect(run.workers).toHaveLength(0);

--- a/packages/pi-conductor/__tests__/package-smoke.test.ts
+++ b/packages/pi-conductor/__tests__/package-smoke.test.ts
@@ -1,9 +1,34 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = join(__dirname, "..");
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function hasTmux(): boolean {
+  try {
+    execFileSync("tmux", ["-V"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function waitForFileText(path: string, expected: string): string {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      const text = readFileSync(path, "utf-8");
+      if (text.includes(expected)) return text;
+    }
+  }
+  return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
 
 function parseFrontmatter(markdown: string): Record<string, string> {
   const match = markdown.match(/^---\n([\s\S]*?)\n---/);
@@ -56,6 +81,35 @@ describe("pi-conductor package smoke", () => {
 
     expect(status).toBe(1);
     expect(output).toContain("Usage: pi-conductor-runner run --contract");
+  });
+
+  it.skipIf(!hasTmux())("smokes real tmux session lifecycle for visible supervision", () => {
+    const runtimeDir = mkdtempSync(join(tmpdir(), "pi-conductor-tmux-smoke-"));
+    const socketPath = join(runtimeDir, "tmux.sock");
+    const logPath = join(runtimeDir, "runner.log");
+    const sessionName = `pi-cond-smoke-${process.pid}-${Date.now()}`;
+    const script =
+      "require('node:fs').writeFileSync(process.argv[1], 'pi-conductor smoke start\\n'); setTimeout(() => {}, 30000);";
+    const command = `${shellQuote(process.execPath)} -e ${shellQuote(script)} ${shellQuote(logPath)}`;
+
+    try {
+      execFileSync("tmux", ["-S", socketPath, "new-session", "-d", "-s", sessionName, command]);
+      execFileSync("tmux", ["-S", socketPath, "has-session", "-t", sessionName]);
+
+      expect(waitForFileText(logPath, "pi-conductor smoke start")).toContain("pi-conductor smoke start");
+
+      execFileSync("tmux", ["-S", socketPath, "kill-session", "-t", sessionName]);
+      expect(() =>
+        execFileSync("tmux", ["-S", socketPath, "has-session", "-t", sessionName], { stdio: "ignore" }),
+      ).toThrow();
+    } finally {
+      try {
+        execFileSync("tmux", ["-S", socketPath, "kill-server"], { stdio: "ignore" });
+      } catch {
+        // Session may already be gone, which is the expected cleanup state.
+      }
+      rmSync(runtimeDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps skill guidance aligned with the conductor safety workflow", () => {

--- a/packages/pi-conductor/__tests__/package-smoke.test.ts
+++ b/packages/pi-conductor/__tests__/package-smoke.test.ts
@@ -1,31 +1,37 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, type StdioOptions } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { shellQuote } from "../extensions/tmux-runtime.js";
 
 const packageRoot = join(__dirname, "..");
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
+const TMUX_SMOKE_TIMEOUT_MS = 5_000;
 
 function hasTmux(): boolean {
   try {
-    execFileSync("tmux", ["-V"], { stdio: "ignore" });
+    execFileSync("tmux", ["-V"], { stdio: "ignore", timeout: TMUX_SMOKE_TIMEOUT_MS });
     return true;
   } catch {
     return false;
   }
 }
 
-function waitForFileText(path: string, expected: string): string {
+function runTmux(socketPath: string, args: string[], options: { stdio?: StdioOptions } = {}): void {
+  execFileSync("tmux", ["-S", socketPath, ...args], {
+    stdio: options.stdio ?? "pipe",
+    timeout: TMUX_SMOKE_TIMEOUT_MS,
+  });
+}
+
+async function waitForFileText(path: string, expected: string): Promise<string> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
     if (existsSync(path)) {
       const text = readFileSync(path, "utf-8");
       if (text.includes(expected)) return text;
     }
+    await new Promise((resolve) => setTimeout(resolve, 25));
   }
   return existsSync(path) ? readFileSync(path, "utf-8") : "";
 }
@@ -83,7 +89,7 @@ describe("pi-conductor package smoke", () => {
     expect(output).toContain("Usage: pi-conductor-runner run --contract");
   });
 
-  it.skipIf(!hasTmux())("smokes real tmux session lifecycle for visible supervision", () => {
+  it.skipIf(!hasTmux())("smokes raw tmux session lifecycle used by visible supervision", async () => {
     const runtimeDir = mkdtempSync(join(tmpdir(), "pi-conductor-tmux-smoke-"));
     const socketPath = join(runtimeDir, "tmux.sock");
     const logPath = join(runtimeDir, "runner.log");
@@ -93,18 +99,16 @@ describe("pi-conductor package smoke", () => {
     const command = `${shellQuote(process.execPath)} -e ${shellQuote(script)} ${shellQuote(logPath)}`;
 
     try {
-      execFileSync("tmux", ["-S", socketPath, "new-session", "-d", "-s", sessionName, command]);
-      execFileSync("tmux", ["-S", socketPath, "has-session", "-t", sessionName]);
+      runTmux(socketPath, ["new-session", "-d", "-s", sessionName, command]);
+      runTmux(socketPath, ["has-session", "-t", sessionName]);
 
-      expect(waitForFileText(logPath, "pi-conductor smoke start")).toContain("pi-conductor smoke start");
+      expect(await waitForFileText(logPath, "pi-conductor smoke start")).toContain("pi-conductor smoke start");
 
-      execFileSync("tmux", ["-S", socketPath, "kill-session", "-t", sessionName]);
-      expect(() =>
-        execFileSync("tmux", ["-S", socketPath, "has-session", "-t", sessionName], { stdio: "ignore" }),
-      ).toThrow();
+      runTmux(socketPath, ["kill-session", "-t", sessionName]);
+      expect(() => runTmux(socketPath, ["has-session", "-t", sessionName], { stdio: "ignore" })).toThrow();
     } finally {
       try {
-        execFileSync("tmux", ["-S", socketPath, "kill-server"], { stdio: "ignore" });
+        runTmux(socketPath, ["kill-server"], { stdio: "ignore" });
       } catch {
         // Session may already be gone, which is the expected cleanup state.
       }

--- a/packages/pi-conductor/__tests__/status.test.ts
+++ b/packages/pi-conductor/__tests__/status.test.ts
@@ -250,7 +250,7 @@ describe("formatRunStatus", () => {
       runtimeStatus: "aborted" as const,
       viewerStatus: "opened" as const,
       cleanupStatus: "failed" as const,
-      diagnostic: "tmux pane command verification failed before cancel: zsh",
+      diagnostic: "tmux pane command verification failed before cancel: vim",
       visibleRuns: "activeVisibleRuns: none",
       finished: true,
       cancel: false,

--- a/packages/pi-conductor/__tests__/tmux-cancel.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-cancel.test.ts
@@ -211,7 +211,7 @@ describe("tmux durable cancellation", () => {
   it("keeps workers out of the idle pool when tmux cleanup fails", async () => {
     tmuxMocks.cancelTmuxRuntime.mockResolvedValueOnce({
       cleanupStatus: "failed" as const,
-      diagnostic: "pane command verification failed before cancel: zsh",
+      diagnostic: "pane command verification failed before cancel: vim",
     });
     const started = await createPersistedTmuxRun();
 

--- a/packages/pi-conductor/__tests__/tmux-runtime.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-runtime.test.ts
@@ -28,6 +28,7 @@ class FakeTmuxAdapter implements TmuxCommandAdapter {
   failKill = false;
   failPs = false;
   replacedPaneCommand = false;
+  paneCurrentCommand = "node";
 
   async execFile(command: string, args: string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv }) {
     this.calls.push({ command, args, cwd: options?.cwd, env: options?.env });
@@ -38,7 +39,7 @@ class FakeTmuxAdapter implements TmuxCommandAdapter {
       throw new Error("can't find session: missing");
     }
     if (args.includes("display-message") && args.includes("#{pane_current_command}")) {
-      return { stdout: this.replacedPaneCommand ? "zsh\n" : "node\n", stderr: "" };
+      return { stdout: this.replacedPaneCommand ? "vim\n" : `${this.paneCurrentCommand}\n`, stderr: "" };
     }
     if (args.includes("display-message")) {
       return { stdout: "@42 %7 4242\n", stderr: "" };
@@ -737,6 +738,34 @@ describe("tmux conductor runtime", () => {
     expect(adapter.calls.some((call) => call.args.includes("kill-session"))).toBe(false);
   });
 
+  it("allows tmux shell wrapper commands during cancellation verification", async () => {
+    const adapter = new FakeTmuxAdapter();
+    adapter.paneCurrentCommand = "zsh";
+    const runtime: RunRuntimeMetadata = {
+      mode: "tmux",
+      status: "running",
+      sessionId: null,
+      cwd: repoDir,
+      command: "'node' '/tmp/pi-conductor-runner' 'run'",
+      contractPath: null,
+      nonceHash: null,
+      runnerPid: null,
+      processGroupId: null,
+      tmux: { socketPath: "/tmp/tmux.sock", sessionName: "owned", windowId: null, paneId: "%7" },
+      logPath: null,
+      viewerCommand: null,
+      viewerStatus: "pending",
+      diagnostics: [],
+      heartbeatAt: null,
+      cleanupStatus: "pending",
+      startedAt: null,
+      finishedAt: null,
+    };
+
+    await expect(cancelTmuxRuntime({ adapter, runtime })).resolves.toMatchObject({ cleanupStatus: "succeeded" });
+    expect(adapter.calls.some((call) => call.args.includes("kill-session"))).toBe(true);
+  });
+
   it("fails closed without killing when pane command verification differs", async () => {
     const adapter = new FakeTmuxAdapter();
     adapter.replacedPaneCommand = true;
@@ -1083,6 +1112,48 @@ describe("tmux conductor runtime", () => {
     expect(reconciled.workers[0]).toMatchObject({ lifecycle: "broken", recoverable: true });
     expect(reconciled.runs[0]).toMatchObject({ status: "stale", errorMessage: expect.stringContaining("runner pid") });
     expect(reconciled.runs[0]?.runtime.status).toBe("exited_error");
+  });
+
+  it("keeps tmux shell wrapper pane commands active during reconciliation", async () => {
+    const { worker, started } = await createStartedTask();
+    const adapter = new FakeTmuxAdapter();
+    const backend = createTmuxWorkerRunRuntimeBackend({
+      commandAdapter: adapter,
+      runnerCommand: ["node", "/tmp/pi-conductor-runner", "run"],
+      waitForCompletion: false,
+      randomHex: () => "f00df00df00df00df00df00df00df00d",
+    });
+    await backend.run({
+      repoRoot: repoDir,
+      worktreePath: worker.worktreePath ?? repoDir,
+      sessionFile: worker.sessionFile ?? join(repoDir, "session.jsonl"),
+      task: "Run in tmux",
+      taskContract: started.taskContract,
+      onRuntimeMetadata: async (metadata) => {
+        const { writeRun } = await import("../extensions/storage.js");
+        const latest = getOrCreateRunForRepo(repoDir);
+        writeRun({
+          ...latest,
+          runs: latest.runs.map((entry) =>
+            entry.runId === started.run.runId ? { ...entry, runtime: { ...entry.runtime, ...metadata } } : entry,
+          ),
+        });
+      },
+    });
+    const logPath = getOrCreateRunForRepo(repoDir).runs[0]?.runtime.logPath;
+    writeFileSync(logPath ?? join(repoDir, "missing-log-path"), "runner output\n", "utf-8");
+    adapter.paneCurrentCommand = "zsh";
+
+    const reconciled = await reconcileTmuxRuntimeForRepo({
+      repoRoot: repoDir,
+      runId: started.run.runId,
+      adapter,
+      now: "2026-04-27T00:00:00.000Z",
+    });
+
+    expect(reconciled.tasks[0]).toMatchObject({ state: "running", activeRunId: started.run.runId });
+    expect(reconciled.workers[0]).toMatchObject({ lifecycle: "running", recoverable: false });
+    expect(reconciled.runs[0]).toMatchObject({ status: "running", errorMessage: null });
   });
 
   it("reconciles a replaced tmux pane command to needs-review", async () => {

--- a/packages/pi-conductor/__tests__/work-runtime-selection.test.ts
+++ b/packages/pi-conductor/__tests__/work-runtime-selection.test.ts
@@ -12,6 +12,13 @@ describe("work runtime selection", () => {
     "show tmux sessions",
     "please show active terminals",
     "can you list current panes",
+    "check current workers",
+    "get current run status",
+    "what's running?",
+    "are any workers active?",
+    "current worker status",
+    "do I have active tmux sessions?",
+    "tail the active run log",
   ])("treats status-only wording as inspection: %s", (request) => {
     expect(isStatusOnlyWorkRequest(request)).toBe(true);
     expect(selectRuntimeModeForWork({ request })).toBeUndefined();
@@ -21,6 +28,10 @@ describe("work runtime selection", () => {
     ["Fix the typo in README.md", undefined],
     ["Run these independent shards in parallel and show me the workers", "iterm-tmux"],
     ["Open a terminal and run this task", "iterm-tmux"],
+    ["Open current run output and fix the failure", "iterm-tmux"],
+    ["Watch active workers run tests", "iterm-tmux"],
+    ["Open all terminals and run this task", "iterm-tmux"],
+    ["Open a terminal and run current task", "iterm-tmux"],
     ["Run this in tmux so I can watch it", "tmux"],
     ["Run this in iTerm so I can watch it", "iterm-tmux"],
     ["Run these shards without tmux", "headless"],

--- a/packages/pi-conductor/__tests__/work-runtime-selection.test.ts
+++ b/packages/pi-conductor/__tests__/work-runtime-selection.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isStatusOnlyWorkRequest, selectRuntimeModeForWork } from "../extensions/work-runtime-selection.js";
+
+describe("work runtime selection", () => {
+  it.each([
+    "show me current workers",
+    "show run status",
+    "inspect current run",
+    "list active task",
+    "watch current worker status",
+    "open current run output",
+    "show tmux sessions",
+    "please show active terminals",
+    "can you list current panes",
+  ])("treats status-only wording as inspection: %s", (request) => {
+    expect(isStatusOnlyWorkRequest(request)).toBe(true);
+    expect(selectRuntimeModeForWork({ request })).toBeUndefined();
+  });
+
+  it.each([
+    ["Fix the typo in README.md", undefined],
+    ["Run these independent shards in parallel and show me the workers", "iterm-tmux"],
+    ["Open a terminal and run this task", "iterm-tmux"],
+    ["Run this in tmux so I can watch it", "tmux"],
+    ["Run this in iTerm so I can watch it", "iterm-tmux"],
+    ["Run these shards without tmux", "headless"],
+    ["Run this but do not use iterm", "headless"],
+  ] as const)("selects expected runtime for execution wording: %s", (request, expected) => {
+    expect(isStatusOnlyWorkRequest(request)).toBe(false);
+    expect(selectRuntimeModeForWork({ request })).toBe(expected);
+  });
+
+  it("lets explicit runtime mode override natural-language inference", () => {
+    expect(
+      selectRuntimeModeForWork({
+        request: "show me current workers",
+        explicitRuntimeMode: "iterm-tmux",
+      }),
+    ).toBe("iterm-tmux");
+    expect(
+      selectRuntimeModeForWork({
+        request: "Run this in parallel and show me the workers",
+        explicitRuntimeMode: "headless",
+      }),
+    ).toBe("headless");
+  });
+});

--- a/packages/pi-conductor/__tests__/work-runtime-selection.test.ts
+++ b/packages/pi-conductor/__tests__/work-runtime-selection.test.ts
@@ -19,6 +19,10 @@ describe("work runtime selection", () => {
     "current worker status",
     "do I have active tmux sessions?",
     "tail the active run log",
+    "open run output",
+    "tail run log",
+    "watch worker status",
+    "open logs",
   ])("treats status-only wording as inspection: %s", (request) => {
     expect(isStatusOnlyWorkRequest(request)).toBe(true);
     expect(selectRuntimeModeForWork({ request })).toBeUndefined();
@@ -29,6 +33,7 @@ describe("work runtime selection", () => {
     ["Run these independent shards in parallel and show me the workers", "iterm-tmux"],
     ["Open a terminal and run this task", "iterm-tmux"],
     ["Open current run output and fix the failure", "iterm-tmux"],
+    ["Open run output and fix the failure", "iterm-tmux"],
     ["Watch active workers run tests", "iterm-tmux"],
     ["Open all terminals and run this task", "iterm-tmux"],
     ["Open a terminal and run current task", "iterm-tmux"],
@@ -41,18 +46,27 @@ describe("work runtime selection", () => {
     expect(selectRuntimeModeForWork({ request })).toBe(expected);
   });
 
-  it("lets explicit runtime mode override natural-language inference", () => {
+  it("lets explicit runtime mode override natural-language runtime inference for execution requests", () => {
     expect(
       selectRuntimeModeForWork({
-        request: "show me current workers",
-        explicitRuntimeMode: "iterm-tmux",
+        request: "Fix the typo in README.md",
+        explicitRuntimeMode: "tmux",
       }),
-    ).toBe("iterm-tmux");
+    ).toBe("tmux");
     expect(
       selectRuntimeModeForWork({
         request: "Run this in parallel and show me the workers",
         explicitRuntimeMode: "headless",
       }),
     ).toBe("headless");
+  });
+
+  it("does not treat explicit runtime mode as execution intent for status-only wording", () => {
+    expect(
+      selectRuntimeModeForWork({
+        request: "show me current workers",
+        explicitRuntimeMode: "iterm-tmux",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/pi-conductor/extensions/tmux-reconcile-policy.ts
+++ b/packages/pi-conductor/extensions/tmux-reconcile-policy.ts
@@ -3,12 +3,19 @@ import type { RunAttemptRecord, RunRecord } from "./types.js";
 
 export type TmuxReconciliationAction = "unchanged" | "lease_cleared" | "diagnostic" | "stale";
 
+function isTmuxShellWrapperCommand(command: string): boolean {
+  return /^(?:sh|bash|zsh|fish|dash|ash|ksh|csh|tcsh)$/i.test(command);
+}
+
 export function tmuxPaneCommandChanged(input: {
   recordedCommand: string | null;
   currentCommand: string | null;
 }): boolean {
   return Boolean(
-    input.currentCommand && input.recordedCommand && !input.recordedCommand.includes(input.currentCommand),
+    input.currentCommand &&
+      input.recordedCommand &&
+      !isTmuxShellWrapperCommand(input.currentCommand) &&
+      !input.recordedCommand.includes(input.currentCommand),
   );
 }
 

--- a/packages/pi-conductor/extensions/tmux-runtime.ts
+++ b/packages/pi-conductor/extensions/tmux-runtime.ts
@@ -12,7 +12,7 @@ import { createRunnerContract, hashRunnerNonce, writeRunnerContract } from "./ru
 import { markRunAttemptStale } from "./runtime-stale.js";
 import { releaseTerminalTmuxWorkerForRepo } from "./runtime-worker-release.js";
 import { getConductorProjectDir } from "./storage.js";
-import { applyTmuxReconciliationState } from "./tmux-reconcile-policy.js";
+import { applyTmuxReconciliationState, tmuxPaneCommandChanged } from "./tmux-reconcile-policy.js";
 import type {
   RunAttemptRecord,
   RunRecord,
@@ -384,7 +384,7 @@ export async function cancelTmuxRuntime(input: {
           diagnostic: `tmux pane command verification failed before cancel: ${message}`,
         };
       }
-      if (currentPaneCommand && !input.runtime.command.includes(currentPaneCommand)) {
+      if (tmuxPaneCommandChanged({ recordedCommand: input.runtime.command, currentCommand: currentPaneCommand })) {
         return {
           cleanupStatus: "failed",
           diagnostic: `tmux pane command verification differed before cancel: ${currentPaneCommand}`,

--- a/packages/pi-conductor/extensions/work-runtime-selection.ts
+++ b/packages/pi-conductor/extensions/work-runtime-selection.ts
@@ -11,8 +11,13 @@ function hasHeadlessRuntimeIntent(request: string): boolean {
 }
 
 function hasStatusOnlyIntent(request: string): boolean {
+  const startsWithInspectionVerb =
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(show|list|display|view|inspect|status)\b/i.test(request);
+  const startsWithViewerInspectionVerb =
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(watch|open)\b/i.test(request) &&
+    /\b(current|active|existing|all|status)\b/i.test(request);
   return (
-    /^(?:please\s+|can you\s+|could you\s+)?\s*(show|list|display|view|inspect|status)\b/i.test(request) &&
+    (startsWithInspectionVerb || startsWithViewerInspectionVerb) &&
     /\b(current|active|existing|all)?\s*(worker|workers|run|runs|task|tasks|project|status|session|sessions|pane|panes|terminal|terminals|tmux|iterm)\b/i.test(
       request,
     )

--- a/packages/pi-conductor/extensions/work-runtime-selection.ts
+++ b/packages/pi-conductor/extensions/work-runtime-selection.ts
@@ -30,7 +30,7 @@ function hasStatusOnlyIntent(request: string): boolean {
   const startsWithInspectionVerb =
     /^(?:please\s+|can you\s+|could you\s+)?\s*(show|list|display|view|inspect|status|check|get)\b/i.test(request);
   const startsWithViewerInspectionVerb =
-    /^(?:please\s+|can you\s+|could you\s+)?\s*(watch|open|tail)\s+(?:the\s+)?(?:current|active|existing|all|status)\b/i.test(
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(watch|open|tail)\s+(?:the\s+)?(?:(?:current|active|existing|all|status)\s+)?(worker|workers|run|runs|task|tasks|session|sessions|pane|panes|terminal|terminals|tmux|iterm|output|log|logs)\b/i.test(
       request,
     );
   const startsWithStatusQuestion =
@@ -67,12 +67,12 @@ export function selectRuntimeModeForWork(input: {
   request: string;
   explicitRuntimeMode?: RunRuntimeMode;
 }): RunRuntimeMode | undefined {
-  if (input.explicitRuntimeMode) {
-    return input.explicitRuntimeMode;
-  }
   const request = input.request.trim();
   if (!request || hasStatusOnlyIntent(request)) {
     return undefined;
+  }
+  if (input.explicitRuntimeMode) {
+    return input.explicitRuntimeMode;
   }
   if (hasHeadlessRuntimeIntent(request)) {
     return "headless";

--- a/packages/pi-conductor/extensions/work-runtime-selection.ts
+++ b/packages/pi-conductor/extensions/work-runtime-selection.ts
@@ -10,17 +10,44 @@ function hasHeadlessRuntimeIntent(request: string): boolean {
   );
 }
 
-function hasStatusOnlyIntent(request: string): boolean {
-  const startsWithInspectionVerb =
-    /^(?:please\s+|can you\s+|could you\s+)?\s*(show|list|display|view|inspect|status)\b/i.test(request);
-  const startsWithViewerInspectionVerb =
-    /^(?:please\s+|can you\s+|could you\s+)?\s*(watch|open)\b/i.test(request) &&
-    /\b(current|active|existing|all|status)\b/i.test(request);
+function hasStatusBlockingExecutionIntent(request: string): boolean {
   return (
-    (startsWithInspectionVerb || startsWithViewerInspectionVerb) &&
-    /\b(current|active|existing|all)?\s*(worker|workers|run|runs|task|tasks|project|status|session|sessions|pane|panes|terminal|terminals|tmux|iterm)\b/i.test(
+    /\b(start|execute|launch|implement|fix|build|ship|create|work on)\b/i.test(request) ||
+    /\bdo\s+(?:this|that|the\s+work|the\s+task|work|task)\b/i.test(request) ||
+    /^(?:please\s+|can you\s+|could you\s+)?\s*run\b/i.test(request) ||
+    /\b(?:and|then|to)\s+run\b/i.test(request) ||
+    /\bworkers?\s+run\b/i.test(request)
+  );
+}
+
+function hasStatusOnlyIntent(request: string): boolean {
+  if (hasStatusBlockingExecutionIntent(request)) {
+    return false;
+  }
+
+  const statusResource =
+    /\b(worker|workers|run|runs|running|task|tasks|project|status|session|sessions|pane|panes|terminal|terminals|tmux|iterm|output|log|logs)\b/i;
+  const startsWithInspectionVerb =
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(show|list|display|view|inspect|status|check|get)\b/i.test(request);
+  const startsWithViewerInspectionVerb =
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(watch|open|tail)\s+(?:the\s+)?(?:current|active|existing|all|status)\b/i.test(
       request,
-    )
+    );
+  const startsWithStatusQuestion =
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(what(?:'s| is)|what are|are there|are any|do i have|is there|is any)\b/i.test(
+      request,
+    );
+  const startsWithResourceStatus =
+    /^(?:please\s+|can you\s+|could you\s+)?\s*(?:the\s+)?(?:current|active|existing|all)\s+(worker|workers|run|runs|task|tasks|project|session|sessions|pane|panes|terminal|terminals|tmux|iterm)\b/i.test(
+      request,
+    );
+
+  return (
+    (startsWithInspectionVerb ||
+      startsWithViewerInspectionVerb ||
+      startsWithStatusQuestion ||
+      startsWithResourceStatus) &&
+    statusResource.test(request)
   );
 }
 


### PR DESCRIPTION
## Summary
- Add a table-driven runtime-selection phrase matrix for status-only, execution, visible supervision, explicit override, and negated runtime wording.
- Treat viewer-style status phrases like “watch current worker status” and “open current run output” as inspection instead of visible execution.
- Add a real-tmux package smoke that skips when tmux is unavailable and validates session launch/log/cleanup lifecycle.
- Document status-only guidance and local visible-runtime smoke steps in the pi-conductor README.

## Validation
- `npx vitest run packages/pi-conductor/__tests__/package-smoke.test.ts packages/pi-conductor/__tests__/work-runtime-selection.test.ts packages/pi-conductor/__tests__/planner-quality.test.ts --reporter=dot`
- `npx vitest run packages/pi-conductor/__tests__ --reporter=dot`
- `npx tsc --noEmit --project packages/pi-conductor/tsconfig.json`
- `npx biome ci packages/pi-conductor`
- `npm run check`
- `git diff --check`
- `specdocs_validate`