### PR TITLE
docs: clarify conductor parallel runtime compatibility

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -152,6 +152,17 @@ Run tools accept `runtimeMode: "headless" | "tmux" | "iterm-tmux"`. `headless` r
 
 Default runtime selection depends on the entry point. `conductor_run_work` stays conservative and defaults ordinary work to `headless` unless the request clearly asks to show/watch/open workers or an explicit `runtimeMode` is provided. Direct `conductor_run_parallel_work` is a lower-level parallel-safe primitive; when its `runtimeMode` is omitted, it prefers non-blocking `tmux` if tmux is available so the parent session can keep accepting natural-language inspection/cancel requests after launch, and falls back to blocking `headless` when tmux is unavailable. Pass `runtimeMode: "headless"` to `conductor_run_parallel_work` when the caller needs the old wait-for-completion behavior.
 
+Compatibility note: older direct parallel-work callers that omitted `runtimeMode` and expected the tool call to return only after completion should now pass `runtimeMode: "headless"`. The omitted-runtime default is intentionally host-sensitive: machines with tmux get supervised launch-and-return behavior, while machines without tmux continue to run headless. Programmatic callers should inspect each result's `executionState` rather than treating `result.status: "success"` as semantic task completion.
+
+`conductor_run_parallel_work` result states distinguish launch from completion:
+
+| `executionState` | Meaning |
+| ---------------- | ------- |
+| `completed` | Headless execution finished and `result.status` describes the terminal worker outcome. |
+| `launched` | A supervised tmux/iTerm-backed run launched successfully and remains represented by durable conductor run state. Inspect `runtimeRuns`, `conductor_project_brief`, or `conductor_list_runs` for current status. |
+| `failed_to_launch` | A supervised non-headless shard failed before conductor could establish an active run. |
+| `interrupted` | Parent orchestration was interrupted and conductor attempted to cancel owned runs/tasks. |
+
 Use conductor status tools rather than typing into worker panes to supervise work. Active visible runs include:
 
 - `viewer=<opened|warning|unavailable|pending>` and `viewerCommand="tmux ... attach-session -r ..."`

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -63,7 +63,7 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
     name: "conductor_run_parallel_work",
     label: "Conductor Run Parallel Work",
     description:
-      "Autonomously split a natural-language request into parallel conductor worker tasks. When no runtimeMode is provided, conductor prefers tmux so the tool can launch supervised workers and return control to the parent session for natural-language follow-up; it falls back to headless when tmux is unavailable. Owned runs/tasks are canceled if the user interrupts with Escape or a task fails before active run creation.",
+      "Autonomously split a natural-language request into parallel conductor worker tasks. When no runtimeMode is provided, conductor prefers tmux so the tool can launch supervised workers and return control to the parent session for natural-language follow-up; it falls back to headless when tmux is unavailable. Use details.results[].executionState to distinguish completed headless work from launched supervised runs, failed launches, and interruptions. Owned runs/tasks are canceled if the user interrupts with Escape or a task fails before active run creation.",
     parameters: Type.Object({
       tasks: Type.Array(
         Type.Object({

--- a/packages/pi-conductor/skills/conductor-orchestration/SKILL.md
+++ b/packages/pi-conductor/skills/conductor-orchestration/SKILL.md
@@ -32,7 +32,7 @@ Use this workflow when `pi-conductor` should coordinate work as a durable local 
    - `conductor_scheduler_tick({ objectiveId, policy: "safe", maxActions: 3 })`
 6. Execute intentionally when ready:
    - Prefer `conductor_run_work({ request, tasks, mode: "auto" })` for natural-language work. Let conductor decide whether to use one worker, parallel workers, or an objective DAG.
-   - Use `conductor_run_parallel_work({ tasks })` only as a lower-level primitive when the work has already been proven parallel-safe. When `runtimeMode` is omitted, it prefers supervised non-blocking `tmux` if available and returns after launch so follow-up natural-language status/cancel requests can continue in the parent session; pass `runtimeMode: "headless"` when you intentionally need to wait for completion.
+   - Use `conductor_run_parallel_work({ tasks })` only as a lower-level primitive when the work has already been proven parallel-safe. When `runtimeMode` is omitted, it prefers supervised non-blocking `tmux` if available and returns after launch so follow-up natural-language status/cancel requests can continue in the parent session; pass `runtimeMode: "headless"` when you intentionally need to wait for completion. Interpret `details.results[].executionState` as the result discriminator: `completed` means headless work reached a terminal worker result, `launched` means a supervised run is still represented by durable conductor state, `failed_to_launch` means no active supervised run was established for that shard, and `interrupted` means parent cancellation ran.
    - `conductor_scheduler_tick({ objectiveId, policy: "execute", maxRuns: 1 })`
    - or `conductor_run_next_action({ objectiveId, policy: "execute" })`
 7. Monitor evidence and blockers:


### PR DESCRIPTION
## Summary
- Add an explicit compatibility note for `conductor_run_parallel_work`'s omitted-runtime behavior.
- Document the `runtimeMode: "headless"` escape hatch for callers that require blocking completion semantics.
- Document the structured `executionState` values so callers can distinguish task completion from supervised launch.

## Issues
- Closes #79
- Closes #80
- Closes #82

## Validation
- `npm run lint`
- `npm run typecheck`
