### PR TITLE
fix: keep conductor storage under static safety limit

### DIFF
--- a/packages/pi-conductor/extensions/artifact-content.ts
+++ b/packages/pi-conductor/extensions/artifact-content.ts
@@ -1,0 +1,50 @@
+import { closeSync, openSync, readSync, statSync } from "node:fs";
+
+export function truncateUtf8(content: string, maxBytes: number): { content: string; truncated: boolean } {
+  let bytes = 0;
+  let output = "";
+  for (const char of content) {
+    const charBytes = Buffer.byteLength(char, "utf-8");
+    if (bytes + charBytes > maxBytes) {
+      return { content: output, truncated: true };
+    }
+    output += char;
+    bytes += charBytes;
+  }
+  return { content: output, truncated: false };
+}
+
+export function boundedArtifactContent(
+  artifactId: string,
+  ref: string,
+  content: string,
+  maxBytes: number,
+  diagnostic: string | null = null,
+): { artifactId: string; ref: string; content: string; truncated: boolean; diagnostic: string | null } {
+  return { artifactId, ref, ...truncateUtf8(content, maxBytes), diagnostic };
+}
+
+export function readBoundedTextFile(path: string, maxBytes: number): { content: string; truncated: boolean } {
+  const size = statSync(path).size;
+  const fd = openSync(path, "r");
+  try {
+    const buffer = Buffer.alloc(Math.min(size, maxBytes + 4));
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    const bounded = truncateUtf8(buffer.subarray(0, bytesRead).toString("utf-8"), maxBytes);
+    return { content: bounded.content, truncated: bounded.truncated || size > maxBytes };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function fileHasBinaryPrefix(path: string): boolean {
+  const size = statSync(path).size;
+  const fd = openSync(path, "r");
+  try {
+    const buffer = Buffer.alloc(Math.min(size, 1024));
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).includes(0);
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -5,15 +5,14 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
-  readSync,
   realpathSync,
   renameSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
+import { boundedArtifactContent, fileHasBinaryPrefix, readBoundedTextFile } from "./artifact-content.js";
 import { deriveProjectKey } from "./project-key.js";
 import { isTerminalRunStatus, isTmuxRuntimeMode } from "./run-status.js";
 import { createRunRuntimeMetadata, mapRunStatusToRuntimeStatus } from "./runtime-metadata.js";
@@ -959,55 +958,6 @@ function childNoteMetadata(
   const metadata = sanitizeChildArtifactMetadata(artifact.metadata);
   if (artifact.type !== "note" || !noteContentRef) return metadata;
   return { ...metadata, [NOTE_CONTENT_REF_METADATA_KEY]: noteContentRef };
-}
-
-function truncateUtf8(content: string, maxBytes: number): { content: string; truncated: boolean } {
-  let bytes = 0;
-  let output = "";
-  for (const char of content) {
-    const charBytes = Buffer.byteLength(char, "utf-8");
-    if (bytes + charBytes > maxBytes) {
-      return { content: output, truncated: true };
-    }
-    output += char;
-    bytes += charBytes;
-  }
-  return { content: output, truncated: false };
-}
-
-function boundedArtifactContent(
-  artifactId: string,
-  ref: string,
-  content: string,
-  maxBytes: number,
-  diagnostic: string | null = null,
-): { artifactId: string; ref: string; content: string; truncated: boolean; diagnostic: string | null } {
-  return { artifactId, ref, ...truncateUtf8(content, maxBytes), diagnostic };
-}
-
-function readBoundedTextFile(path: string, maxBytes: number): { content: string; truncated: boolean } {
-  const size = statSync(path).size;
-  const fd = openSync(path, "r");
-  try {
-    const buffer = Buffer.alloc(Math.min(size, maxBytes + 4));
-    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
-    const bounded = truncateUtf8(buffer.subarray(0, bytesRead).toString("utf-8"), maxBytes);
-    return { content: bounded.content, truncated: bounded.truncated || size > maxBytes };
-  } finally {
-    closeSync(fd);
-  }
-}
-
-function fileHasBinaryPrefix(path: string): boolean {
-  const size = statSync(path).size;
-  const fd = openSync(path, "r");
-  try {
-    const buffer = Buffer.alloc(Math.min(size, 1024));
-    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
-    return buffer.subarray(0, bytesRead).includes(0);
-  } finally {
-    closeSync(fd);
-  }
 }
 
 export function readArtifactContentForRepo(


### PR DESCRIPTION
## Summary
- Move bounded artifact content helpers out of `storage.ts` into `artifact-content.ts`.
- Restore the static safety guard requiring `storage.ts` to stay below 1600 lines.
- Keep the artifact read behavior from PR #85 unchanged.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/pi-conductor/__tests__/static-safety.test.ts packages/pi-conductor/__tests__/storage.test.ts packages/pi-conductor/__tests__/run-flow.test.ts`
- `npx vitest run packages/pi-conductor/__tests__ --coverage.enabled --coverage.reportsDirectory=coverage/pi-conductor --coverage.include=packages/pi-conductor/extensions/**/*.ts --coverage.thresholds.lines=70 --coverage.thresholds.statements=70 --coverage.thresholds.functions=70 --coverage.thresholds.branches=60`