### PR TITLE
feat: add conductor active worker viewer

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -74,6 +74,7 @@ Resource/control-plane tools:
 - `conductor_resource_timeline`
 - `conductor_run_work`
 - `conductor_run_parallel_work`
+- `conductor_view_active_workers`
 - `conductor_cancel_active_work`
 - `conductor_run_next_action`
 - `conductor_assess_task`
@@ -165,7 +166,9 @@ Programmatic callers should inspect `details.taskResults` for per-task IDs and h
 | `failed_to_launch` | A supervised non-headless shard failed before conductor could establish an active run. |
 | `interrupted` | Parent orchestration was interrupted and conductor attempted to cancel owned runs/tasks. |
 
-Use conductor status tools rather than typing into worker panes to supervise work. Active visible runs include:
+Use conductor status tools rather than typing into worker panes to supervise work. Active visible runs can be inspected with `conductor_view_active_workers`, optionally scoped by `taskId`, `workerId`, or `runId`. The response includes worker names, task titles, run IDs, runtime/viewer status, attach commands, log-tail commands, latest progress, diagnostics, and cancel tool calls.
+
+Active visible runs include:
 
 - `viewer=<opened|warning|unavailable|pending>` and `viewerCommand="tmux ... attach-session -r ..."`
 - `log=<path-or-ref>` and the latest runtime diagnostic/heartbeat

--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -162,7 +162,7 @@ Programmatic callers should inspect `details.taskResults` for per-task IDs and h
 | `executionState` | Meaning |
 | ---------------- | ------- |
 | `completed` | Headless execution finished and `result.status` describes the terminal worker outcome. |
-| `launched` | A supervised tmux/iTerm-backed run launched successfully and remains represented by durable conductor run state. Inspect `runtimeRuns`, `conductor_project_brief`, or `conductor_list_runs` for current status. |
+| `launched` | A supervised tmux/iTerm-backed run launched successfully and remains represented by durable conductor run state. Inspect `runtimeRuns`, `conductor_view_active_workers`, `conductor_project_brief`, or `conductor_list_runs` for current status. |
 | `failed_to_launch` | A supervised non-headless shard failed before conductor could establish an active run. |
 | `interrupted` | Parent orchestration was interrupted and conductor attempted to cancel owned runs/tasks. |
 
@@ -224,7 +224,7 @@ conductor_run_parallel_work({
   ]
 })
 conductor_project_brief({ maxActions: 10, recentEventLimit: 20 })
-conductor_list_runs({ status: "running" })
+conductor_view_active_workers({})
 ```
 
 For blocking completion semantics, request headless explicitly:

--- a/packages/pi-conductor/__tests__/active-worker-viewer.test.ts
+++ b/packages/pi-conductor/__tests__/active-worker-viewer.test.ts
@@ -108,6 +108,19 @@ describe("active worker viewer summaries", () => {
       name: "conductor_cancel_task_run",
       params: { runId: started.run.runId, reason: "Parent requested cancellation" },
     });
+    expect(summary.entries[0]?.nextToolCalls).toEqual([
+      { name: "conductor_view_active_workers", params: { runId: started.run.runId }, purpose: "refresh" },
+      {
+        name: "conductor_resource_timeline",
+        params: { runId: started.run.runId, includeArtifacts: true },
+        purpose: "timeline",
+      },
+      {
+        name: "conductor_cancel_task_run",
+        params: { runId: started.run.runId, reason: "<reason>" },
+        purpose: "cancel",
+      },
+    ]);
 
     const markdown = formatActiveWorkerViewerSummary(summary);
     expect(markdown).toContain("active supervised conductor workers: 1");
@@ -200,6 +213,25 @@ describe("active worker viewer summaries", () => {
     ).toEqual([]);
   });
 
+  it("renders next-action tool calls in model-visible text", async () => {
+    const worker = await createWorkerForRepo(repoDir, "next-action-worker");
+    const task = createTaskForRepo(repoDir, { title: "Next action task", prompt: "Watch me" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "tmux" });
+
+    const tool = collectTools().find((entry) => entry.name === "conductor_next_actions");
+    const result = (await tool?.execute?.(
+      "tool-call-1",
+      { includeLowPriority: true, reconcile: false },
+      undefined,
+      undefined,
+      { cwd: repoDir },
+    )) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain("conductor_view_active_workers");
+    expect(result.content[0]?.text).toContain(started.run.runId);
+  });
+
   it("returns an empty active-viewer response without creating conductor state", () => {
     const runFile = getRunFile(deriveProjectKey(resolve(repoDir)));
 
@@ -232,5 +264,23 @@ describe("active worker viewer summaries", () => {
     expect(formatActiveWorkerViewerSummary(summary)).toBe(
       "no active supervised conductor workers matched the requested scope",
     );
+  });
+
+  it("omits active-looking supervised runs with terminal runtime status", async () => {
+    const worker = await createWorkerForRepo(repoDir, "stale-worker");
+    const task = createTaskForRepo(repoDir, { title: "Stale task", prompt: "Run" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "tmux" });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId
+          ? { ...entry, runtime: { ...entry.runtime, status: "exited_error" as const } }
+          : entry,
+      ),
+    });
+
+    expect(summarizeActiveWorkerViewersForRepo(repoDir).entries).toEqual([]);
   });
 });

--- a/packages/pi-conductor/__tests__/active-worker-viewer.test.ts
+++ b/packages/pi-conductor/__tests__/active-worker-viewer.test.ts
@@ -1,0 +1,184 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  formatActiveWorkerViewerSummary,
+  summarizeActiveWorkerViewersForRepo,
+} from "../extensions/active-worker-viewer.js";
+import {
+  assignTaskForRepo,
+  createTaskForRepo,
+  createWorkerForRepo,
+  getOrCreateRunForRepo,
+  startTaskRunForRepo,
+} from "../extensions/conductor.js";
+import conductorExtension from "../extensions/index.js";
+import { createRunRuntimeMetadata } from "../extensions/runtime-metadata.js";
+import { writeRun } from "../extensions/storage.js";
+
+type RegisteredTool = {
+  name: string;
+  execute?: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: { cwd: string },
+  ) => Promise<unknown> | unknown;
+};
+
+function collectTools(): RegisteredTool[] {
+  const tools: RegisteredTool[] = [];
+  conductorExtension({
+    registerCommand: () => undefined,
+    registerTool: (tool: RegisteredTool) => tools.push(tool),
+  } as never);
+  return tools;
+}
+
+describe("active worker viewer summaries", () => {
+  let repoDir: string;
+  let conductorHome: string;
+
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
+
+  afterEach(() => {
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) rmSync(repoDir, { recursive: true, force: true });
+    if (existsSync(conductorHome)) rmSync(conductorHome, { recursive: true, force: true });
+  });
+
+  it("lists active supervised worker attach, log, status, and cancel details", async () => {
+    const worker = await createWorkerForRepo(repoDir, "viewer-worker");
+    const task = createTaskForRepo(repoDir, { title: "Visible | task", prompt: "Watch me" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "iterm-tmux" });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      tasks: run.tasks.map((entry) =>
+        entry.taskId === task.taskId ? { ...entry, latestProgress: "line one\nline | two" } : entry,
+      ),
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId
+          ? {
+              ...entry,
+              runtime: {
+                ...createRunRuntimeMetadata({ mode: "iterm-tmux", status: "running" }),
+                viewerStatus: "opened" as const,
+                viewerCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+                logPath: "/tmp/pi-conductor/runtime/run-1/runner.log",
+                diagnostics: ["iTerm2 viewer opened"],
+              },
+            }
+          : entry,
+      ),
+    });
+
+    const summary = summarizeActiveWorkerViewersForRepo(repoDir);
+
+    expect(summary.entries).toHaveLength(1);
+    expect(summary.entries[0]).toMatchObject({
+      workerName: "viewer-worker",
+      taskTitle: "Visible | task",
+      runId: started.run.runId,
+      runtimeMode: "iterm-tmux",
+      runtimeStatus: "running",
+      viewerStatus: "opened",
+      attachCommand: "tmux -S '/tmp/tmux.sock' attach-session -r -t 'pi-cond-run'",
+      logTailCommand: "tail -f '/tmp/pi-conductor/runtime/run-1/runner.log'",
+      latestProgress: "line one\nline | two",
+      diagnostic: "iTerm2 viewer opened",
+    });
+    expect(summary.entries[0]?.cancelTool).toEqual({
+      name: "conductor_cancel_task_run",
+      params: { runId: started.run.runId, reason: "Parent requested cancellation" },
+    });
+
+    const markdown = formatActiveWorkerViewerSummary(summary);
+    expect(markdown).toContain("active supervised conductor workers: 1");
+    expect(markdown).toContain("Visible \\| task");
+    expect(markdown).toContain("line one<br>line \\| two");
+    expect(markdown).toContain("iTerm2 viewer opened");
+  });
+
+  it("falls back to tmux attach instructions when viewer command is unavailable", async () => {
+    const worker = await createWorkerForRepo(repoDir, "tmux-worker");
+    const task = createTaskForRepo(repoDir, { title: "Tmux task", prompt: "Watch me" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    const started = startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "tmux" });
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      runs: run.runs.map((entry) =>
+        entry.runId === started.run.runId
+          ? {
+              ...entry,
+              runtime: {
+                ...createRunRuntimeMetadata({ mode: "tmux", status: "running" }),
+                viewerStatus: "unavailable" as const,
+                tmux: {
+                  socketPath: "/tmp/with space/tmux.sock",
+                  sessionName: "pi cond run",
+                  windowId: null,
+                  paneId: null,
+                },
+                logPath: null,
+                diagnostics: ["iTerm2 unavailable"],
+              },
+            }
+          : entry,
+      ),
+    });
+
+    const summary = summarizeActiveWorkerViewersForRepo(repoDir, { runId: started.run.runId });
+
+    expect(summary.entries).toHaveLength(1);
+    expect(summary.entries[0]?.viewerStatus).toBe("unavailable");
+    expect(summary.entries[0]?.attachCommand).toBe(
+      "tmux -S '/tmp/with space/tmux.sock' attach-session -r -t 'pi cond run'",
+    );
+  });
+
+  it("exposes active worker viewing as a registered tool", async () => {
+    const worker = await createWorkerForRepo(repoDir, "tool-worker");
+    const task = createTaskForRepo(repoDir, { title: "Tool task", prompt: "Watch me" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "tmux" });
+
+    const tool = collectTools().find((entry) => entry.name === "conductor_view_active_workers");
+    const result = (await tool?.execute?.("tool-call-1", { taskId: task.taskId }, undefined, undefined, {
+      cwd: repoDir,
+    })) as { content: Array<{ text: string }>; details: { entries: unknown[] } };
+
+    expect(result.content[0]?.text).toContain("active supervised conductor workers: 1");
+    expect(result.content[0]?.text).toContain("tool-worker");
+    expect(result.details.entries).toHaveLength(1);
+  });
+
+  it("returns an empty active-viewer response for headless or terminal runs", async () => {
+    const worker = await createWorkerForRepo(repoDir, "headless-worker");
+    const task = createTaskForRepo(repoDir, { title: "Headless task", prompt: "Run" });
+    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
+    startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "headless" });
+
+    const summary = summarizeActiveWorkerViewersForRepo(repoDir);
+
+    expect(summary.entries).toEqual([]);
+    expect(formatActiveWorkerViewerSummary(summary)).toBe(
+      "no active supervised conductor workers matched the requested scope",
+    );
+  });
+});

--- a/packages/pi-conductor/__tests__/active-worker-viewer.test.ts
+++ b/packages/pi-conductor/__tests__/active-worker-viewer.test.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   formatActiveWorkerViewerSummary,
@@ -15,11 +15,13 @@ import {
   startTaskRunForRepo,
 } from "../extensions/conductor.js";
 import conductorExtension from "../extensions/index.js";
+import { deriveProjectKey } from "../extensions/project-key.js";
 import { createRunRuntimeMetadata } from "../extensions/runtime-metadata.js";
-import { writeRun } from "../extensions/storage.js";
+import { completeTaskRun, getRunFile, writeRun } from "../extensions/storage.js";
 
 type RegisteredTool = {
   name: string;
+  parameters?: unknown;
   execute?: (
     toolCallId: string,
     params: Record<string, unknown>,
@@ -130,8 +132,8 @@ describe("active worker viewer summaries", () => {
                 ...createRunRuntimeMetadata({ mode: "tmux", status: "running" }),
                 viewerStatus: "unavailable" as const,
                 tmux: {
-                  socketPath: "/tmp/with space/tmux.sock",
-                  sessionName: "pi cond run",
+                  socketPath: "/tmp/with space/it's/tmux.sock",
+                  sessionName: "pi cond run 'quoted'",
                   windowId: null,
                   paneId: null,
                 },
@@ -148,7 +150,7 @@ describe("active worker viewer summaries", () => {
     expect(summary.entries).toHaveLength(1);
     expect(summary.entries[0]?.viewerStatus).toBe("unavailable");
     expect(summary.entries[0]?.attachCommand).toBe(
-      "tmux -S '/tmp/with space/tmux.sock' attach-session -r -t 'pi cond run'",
+      "tmux -S '/tmp/with space/it'\"'\"'s/tmux.sock' attach-session -r -t 'pi cond run '\"'\"'quoted'\"'\"''",
     );
   });
 
@@ -166,13 +168,63 @@ describe("active worker viewer summaries", () => {
     expect(result.content[0]?.text).toContain("active supervised conductor workers: 1");
     expect(result.content[0]?.text).toContain("tool-worker");
     expect(result.details.entries).toHaveLength(1);
+    const schema = JSON.stringify(tool?.parameters);
+    expect(schema).toContain("taskId");
+    expect(schema).toContain("workerId");
+    expect(schema).toContain("runId");
   });
 
-  it("returns an empty active-viewer response for headless or terminal runs", async () => {
-    const worker = await createWorkerForRepo(repoDir, "headless-worker");
-    const task = createTaskForRepo(repoDir, { title: "Headless task", prompt: "Run" });
-    assignTaskForRepo(repoDir, task.taskId, worker.workerId);
-    startTaskRunForRepo(repoDir, { taskId: task.taskId, runtimeMode: "headless" });
+  it("filters active supervised workers by task, worker, and run", async () => {
+    const firstWorker = await createWorkerForRepo(repoDir, "first-worker");
+    const secondWorker = await createWorkerForRepo(repoDir, "second-worker");
+    const firstTask = createTaskForRepo(repoDir, { title: "First task", prompt: "Run" });
+    const secondTask = createTaskForRepo(repoDir, { title: "Second task", prompt: "Run" });
+    assignTaskForRepo(repoDir, firstTask.taskId, firstWorker.workerId);
+    assignTaskForRepo(repoDir, secondTask.taskId, secondWorker.workerId);
+    const firstRun = startTaskRunForRepo(repoDir, { taskId: firstTask.taskId, runtimeMode: "tmux" });
+    const secondRun = startTaskRunForRepo(repoDir, { taskId: secondTask.taskId, runtimeMode: "iterm-tmux" });
+
+    expect(summarizeActiveWorkerViewersForRepo(repoDir).entries).toHaveLength(2);
+    expect(summarizeActiveWorkerViewersForRepo(repoDir, { taskId: firstTask.taskId }).entries).toMatchObject([
+      { taskId: firstTask.taskId, runId: firstRun.run.runId },
+    ]);
+    expect(summarizeActiveWorkerViewersForRepo(repoDir, { workerId: secondWorker.workerId }).entries).toMatchObject([
+      { workerId: secondWorker.workerId, runId: secondRun.run.runId },
+    ]);
+    expect(summarizeActiveWorkerViewersForRepo(repoDir, { runId: secondRun.run.runId }).entries).toMatchObject([
+      { taskId: secondTask.taskId, runId: secondRun.run.runId },
+    ]);
+    expect(
+      summarizeActiveWorkerViewersForRepo(repoDir, { taskId: firstTask.taskId, workerId: secondWorker.workerId })
+        .entries,
+    ).toEqual([]);
+  });
+
+  it("returns an empty active-viewer response without creating conductor state", () => {
+    const runFile = getRunFile(deriveProjectKey(resolve(repoDir)));
+
+    const summary = summarizeActiveWorkerViewersForRepo(repoDir);
+
+    expect(summary.entries).toEqual([]);
+    expect(existsSync(runFile)).toBe(false);
+  });
+
+  it("returns an empty active-viewer response for headless or terminal supervised runs", async () => {
+    const headlessWorker = await createWorkerForRepo(repoDir, "headless-worker");
+    const headlessTask = createTaskForRepo(repoDir, { title: "Headless task", prompt: "Run" });
+    assignTaskForRepo(repoDir, headlessTask.taskId, headlessWorker.workerId);
+    startTaskRunForRepo(repoDir, { taskId: headlessTask.taskId, runtimeMode: "headless" });
+    const tmuxWorker = await createWorkerForRepo(repoDir, "terminal-worker");
+    const tmuxTask = createTaskForRepo(repoDir, { title: "Terminal task", prompt: "Run" });
+    assignTaskForRepo(repoDir, tmuxTask.taskId, tmuxWorker.workerId);
+    const terminalRun = startTaskRunForRepo(repoDir, { taskId: tmuxTask.taskId, runtimeMode: "tmux" });
+    writeRun(
+      completeTaskRun(getOrCreateRunForRepo(repoDir), {
+        runId: terminalRun.run.runId,
+        status: "succeeded",
+        completionSummary: "done",
+      }),
+    );
 
     const summary = summarizeActiveWorkerViewersForRepo(repoDir);
 

--- a/packages/pi-conductor/__tests__/index.test.ts
+++ b/packages/pi-conductor/__tests__/index.test.ts
@@ -33,6 +33,7 @@ describe("pi-conductor extension", () => {
       "conductor_run_next_action",
       "conductor_run_work",
       "conductor_run_parallel_work",
+      "conductor_view_active_workers",
       "conductor_cancel_active_work",
       "conductor_schedule_objective",
       "conductor_scheduler_tick",

--- a/packages/pi-conductor/__tests__/next-actions.test.ts
+++ b/packages/pi-conductor/__tests__/next-actions.test.ts
@@ -133,6 +133,28 @@ describe("computeNextActions", () => {
     });
   });
 
+  it("keeps event-list fallback for low-priority headless run inspection", () => {
+    let run = addWorker(createEmptyRun("abc", "/repo"), usableWorker());
+    run = assignTaskToWorker(
+      addTask(run, createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" })),
+      "task-1",
+      "worker-1",
+    );
+    run = startTaskRun(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      workerId: "worker-1",
+      backend: "native",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    });
+
+    const result = computeNextActions(run, { includeLowPriority: true, now: "2026-04-24T00:00:00.000Z" });
+
+    expect(result.actions.find((action) => action.kind === "wait_for_run")).toMatchObject({
+      toolCall: { name: "conductor_list_events", params: { runId: "run-1", limit: 20 } },
+    });
+  });
+
   it("does not recommend intervention for an unexpired active run by default", () => {
     let run = addWorker(createEmptyRun("abc", "/repo"), usableWorker());
     run = assignTaskToWorker(

--- a/packages/pi-conductor/__tests__/next-actions.test.ts
+++ b/packages/pi-conductor/__tests__/next-actions.test.ts
@@ -110,6 +110,29 @@ describe("computeNextActions", () => {
     });
   });
 
+  it("recommends active worker viewing for low-priority supervised run inspection", () => {
+    let run = addWorker(createEmptyRun("abc", "/repo"), usableWorker());
+    run = assignTaskToWorker(
+      addTask(run, createTaskRecord({ taskId: "task-1", title: "Build", prompt: "Do it" })),
+      "task-1",
+      "worker-1",
+    );
+    run = startTaskRun(run, {
+      runId: "run-1",
+      taskId: "task-1",
+      workerId: "worker-1",
+      backend: "native",
+      runtimeMode: "tmux",
+      leaseExpiresAt: "2026-04-24T01:00:00.000Z",
+    });
+
+    const result = computeNextActions(run, { includeLowPriority: true, now: "2026-04-24T00:00:00.000Z" });
+
+    expect(result.actions.find((action) => action.kind === "wait_for_run")).toMatchObject({
+      toolCall: { name: "conductor_view_active_workers", params: { runId: "run-1" } },
+    });
+  });
+
   it("does not recommend intervention for an unexpired active run by default", () => {
     let run = addWorker(createEmptyRun("abc", "/repo"), usableWorker());
     run = assignTaskToWorker(

--- a/packages/pi-conductor/extensions/active-worker-viewer.ts
+++ b/packages/pi-conductor/extensions/active-worker-viewer.ts
@@ -1,0 +1,121 @@
+import { getOrCreateRunForRepo } from "./repo-run.js";
+import { isTerminalRunStatus } from "./run-status.js";
+import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode, TaskRecord, WorkerRecord } from "./types.js";
+
+export type ActiveWorkerViewerInput = {
+  taskId?: string;
+  workerId?: string;
+  runId?: string;
+};
+
+export type ActiveWorkerViewerEntry = {
+  taskId: string;
+  taskTitle: string;
+  workerId: string;
+  workerName: string;
+  runId: string;
+  runStatus: RunAttemptRecord["status"];
+  runtimeMode: RunRuntimeMode;
+  runtimeStatus: RunRuntimeMetadata["status"];
+  viewerStatus: RunRuntimeMetadata["viewerStatus"];
+  viewerCommand: string | null;
+  attachCommand: string | null;
+  logPath: string | null;
+  logTailCommand: string | null;
+  latestProgress: string | null;
+  diagnostic: string | null;
+  cancelTool: { name: "conductor_cancel_task_run"; params: { runId: string; reason: string } };
+};
+
+export type ActiveWorkerViewerSummary = {
+  entries: ActiveWorkerViewerEntry[];
+  filters: ActiveWorkerViewerInput;
+};
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function isSupervisedRuntime(mode: RunRuntimeMode): boolean {
+  return mode === "tmux" || mode === "iterm-tmux";
+}
+
+function isActiveRun(run: RunAttemptRecord): boolean {
+  return !run.finishedAt && !isTerminalRunStatus(run.status);
+}
+
+function fallbackAttachCommand(runtime: RunRuntimeMetadata): string | null {
+  if (runtime.viewerCommand) return runtime.viewerCommand;
+  const tmux = runtime.tmux;
+  if (!tmux?.socketPath || !tmux.sessionName) return null;
+  return `tmux -S ${shellQuote(tmux.socketPath)} attach-session -r -t ${shellQuote(tmux.sessionName)}`;
+}
+
+function logTailCommand(logPath: string | null): string | null {
+  return logPath ? `tail -f ${shellQuote(logPath)}` : null;
+}
+
+function matchesFilters(run: RunAttemptRecord, input: ActiveWorkerViewerInput): boolean {
+  return (
+    (!input.runId || run.runId === input.runId) &&
+    (!input.taskId || run.taskId === input.taskId) &&
+    (!input.workerId || run.workerId === input.workerId)
+  );
+}
+
+export function summarizeActiveWorkerViewersForRepo(
+  repoRoot: string,
+  input: ActiveWorkerViewerInput = {},
+): ActiveWorkerViewerSummary {
+  const project = getOrCreateRunForRepo(repoRoot);
+  const tasksById = new Map(project.tasks.map((task) => [task.taskId, task] as const));
+  const workersById = new Map(project.workers.map((worker) => [worker.workerId, worker] as const));
+  const entries = project.runs
+    .filter((run) => isActiveRun(run) && isSupervisedRuntime(run.runtime.mode) && matchesFilters(run, input))
+    .map((run) => {
+      const task = tasksById.get(run.taskId) as TaskRecord | undefined;
+      const worker = workersById.get(run.workerId) as WorkerRecord | undefined;
+      return {
+        taskId: run.taskId,
+        taskTitle: task?.title ?? "<missing task>",
+        workerId: run.workerId,
+        workerName: worker?.name ?? "<missing worker>",
+        runId: run.runId,
+        runStatus: run.status,
+        runtimeMode: run.runtime.mode,
+        runtimeStatus: run.runtime.status,
+        viewerStatus: run.runtime.viewerStatus,
+        viewerCommand: run.runtime.viewerCommand,
+        attachCommand: fallbackAttachCommand(run.runtime),
+        logPath: run.runtime.logPath,
+        logTailCommand: logTailCommand(run.runtime.logPath),
+        latestProgress: task?.latestProgress ?? null,
+        diagnostic: run.runtime.diagnostics.at(-1) ?? null,
+        cancelTool: {
+          name: "conductor_cancel_task_run" as const,
+          params: { runId: run.runId, reason: "Parent requested cancellation" },
+        },
+      };
+    });
+  return { entries, filters: input };
+}
+
+function cell(value: string | null | undefined): string {
+  return (value ?? "none").replace(/\r\n?/g, "\n").replace(/\n/g, "<br>").replace(/\|/g, "\\|");
+}
+
+export function formatActiveWorkerViewerSummary(summary: ActiveWorkerViewerSummary): string {
+  if (summary.entries.length === 0) {
+    return "no active supervised conductor workers matched the requested scope";
+  }
+  const rows = summary.entries.map(
+    (entry) =>
+      `| ${cell(entry.workerName)} | ${cell(entry.workerId)} | ${cell(entry.taskTitle)} | ${cell(entry.taskId)} | ${cell(entry.runId)} | ${cell(entry.runStatus)} | ${cell(entry.runtimeMode)} | ${cell(entry.runtimeStatus)} | ${cell(entry.viewerStatus)} | ${cell(entry.attachCommand)} | ${cell(entry.logTailCommand)} | ${cell(entry.latestProgress)} | ${cell(entry.diagnostic)} | ${cell(`${entry.cancelTool.name}(${JSON.stringify(entry.cancelTool.params)})`)} |`,
+  );
+  return [
+    `active supervised conductor workers: ${summary.entries.length}`,
+    "| Worker | workerId | Task | taskId | runId | Run status | Runtime | Runtime status | Viewer | Attach command | Log tail | Latest progress | Diagnostic | Cancel |",
+    "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}

--- a/packages/pi-conductor/extensions/active-worker-viewer.ts
+++ b/packages/pi-conductor/extensions/active-worker-viewer.ts
@@ -1,5 +1,7 @@
-import { getOrCreateRunForRepo } from "./repo-run.js";
+import { resolve } from "node:path";
+import { deriveProjectKey } from "./project-key.js";
 import { isTerminalRunStatus } from "./run-status.js";
+import { readRun } from "./storage.js";
 import type { RunAttemptRecord, RunRuntimeMetadata, RunRuntimeMode, TaskRecord, WorkerRecord } from "./types.js";
 
 export type ActiveWorkerViewerInput = {
@@ -41,7 +43,11 @@ function isSupervisedRuntime(mode: RunRuntimeMode): boolean {
 }
 
 function isActiveRun(run: RunAttemptRecord): boolean {
-  return !run.finishedAt && !isTerminalRunStatus(run.status);
+  return (
+    !run.finishedAt &&
+    !isTerminalRunStatus(run.status) &&
+    !["unavailable", "exited_success", "exited_error", "aborted"].includes(run.runtime.status)
+  );
 }
 
 function fallbackAttachCommand(runtime: RunRuntimeMetadata): string | null {
@@ -67,7 +73,8 @@ export function summarizeActiveWorkerViewersForRepo(
   repoRoot: string,
   input: ActiveWorkerViewerInput = {},
 ): ActiveWorkerViewerSummary {
-  const project = getOrCreateRunForRepo(repoRoot);
+  const project = readRun(deriveProjectKey(resolve(repoRoot)));
+  if (!project) return { entries: [], filters: input };
   const tasksById = new Map(project.tasks.map((task) => [task.taskId, task] as const));
   const workersById = new Map(project.workers.map((worker) => [worker.workerId, worker] as const));
   const entries = project.runs

--- a/packages/pi-conductor/extensions/active-worker-viewer.ts
+++ b/packages/pi-conductor/extensions/active-worker-viewer.ts
@@ -27,6 +27,7 @@ export type ActiveWorkerViewerEntry = {
   latestProgress: string | null;
   diagnostic: string | null;
   cancelTool: { name: "conductor_cancel_task_run"; params: { runId: string; reason: string } };
+  nextToolCalls: Array<{ name: string; params: Record<string, unknown>; purpose: "refresh" | "timeline" | "cancel" }>;
 };
 
 export type ActiveWorkerViewerSummary = {
@@ -102,6 +103,19 @@ export function summarizeActiveWorkerViewersForRepo(
           name: "conductor_cancel_task_run" as const,
           params: { runId: run.runId, reason: "Parent requested cancellation" },
         },
+        nextToolCalls: [
+          { name: "conductor_view_active_workers", params: { runId: run.runId }, purpose: "refresh" as const },
+          {
+            name: "conductor_resource_timeline",
+            params: { runId: run.runId, includeArtifacts: true },
+            purpose: "timeline" as const,
+          },
+          {
+            name: "conductor_cancel_task_run",
+            params: { runId: run.runId, reason: "<reason>" },
+            purpose: "cancel" as const,
+          },
+        ],
       };
     });
   return { entries, filters: input };
@@ -117,11 +131,11 @@ export function formatActiveWorkerViewerSummary(summary: ActiveWorkerViewerSumma
   }
   const rows = summary.entries.map(
     (entry) =>
-      `| ${cell(entry.workerName)} | ${cell(entry.workerId)} | ${cell(entry.taskTitle)} | ${cell(entry.taskId)} | ${cell(entry.runId)} | ${cell(entry.runStatus)} | ${cell(entry.runtimeMode)} | ${cell(entry.runtimeStatus)} | ${cell(entry.viewerStatus)} | ${cell(entry.attachCommand)} | ${cell(entry.logTailCommand)} | ${cell(entry.latestProgress)} | ${cell(entry.diagnostic)} | ${cell(`${entry.cancelTool.name}(${JSON.stringify(entry.cancelTool.params)})`)} |`,
+      `| ${cell(entry.workerName)} | ${cell(entry.workerId)} | ${cell(entry.taskTitle)} | ${cell(entry.taskId)} | ${cell(entry.runId)} | ${cell(entry.runStatus)} | ${cell(entry.runtimeMode)} | ${cell(entry.runtimeStatus)} | ${cell(entry.viewerStatus)} | ${cell(entry.attachCommand)} | ${cell(entry.logTailCommand)} | ${cell(entry.latestProgress)} | ${cell(entry.diagnostic)} | ${cell(entry.nextToolCalls.map((call) => `${call.name}(${JSON.stringify(call.params)})`).join("; "))} |`,
   );
   return [
     `active supervised conductor workers: ${summary.entries.length}`,
-    "| Worker | workerId | Task | taskId | runId | Run status | Runtime | Runtime status | Viewer | Attach command | Log tail | Latest progress | Diagnostic | Cancel |",
+    "| Worker | workerId | Task | taskId | runId | Run status | Runtime | Runtime status | Viewer | Attach command | Log tail | Latest progress | Diagnostic | Next tools |",
     "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ...rows,
   ].join("\n");

--- a/packages/pi-conductor/extensions/next-actions.ts
+++ b/packages/pi-conductor/extensions/next-actions.ts
@@ -154,7 +154,10 @@ export function computeNextActions(
             workerId: attempt.workerId,
             runId: attempt.runId,
           },
-          toolCall: { name: "conductor_list_events", params: { runId: attempt.runId, limit: 20 } },
+          toolCall:
+            attempt.runtime.mode === "tmux" || attempt.runtime.mode === "iterm-tmux"
+              ? { name: "conductor_view_active_workers", params: { runId: attempt.runId } }
+              : { name: "conductor_list_events", params: { runId: attempt.runId, limit: 20 } },
           requiresHuman: false,
           destructive: false,
           blockedBy: [],

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { formatActiveWorkerViewerSummary, summarizeActiveWorkerViewersForRepo } from "../active-worker-viewer.js";
 import * as conductor from "../conductor.js";
 import { formatParallelTaskResultsTable } from "../parallel-work-results.js";
 
@@ -109,6 +110,26 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
       const result = await conductor.runParallelWorkForRepo(ctx.cwd, params, signal);
       const text = summarizeParallelWorkToolText(result, signal?.aborted ?? false);
       return { content: [{ type: "text", text }], details: result };
+    },
+  });
+
+  pi.registerTool({
+    name: "conductor_view_active_workers",
+    label: "Conductor View Active Workers",
+    description:
+      "List active supervised tmux/iTerm conductor workers with run IDs, worker names, task titles, runtime/viewer status, attach/log commands, and cancel tool calls. Scope by taskId, workerId, or runId when inspecting one active worker.",
+    parameters: Type.Object({
+      taskId: Type.Optional(Type.String({ description: "Optional task ID to inspect" })),
+      workerId: Type.Optional(Type.String({ description: "Optional worker ID to inspect" })),
+      runId: Type.Optional(Type.String({ description: "Optional run ID to inspect" })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const summary = summarizeActiveWorkerViewersForRepo(ctx.cwd, {
+        taskId: params.taskId as string | undefined,
+        workerId: params.workerId as string | undefined,
+        runId: params.runId as string | undefined,
+      });
+      return { content: [{ type: "text", text: formatActiveWorkerViewerSummary(summary) }], details: summary };
     },
   });
 

--- a/packages/pi-conductor/extensions/tools/orchestration-tools.ts
+++ b/packages/pi-conductor/extensions/tools/orchestration-tools.ts
@@ -22,7 +22,7 @@ export function summarizeParallelWorkToolText(
   const finishedText = `${semanticCompleted} completed, ${result.results.length - semanticCompleted} need follow-up${canceledText}`;
   const launchedText = `${launched} launched, ${result.results.length - launched} failed to launch${canceledText}`;
   const followUpText =
-    'inspect with conductor_project_brief or conductor_list_runs({ status: "running" }); cancel with conductor_cancel_active_work';
+    "inspect active viewers with conductor_view_active_workers({}); scope by taskId/workerId/runId; cancel with conductor_cancel_active_work";
   const resultTable = formatParallelTaskResultsTable(result.taskResults);
   if (aborted) {
     return `interrupted parallel conductor work with ${runtimeText}; canceled ${result.canceledRuns.length} active run(s) and ${result.canceledTasks.length} task(s)${resultTable}`;
@@ -73,12 +73,14 @@ export function registerOrchestrationTools(pi: ExtensionAPI): void {
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await conductor.runWorkForRepo(ctx.cwd, params, signal);
       const runtimeText = `runtime=${result.runtimeMode}${result.runtimeRuns.length > 0 ? ` runs=${result.runtimeRuns.length}` : ""}`;
+      const viewerText =
+        result.runtimeRuns.length > 0 ? "; inspect active viewers with conductor_view_active_workers({})" : "";
       const text =
         result.decision.mode === "parallel"
-          ? `routed work to ${result.tasks.length} parallel conductor worker(s) with ${runtimeText}: ${result.decision.reason}`
+          ? `routed work to ${result.tasks.length} parallel conductor worker(s) with ${runtimeText}: ${result.decision.reason}${viewerText}`
           : result.decision.mode === "objective"
-            ? `routed work to an objective with ${result.tasks.length} task(s) with ${runtimeText}: ${result.decision.reason}`
-            : `routed work to one conductor worker with ${runtimeText}: ${result.decision.reason}`;
+            ? `routed work to an objective with ${result.tasks.length} task(s) with ${runtimeText}: ${result.decision.reason}${viewerText}`
+            : `routed work to one conductor worker with ${runtimeText}: ${result.decision.reason}${viewerText}`;
       return { content: [{ type: "text", text }], details: result };
     },
   });

--- a/packages/pi-conductor/extensions/tools/project-tools.ts
+++ b/packages/pi-conductor/extensions/tools/project-tools.ts
@@ -4,6 +4,15 @@ import * as backends from "../backends.js";
 import * as conductor from "../conductor.js";
 
 const schedulerPolicySchema = Type.Union([Type.Literal("safe"), Type.Literal("execute")]);
+
+function formatNextActionText(
+  action: { priority: string; title: string; toolCall: null | { name: string; params: Record<string, unknown> } },
+  index: number,
+): string {
+  const toolText = action.toolCall ? ` — call ${action.toolCall.name}(${JSON.stringify(action.toolCall.params)})` : "";
+  return `${index + 1}. [${action.priority}] ${action.title}${toolText}`;
+}
+
 export function registerProjectTools(pi: ExtensionAPI, findRepoRoot: (cwd: string) => string | null): void {
   pi.registerTool({
     name: "conductor_get_project",
@@ -143,9 +152,7 @@ export function registerProjectTools(pi: ExtensionAPI, findRepoRoot: (cwd: strin
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const recommendations = conductor.getNextActionsForRepo(ctx.cwd, params);
       const text = recommendations.actions.length
-        ? recommendations.actions
-            .map((action, index) => `${index + 1}. [${action.priority}] ${action.title}`)
-            .join("\n")
+        ? recommendations.actions.map(formatNextActionText).join("\n")
         : `No conductor actions recommended: ${recommendations.summary.headline}`;
       return { content: [{ type: "text", text }], details: recommendations };
     },


### PR DESCRIPTION
## Summary
- Add `conductor_view_active_workers` for inspecting active supervised tmux/iTerm conductor runs.
- Return worker/task/run identity, runtime and viewer status, attach/log-tail commands, latest progress, diagnostics, and cancel tool calls.
- Support scoping by `taskId`, `workerId`, or `runId`, and document the supervised viewing workflow.

## Issues
- Closes #81

## Validation
- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/pi-conductor/__tests__/static-safety.test.ts packages/pi-conductor/__tests__/active-worker-viewer.test.ts packages/pi-conductor/__tests__/index.test.ts packages/pi-conductor/__tests__/task-brief.test.ts packages/pi-conductor/__tests__/tool-runtime-contract.test.ts`