### PR TITLE
fix: keep conductor task artifacts readable and linked

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -272,7 +272,7 @@ conductor_prepare_human_review({ objectiveId })
 
 ### Read bounded local artifact evidence safely
 
-Use artifact IDs/refs from evidence bundles or timelines; conductor rejects unsafe traversal, symlink escapes, binary reads, and unsupported refs. Artifact metadata keys `root` and `worktreeRoot` are trusted only for conductor-owned system artifacts; child-run progress/completion artifacts may round-trip those metadata keys, but artifact reads ignore them as trusted roots.
+Use artifact IDs/refs from evidence bundles or timelines; conductor rejects unsafe traversal, symlink escapes, binary reads, and unsupported refs. Task evidence is aggregate evidence: child-run progress/completion artifacts are linked to both the task and the run, and task-scoped APIs (`conductor_list_artifacts({ taskId })`, task briefs, timelines, evidence bundles, and raw task `artifactIds`) should agree on the same artifact IDs. Artifact metadata keys `root` and `worktreeRoot` are trusted only for conductor-owned system artifacts; child-run progress/completion artifacts may round-trip those metadata keys, but artifact reads ignore them as trusted roots. Child-run `note` artifacts are readable through captured progress/completion text; legacy metadata-only notes return their metadata with a diagnostic instead of an ambiguous missing-file error.
 
 ```text
 conductor_list_artifacts({ taskId })

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -39,6 +39,7 @@ import {
 } from "../extensions/conductor.js";
 import { deriveProjectKey } from "../extensions/project-key.js";
 import { getRunLockFile, readArtifactContentForRepo } from "../extensions/storage.js";
+import { queryConductorArtifacts } from "../extensions/storage-query.js";
 import { createTmuxRuntimePaths } from "../extensions/tmux-runtime.js";
 
 function forceTmuxUnavailable(): () => void {
@@ -121,6 +122,10 @@ describe("durable task run flows", () => {
     expect(persisted.tasks[0]).toMatchObject({ state: "completed", latestProgress: "halfway", activeRunId: null });
     expect(persisted.runs[0]).toMatchObject({ status: "succeeded", completionSummary: "done with evidence" });
     expect(persisted.artifacts.map((artifact) => artifact.type)).toEqual(["log", "completion_report"]);
+    expect(persisted.tasks[0]?.artifactIds).toEqual(persisted.artifacts.map((artifact) => artifact.artifactId));
+    expect(
+      queryConductorArtifacts(persisted, { taskId: task.taskId }).artifacts.map((artifact) => artifact.artifactId),
+    ).toEqual(persisted.tasks[0]?.artifactIds);
     expect(persisted.events.map((event) => event.type)).toContain("run.progress_reported");
     expect(persisted.events.map((event) => event.type)).toContain("run.completed");
   });
@@ -141,6 +146,35 @@ describe("durable task run flows", () => {
     await runTaskForRepo(repoDir, task.taskId);
 
     expect(getOrCreateRunForRepo(repoDir).runs[0]?.runtime.diagnostics).toContain("metadata after retry");
+  });
+
+  it("reads child note artifacts from captured progress content", async () => {
+    const worker = await createWorkerForRepo(repoDir, "note-worker");
+    const task = createTaskForRepo(repoDir, { title: "Note artifact", prompt: "Record note" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    runtimeMocks.runWorkerPromptRuntime.mockImplementationOnce(async ({ taskContract, onConductorProgress }) => {
+      await onConductorProgress?.({
+        runId: taskContract.runId,
+        taskId: task.taskId,
+        progress: "primary source summary",
+        artifact: { type: "note", ref: "project-scan-summary", metadata: { source: "worker" } },
+      });
+      return { status: "success", finalText: "done", errorMessage: null, sessionId: "note-session" };
+    });
+
+    await runTaskForRepo(repoDir, task.taskId);
+
+    const persisted = getOrCreateRunForRepo(repoDir);
+    const artifact = persisted.artifacts.find((entry) => entry.type === "note");
+    if (!artifact) throw new Error("expected note artifact");
+    expect(persisted.tasks[0]?.artifactIds).toContain(artifact.artifactId);
+    expect(readArtifactContentForRepo(repoDir, artifact.artifactId)).toMatchObject({
+      artifactId: artifact.artifactId,
+      ref: "project-scan-summary",
+      content: "primary source summary",
+      diagnostic: null,
+    });
   });
 
   it("does not let child artifacts opt into conductor storage reads", async () => {

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -169,6 +169,7 @@ describe("durable task run flows", () => {
     const artifact = persisted.artifacts.find((entry) => entry.type === "note");
     if (!artifact) throw new Error("expected note artifact");
     expect(persisted.tasks[0]?.artifactIds).toContain(artifact.artifactId);
+    expect(JSON.stringify(artifact.metadata)).not.toContain("primary source summary");
     expect(readArtifactContentForRepo(repoDir, artifact.artifactId)).toMatchObject({
       artifactId: artifact.artifactId,
       ref: "project-scan-summary",
@@ -204,6 +205,63 @@ describe("durable task run flows", () => {
       content: "final",
       truncated: true,
       diagnostic: null,
+    });
+  });
+
+  it("bounds child note artifacts by UTF-8 bytes", async () => {
+    const worker = await createWorkerForRepo(repoDir, "unicode-note-worker");
+    const task = createTaskForRepo(repoDir, { title: "Unicode note artifact", prompt: "Record unicode note" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    runtimeMocks.runWorkerPromptRuntime.mockImplementationOnce(async ({ taskContract, onConductorProgress }) => {
+      await onConductorProgress?.({
+        runId: taskContract.runId,
+        taskId: task.taskId,
+        progress: "éclair",
+        artifact: { type: "note", ref: "unicode-summary" },
+      });
+      return { status: "success", finalText: "done", errorMessage: null, sessionId: "unicode-note-session" };
+    });
+
+    await runTaskForRepo(repoDir, task.taskId);
+
+    const artifact = getOrCreateRunForRepo(repoDir).artifacts.find((entry) => entry.type === "note");
+    if (!artifact) throw new Error("expected note artifact");
+    expect(readArtifactContentForRepo(repoDir, artifact.artifactId, { maxBytes: 1 })).toMatchObject({
+      content: "",
+      truncated: true,
+      diagnostic: null,
+    });
+  });
+
+  it("reports missing captured child-note content files", async () => {
+    const worker = await createWorkerForRepo(repoDir, "missing-captured-note-worker");
+    const task = createTaskForRepo(repoDir, { title: "Missing captured note", prompt: "Record note" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    runtimeMocks.runWorkerPromptRuntime.mockImplementationOnce(async ({ taskContract, onConductorProgress }) => {
+      await onConductorProgress?.({
+        runId: taskContract.runId,
+        taskId: task.taskId,
+        progress: "stored note content",
+        artifact: { type: "note", ref: "missing-captured-note" },
+      });
+      return { status: "success", finalText: "done", errorMessage: null, sessionId: "missing-note-session" };
+    });
+
+    await runTaskForRepo(repoDir, task.taskId);
+
+    const persisted = getOrCreateRunForRepo(repoDir);
+    const artifact = persisted.artifacts.find((entry) => entry.type === "note");
+    if (!artifact) throw new Error("expected note artifact");
+    const contentRef = artifact.metadata.conductorNoteContentRef;
+    if (typeof contentRef !== "string") throw new Error("expected captured note content ref");
+    rmSync(join(persisted.storageDir, contentRef), { force: true });
+
+    expect(readArtifactContentForRepo(repoDir, artifact.artifactId)).toMatchObject({
+      content: null,
+      truncated: false,
+      diagnostic: "Captured note content file is missing",
     });
   });
 

--- a/packages/pi-conductor/__tests__/run-flow.test.ts
+++ b/packages/pi-conductor/__tests__/run-flow.test.ts
@@ -177,6 +177,36 @@ describe("durable task run flows", () => {
     });
   });
 
+  it("reads child note artifacts from captured completion summaries", async () => {
+    const worker = await createWorkerForRepo(repoDir, "completion-note-worker");
+    const task = createTaskForRepo(repoDir, { title: "Completion note artifact", prompt: "Record completion note" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+
+    runtimeMocks.runWorkerPromptRuntime.mockImplementationOnce(async ({ taskContract, onConductorComplete }) => {
+      await onConductorComplete?.({
+        runId: taskContract.runId,
+        taskId: task.taskId,
+        status: "succeeded",
+        completionSummary: "final source summary",
+        artifact: { type: "note", ref: "completion-summary", metadata: { content: "caller metadata" } },
+      });
+      return { status: "success", finalText: "done", errorMessage: null, sessionId: "completion-note-session" };
+    });
+
+    await runTaskForRepo(repoDir, task.taskId);
+
+    const persisted = getOrCreateRunForRepo(repoDir);
+    const artifact = persisted.artifacts.find((entry) => entry.type === "note");
+    if (!artifact) throw new Error("expected note artifact");
+    expect(persisted.tasks[0]?.artifactIds).toContain(artifact.artifactId);
+    expect(persisted.runs[0]?.artifactIds).toContain(artifact.artifactId);
+    expect(readArtifactContentForRepo(repoDir, artifact.artifactId, { maxBytes: 5 })).toMatchObject({
+      content: "final",
+      truncated: true,
+      diagnostic: null,
+    });
+  });
+
   it("does not let child artifacts opt into conductor storage reads", async () => {
     const worker = await createWorkerForRepo(repoDir, "backend");
     const task = createTaskForRepo(repoDir, { title: "Artifact escape", prompt: "Try to read storage" });

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deriveProjectKey } from "../extensions/project-key.js";
 import {
   addConductorArtifact,
   addTask,
@@ -18,6 +19,7 @@ import {
   mutateRun,
   queryConductorArtifacts,
   queryConductorEvents,
+  readArtifactContentForRepo,
   readRun,
   reconcileRunLeases,
   recordRunHeartbeat,
@@ -30,6 +32,7 @@ import {
   validateRunRecord,
   writeRun,
 } from "../extensions/storage.js";
+import { normalizeProjectRecord } from "../extensions/storage-normalize.js";
 
 describe("storage helpers", () => {
   let conductorHome: string;
@@ -656,6 +659,57 @@ describe("storage helpers", () => {
       completed.artifacts.map((artifact) => artifact.artifactId),
     );
     expect(completed.runs.find((entry) => entry.runId === "run-1")?.completionSummary).toBe("implemented and verified");
+  });
+
+  it("normalizes legacy task artifact ids from task-scoped artifact refs", () => {
+    let run = addTask(
+      createEmptyRun("abc", "/repo"),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-legacy-note",
+      type: "note",
+      ref: "note://legacy",
+      resourceRefs: { taskId: "task-1", runId: "run-legacy" },
+      producer: { type: "child_run", id: "run-legacy" },
+      metadata: { summary: "legacy" },
+    });
+    const legacyRun = {
+      ...run,
+      tasks: run.tasks.map((task) => (task.taskId === "task-1" ? { ...task, artifactIds: [] } : task)),
+    };
+
+    const normalized = normalizeProjectRecord(legacyRun);
+
+    expect(normalized.tasks.find((task) => task.taskId === "task-1")?.artifactIds).toEqual(["artifact-legacy-note"]);
+  });
+
+  it("reads metadata-only note artifacts with bounded diagnostics", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    let run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-note-legacy",
+      type: "note",
+      ref: "note://legacy-summary",
+      resourceRefs: { taskId: "task-1" },
+      producer: { type: "child_run", id: "run-legacy" },
+      metadata: { summary: "legacy summary", details: "more details" },
+    });
+    writeRun(run);
+
+    const content = readArtifactContentForRepo(repoRoot, "artifact-note-legacy", { maxBytes: 24 });
+
+    expect(content).toMatchObject({
+      artifactId: "artifact-note-legacy",
+      ref: "note://legacy-summary",
+      truncated: true,
+      diagnostic: "Metadata-only note artifact has no readable content file",
+    });
+    expect(content.content).toBe('{\n  "metadata": {\n    "s');
   });
 
   it("creates a worker record with default lifecycle metadata", () => {

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -712,6 +712,61 @@ describe("storage helpers", () => {
     expect(content.content).toBe('{\n  "metadata": {\n    "s');
   });
 
+  it("reports missing local note files as missing artifacts", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    let run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-note-missing",
+      type: "note",
+      ref: "missing-note.txt",
+      resourceRefs: { taskId: "task-1" },
+      producer: { type: "system", id: "test" },
+      metadata: { summary: "metadata exists" },
+    });
+    writeRun(run);
+
+    expect(readArtifactContentForRepo(repoRoot, "artifact-note-missing")).toMatchObject({
+      artifactId: "artifact-note-missing",
+      ref: "missing-note.txt",
+      content: null,
+      truncated: false,
+      diagnostic: "Artifact file is missing",
+    });
+  });
+
+  it("degrades legacy artifacts without metadata to bounded diagnostics", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    const run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    writeRun({
+      ...run,
+      artifacts: [
+        {
+          artifactId: "artifact-note-no-metadata",
+          type: "note",
+          ref: "note://legacy-no-metadata",
+          resourceRefs: { projectKey, taskId: "task-1" },
+          producer: { type: "child_run", id: "run-legacy" },
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        } as never,
+      ],
+    });
+
+    expect(readArtifactContentForRepo(repoRoot, "artifact-note-no-metadata", { maxBytes: 10 })).toMatchObject({
+      content: '{\n  "metad',
+      truncated: true,
+      diagnostic: "Metadata-only note artifact has no readable content file",
+    });
+  });
+
   it("creates a worker record with default lifecycle metadata", () => {
     const worker = createWorkerRecord({
       workerId: "worker-1",

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -633,6 +633,9 @@ describe("storage helpers", () => {
     expect(withProgress.tasks.find((entry) => entry.taskId === "task-1")?.latestProgress).toBe("tests passing");
     expect(withProgress.artifacts).toHaveLength(1);
     expect(withProgress.artifacts[0]?.resourceRefs).toMatchObject({ taskId: "task-1", runId: "run-1" });
+    expect(withProgress.tasks.find((entry) => entry.taskId === "task-1")?.artifactIds).toContain(
+      withProgress.artifacts[0]?.artifactId,
+    );
     expect(withProgress.runs.find((entry) => entry.runId === "run-1")?.artifactIds).toContain(
       withProgress.artifacts[0]?.artifactId,
     );
@@ -649,6 +652,9 @@ describe("storage helpers", () => {
     expect(completed.tasks.find((entry) => entry.taskId === "task-1")?.state).toBe("completed");
     expect(completed.artifacts).toHaveLength(2);
     expect(completed.artifacts[1]?.type).toBe("completion_report");
+    expect(completed.tasks.find((entry) => entry.taskId === "task-1")?.artifactIds).toEqual(
+      completed.artifacts.map((artifact) => artifact.artifactId),
+    );
     expect(completed.runs.find((entry) => entry.runId === "run-1")?.completionSummary).toBe("implemented and verified");
   });
 

--- a/packages/pi-conductor/__tests__/storage.test.ts
+++ b/packages/pi-conductor/__tests__/storage.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -470,6 +470,171 @@ describe("storage helpers", () => {
     expect(duplicateCompletion.runs[0]).toMatchObject({ status: "succeeded", completionSummary: "done" });
   });
 
+  it("deduplicates child progress artifacts by idempotency key", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    let run = addWorker(
+      createEmptyRun(deriveProjectKey(repoRoot), repoRoot),
+      createWorkerRecord({
+        workerId: "worker-1",
+        name: "backend",
+        branch: "conductor/backend",
+        worktreePath: repoRoot,
+        sessionFile: null,
+      }),
+    );
+    run = assignTaskToWorker(
+      addTask(run, createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" })),
+      "task-1",
+      "worker-1",
+    );
+    run = startTaskRun(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      workerId: "worker-1",
+      backend: "native",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    });
+
+    const progressed = recordTaskProgress(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      progress: "halfway",
+      idempotencyKey: "progress-note-1",
+      artifact: { type: "note", ref: "progress-note" },
+    });
+    const duplicateProgress = recordTaskProgress(progressed, {
+      runId: "run-1",
+      taskId: "task-1",
+      progress: "halfway replay",
+      idempotencyKey: "progress-note-1",
+      artifact: { type: "note", ref: "progress-note-replay" },
+    });
+
+    expect(duplicateProgress.artifacts).toHaveLength(progressed.artifacts.length);
+    expect(duplicateProgress.tasks[0]?.artifactIds).toEqual(progressed.tasks[0]?.artifactIds);
+    expect(duplicateProgress.runs[0]?.artifactIds).toEqual(progressed.runs[0]?.artifactIds);
+  });
+
+  it("deduplicates child completion artifacts by idempotency key", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    let run = addWorker(
+      createEmptyRun(deriveProjectKey(repoRoot), repoRoot),
+      createWorkerRecord({
+        workerId: "worker-1",
+        name: "backend",
+        branch: "conductor/backend",
+        worktreePath: repoRoot,
+        sessionFile: null,
+      }),
+    );
+    run = assignTaskToWorker(
+      addTask(run, createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" })),
+      "task-1",
+      "worker-1",
+    );
+    run = startTaskRun(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      workerId: "worker-1",
+      backend: "native",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    });
+
+    const completed = recordTaskCompletion(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      status: "succeeded",
+      completionSummary: "done",
+      idempotencyKey: "completion-note-1",
+      artifact: { type: "note", ref: "completion-note" },
+    });
+    const duplicateCompletion = recordTaskCompletion(completed, {
+      runId: "run-1",
+      taskId: "task-1",
+      status: "failed",
+      completionSummary: "late replay",
+      idempotencyKey: "completion-note-1",
+      artifact: { type: "note", ref: "completion-note-replay" },
+    });
+
+    expect(duplicateCompletion.artifacts).toHaveLength(completed.artifacts.length);
+    expect(duplicateCompletion.tasks[0]?.artifactIds).toEqual(completed.tasks[0]?.artifactIds);
+    expect(duplicateCompletion.runs[0]?.artifactIds).toEqual(completed.runs[0]?.artifactIds);
+  });
+
+  it("validates child note refs before writing captured content", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    let run = addWorker(
+      createEmptyRun(deriveProjectKey(repoRoot), repoRoot),
+      createWorkerRecord({
+        workerId: "worker-1",
+        name: "backend",
+        branch: "conductor/backend",
+        worktreePath: repoRoot,
+        sessionFile: null,
+      }),
+    );
+    run = assignTaskToWorker(
+      addTask(run, createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" })),
+      "task-1",
+      "worker-1",
+    );
+    run = startTaskRun(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      workerId: "worker-1",
+      backend: "native",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    });
+
+    expect(() =>
+      recordTaskProgress(run, {
+        runId: "run-1",
+        taskId: "task-1",
+        progress: "orphan me",
+        artifact: { type: "note", ref: "../unsafe-note" },
+      }),
+    ).toThrow("Unsafe artifact ref");
+    expect(existsSync(join(run.storageDir, "artifacts"))).toBe(false);
+  });
+
+  it("validates child completion note refs before writing captured content", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    let run = addWorker(
+      createEmptyRun(deriveProjectKey(repoRoot), repoRoot),
+      createWorkerRecord({
+        workerId: "worker-1",
+        name: "backend",
+        branch: "conductor/backend",
+        worktreePath: repoRoot,
+        sessionFile: null,
+      }),
+    );
+    run = assignTaskToWorker(
+      addTask(run, createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" })),
+      "task-1",
+      "worker-1",
+    );
+    run = startTaskRun(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      workerId: "worker-1",
+      backend: "native",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    });
+
+    expect(() =>
+      recordTaskCompletion(run, {
+        runId: "run-1",
+        taskId: "task-1",
+        status: "succeeded",
+        completionSummary: "orphan me",
+        artifact: { type: "note", ref: "../unsafe-note" },
+      }),
+    ).toThrow("Unsafe artifact ref");
+    expect(existsSync(join(run.storageDir, "artifacts"))).toBe(false);
+  });
+
   it("audits duplicate completion after terminal runs without changing task state", () => {
     let run = addWorker(
       createEmptyRun("abc", "/repo"),
@@ -710,6 +875,100 @@ describe("storage helpers", () => {
       diagnostic: "Metadata-only note artifact has no readable content file",
     });
     expect(content.content).toBe('{\n  "metadata": {\n    "s');
+  });
+
+  it("reads legacy child note artifacts with relative refs as metadata-only diagnostics", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    let run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-note-relative-legacy",
+      type: "note",
+      ref: "relative-legacy-note",
+      resourceRefs: { taskId: "task-1" },
+      producer: { type: "child_run", id: "run-legacy" },
+      metadata: { summary: "legacy relative note" },
+    });
+    writeRun(run);
+
+    expect(readArtifactContentForRepo(repoRoot, "artifact-note-relative-legacy")).toMatchObject({
+      content: expect.stringContaining("legacy relative note"),
+      diagnostic: "Metadata-only note artifact has no readable content file",
+      contentSource: "metadata_fallback",
+    });
+  });
+
+  it("rejects untrusted captured note content refs in persisted metadata", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    let run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-note-untrusted-ref",
+      type: "note",
+      ref: "note-ref",
+      resourceRefs: { taskId: "task-1" },
+      producer: { type: "child_run", id: "run-legacy" },
+      metadata: { conductorNoteContentRef: "run.json" },
+    });
+    writeRun(run);
+
+    expect(() => readArtifactContentForRepo(repoRoot, "artifact-note-untrusted-ref")).toThrow(
+      "untrusted captured note content ref",
+    );
+  });
+
+  it("rejects symlinked captured note content refs", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    let run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-note-symlink-ref",
+      type: "note",
+      ref: "note-ref",
+      resourceRefs: { taskId: "task-1" },
+      producer: { type: "child_run", id: "run-legacy" },
+      metadata: { conductorNoteContentRef: "artifacts/artifact-note-symlink-ref.txt" },
+    });
+    writeRun(run);
+    mkdirSync(join(run.storageDir, "artifacts"), { recursive: true });
+    const target = join(tmpdir(), "pi-conductor-symlink-target.txt");
+    writeFileSync(target, "outside storage", "utf-8");
+    symlinkSync(target, join(run.storageDir, "artifacts", "artifact-note-symlink-ref.txt"));
+
+    expect(() => readArtifactContentForRepo(repoRoot, "artifact-note-symlink-ref")).toThrow("Unsafe captured note ref");
+  });
+
+  it("keeps system external note refs external instead of metadata fallbacks", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "pi-conductor-repo-"));
+    const projectKey = deriveProjectKey(repoRoot);
+    let run = addTask(
+      createEmptyRun(projectKey, repoRoot),
+      createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" }),
+    );
+    run = addConductorArtifact(run, {
+      artifactId: "artifact-note-external-system",
+      type: "note",
+      ref: "https://example.com/note",
+      resourceRefs: { taskId: "task-1" },
+      producer: { type: "system", id: "test" },
+      metadata: { summary: "external note" },
+    });
+    writeRun(run);
+
+    expect(readArtifactContentForRepo(repoRoot, "artifact-note-external-system")).toMatchObject({
+      content: null,
+      diagnostic: "Artifact ref is external or virtual",
+      contentSource: "none",
+    });
   });
 
   it("reports missing local note files as missing artifacts", () => {

--- a/packages/pi-conductor/extensions/runtime-artifacts.ts
+++ b/packages/pi-conductor/extensions/runtime-artifacts.ts
@@ -58,17 +58,7 @@ export function recordRuntimeMetadataForRun(input: {
     producer: { type: "system", id: "runtime" },
     metadata: { runtimeMode: input.runtimeMode, path: input.metadata.logPath, ...(logRoot ? { root: logRoot } : {}) },
   });
-  const artifact = withArtifact.artifacts.at(-1);
-  return artifact
-    ? {
-        ...withArtifact,
-        runs: withArtifact.runs.map((entry) =>
-          entry.runId === input.runId
-            ? { ...entry, artifactIds: [...entry.artifactIds, artifact.artifactId], updatedAt: now }
-            : entry,
-        ),
-      }
-    : withArtifact;
+  return withArtifact;
 }
 
 function runtimeLogArtifactRef(storageDir: string, logPath: string): string {

--- a/packages/pi-conductor/extensions/storage-normalize.ts
+++ b/packages/pi-conductor/extensions/storage-normalize.ts
@@ -1,5 +1,6 @@
 import { normalizeRunRuntimeMetadata } from "./runtime-metadata.js";
 import type {
+  ArtifactRecord,
   GateOperation,
   GateRecord,
   PersistedRunAttemptRecord,
@@ -11,6 +12,7 @@ import type {
 } from "./types.js";
 
 export function normalizeProjectRecord(run: RunRecord | PersistedRunRecord): RunRecord {
+  const artifacts = run.artifacts;
   return {
     ...run,
     schemaVersion: run.schemaVersion,
@@ -18,10 +20,10 @@ export function normalizeProjectRecord(run: RunRecord | PersistedRunRecord): Run
     workers: run.workers.map(normalizeWorkerRecord),
     archivedWorkers: run.archivedWorkers.map(normalizeWorkerRecord),
     objectives: run.objectives,
-    tasks: run.tasks.map(normalizeTaskRecord),
+    tasks: run.tasks.map((task) => normalizeTaskRecord(task, artifacts)),
     runs: run.runs.map(normalizeRunAttemptRecord),
     gates: run.gates.map(normalizeGateRecord),
-    artifacts: run.artifacts,
+    artifacts,
     events: run.events,
   };
 }
@@ -51,11 +53,19 @@ function normalizeGateRecord(gate: GateRecord): GateRecord {
   };
 }
 
-function normalizeTaskRecord(task: TaskRecord): TaskRecord {
+function normalizeTaskRecord(task: TaskRecord, artifacts: ArtifactRecord[]): TaskRecord {
   return {
     ...task,
     objectiveId: task.objectiveId,
     dependsOnTaskIds: task.dependsOnTaskIds,
+    artifactIds: [
+      ...new Set([
+        ...task.artifactIds,
+        ...artifacts
+          .filter((artifact) => artifact.resourceRefs.taskId === task.taskId)
+          .map((artifact) => artifact.artifactId),
+      ]),
+    ],
   };
 }
 

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -922,19 +923,52 @@ function createArtifactId(runId: string): string {
   return `artifact-${runId}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+const NOTE_CONTENT_REF_METADATA_KEY = "conductorNoteContentRef";
+const CHILD_ARTIFACT_RESERVED_METADATA_KEYS = new Set([NOTE_CONTENT_REF_METADATA_KEY]);
+
 function sanitizeChildArtifactMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
-  return { ...(metadata ?? {}) };
+  return Object.fromEntries(
+    Object.entries(metadata ?? {}).filter(([key]) => !CHILD_ARTIFACT_RESERVED_METADATA_KEYS.has(key)),
+  );
 }
 
-const NOTE_CONTENT_METADATA_KEY = "conductorNoteContent";
+function capturedNoteContentRef(artifactId: string): string {
+  return `artifacts/${artifactId}.txt`;
+}
+
+function writeCapturedNoteContent(run: RunRecord, artifactId: string, content: string): string {
+  const ref = capturedNoteContentRef(artifactId);
+  const path = resolve(run.storageDir, ref);
+  if (!path.startsWith(`${resolve(run.storageDir)}/`)) {
+    throw new Error(`Unsafe captured note ref '${ref}'`);
+  }
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, content, "utf-8");
+  return ref;
+}
 
 function childNoteMetadata(
   artifact: { type: ArtifactType; metadata?: Record<string, unknown> } | undefined,
-  content: string,
+  noteContentRef: string | null,
 ): Record<string, unknown> | undefined {
   if (!artifact) return undefined;
-  if (artifact.type !== "note") return sanitizeChildArtifactMetadata(artifact.metadata);
-  return { ...sanitizeChildArtifactMetadata(artifact.metadata), [NOTE_CONTENT_METADATA_KEY]: content };
+  const metadata = sanitizeChildArtifactMetadata(artifact.metadata);
+  if (artifact.type !== "note" || !noteContentRef) return metadata;
+  return { ...metadata, [NOTE_CONTENT_REF_METADATA_KEY]: noteContentRef };
+}
+
+function truncateUtf8(content: string, maxBytes: number): { content: string; truncated: boolean } {
+  let bytes = 0;
+  let output = "";
+  for (const char of content) {
+    const charBytes = Buffer.byteLength(char, "utf-8");
+    if (bytes + charBytes > maxBytes) {
+      return { content: output, truncated: true };
+    }
+    output += char;
+    bytes += charBytes;
+  }
+  return { content: output, truncated: false };
 }
 
 function boundedArtifactContent(
@@ -944,13 +978,32 @@ function boundedArtifactContent(
   maxBytes: number,
   diagnostic: string | null = null,
 ): { artifactId: string; ref: string; content: string; truncated: boolean; diagnostic: string | null } {
-  return {
-    artifactId,
-    ref,
-    content: content.slice(0, maxBytes),
-    truncated: content.length > maxBytes,
-    diagnostic,
-  };
+  return { artifactId, ref, ...truncateUtf8(content, maxBytes), diagnostic };
+}
+
+function readBoundedTextFile(path: string, maxBytes: number): { content: string; truncated: boolean } {
+  const size = statSync(path).size;
+  const fd = openSync(path, "r");
+  try {
+    const buffer = Buffer.alloc(Math.min(size, maxBytes + 4));
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    const bounded = truncateUtf8(buffer.subarray(0, bytesRead).toString("utf-8"), maxBytes);
+    return { content: bounded.content, truncated: bounded.truncated || size > maxBytes };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fileHasBinaryPrefix(path: string): boolean {
+  const size = statSync(path).size;
+  const fd = openSync(path, "r");
+  try {
+    const buffer = Buffer.alloc(Math.min(size, 1024));
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).includes(0);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 export function readArtifactContentForRepo(
@@ -960,19 +1013,42 @@ export function readArtifactContentForRepo(
 ): { artifactId: string; ref: string; content: string | null; truncated: boolean; diagnostic: string | null } {
   const normalizedRoot = resolve(repoRoot);
   const run = readRun(deriveProjectKey(normalizedRoot));
-  const artifact = run?.artifacts.find((entry) => entry.artifactId === artifactId);
+  if (!run) {
+    throw new Error(`Artifact ${artifactId} not found`);
+  }
+  const artifact = run.artifacts.find((entry) => entry.artifactId === artifactId);
   if (!artifact) {
     throw new Error(`Artifact ${artifactId} not found`);
   }
   const maxBytes = Math.max(1, Math.min(input.maxBytes ?? 8192, 1024 * 1024));
-  const capturedNoteContent = artifact.metadata[NOTE_CONTENT_METADATA_KEY];
-  if (artifact.type === "note" && artifact.producer.type === "child_run" && typeof capturedNoteContent === "string") {
-    assertSafeArtifactRef(artifact.ref);
-    return boundedArtifactContent(artifactId, artifact.ref, capturedNoteContent, maxBytes);
+  const metadata = artifact.metadata ?? {};
+  const capturedNoteContentRef = metadata[NOTE_CONTENT_REF_METADATA_KEY];
+  if (
+    artifact.type === "note" &&
+    artifact.producer.type === "child_run" &&
+    typeof capturedNoteContentRef === "string"
+  ) {
+    assertSafeArtifactRef(capturedNoteContentRef);
+    const noteContentPath = resolve(run.storageDir, capturedNoteContentRef);
+    const storageRoot = resolve(run.storageDir);
+    if (!noteContentPath.startsWith(`${storageRoot}/`)) {
+      throw new Error(`Unsafe captured note ref '${capturedNoteContentRef}'`);
+    }
+    if (!existsSync(noteContentPath)) {
+      return {
+        artifactId,
+        ref: artifact.ref,
+        content: null,
+        truncated: false,
+        diagnostic: "Captured note content file is missing",
+      };
+    }
+    const content = readBoundedTextFile(noteContentPath, maxBytes);
+    return { artifactId, ref: artifact.ref, ...content, diagnostic: null };
   }
   if (artifact.type === "note") {
     assertSafeArtifactRef(artifact.ref);
-    const metadataContent = JSON.stringify({ metadata: artifact.metadata }, null, 2);
+    const metadataContent = JSON.stringify({ metadata }, null, 2);
     if (/^[a-z][a-z0-9+.-]*:/i.test(artifact.ref)) {
       return boundedArtifactContent(
         artifactId,
@@ -994,14 +1070,14 @@ export function readArtifactContentForRepo(
   }
   assertSafeArtifactRef(artifact.ref);
   const trustsMetadataRoots = artifact.producer.type !== "child_run";
-  const metadataRoot = trustsMetadataRoots ? artifact.metadata.worktreeRoot : undefined;
+  const metadataRoot = trustsMetadataRoots ? metadata.worktreeRoot : undefined;
   const worker = artifact.resourceRefs.workerId
     ? [...(run?.workers ?? []), ...(run?.archivedWorkers ?? [])].find(
         (entry) => entry.workerId === artifact.resourceRefs.workerId,
       )
     : null;
   const readRoot =
-    trustsMetadataRoots && artifact.metadata.root === "storage"
+    trustsMetadataRoots && metadata.root === "storage"
       ? (run?.storageDir ?? getConductorProjectDir(deriveProjectKey(normalizedRoot)))
       : typeof metadataRoot === "string"
         ? resolve(metadataRoot)
@@ -1014,15 +1090,6 @@ export function readArtifactContentForRepo(
     throw new Error(`Unsafe artifact ref '${artifact.ref}'`);
   }
   if (!existsSync(artifactPath)) {
-    if (artifact.type === "note") {
-      return boundedArtifactContent(
-        artifactId,
-        artifact.ref,
-        JSON.stringify({ metadata: artifact.metadata }, null, 2),
-        maxBytes,
-        "Metadata-only note artifact has no readable content file",
-      );
-    }
     return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact file is missing" };
   }
   const realRoot = realpathSync(readRoot);
@@ -1033,9 +1100,7 @@ export function readArtifactContentForRepo(
   if (!lstatSync(realArtifactPath).isFile()) {
     return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact ref is not a file" };
   }
-  const size = statSync(realArtifactPath).size;
-  const buffer = readFileSync(realArtifactPath);
-  if (buffer.subarray(0, Math.min(buffer.length, 1024)).includes(0)) {
+  if (fileHasBinaryPrefix(realArtifactPath)) {
     return {
       artifactId,
       ref: artifact.ref,
@@ -1044,8 +1109,8 @@ export function readArtifactContentForRepo(
       diagnostic: "Artifact file appears to be binary",
     };
   }
-  const content = buffer.toString("utf-8").slice(0, maxBytes);
-  return { artifactId, ref: artifact.ref, content, truncated: size > maxBytes, diagnostic: null };
+  const content = readBoundedTextFile(realArtifactPath, maxBytes);
+  return { artifactId, ref: artifact.ref, ...content, diagnostic: null };
 }
 
 export function addConductorArtifact(
@@ -1171,21 +1236,27 @@ export function recordTaskProgress(
     });
   }
   const runAttempt = getActiveRunForTask(normalized, input);
-  const artifact = input.artifact
-    ? createArtifactRecord({
-        artifactId: createArtifactId(input.runId),
-        type: input.artifact.type,
-        ref: input.artifact.ref,
-        resourceRefs: {
-          projectKey: normalized.projectKey,
-          taskId: input.taskId,
-          workerId: runAttempt.workerId,
-          runId: input.runId,
-        },
-        producer: { type: "child_run", id: input.runId },
-        metadata: childNoteMetadata(input.artifact, input.progress),
-      })
-    : null;
+  const artifactId = input.artifact ? createArtifactId(input.runId) : null;
+  const capturedNoteRef =
+    input.artifact?.type === "note" && artifactId
+      ? writeCapturedNoteContent(normalized, artifactId, input.progress)
+      : null;
+  const artifact =
+    input.artifact && artifactId
+      ? createArtifactRecord({
+          artifactId,
+          type: input.artifact.type,
+          ref: input.artifact.ref,
+          resourceRefs: {
+            projectKey: normalized.projectKey,
+            taskId: input.taskId,
+            workerId: runAttempt.workerId,
+            runId: input.runId,
+          },
+          producer: { type: "child_run", id: input.runId },
+          metadata: childNoteMetadata(input.artifact, capturedNoteRef),
+        })
+      : null;
   const artifactIds = artifact ? [artifact.artifactId] : [];
   const updated = {
     ...normalized,
@@ -1256,21 +1327,27 @@ export function recordTaskCompletion(
     });
   }
   const runAttempt = getActiveRunForTask(normalized, input);
-  const artifact = input.artifact
-    ? createArtifactRecord({
-        artifactId: createArtifactId(input.runId),
-        type: input.artifact.type,
-        ref: input.artifact.ref,
-        resourceRefs: {
-          projectKey: normalized.projectKey,
-          taskId: input.taskId,
-          workerId: runAttempt.workerId,
-          runId: input.runId,
-        },
-        producer: { type: "child_run", id: input.runId },
-        metadata: childNoteMetadata(input.artifact, input.completionSummary),
-      })
-    : null;
+  const artifactId = input.artifact ? createArtifactId(input.runId) : null;
+  const capturedNoteRef =
+    input.artifact?.type === "note" && artifactId
+      ? writeCapturedNoteContent(normalized, artifactId, input.completionSummary)
+      : null;
+  const artifact =
+    input.artifact && artifactId
+      ? createArtifactRecord({
+          artifactId,
+          type: input.artifact.type,
+          ref: input.artifact.ref,
+          resourceRefs: {
+            projectKey: normalized.projectKey,
+            taskId: input.taskId,
+            workerId: runAttempt.workerId,
+            runId: input.runId,
+          },
+          producer: { type: "child_run", id: input.runId },
+          metadata: childNoteMetadata(input.artifact, capturedNoteRef),
+        })
+      : null;
   const withArtifact = artifact
     ? {
         ...normalized,

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -926,6 +926,15 @@ function sanitizeChildArtifactMetadata(metadata: Record<string, unknown> | undef
   return { ...(metadata ?? {}) };
 }
 
+function childNoteMetadata(
+  artifact: { type: ArtifactType; metadata?: Record<string, unknown> } | undefined,
+  content: string,
+): Record<string, unknown> | undefined {
+  if (!artifact) return undefined;
+  if (artifact.type !== "note") return sanitizeChildArtifactMetadata(artifact.metadata);
+  return { ...sanitizeChildArtifactMetadata(artifact.metadata), content };
+}
+
 export function readArtifactContentForRepo(
   repoRoot: string,
   artifactId: string,
@@ -936,6 +945,17 @@ export function readArtifactContentForRepo(
   const artifact = run?.artifacts.find((entry) => entry.artifactId === artifactId);
   if (!artifact) {
     throw new Error(`Artifact ${artifactId} not found`);
+  }
+  if (artifact.type === "note" && typeof artifact.metadata.content === "string") {
+    const maxBytes = Math.max(1, Math.min(input.maxBytes ?? 8192, 1024 * 1024));
+    const content = artifact.metadata.content.slice(0, maxBytes);
+    return {
+      artifactId,
+      ref: artifact.ref,
+      content,
+      truncated: artifact.metadata.content.length > maxBytes,
+      diagnostic: null,
+    };
   }
   if (/^[a-z][a-z0-9+.-]*:/i.test(artifact.ref)) {
     return {
@@ -968,6 +988,15 @@ export function readArtifactContentForRepo(
     throw new Error(`Unsafe artifact ref '${artifact.ref}'`);
   }
   if (!existsSync(artifactPath)) {
+    if (artifact.type === "note") {
+      return {
+        artifactId,
+        ref: artifact.ref,
+        content: JSON.stringify({ metadata: artifact.metadata }, null, 2),
+        truncated: false,
+        diagnostic: "Metadata-only note artifact has no readable content file",
+      };
+    }
     return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact file is missing" };
   }
   const realRoot = realpathSync(readRoot);
@@ -1107,14 +1136,21 @@ export function recordTaskProgress(
           runId: input.runId,
         },
         producer: { type: "child_run", id: input.runId },
-        metadata: sanitizeChildArtifactMetadata(input.artifact.metadata),
+        metadata: childNoteMetadata(input.artifact, input.progress),
       })
     : null;
   const artifactIds = artifact ? [artifact.artifactId] : [];
   const updated = {
     ...normalized,
     tasks: normalized.tasks.map((entry) =>
-      entry.taskId === input.taskId ? { ...entry, latestProgress: input.progress, updatedAt: now } : entry,
+      entry.taskId === input.taskId
+        ? {
+            ...entry,
+            latestProgress: input.progress,
+            artifactIds: [...entry.artifactIds, ...artifactIds],
+            updatedAt: now,
+          }
+        : entry,
     ),
     runs: normalized.runs.map((entry) =>
       entry.runId === input.runId
@@ -1185,12 +1221,17 @@ export function recordTaskCompletion(
           runId: input.runId,
         },
         producer: { type: "child_run", id: input.runId },
-        metadata: sanitizeChildArtifactMetadata(input.artifact.metadata),
+        metadata: childNoteMetadata(input.artifact, input.completionSummary),
       })
     : null;
   const withArtifact = artifact
     ? {
         ...normalized,
+        tasks: normalized.tasks.map((entry) =>
+          entry.taskId === input.taskId
+            ? { ...entry, artifactIds: [...entry.artifactIds, artifact.artifactId] }
+            : entry,
+        ),
         runs: normalized.runs.map((entry) =>
           entry.runId === input.runId ? { ...entry, artifactIds: [...entry.artifactIds, artifact.artifactId] } : entry,
         ),

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -936,6 +936,10 @@ function capturedNoteContentRef(artifactId: string): string {
   return `artifacts/${artifactId}.txt`;
 }
 
+function isMetadataOnlyChildNote(artifact: ArtifactRecord, noteContentRef: unknown): boolean {
+  return artifact.type === "note" && artifact.producer.type === "child_run" && typeof noteContentRef !== "string";
+}
+
 function writeCapturedNoteContent(run: RunRecord, artifactId: string, content: string): string {
   const ref = capturedNoteContentRef(artifactId);
   const path = resolve(run.storageDir, ref);
@@ -1010,7 +1014,14 @@ export function readArtifactContentForRepo(
   repoRoot: string,
   artifactId: string,
   input: { maxBytes?: number } = {},
-): { artifactId: string; ref: string; content: string | null; truncated: boolean; diagnostic: string | null } {
+): {
+  artifactId: string;
+  ref: string;
+  content: string | null;
+  truncated: boolean;
+  diagnostic: string | null;
+  contentSource: "artifact_file" | "captured_note" | "metadata_fallback" | "none";
+} {
   const normalizedRoot = resolve(repoRoot);
   const run = readRun(deriveProjectKey(normalizedRoot));
   if (!run) {
@@ -1022,17 +1033,20 @@ export function readArtifactContentForRepo(
   }
   const maxBytes = Math.max(1, Math.min(input.maxBytes ?? 8192, 1024 * 1024));
   const metadata = artifact.metadata ?? {};
-  const capturedNoteContentRef = metadata[NOTE_CONTENT_REF_METADATA_KEY];
+  const noteContentRefMetadata = metadata[NOTE_CONTENT_REF_METADATA_KEY];
   if (
     artifact.type === "note" &&
     artifact.producer.type === "child_run" &&
-    typeof capturedNoteContentRef === "string"
+    typeof noteContentRefMetadata === "string"
   ) {
-    assertSafeArtifactRef(capturedNoteContentRef);
-    const noteContentPath = resolve(run.storageDir, capturedNoteContentRef);
-    const storageRoot = resolve(run.storageDir);
-    if (!noteContentPath.startsWith(`${storageRoot}/`)) {
-      throw new Error(`Unsafe captured note ref '${capturedNoteContentRef}'`);
+    const expectedRef = capturedNoteContentRef(artifactId);
+    if (noteContentRefMetadata !== expectedRef) {
+      throw new Error(`Artifact ${artifact.artifactId} declares an untrusted captured note content ref`);
+    }
+    const storageRoot = realpathSync(run.storageDir);
+    const noteContentPath = resolve(run.storageDir, noteContentRefMetadata);
+    if (!noteContentPath.startsWith(`${resolve(run.storageDir)}/`)) {
+      throw new Error(`Unsafe captured note ref '${noteContentRefMetadata}'`);
     }
     if (!existsSync(noteContentPath)) {
       return {
@@ -1041,22 +1055,33 @@ export function readArtifactContentForRepo(
         content: null,
         truncated: false,
         diagnostic: "Captured note content file is missing",
+        contentSource: "none",
       };
     }
-    const content = readBoundedTextFile(noteContentPath, maxBytes);
-    return { artifactId, ref: artifact.ref, ...content, diagnostic: null };
+    if (!lstatSync(noteContentPath).isFile()) {
+      throw new Error(`Unsafe captured note ref '${noteContentRefMetadata}'`);
+    }
+    const realNoteContentPath = realpathSync(noteContentPath);
+    if (!realNoteContentPath.startsWith(`${storageRoot}/`)) {
+      throw new Error(`Unsafe captured note ref '${noteContentRefMetadata}'`);
+    }
+    const content = readBoundedTextFile(realNoteContentPath, maxBytes);
+    return { artifactId, ref: artifact.ref, ...content, diagnostic: null, contentSource: "captured_note" };
   }
   if (artifact.type === "note") {
     assertSafeArtifactRef(artifact.ref);
     const metadataContent = JSON.stringify({ metadata }, null, 2);
-    if (/^[a-z][a-z0-9+.-]*:/i.test(artifact.ref)) {
-      return boundedArtifactContent(
-        artifactId,
-        artifact.ref,
-        metadataContent,
-        maxBytes,
-        "Metadata-only note artifact has no readable content file",
-      );
+    if (isMetadataOnlyChildNote(artifact, noteContentRefMetadata)) {
+      return {
+        ...boundedArtifactContent(
+          artifactId,
+          artifact.ref,
+          metadataContent,
+          maxBytes,
+          "Metadata-only note artifact has no readable content file",
+        ),
+        contentSource: "metadata_fallback",
+      };
     }
   }
   if (/^[a-z][a-z0-9+.-]*:/i.test(artifact.ref)) {
@@ -1066,6 +1091,7 @@ export function readArtifactContentForRepo(
       content: null,
       truncated: false,
       diagnostic: "Artifact ref is external or virtual",
+      contentSource: "none",
     };
   }
   assertSafeArtifactRef(artifact.ref);
@@ -1090,7 +1116,14 @@ export function readArtifactContentForRepo(
     throw new Error(`Unsafe artifact ref '${artifact.ref}'`);
   }
   if (!existsSync(artifactPath)) {
-    return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact file is missing" };
+    return {
+      artifactId,
+      ref: artifact.ref,
+      content: null,
+      truncated: false,
+      diagnostic: "Artifact file is missing",
+      contentSource: "none",
+    };
   }
   const realRoot = realpathSync(readRoot);
   const realArtifactPath = realpathSync(artifactPath);
@@ -1098,7 +1131,14 @@ export function readArtifactContentForRepo(
     throw new Error(`Unsafe artifact ref '${artifact.ref}'`);
   }
   if (!lstatSync(realArtifactPath).isFile()) {
-    return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact ref is not a file" };
+    return {
+      artifactId,
+      ref: artifact.ref,
+      content: null,
+      truncated: false,
+      diagnostic: "Artifact ref is not a file",
+      contentSource: "none",
+    };
   }
   if (fileHasBinaryPrefix(realArtifactPath)) {
     return {
@@ -1107,10 +1147,11 @@ export function readArtifactContentForRepo(
       content: null,
       truncated: false,
       diagnostic: "Artifact file appears to be binary",
+      contentSource: "none",
     };
   }
   const content = readBoundedTextFile(realArtifactPath, maxBytes);
-  return { artifactId, ref: artifact.ref, ...content, diagnostic: null };
+  return { artifactId, ref: artifact.ref, ...content, diagnostic: null, contentSource: "artifact_file" };
 }
 
 export function addConductorArtifact(
@@ -1236,6 +1277,7 @@ export function recordTaskProgress(
     });
   }
   const runAttempt = getActiveRunForTask(normalized, input);
+  if (input.artifact) assertSafeArtifactRef(input.artifact.ref);
   const artifactId = input.artifact ? createArtifactId(input.runId) : null;
   const capturedNoteRef =
     input.artifact?.type === "note" && artifactId
@@ -1327,6 +1369,7 @@ export function recordTaskCompletion(
     });
   }
   const runAttempt = getActiveRunForTask(normalized, input);
+  if (input.artifact) assertSafeArtifactRef(input.artifact.ref);
   const artifactId = input.artifact ? createArtifactId(input.runId) : null;
   const capturedNoteRef =
     input.artifact?.type === "note" && artifactId

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -926,13 +926,31 @@ function sanitizeChildArtifactMetadata(metadata: Record<string, unknown> | undef
   return { ...(metadata ?? {}) };
 }
 
+const NOTE_CONTENT_METADATA_KEY = "conductorNoteContent";
+
 function childNoteMetadata(
   artifact: { type: ArtifactType; metadata?: Record<string, unknown> } | undefined,
   content: string,
 ): Record<string, unknown> | undefined {
   if (!artifact) return undefined;
   if (artifact.type !== "note") return sanitizeChildArtifactMetadata(artifact.metadata);
-  return { ...sanitizeChildArtifactMetadata(artifact.metadata), content };
+  return { ...sanitizeChildArtifactMetadata(artifact.metadata), [NOTE_CONTENT_METADATA_KEY]: content };
+}
+
+function boundedArtifactContent(
+  artifactId: string,
+  ref: string,
+  content: string,
+  maxBytes: number,
+  diagnostic: string | null = null,
+): { artifactId: string; ref: string; content: string; truncated: boolean; diagnostic: string | null } {
+  return {
+    artifactId,
+    ref,
+    content: content.slice(0, maxBytes),
+    truncated: content.length > maxBytes,
+    diagnostic,
+  };
 }
 
 export function readArtifactContentForRepo(
@@ -946,16 +964,24 @@ export function readArtifactContentForRepo(
   if (!artifact) {
     throw new Error(`Artifact ${artifactId} not found`);
   }
-  if (artifact.type === "note" && typeof artifact.metadata.content === "string") {
-    const maxBytes = Math.max(1, Math.min(input.maxBytes ?? 8192, 1024 * 1024));
-    const content = artifact.metadata.content.slice(0, maxBytes);
-    return {
-      artifactId,
-      ref: artifact.ref,
-      content,
-      truncated: artifact.metadata.content.length > maxBytes,
-      diagnostic: null,
-    };
+  const maxBytes = Math.max(1, Math.min(input.maxBytes ?? 8192, 1024 * 1024));
+  const capturedNoteContent = artifact.metadata[NOTE_CONTENT_METADATA_KEY];
+  if (artifact.type === "note" && artifact.producer.type === "child_run" && typeof capturedNoteContent === "string") {
+    assertSafeArtifactRef(artifact.ref);
+    return boundedArtifactContent(artifactId, artifact.ref, capturedNoteContent, maxBytes);
+  }
+  if (artifact.type === "note") {
+    assertSafeArtifactRef(artifact.ref);
+    const metadataContent = JSON.stringify({ metadata: artifact.metadata }, null, 2);
+    if (/^[a-z][a-z0-9+.-]*:/i.test(artifact.ref)) {
+      return boundedArtifactContent(
+        artifactId,
+        artifact.ref,
+        metadataContent,
+        maxBytes,
+        "Metadata-only note artifact has no readable content file",
+      );
+    }
   }
   if (/^[a-z][a-z0-9+.-]*:/i.test(artifact.ref)) {
     return {
@@ -989,13 +1015,13 @@ export function readArtifactContentForRepo(
   }
   if (!existsSync(artifactPath)) {
     if (artifact.type === "note") {
-      return {
+      return boundedArtifactContent(
         artifactId,
-        ref: artifact.ref,
-        content: JSON.stringify({ metadata: artifact.metadata }, null, 2),
-        truncated: false,
-        diagnostic: "Metadata-only note artifact has no readable content file",
-      };
+        artifact.ref,
+        JSON.stringify({ metadata: artifact.metadata }, null, 2),
+        maxBytes,
+        "Metadata-only note artifact has no readable content file",
+      );
     }
     return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact file is missing" };
   }
@@ -1007,7 +1033,6 @@ export function readArtifactContentForRepo(
   if (!lstatSync(realArtifactPath).isFile()) {
     return { artifactId, ref: artifact.ref, content: null, truncated: false, diagnostic: "Artifact ref is not a file" };
   }
-  const maxBytes = Math.max(1, Math.min(input.maxBytes ?? 8192, 1024 * 1024));
   const size = statSync(realArtifactPath).size;
   const buffer = readFileSync(realArtifactPath);
   if (buffer.subarray(0, Math.min(buffer.length, 1024)).includes(0)) {
@@ -1046,6 +1071,28 @@ export function addConductorArtifact(
   });
   const updated = {
     ...normalized,
+    tasks: artifact.resourceRefs.taskId
+      ? normalized.tasks.map((task) =>
+          task.taskId === artifact.resourceRefs.taskId
+            ? {
+                ...task,
+                artifactIds: [...new Set([...task.artifactIds, artifact.artifactId])],
+                updatedAt: artifact.updatedAt,
+              }
+            : task,
+        )
+      : normalized.tasks,
+    runs: artifact.resourceRefs.runId
+      ? normalized.runs.map((attempt) =>
+          attempt.runId === artifact.resourceRefs.runId
+            ? {
+                ...attempt,
+                artifactIds: [...new Set([...attempt.artifactIds, artifact.artifactId])],
+                updatedAt: artifact.updatedAt,
+              }
+            : attempt,
+        )
+      : normalized.runs,
     artifacts: [...normalized.artifacts, artifact],
     updatedAt: artifact.updatedAt,
   };

--- a/packages/pi-conductor/extensions/tools/evidence-tools.ts
+++ b/packages/pi-conductor/extensions/tools/evidence-tools.ts
@@ -23,8 +23,12 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const result = storage.readArtifactContentForRepo(ctx.cwd, params.artifactId, { maxBytes: params.maxBytes });
+      const text =
+        result.diagnostic && result.content
+          ? `${result.content}\n\nDiagnostic: ${result.diagnostic}`
+          : (result.content ?? result.diagnostic ?? "no content");
       return {
-        content: [{ type: "text", text: result.content ?? result.diagnostic ?? "no content" }],
+        content: [{ type: "text", text }],
         details: result,
       };
     },


### PR DESCRIPTION
## Summary
- Link child-run progress/completion artifacts onto both the run and owning task so task evidence views agree.
- Capture child note artifact content from progress/completion text so `conductor_read_artifact` can read note artifacts without relying on worker files.
- Return a metadata-only diagnostic for legacy note artifacts without readable content instead of an ambiguous missing-file error.
- Document task evidence as aggregate task/run evidence in the pi-conductor README.

## Issues
- Closes #71
- Closes #72

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run packages/pi-conductor/__tests__/storage.test.ts packages/pi-conductor/__tests__/run-flow.test.ts packages/pi-conductor/__tests__/readiness.test.ts packages/pi-conductor/__tests__/timeline.test.ts packages/pi-conductor/__tests__/task-brief.test.ts`
