### PR TITLE
feat: prefer non-blocking tmux for parallel conductor work

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -148,7 +148,9 @@ Optional backend adapters such as `pi-subagents` may be used later, but they do 
 
 ### Supervised visible runtime
 
-Run tools accept `runtimeMode: "headless" | "tmux" | "iterm-tmux"`. `headless` remains the default. `tmux` launches the conductor runner in a private tmux session and records the attach command, runtime log path, heartbeat, diagnostics, and cleanup state on the durable run. `iterm-tmux` uses the same tmux control plane and best-effort opens iTerm2 as a viewer on macOS; if iTerm2 is unavailable or launch fails, the tmux run remains active and status output shows a warning plus the manual read-only attach command.
+Run tools accept `runtimeMode: "headless" | "tmux" | "iterm-tmux"`. `headless` runs in-process and waits for completion. `tmux` launches the conductor runner in a private tmux session and records the attach command, runtime log path, heartbeat, diagnostics, and cleanup state on the durable run. `iterm-tmux` uses the same tmux control plane and best-effort opens iTerm2 as a viewer on macOS; if iTerm2 is unavailable or launch fails, the tmux run remains active and status output shows a warning plus the manual read-only attach command.
+
+Default runtime selection depends on the entry point. `conductor_run_work` stays conservative and defaults ordinary work to `headless` unless the request clearly asks to show/watch/open workers or an explicit `runtimeMode` is provided. Direct `conductor_run_parallel_work` is a lower-level parallel-safe primitive; when its `runtimeMode` is omitted, it prefers non-blocking `tmux` if tmux is available so the parent session can keep accepting natural-language inspection/cancel requests after launch, and falls back to blocking `headless` when tmux is unavailable. Pass `runtimeMode: "headless"` to `conductor_run_parallel_work` when the caller needs the old wait-for-completion behavior.
 
 Use conductor status tools rather than typing into worker panes to supervise work. Active visible runs include:
 
@@ -196,10 +198,24 @@ The router is conservative. It splits only when work items are independent, have
 
 Runtime mode selection is also conservative. Explicit `runtimeMode` wins. If omitted, normal work defaults to `headless`, while unambiguous execution requests such as “run these shards in parallel and show/watch/open the workers” infer `iterm-tmux`. Status-only phrases such as “show me current workers” do not infer visible execution; use status/list tools for inspection. Inferred visible runs still fail closed when tmux is unavailable and return runtime summaries with viewer/log/cancel details when runs are created.
 
-`conductor_run_parallel_work` remains the lower-level primitive for callers that already made a parallel-safe decision:
+`conductor_run_parallel_work` remains the lower-level primitive for callers that already made a parallel-safe decision. Omitting `runtimeMode` launches supervised tmux workers when available and returns after launch; the durable runs continue in conductor state and can be inspected or canceled by follow-up natural-language requests:
 
 ```text
 conductor_run_parallel_work({
+  tasks: [
+    { title: "Backend shard", prompt: "Implement and verify the backend changes" },
+    { title: "Tests shard", prompt: "Add focused regression tests and report evidence" }
+  ]
+})
+conductor_project_brief({ maxActions: 10, recentEventLimit: 20 })
+conductor_list_runs({ status: "running" })
+```
+
+For blocking completion semantics, request headless explicitly:
+
+```text
+conductor_run_parallel_work({
+  runtimeMode: "headless",
   tasks: [
     { title: "Backend shard", prompt: "Implement and verify the backend changes" },
     { title: "Tests shard", prompt: "Add focused regression tests and report evidence" }

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -514,6 +514,7 @@ describe("conductor service", () => {
       );
 
       expect(result.runtimeMode).toBe("tmux");
+      expect(result.results.map((entry) => entry.executionState)).toEqual(["launched", "launched"]);
       expect(seenOptions).toEqual([
         { runtimeMode: "tmux", waitForCompletion: false },
         { runtimeMode: "tmux", waitForCompletion: false },
@@ -542,6 +543,7 @@ describe("conductor service", () => {
       );
 
       expect(result.runtimeMode).toBe("headless");
+      expect(result.results.map((entry) => entry.executionState)).toEqual(["completed"]);
       expect(seenOptions).toEqual([{ runtimeMode: "headless", waitForCompletion: true }]);
     } finally {
       restorePath();

--- a/packages/pi-conductor/__tests__/conductor.test.ts
+++ b/packages/pi-conductor/__tests__/conductor.test.ts
@@ -486,6 +486,68 @@ describe("conductor service", () => {
     expect(seenRuntimeModes).toEqual(["tmux", "tmux"]);
   });
 
+  it("defaults direct parallel work to non-blocking tmux when tmux is available", async () => {
+    const restorePath = forceTmuxAvailable();
+    const seenOptions: Array<{ runtimeMode?: string; waitForCompletion?: boolean }> = [];
+
+    try {
+      const result = await runParallelWorkForRepo(
+        repoDir,
+        {
+          workerPrefix: "parallel",
+          tasks: [
+            { title: "First shard", prompt: "Do first shard" },
+            { title: "Second shard", prompt: "Do second shard" },
+          ],
+        },
+        undefined,
+        async (_root, taskId, _signal, options) => {
+          seenOptions.push(options ?? {});
+          return {
+            workerName: taskId,
+            status: "success",
+            finalText: "launched",
+            errorMessage: null,
+            sessionId: taskId,
+          };
+        },
+      );
+
+      expect(result.runtimeMode).toBe("tmux");
+      expect(seenOptions).toEqual([
+        { runtimeMode: "tmux", waitForCompletion: false },
+        { runtimeMode: "tmux", waitForCompletion: false },
+      ]);
+    } finally {
+      restorePath();
+    }
+  });
+
+  it("falls back direct parallel work to headless when tmux is unavailable", async () => {
+    const restorePath = forceTmuxUnavailable();
+    const seenOptions: Array<{ runtimeMode?: string; waitForCompletion?: boolean }> = [];
+
+    try {
+      const result = await runParallelWorkForRepo(
+        repoDir,
+        {
+          workerPrefix: "parallel",
+          tasks: [{ title: "Only shard", prompt: "Do only shard" }],
+        },
+        undefined,
+        async (_root, taskId, _signal, options) => {
+          seenOptions.push(options ?? {});
+          return { workerName: taskId, status: "success", finalText: "done", errorMessage: null, sessionId: null };
+        },
+      );
+
+      expect(result.runtimeMode).toBe("headless");
+      expect(seenOptions).toEqual([{ runtimeMode: "headless", waitForCompletion: true }]);
+    } finally {
+      restorePath();
+    }
+  });
+
   it("fails direct visible parallel runtime preflight before creating workers or tasks", async () => {
     const restorePath = forceTmuxUnavailable();
     try {

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -235,6 +235,29 @@ describe("durable task run flows", () => {
     expect(persisted.workers[0]).toMatchObject({ lifecycle: "running", recoverable: false });
   });
 
+  it("does not leave non-blocking tmux runs active when launch aborts", async () => {
+    const worker = await createWorkerForRepo(repoDir, "tmux-detached-abort");
+    const task = createTaskForRepo(repoDir, { title: "Tmux detached abort", prompt: "Abort launch" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    runtimeMocks.runWorkerPromptRuntime.mockResolvedValueOnce({
+      status: "aborted",
+      finalText: null,
+      errorMessage: null,
+      sessionId: null,
+    });
+
+    const result = await runTaskForRepo(repoDir, task.taskId, undefined, {
+      runtimeMode: "tmux",
+      waitForCompletion: false,
+    });
+
+    expect(result.status).toBe("aborted");
+    const persisted = getOrCreateRunForRepo(repoDir);
+    expect(persisted.runs[0]).toMatchObject({ status: "aborted", finishedAt: expect.any(String) });
+    expect(persisted.tasks[0]).toMatchObject({ state: "canceled", activeRunId: null });
+    expect(persisted.workers[0]).toMatchObject({ lifecycle: "idle", recoverable: false });
+  });
+
   it("releases tmux workers when the runtime returns an aborted result", async () => {
     const worker = await createWorkerForRepo(repoDir, "tmux-abort");
     const task = createTaskForRepo(repoDir, { title: "Tmux abort", prompt: "Abort visibly" });

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -212,6 +212,29 @@ describe("durable task run flows", () => {
     expect(content.diagnostic).toBe("Artifact file is missing");
   });
 
+  it("leaves tmux runs active when launched without waiting for completion", async () => {
+    const worker = await createWorkerForRepo(repoDir, "tmux-detached");
+    const task = createTaskForRepo(repoDir, { title: "Tmux detached", prompt: "Launch visibly" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    runtimeMocks.runWorkerPromptRuntime.mockResolvedValueOnce({
+      status: "success",
+      finalText: "tmux runtime launched",
+      errorMessage: null,
+      sessionId: "tmux-session-1",
+    });
+
+    const result = await runTaskForRepo(repoDir, task.taskId, undefined, {
+      runtimeMode: "tmux",
+      waitForCompletion: false,
+    });
+
+    expect(result.status).toBe("success");
+    const persisted = getOrCreateRunForRepo(repoDir);
+    expect(persisted.runs[0]).toMatchObject({ status: "running", finishedAt: null, runtime: { mode: "tmux" } });
+    expect(persisted.tasks[0]).toMatchObject({ state: "running", activeRunId: persisted.runs[0]?.runId });
+    expect(persisted.workers[0]).toMatchObject({ lifecycle: "running", recoverable: false });
+  });
+
   it("releases tmux workers when the runtime returns an aborted result", async () => {
     const worker = await createWorkerForRepo(repoDir, "tmux-abort");
     const task = createTaskForRepo(repoDir, { title: "Tmux abort", prompt: "Abort visibly" });

--- a/packages/pi-conductor/__tests__/tmux-runtime.test.ts
+++ b/packages/pi-conductor/__tests__/tmux-runtime.test.ts
@@ -27,6 +27,7 @@ class FakeTmuxAdapter implements TmuxCommandAdapter {
   failHasSession = false;
   failKill = false;
   failPs = false;
+  failPaneMetadata = false;
   replacedPaneCommand = false;
   paneCurrentCommand = "node";
 
@@ -42,6 +43,9 @@ class FakeTmuxAdapter implements TmuxCommandAdapter {
       return { stdout: this.replacedPaneCommand ? "vim\n" : `${this.paneCurrentCommand}\n`, stderr: "" };
     }
     if (args.includes("display-message")) {
+      if (this.failPaneMetadata) {
+        throw new Error("pane metadata unavailable");
+      }
       return { stdout: "@42 %7 4242\n", stderr: "" };
     }
     if (command === "ps") {
@@ -172,6 +176,43 @@ describe("tmux conductor runtime", () => {
     expect(contractContent).not.toContain("abc123def4567890abc123def4567890");
     expect(existsSync(persisted?.runtime.logPath ?? "")).toBe(true);
     expect(statSync(persisted?.runtime.logPath ?? "").mode & 0o777).toBe(0o600);
+  });
+
+  it("fails non-blocking tmux launch when pane metadata cannot be verified", async () => {
+    const { worker, started } = await createStartedTask();
+    const adapter = new FakeTmuxAdapter();
+    adapter.failPaneMetadata = true;
+    const backend = createTmuxWorkerRunRuntimeBackend({
+      commandAdapter: adapter,
+      runnerCommand: ["node", "/tmp/pi-conductor-runner", "run"],
+      waitForCompletion: false,
+      randomHex: () => "abc123def4567890abc123def4567890",
+      now: () => "2026-04-27T00:00:00.000Z",
+    });
+
+    const result = await backend.run({
+      repoRoot: repoDir,
+      worktreePath: worker.worktreePath ?? repoDir,
+      sessionFile: worker.sessionFile ?? join(repoDir, "session.jsonl"),
+      task: "Run in tmux",
+      taskContract: started.taskContract,
+      onRuntimeMetadata: async (metadata) => {
+        const latest = getOrCreateRunForRepo(repoDir);
+        const { writeRun } = await import("../extensions/storage.js");
+        writeRun({
+          ...latest,
+          runs: latest.runs.map((entry) =>
+            entry.runId === started.run.runId ? { ...entry, runtime: { ...entry.runtime, ...metadata } } : entry,
+          ),
+        });
+      },
+    });
+
+    expect(result).toMatchObject({ status: "error", errorMessage: expect.stringContaining("pane metadata") });
+    expect(adapter.calls.some((call) => call.args.includes("kill-session"))).toBe(true);
+    const persisted = getOrCreateRunForRepo(repoDir).runs[0];
+    expect(persisted?.runtime).toMatchObject({ status: "aborted", cleanupStatus: "succeeded" });
+    expect(persisted?.runtime.diagnostics.join("\n")).toContain("pane metadata unavailable");
   });
 
   it("opens iTerm2 as a viewer over an iterm-tmux run", async () => {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1122,6 +1122,7 @@ export async function runParallelWorkForRepo(
   results: Array<{
     taskId: string;
     status: "fulfilled" | "rejected";
+    executionState: "completed" | "launched" | "failed_to_launch" | "interrupted";
     result: WorkerRunResult | null;
     error: string | null;
   }>;
@@ -1275,16 +1276,34 @@ export async function runParallelWorkForRepo(
     if (signal?.aborted) await requestCancelOwnedWork();
     await Promise.allSettled(pendingCancellations);
     collectOwnedCanceledWork();
-    const results = settled.map((entry, index) =>
-      entry.status === "fulfilled"
-        ? { taskId: tasks[index]?.taskId ?? "", status: "fulfilled" as const, result: entry.value, error: null }
-        : {
-            taskId: tasks[index]?.taskId ?? "",
-            status: "rejected" as const,
-            result: null,
-            error: errorMessage(entry.reason),
-          },
-    );
+    const results = settled.map((entry, index) => {
+      const taskId = tasks[index]?.taskId ?? "";
+      if (signal?.aborted) {
+        return {
+          taskId,
+          status: entry.status,
+          executionState: "interrupted" as const,
+          result: entry.status === "fulfilled" ? entry.value : null,
+          error: entry.status === "rejected" ? errorMessage(entry.reason) : null,
+        };
+      }
+      if (entry.status === "fulfilled") {
+        return {
+          taskId,
+          status: "fulfilled" as const,
+          executionState: runtimeMode === "headless" ? ("completed" as const) : ("launched" as const),
+          result: entry.value,
+          error: null,
+        };
+      }
+      return {
+        taskId,
+        status: "rejected" as const,
+        executionState: runtimeMode === "headless" ? ("completed" as const) : ("failed_to_launch" as const),
+        result: null,
+        error: errorMessage(entry.reason),
+      };
+    });
     return {
       workers,
       tasks,

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -111,8 +111,12 @@ export type ParallelWorkRunner = (
   repoRoot: string,
   taskId: string,
   signal?: AbortSignal,
-  input?: { runtimeMode?: RunRuntimeMode },
+  input?: { runtimeMode?: RunRuntimeMode; waitForCompletion?: boolean },
 ) => Promise<WorkerRunResult>;
+
+function defaultParallelRuntimeMode(): RunRuntimeMode {
+  return getConductorRuntimeModeStatus("tmux").available ? "tmux" : "headless";
+}
 
 function assertRuntimeModeAvailable(runtimeMode: RunRuntimeMode): void {
   const runtimeStatus = getConductorRuntimeModeStatus(runtimeMode);
@@ -1142,7 +1146,7 @@ export async function runParallelWorkForRepo(
       workerName: item.workerName?.trim() || `${workerPrefix}-${index + 1}`,
     };
   });
-  const runtimeMode = input.runtimeMode ?? "headless";
+  const runtimeMode = input.runtimeMode ?? defaultParallelRuntimeMode();
   if (runtimeMode !== "headless") {
     assertRuntimeModeAvailable(runtimeMode);
   }
@@ -1251,7 +1255,12 @@ export async function runParallelWorkForRepo(
     const settled = await Promise.allSettled(
       tasks.map((task, index) =>
         Promise.resolve()
-          .then(() => runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, { runtimeMode }))
+          .then(() =>
+            runner(repoRoot, task.taskId, liveControllers[index]?.signal ?? signal, {
+              runtimeMode,
+              waitForCompletion: runtimeMode === "headless",
+            }),
+          )
           .catch((error) => {
             applyCanceledWork(
               cancelPendingStartupFailureForRepo(repoRoot, {
@@ -1906,16 +1915,17 @@ export async function runTaskForRepo(
   repoRoot: string,
   taskId: string,
   signal?: AbortSignal,
-  input: { runtimeMode?: RunRuntimeMode } = {},
+  input: { runtimeMode?: RunRuntimeMode; waitForCompletion?: boolean } = {},
 ): Promise<WorkerRunResult> {
   const runtimeMode = input.runtimeMode ?? "headless";
+  const waitForCompletion = input.waitForCompletion ?? true;
   const runtimeStatus = getConductorRuntimeModeStatus(runtimeMode);
   if (!runtimeStatus.available) {
     throw new Error(
       `Runtime mode ${runtimeMode} unavailable: ${runtimeStatus.diagnostic ?? "not available"}. Use conductor_backend_status to inspect available runtime modes; headless is available.`,
     );
   }
-  const runtimeBackend = getWorkerRunRuntimeBackend(runtimeMode);
+  const runtimeBackend = getWorkerRunRuntimeBackend(runtimeMode, { waitForCompletion });
   const currentRun = getOrCreateRunForRepo(repoRoot);
   const task = currentRun.tasks.find((entry) => entry.taskId === taskId);
   const workerId = task?.assignedWorkerId;
@@ -1978,6 +1988,16 @@ export async function runTaskForRepo(
         createFollowUpTaskForRepo(repoRoot, followUp);
       },
     });
+
+    if (!waitForCompletion && isTmuxRuntimeMode(runtimeMode)) {
+      return {
+        workerName: worker.name,
+        status: runtimeResult.status,
+        finalText: runtimeResult.finalText,
+        errorMessage: runtimeResult.errorMessage,
+        sessionId: runtimeResult.sessionId,
+      };
+    }
 
     let createdFallbackCompletion = false;
     await mutateRepoRunWithLockRetry(repoRoot, (latest) => {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -1989,14 +1989,17 @@ export async function runTaskForRepo(
       },
     });
 
-    if (!waitForCompletion && isTmuxRuntimeMode(runtimeMode)) {
-      return {
-        workerName: worker.name,
-        status: runtimeResult.status,
-        finalText: runtimeResult.finalText,
-        errorMessage: runtimeResult.errorMessage,
-        sessionId: runtimeResult.sessionId,
-      };
+    if (!waitForCompletion && isTmuxRuntimeMode(runtimeMode) && runtimeResult.status === "success") {
+      const latestAttempt = getOrCreateRunForRepo(repoRoot).runs.find((entry) => entry.runId === started.run.runId);
+      if (latestAttempt && !latestAttempt.finishedAt && !isTerminalRunStatus(latestAttempt.status)) {
+        return {
+          workerName: worker.name,
+          status: runtimeResult.status,
+          finalText: runtimeResult.finalText,
+          errorMessage: runtimeResult.errorMessage,
+          sessionId: runtimeResult.sessionId,
+        };
+      }
     }
 
     let createdFallbackCompletion = false;

--- a/packages/pi-conductor/extensions/runtime.ts
+++ b/packages/pi-conductor/extensions/runtime.ts
@@ -35,7 +35,10 @@ export interface WorkerRunRuntimeBackend {
   run(input: RuntimeRunContext): Promise<RuntimeRunResult>;
 }
 
-export function getWorkerRunRuntimeBackend(mode: RunRuntimeMode = "headless"): WorkerRunRuntimeBackend {
+export function getWorkerRunRuntimeBackend(
+  mode: RunRuntimeMode = "headless",
+  options: { waitForCompletion?: boolean } = {},
+): WorkerRunRuntimeBackend {
   if (mode === "headless") {
     return {
       mode,
@@ -44,7 +47,7 @@ export function getWorkerRunRuntimeBackend(mode: RunRuntimeMode = "headless"): W
     };
   }
   if (mode === "tmux" || mode === "iterm-tmux") {
-    return createTmuxWorkerRunRuntimeBackend({ mode });
+    return createTmuxWorkerRunRuntimeBackend({ mode, waitForCompletion: options.waitForCompletion });
   }
   throw new Error(`${mode} runtime is not implemented yet`);
 }

--- a/packages/pi-conductor/extensions/tmux-runtime.ts
+++ b/packages/pi-conductor/extensions/tmux-runtime.ts
@@ -703,6 +703,24 @@ export function createTmuxWorkerRunRuntimeBackend(options: TmuxRuntimeOptions = 
           return mapTerminalRunToRuntimeResult(durableRun);
         }
         const paneMetadata = await inspectTmuxPaneMetadata({ adapter, socketPath: paths.socketPath, sessionName });
+        if (!waitForCompletion && paneMetadata.diagnostic) {
+          const cleanup = await cancelTmuxRuntime({ adapter, runtime: buildCancellationRuntime() });
+          await input.onRuntimeMetadata?.({
+            status: "aborted",
+            cleanupStatus: cleanup.cleanupStatus,
+            finishedAt: now(),
+            diagnostics: [
+              paneMetadata.diagnostic,
+              cleanup.diagnostic ?? `tmux session ${sessionName} cleanup after metadata failure`,
+            ],
+          });
+          return {
+            status: "error",
+            finalText: null,
+            errorMessage: paneMetadata.diagnostic,
+            sessionId: null,
+          };
+        }
         const runningDiagnostics = [
           `tmux session ${sessionName} launched`,
           ...(paneMetadata.diagnostic ? [paneMetadata.diagnostic] : []),

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -90,11 +90,13 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
         result.canceledTasks.length > 0 ? `; canceled ${result.canceledTasks.length} pre-run task(s)` : "";
       const finishedText = `${completed} succeeded, ${result.results.length - completed} need follow-up${canceledText}`;
       const launchedText = `${completed} launched, ${result.results.length - completed} failed to launch${canceledText}`;
+      const followUpText =
+        'inspect with conductor_project_brief or conductor_list_runs({ status: "running" }); cancel with conductor_cancel_active_work';
       const text = signal?.aborted
         ? `interrupted parallel conductor work with ${runtimeText}; canceled ${result.canceledRuns.length} active run(s) and ${result.canceledTasks.length} task(s)`
         : result.runtimeMode === "headless"
           ? `ran ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${finishedText}`
-          : `launched ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${launchedText}`;
+          : `launched ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${launchedText}; ${followUpText}`;
       return { content: [{ type: "text", text }], details: result };
     },
   });

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -63,7 +63,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
     name: "conductor_run_parallel_work",
     label: "Conductor Run Parallel Work",
     description:
-      "Autonomously split a natural-language request into parallel conductor worker tasks, run them under one foreground orchestration boundary, and cancel owned runs/tasks if the user interrupts with Escape or a task fails before active run creation",
+      "Autonomously split a natural-language request into parallel conductor worker tasks. When no runtimeMode is provided, conductor prefers tmux so the tool can launch supervised workers and return control to the parent session for natural-language follow-up; it falls back to headless when tmux is unavailable. Owned runs/tasks are canceled if the user interrupts with Escape or a task fails before active run creation.",
     parameters: Type.Object({
       tasks: Type.Array(
         Type.Object({
@@ -78,7 +78,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       ),
       runtimeMode: Type.Optional(
         runtimeModeSchema(
-          "Explicit runtime mode for every parallel worker; use iterm-tmux for tmux plus best-effort iTerm2 viewer.",
+          "Explicit runtime mode for every parallel worker; omit to prefer tmux when available so control returns after launch, or set headless to wait for completion in-process.",
         ),
       ),
     }),
@@ -88,9 +88,13 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       const runtimeText = `runtime=${result.runtimeMode}${result.runtimeRuns.length > 0 ? ` runs=${result.runtimeRuns.length}` : ""}`;
       const canceledText =
         result.canceledTasks.length > 0 ? `; canceled ${result.canceledTasks.length} pre-run task(s)` : "";
+      const finishedText = `${completed} succeeded, ${result.results.length - completed} need follow-up${canceledText}`;
+      const launchedText = `${completed} launched, ${result.results.length - completed} failed to launch${canceledText}`;
       const text = signal?.aborted
         ? `interrupted parallel conductor work with ${runtimeText}; canceled ${result.canceledRuns.length} active run(s) and ${result.canceledTasks.length} task(s)`
-        : `ran ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${completed} succeeded, ${result.results.length - completed} need follow-up${canceledText}`;
+        : result.runtimeMode === "headless"
+          ? `ran ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${finishedText}`
+          : `launched ${result.tasks.length} parallel conductor task(s) with ${runtimeText}; ${launchedText}`;
       return { content: [{ type: "text", text }], details: result };
     },
   });

--- a/packages/pi-conductor/skills/conductor-orchestration/SKILL.md
+++ b/packages/pi-conductor/skills/conductor-orchestration/SKILL.md
@@ -32,7 +32,7 @@ Use this workflow when `pi-conductor` should coordinate work as a durable local 
    - `conductor_scheduler_tick({ objectiveId, policy: "safe", maxActions: 3 })`
 6. Execute intentionally when ready:
    - Prefer `conductor_run_work({ request, tasks, mode: "auto" })` for natural-language work. Let conductor decide whether to use one worker, parallel workers, or an objective DAG.
-   - Use `conductor_run_parallel_work({ tasks })` only as a lower-level primitive when the work has already been proven parallel-safe.
+   - Use `conductor_run_parallel_work({ tasks })` only as a lower-level primitive when the work has already been proven parallel-safe. When `runtimeMode` is omitted, it prefers supervised non-blocking `tmux` if available and returns after launch so follow-up natural-language status/cancel requests can continue in the parent session; pass `runtimeMode: "headless"` when you intentionally need to wait for completion.
    - `conductor_scheduler_tick({ objectiveId, policy: "execute", maxRuns: 1 })`
    - or `conductor_run_next_action({ objectiveId, policy: "execute" })`
 7. Monitor evidence and blockers:


### PR DESCRIPTION
## Summary
- Make `conductor_run_parallel_work` default to non-blocking supervised tmux execution when tmux is available.
- Keep explicit `runtimeMode: "headless"` as a blocking, wait-for-completion path.
- Add support for `waitForCompletion` plumbing in runtime backend selection.
- Ensure `runTaskForRepo` preserves active tmux runs on launch and does not finalize terminal attempts while detached.
- Update tool text to avoid mislabeling launch-vs-completion and clarify runtime semantics.
- Add tests for default/non-blocking tmux path and detached tmux behavior.
- Update README and conductor orchestration skill docs with run-mode semantics and follow-up inspection guidance.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run packages/pi-conductor/__tests__/conductor.test.ts packages/pi-conductor/__tests__/run-flow.test.ts packages/pi-conductor/__tests__/tool-runtime-contract.test.ts`

## Notes
- Open follow-up issue #78 tracks the broader consistency decision between `conductor_run_work` and `conductor_run_parallel_work` defaults.
