### PR TITLE
fix(pi-conductor): clean up startup failure work

### DIFF
--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -837,6 +837,108 @@ describe("conductor service", () => {
     expect(run.tasks.find((task) => task.taskId === unrelatedTask.taskId)).toMatchObject({ state: "assigned" });
   });
 
+  it("cancels a synchronously rejected parallel startup task", async () => {
+    const restorePath = forceTmuxAvailable();
+
+    let result: Awaited<ReturnType<typeof runParallelWorkForRepo>> | null = null;
+    try {
+      result = await runParallelWorkForRepo(
+        repoDir,
+        {
+          workerPrefix: "startup-sync",
+          runtimeMode: "tmux",
+          tasks: [{ title: "Startup sync shard", prompt: "Start sync shard" }],
+        },
+        undefined,
+        () => {
+          throw new Error("synchronous runtime startup failure");
+        },
+      );
+    } finally {
+      restorePath();
+    }
+    if (!result) throw new Error("expected parallel result");
+
+    expect(result.results).toMatchObject([{ status: "rejected", error: expect.stringContaining("synchronous") }]);
+    expect(result.canceledTasks).toHaveLength(1);
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
+  });
+
+  it("cancels a failed parallel startup task before a slow sibling settles", async () => {
+    const restorePath = forceTmuxAvailable();
+    let releaseSlowSibling: () => void = () => undefined;
+    const slowSibling = new Promise<void>((resolve) => {
+      releaseSlowSibling = resolve;
+    });
+
+    let resultPromise: Promise<Awaited<ReturnType<typeof runParallelWorkForRepo>>> | null = null;
+    try {
+      resultPromise = runParallelWorkForRepo(
+        repoDir,
+        {
+          workerPrefix: "startup-mixed",
+          runtimeMode: "tmux",
+          tasks: [
+            { title: "Startup slow shard", prompt: "Start slow shard" },
+            { title: "Startup rejected shard", prompt: "Start rejected shard" },
+          ],
+        },
+        undefined,
+        async (root, taskId) => {
+          const task = getOrCreateRunForRepo(root).tasks.find((entry) => entry.taskId === taskId);
+          if (task?.title === "Startup rejected shard") {
+            throw new Error("runtime disappeared before run start");
+          }
+          await slowSibling;
+          return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+        },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const beforeSlowSettles = getOrCreateRunForRepo(repoDir);
+      expect(beforeSlowSettles.tasks.find((task) => task.title === "Startup rejected shard")).toMatchObject({
+        state: "canceled",
+        activeRunId: null,
+      });
+      expect(beforeSlowSettles.tasks.find((task) => task.title === "Startup slow shard")).toMatchObject({
+        state: "assigned",
+        activeRunId: null,
+      });
+      releaseSlowSibling();
+      const result = await resultPromise;
+      expect(result.results.map((entry) => entry.status)).toEqual(["fulfilled", "rejected"]);
+      expect(result.canceledTasks).toHaveLength(1);
+    } finally {
+      releaseSlowSibling();
+      restorePath();
+    }
+  });
+
+  it("does not relabel active-run failures as pending startup cancellation", async () => {
+    const result = await runParallelWorkForRepo(
+      repoDir,
+      {
+        workerPrefix: "active-failure",
+        tasks: [{ title: "Active failure shard", prompt: "Start then fail" }],
+      },
+      undefined,
+      async (root, taskId) => {
+        const started = startTaskRunForRepo(root, { taskId });
+        cancelTaskRunForRepo(root, { runId: started.run.runId, reason: "runtime failed after run start" });
+        throw new Error("runtime failed after run start");
+      },
+    );
+
+    expect(result.results).toMatchObject([{ status: "rejected", error: expect.stringContaining("after run start") }]);
+    expect(result.canceledRuns).toHaveLength(1);
+    expect(result.canceledTasks).toHaveLength(1);
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.runs[0]).toMatchObject({ status: "aborted", errorMessage: "runtime failed after run start" });
+    expect(run.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
+  });
+
   it("cancels owned objective tasks when visible startup fails after high-level preflight", async () => {
     const unrelatedTask = createTaskForRepo(repoDir, { title: "Objective unrelated", prompt: "Keep draft" });
     const restorePath = forceTmuxAvailableThenUnavailable();

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -39,6 +39,33 @@ function forceTmuxAvailable(): () => void {
   return withFakeTmux("printf 'tmux 3.4\\n'");
 }
 
+function forceTmuxAvailableThenUnavailable(): () => void {
+  const originalPath = process.env.PATH;
+  const fakeBin = mkdtempSync(join(tmpdir(), "pi-conductor-fake-bin-"));
+  const stateFile = join(fakeBin, "tmux-count");
+  const fakeTmux = join(fakeBin, "tmux");
+  writeFileSync(
+    fakeTmux,
+    `#!/bin/sh
+count=$(cat '${stateFile}' 2>/dev/null || printf 0)
+count=$((count + 1))
+printf %s "$count" > '${stateFile}'
+if [ "$count" -eq 1 ]; then
+  printf 'tmux 3.4\\n'
+  exit 0
+fi
+exit 127
+`,
+    "utf-8",
+  );
+  chmodSync(fakeTmux, 0o755);
+  process.env.PATH = `${fakeBin}:${originalPath ?? ""}`;
+  return () => {
+    process.env.PATH = originalPath;
+    rmSync(fakeBin, { recursive: true, force: true });
+  };
+}
+
 function withFakeTmux(scriptBody: string): () => void {
   const originalPath = process.env.PATH;
   const fakeBin = mkdtempSync(join(tmpdir(), "pi-conductor-fake-bin-"));
@@ -730,6 +757,120 @@ describe("conductor service", () => {
     }
 
     expect(seenRuntimeMode).toBe("iterm-tmux");
+  });
+
+  it("cancels owned single-work tasks when runtime startup fails before creating a run", async () => {
+    const unrelatedWorker = await createWorkerForRepo(repoDir, "unrelated-worker");
+    const unrelatedTask = createTaskForRepo(repoDir, { title: "Unrelated", prompt: "Keep assigned" });
+    assignTaskForRepo(repoDir, unrelatedTask.taskId, unrelatedWorker.workerId);
+    const restorePath = forceTmuxAvailable();
+
+    try {
+      await expect(
+        runWorkForRepo(
+          repoDir,
+          {
+            request: "Fix one focused issue visibly",
+            runtimeMode: "tmux",
+            tasks: [{ title: "Startup single", prompt: "Start visibly", writeScope: ["README.md"] }],
+          },
+          undefined,
+          async () => {
+            throw new Error("runtime disappeared before run start");
+          },
+        ),
+      ).rejects.toThrow(/runtime disappeared/i);
+    } finally {
+      restorePath();
+    }
+
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks.find((task) => task.title === "Startup single")).toMatchObject({
+      state: "canceled",
+      activeRunId: null,
+    });
+    expect(run.tasks.find((task) => task.taskId === unrelatedTask.taskId)).toMatchObject({ state: "assigned" });
+    expect(run.workers.find((worker) => worker.workerId === unrelatedWorker.workerId)).toMatchObject({
+      lifecycle: "idle",
+      recoverable: false,
+    });
+  });
+
+  it("cancels owned parallel tasks when every runtime startup fails before creating runs", async () => {
+    const unrelatedWorker = await createWorkerForRepo(repoDir, "parallel-unrelated-worker");
+    const unrelatedTask = createTaskForRepo(repoDir, { title: "Parallel unrelated", prompt: "Keep assigned" });
+    assignTaskForRepo(repoDir, unrelatedTask.taskId, unrelatedWorker.workerId);
+    const restorePath = forceTmuxAvailable();
+
+    let result: Awaited<ReturnType<typeof runParallelWorkForRepo>> | null = null;
+    try {
+      result = await runParallelWorkForRepo(
+        repoDir,
+        {
+          workerPrefix: "startup-parallel",
+          runtimeMode: "tmux",
+          tasks: [
+            { title: "Startup shard one", prompt: "Start shard one" },
+            { title: "Startup shard two", prompt: "Start shard two" },
+          ],
+        },
+        undefined,
+        async () => {
+          throw new Error("runtime disappeared before run start");
+        },
+      );
+    } finally {
+      restorePath();
+    }
+    if (!result) throw new Error("expected parallel result");
+
+    expect(result.results.map((entry) => entry.status)).toEqual(["rejected", "rejected"]);
+    expect(result.canceledRuns).toEqual([]);
+    expect(result.canceledTasks).toHaveLength(2);
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks.filter((task) => task.title.startsWith("Startup shard")).map((task) => task.state)).toEqual([
+      "canceled",
+      "canceled",
+    ]);
+    expect(run.tasks.find((task) => task.taskId === unrelatedTask.taskId)).toMatchObject({ state: "assigned" });
+  });
+
+  it("cancels owned objective tasks when visible startup fails after high-level preflight", async () => {
+    const unrelatedTask = createTaskForRepo(repoDir, { title: "Objective unrelated", prompt: "Keep draft" });
+    const restorePath = forceTmuxAvailableThenUnavailable();
+
+    try {
+      await expect(
+        runWorkForRepo(repoDir, {
+          request: "Implement the visible feature, then verify it in tmux",
+          runtimeMode: "tmux",
+          tasks: [
+            { title: "Objective implement", prompt: "Implement visibly", writeScope: ["extensions/"] },
+            {
+              title: "Objective verify",
+              prompt: "Verify visibly",
+              writeScope: ["__tests__/"],
+              dependsOn: ["Objective implement"],
+            },
+          ],
+        }),
+      ).rejects.toThrow(/Runtime mode tmux unavailable|runtime mode tmux unavailable/i);
+    } finally {
+      restorePath();
+    }
+
+    const run = getOrCreateRunForRepo(repoDir);
+    expect(run.runs).toHaveLength(0);
+    expect(
+      run.tasks
+        .filter((task) => task.title === "Objective implement" || task.title === "Objective verify")
+        .map((task) => task.state),
+    ).toEqual(["canceled", "canceled"]);
+    expect(run.tasks.find((task) => task.taskId === unrelatedTask.taskId)).toMatchObject({
+      state: unrelatedTask.state,
+    });
   });
 
   it("routes independent scoped work items to parallel workers", async () => {

--- a/packages/pi-conductor/__tests__/scheduler.test.ts
+++ b/packages/pi-conductor/__tests__/scheduler.test.ts
@@ -14,11 +14,14 @@ import { writeRun } from "../extensions/storage.js";
 
 const runtimeTracking = vi.hoisted(() => ({
   runWorkerPromptInputs: [] as Array<{ signal?: AbortSignal | undefined }>,
+  preflightError: null as string | null,
 }));
 
 vi.mock("../extensions/runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../extensions/runtime.js")>();
-  const preflightWorkerRunRuntime = vi.fn(() => undefined);
+  const preflightWorkerRunRuntime = vi.fn(() => {
+    if (runtimeTracking.preflightError) throw new Error(runtimeTracking.preflightError);
+  });
   const runWorkerPromptRuntime = vi.fn(async (input) => {
     runtimeTracking.runWorkerPromptInputs.push(input);
     await input.onConductorComplete?.({
@@ -54,6 +57,7 @@ describe("conductor scheduler and async next action", () => {
     repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
     process.env.PI_CONDUCTOR_HOME = conductorHome;
     runtimeTracking.runWorkerPromptInputs.length = 0;
+    runtimeTracking.preflightError = null;
   });
 
   afterEach(() => {
@@ -237,6 +241,33 @@ describe("conductor scheduler and async next action", () => {
     expect(runtimeTracking.runWorkerPromptInputs[0]?.signal).not.toBe(controller.signal);
     expect(runtimeTracking.runWorkerPromptInputs[0]?.signal?.aborted).toBe(false);
     expect(task).toBeTruthy();
+  });
+
+  it("cancels assigned objective tasks when runtime preflight fails before run start", async () => {
+    const objective = createObjectiveForRepo(repoRoot, { title: "Objective", prompt: "Prompt" });
+    const task = createTaskForRepo(repoRoot, {
+      title: "Run me",
+      prompt: "Do work",
+      objectiveId: objective.objectiveId,
+    });
+    const unrelated = addUsableWorkerAndAssignedTask();
+    runtimeTracking.preflightError = "runtime disappeared before active run";
+
+    await expect(
+      scheduleObjectiveForRepo(repoRoot, {
+        objectiveId: objective.objectiveId,
+        maxConcurrency: 1,
+        executeRuns: true,
+      }),
+    ).rejects.toThrow(/runtime disappeared/i);
+
+    const run = getOrCreateRunForRepo(repoRoot);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks.find((entry) => entry.taskId === task.taskId)).toMatchObject({
+      state: "canceled",
+      activeRunId: null,
+    });
+    expect(run.tasks.find((entry) => entry.taskId === unrelated.taskId)).toMatchObject({ state: "assigned" });
   });
 
   it("scheduler ticks skip model execution unless explicitly enabled", async () => {

--- a/packages/pi-conductor/__tests__/scheduler.test.ts
+++ b/packages/pi-conductor/__tests__/scheduler.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  assignTaskForRepo,
   createObjectiveForRepo,
   createTaskForRepo,
   getOrCreateRunForRepo,
@@ -243,6 +244,35 @@ describe("conductor scheduler and async next action", () => {
     expect(task).toBeTruthy();
   });
 
+  it("cancels run-next-action tasks when runtime preflight fails before run start", async () => {
+    const task = addUsableWorkerAndAssignedTask();
+    runtimeTracking.preflightError = "runtime disappeared before active run";
+
+    await expect(runNextActionForRepo(repoRoot, { executeRuns: true })).rejects.toThrow(/runtime disappeared/i);
+
+    const run = getOrCreateRunForRepo(repoRoot);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks.find((entry) => entry.taskId === task.taskId)).toMatchObject({
+      state: "canceled",
+      activeRunId: null,
+    });
+  });
+
+  it("cancels scheduler tick run-task actions when runtime preflight fails before run start", async () => {
+    const task = addUsableWorkerAndAssignedTask();
+    runtimeTracking.preflightError = "runtime disappeared before active run";
+
+    await expect(schedulerTickForRepo(repoRoot, { policy: "execute" })).rejects.toThrow(/runtime disappeared/i);
+
+    const run = getOrCreateRunForRepo(repoRoot);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks.find((entry) => entry.taskId === task.taskId)).toMatchObject({
+      state: "canceled",
+      activeRunId: null,
+    });
+    expect(run.events.at(-1)).toMatchObject({ type: "scheduler.tick_failed" });
+  });
+
   it("cancels assigned objective tasks when runtime preflight fails before run start", async () => {
     const objective = createObjectiveForRepo(repoRoot, { title: "Objective", prompt: "Prompt" });
     const task = createTaskForRepo(repoRoot, {
@@ -265,6 +295,34 @@ describe("conductor scheduler and async next action", () => {
     expect(run.runs).toHaveLength(0);
     expect(run.tasks.find((entry) => entry.taskId === task.taskId)).toMatchObject({
       state: "canceled",
+      activeRunId: null,
+    });
+    expect(run.tasks.find((entry) => entry.taskId === unrelated.taskId)).toMatchObject({ state: "assigned" });
+  });
+
+  it("does not cancel pre-existing assigned objective tasks on runtime preflight failure", async () => {
+    const objective = createObjectiveForRepo(repoRoot, { title: "Objective", prompt: "Prompt" });
+    const task = createTaskForRepo(repoRoot, {
+      title: "Already assigned",
+      prompt: "Do work",
+      objectiveId: objective.objectiveId,
+    });
+    const unrelated = addUsableWorkerAndAssignedTask();
+    assignTaskForRepo(repoRoot, task.taskId, "worker-1");
+    runtimeTracking.preflightError = "runtime disappeared before active run";
+
+    await expect(
+      scheduleObjectiveForRepo(repoRoot, {
+        objectiveId: objective.objectiveId,
+        maxConcurrency: 1,
+        executeRuns: true,
+      }),
+    ).rejects.toThrow(/runtime disappeared/i);
+
+    const run = getOrCreateRunForRepo(repoRoot);
+    expect(run.runs).toHaveLength(0);
+    expect(run.tasks.find((entry) => entry.taskId === task.taskId)).toMatchObject({
+      state: "assigned",
       activeRunId: null,
     });
     expect(run.tasks.find((entry) => entry.taskId === unrelated.taskId)).toMatchObject({ state: "assigned" });

--- a/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
+++ b/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
@@ -15,6 +15,7 @@ import conductorExtension from "../extensions/index.js";
 
 type RegisteredTool = {
   name: string;
+  description?: string;
   parameters?: unknown;
   execute?: (
     toolCallId: string,
@@ -63,6 +64,12 @@ describe("conductor runtime-mode tool contracts", () => {
     delete process.env.PI_CONDUCTOR_HOME;
     if (existsSync(repoDir)) rmSync(repoDir, { recursive: true, force: true });
     if (existsSync(conductorHome)) rmSync(conductorHome, { recursive: true, force: true });
+  });
+
+  it("documents parallel pre-run startup cancellation semantics", () => {
+    const tool = collectTools().find((entry) => entry.name === "conductor_run_parallel_work");
+
+    expect(tool?.description).toContain("fails before active run creation");
   });
 
   it("forwards runtimeMode through registered start, run, retry, and delegate tools", async () => {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -605,12 +605,20 @@ async function executeConductorAction(
     if (!input.executeRuns) {
       return { executed: false, reason: "run execution disabled by scheduler policy", action, result: null };
     }
-    return {
-      executed: true,
-      reason: null,
-      action,
-      result: await runTaskForRepo(repoRoot, action.toolCall.params.taskId, signal),
-    };
+    try {
+      return {
+        executed: true,
+        reason: null,
+        action,
+        result: await runTaskForRepo(repoRoot, action.toolCall.params.taskId, signal),
+      };
+    } catch (error) {
+      cancelPendingStartupFailureForRepo(repoRoot, {
+        reason: `Conductor run_task failed before run start: ${errorMessage(error)}`,
+        taskIds: [action.toolCall.params.taskId],
+      });
+      throw error;
+    }
   }
   if (action.kind === "retry_task" && typeof action.toolCall?.params.taskId === "string") {
     return {
@@ -693,6 +701,7 @@ export async function scheduleObjectiveForRepo(
     (worker) => worker.lifecycle === "idle" && !worker.recoverable && worker.worktreePath && worker.sessionFile,
   );
   const assigned: TaskRecord[] = [];
+  const assignedByThisCall = new Set<string>();
   const executed: Array<{ taskId: string; result: unknown }> = [];
   const skipped: string[] = [];
   for (const task of runnableTasks) {
@@ -705,6 +714,7 @@ export async function scheduleObjectiveForRepo(
       }
       schedulableTask = assignTaskForRepo(repoRoot, task.taskId, worker.workerId);
       assigned.push(schedulableTask);
+      assignedByThisCall.add(schedulableTask.taskId);
     }
     if (schedulerPolicy.executeRuns) {
       try {
@@ -713,11 +723,12 @@ export async function scheduleObjectiveForRepo(
         });
         executed.push({ taskId: schedulableTask.taskId, result });
       } catch (error) {
-        cancelPendingWorkForRepo(repoRoot, {
-          reason: `Objective scheduling failed before run start: ${errorMessage(error)}`,
-          taskIds: new Set([schedulableTask.taskId]),
-          workerIds: new Set(),
-        });
+        if (assignedByThisCall.has(schedulableTask.taskId)) {
+          cancelPendingStartupFailureForRepo(repoRoot, {
+            reason: `Objective scheduling failed before run start: ${errorMessage(error)}`,
+            taskIds: [schedulableTask.taskId],
+          });
+        }
         throw error;
       }
     }
@@ -1239,22 +1250,19 @@ export async function runParallelWorkForRepo(
     }
     const settled = await Promise.allSettled(
       tasks.map((task, index) =>
-        runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode }),
+        Promise.resolve()
+          .then(() => runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode }))
+          .catch((error) => {
+            applyCanceledWork(
+              cancelPendingStartupFailureForRepo(repoRoot, {
+                reason: "Parent conductor parallel work failed before run start",
+                taskIds: [task.taskId],
+              }),
+            );
+            throw error;
+          }),
       ),
     );
-    const rejectedTaskIds = settled
-      .map((entry, index) => (entry.status === "rejected" ? tasks[index]?.taskId : null))
-      .filter((taskId): taskId is string => Boolean(taskId));
-    if (rejectedTaskIds.length > 0) {
-      applyCanceledWork({
-        canceledRuns: [],
-        canceledTasks: cancelPendingWorkForRepo(repoRoot, {
-          reason: "Parent conductor parallel work failed before run start",
-          taskIds: new Set(rejectedTaskIds),
-          workerIds: new Set(),
-        }).canceledTasks,
-      });
-    }
     if (signal?.aborted) await requestCancelOwnedWork();
     await Promise.allSettled(pendingCancellations);
     collectOwnedCanceledWork();
@@ -1394,10 +1402,9 @@ export async function runWorkForRepo(
           )
         : null;
     } catch (error) {
-      cancelPendingWorkForRepo(repoRoot, {
+      cancelPendingStartupFailureForRepo(repoRoot, {
         reason: `Parent conductor objective work failed before run start: ${errorMessage(error)}`,
-        taskIds: new Set(planned.tasks.map((task) => task.taskId)),
-        workerIds: new Set(),
+        taskIds: planned.tasks.map((task) => task.taskId),
       });
       throw error;
     }
@@ -1452,10 +1459,10 @@ export async function runWorkForRepo(
     try {
       result = await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode });
     } catch (error) {
-      cancelPendingWorkForRepo(repoRoot, {
+      cancelPendingStartupFailureForRepo(repoRoot, {
         reason: `Parent conductor work failed before run start: ${errorMessage(error)}`,
-        taskIds: new Set([delegated.task.taskId]),
-        workerIds: new Set([delegated.worker.workerId]),
+        taskIds: [delegated.task.taskId],
+        workerIds: [delegated.worker.workerId],
       });
       throw error;
     }
@@ -1469,6 +1476,20 @@ export async function runWorkForRepo(
     objective: null,
     runtimeMode,
     runtimeRuns: summarizeRunWorkRuntime(repoRoot, [delegated.task.taskId]),
+  };
+}
+
+function cancelPendingStartupFailureForRepo(
+  repoRoot: string,
+  input: { reason: string; taskIds: string[]; workerIds?: string[] },
+): { canceledRuns: string[]; canceledTasks: string[] } {
+  return {
+    canceledRuns: [],
+    canceledTasks: cancelPendingWorkForRepo(repoRoot, {
+      reason: input.reason,
+      taskIds: new Set(input.taskIds),
+      workerIds: new Set(input.workerIds ?? []),
+    }).canceledTasks,
   };
 }
 

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -707,8 +707,19 @@ export async function scheduleObjectiveForRepo(
       assigned.push(schedulableTask);
     }
     if (schedulerPolicy.executeRuns) {
-      const result = await runTaskForRepo(repoRoot, schedulableTask.taskId, signal, { runtimeMode: input.runtimeMode });
-      executed.push({ taskId: schedulableTask.taskId, result });
+      try {
+        const result = await runTaskForRepo(repoRoot, schedulableTask.taskId, signal, {
+          runtimeMode: input.runtimeMode,
+        });
+        executed.push({ taskId: schedulableTask.taskId, result });
+      } catch (error) {
+        cancelPendingWorkForRepo(repoRoot, {
+          reason: `Objective scheduling failed before run start: ${errorMessage(error)}`,
+          taskIds: new Set([schedulableTask.taskId]),
+          workerIds: new Set(),
+        });
+        throw error;
+      }
     }
   }
   return { objectiveId: input.objectiveId ?? null, assigned, executed, skipped };
@@ -1231,6 +1242,19 @@ export async function runParallelWorkForRepo(
         runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode }),
       ),
     );
+    const rejectedTaskIds = settled
+      .map((entry, index) => (entry.status === "rejected" ? tasks[index]?.taskId : null))
+      .filter((taskId): taskId is string => Boolean(taskId));
+    if (rejectedTaskIds.length > 0) {
+      applyCanceledWork({
+        canceledRuns: [],
+        canceledTasks: cancelPendingWorkForRepo(repoRoot, {
+          reason: "Parent conductor parallel work failed before run start",
+          taskIds: new Set(rejectedTaskIds),
+          workerIds: new Set(),
+        }).canceledTasks,
+      });
+    }
     if (signal?.aborted) await requestCancelOwnedWork();
     await Promise.allSettled(pendingCancellations);
     collectOwnedCanceledWork();
@@ -1355,18 +1379,28 @@ export async function runWorkForRepo(
         workers = [await createWorkerForRepo(repoRoot, `${workerPrefix}-objective-1`)];
       }
     }
-    const schedule = execute
-      ? await scheduleObjectiveForRepo(
-          repoRoot,
-          {
-            objectiveId: objective.objectiveId,
-            policy: "execute",
-            maxConcurrency: input.maxWorkers,
-            runtimeMode,
-          },
-          signal,
-        )
-      : null;
+    let schedule: Awaited<ReturnType<typeof scheduleObjectiveForRepo>> | null = null;
+    try {
+      schedule = execute
+        ? await scheduleObjectiveForRepo(
+            repoRoot,
+            {
+              objectiveId: objective.objectiveId,
+              policy: "execute",
+              maxConcurrency: input.maxWorkers,
+              runtimeMode,
+            },
+            signal,
+          )
+        : null;
+    } catch (error) {
+      cancelPendingWorkForRepo(repoRoot, {
+        reason: `Parent conductor objective work failed before run start: ${errorMessage(error)}`,
+        taskIds: new Set(planned.tasks.map((task) => task.taskId)),
+        workerIds: new Set(),
+      });
+      throw error;
+    }
     const scheduledWorkerIds = new Set(schedule?.assigned.map((task) => task.assignedWorkerId).filter(Boolean));
     return {
       decision,
@@ -1413,7 +1447,19 @@ export async function runWorkForRepo(
       runtimeRuns: summarizeRunWorkRuntime(repoRoot, [delegated.task.taskId]),
     };
   }
-  const result = execute ? await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode }) : null;
+  let result: WorkerRunResult | null = null;
+  if (execute) {
+    try {
+      result = await runner(repoRoot, delegated.task.taskId, signal, { runtimeMode });
+    } catch (error) {
+      cancelPendingWorkForRepo(repoRoot, {
+        reason: `Parent conductor work failed before run start: ${errorMessage(error)}`,
+        taskIds: new Set([delegated.task.taskId]),
+        workerIds: new Set([delegated.worker.workerId]),
+      });
+      throw error;
+    }
+  }
   return {
     decision,
     workers: [delegated.worker],

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -63,7 +63,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
     name: "conductor_run_parallel_work",
     label: "Conductor Run Parallel Work",
     description:
-      "Autonomously split a natural-language request into parallel conductor worker tasks, run them under one foreground orchestration boundary, and cancel owned runs/tasks if the user interrupts with Escape",
+      "Autonomously split a natural-language request into parallel conductor worker tasks, run them under one foreground orchestration boundary, and cancel owned runs/tasks if the user interrupts with Escape or a task fails before active run creation",
     parameters: Type.Object({
       tasks: Type.Array(
         Type.Object({
@@ -86,9 +86,11 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       const result = await conductor.runParallelWorkForRepo(ctx.cwd, params, signal);
       const completed = result.results.filter((entry) => entry.result?.status === "success").length;
       const runtimeText = `runtime=${result.runtimeMode}${result.runtimeRuns.length > 0 ? ` runs=${result.runtimeRuns.length}` : ""}`;
+      const canceledText =
+        result.canceledTasks.length > 0 ? `; canceled ${result.canceledTasks.length} pre-run task(s)` : "";
       const text = signal?.aborted
         ? `interrupted parallel conductor work with ${runtimeText}; canceled ${result.canceledRuns.length} active run(s) and ${result.canceledTasks.length} task(s)`
-        : `ran ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${completed} succeeded, ${result.results.length - completed} need follow-up`;
+        : `ran ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${completed} succeeded, ${result.results.length - completed} need follow-up${canceledText}`;
       return { content: [{ type: "text", text }], details: result };
     },
   });


### PR DESCRIPTION
## Summary
- Cancel conductor-owned pending single-work tasks when runtime startup fails before an active run is created.
- Cancel failed parallel startup tasks and report their canceled task IDs without touching unrelated pre-existing work.
- Clean up owned objective tasks when visible startup disappears after high-level preflight, and add scheduler-level cleanup for objective task preflight failures.

## Validation
- `npx vitest run packages/pi-conductor/__tests__/conductor.test.ts packages/pi-conductor/__tests__/scheduler.test.ts --reporter=dot`
- `npx vitest run packages/pi-conductor/__tests__ --reporter=dot`
- `npx tsc --noEmit --project packages/pi-conductor/tsconfig.json`
- `npx biome ci packages/pi-conductor`
- `npm run check`
- `git diff --check`
- `specdocs_validate`