### PR TITLE
fix: document evidence bundle purpose values

### DIFF
--- a/packages/pi-conductor/README.md
+++ b/packages/pi-conductor/README.md
@@ -302,7 +302,7 @@ For non-UI automation, inspect gates and evidence without approving as a human:
 conductor_list_gates({ status: "open" })
 conductor_prepare_human_review({ taskId })
 conductor_check_readiness({ taskId, purpose: "pr_readiness" })
-conductor_build_evidence_bundle({ taskId, includeEvents: true })
+conductor_build_evidence_bundle({ taskId, purpose: "task_review", includeEvents: true })
 conductor_resource_timeline({ taskId, includeArtifacts: true })
 ```
 

--- a/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
+++ b/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
@@ -92,17 +92,30 @@ describe("conductor tool contracts", () => {
     const evidenceSchema = JSON.stringify(evidenceTool.parameters);
     const readinessSchema = JSON.stringify(readinessTool.parameters);
 
-    expect(evidenceTool.description).toContain("task_review (default), pr_readiness, handoff");
+    expect(evidenceTool.description).toContain("task_review, pr_readiness, handoff");
+    expect(evidenceTool.description).toContain("Default: task_review");
     expect(evidenceSchema).toContain("Valid values: task_review");
     expect(evidenceSchema).toContain("pr_readiness");
     expect(evidenceSchema).toContain("handoff");
     expect(readinessTool.description).toContain("task_review, pr_readiness");
+    expect(readinessTool.description).toContain("If invalid, retry");
     expect(readinessSchema).toContain("Valid values: task_review");
+    expect(readinessSchema).toContain("pr_readiness");
     await expect(
       evidenceTool.execute?.("tool-call-purpose", { taskId: "task-1", purpose: "review" }, undefined, undefined, {
         cwd: repoDir,
       }),
     ).rejects.toThrow(/Accepted values: task_review, pr_readiness, handoff/);
+    await expect(
+      evidenceTool.execute?.("tool-call-purpose", { taskId: "task-1", purpose: "" }, undefined, undefined, {
+        cwd: repoDir,
+      }),
+    ).rejects.toThrow(/Accepted values: task_review, pr_readiness, handoff/);
+    await expect(
+      readinessTool.execute?.("tool-call-readiness", { taskId: "task-1", purpose: "review" }, undefined, undefined, {
+        cwd: repoDir,
+      }),
+    ).rejects.toThrow(/Accepted values: task_review, pr_readiness/);
   });
 
   it("forwards runtimeMode through registered start, run, retry, and delegate tools", async () => {

--- a/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
+++ b/packages/pi-conductor/__tests__/tool-runtime-contract.test.ts
@@ -44,7 +44,7 @@ function getTool(tools: RegisteredTool[], name: string): RegisteredTool {
   return tool;
 }
 
-describe("conductor runtime-mode tool contracts", () => {
+describe("conductor tool contracts", () => {
   let repoDir: string;
   let conductorHome: string;
 
@@ -83,6 +83,26 @@ describe("conductor runtime-mode tool contracts", () => {
     expect(tool?.description).toContain("must not treat tool success as semantic completion");
     expect(schema).toContain("Pass headless for blocking execution");
     expect(schema).toContain("parallel work prefer tmux");
+  });
+
+  it("documents evidence bundle purpose values and invalid-purpose diagnostics", async () => {
+    const tools = collectTools();
+    const evidenceTool = getTool(tools, "conductor_build_evidence_bundle");
+    const readinessTool = getTool(tools, "conductor_check_readiness");
+    const evidenceSchema = JSON.stringify(evidenceTool.parameters);
+    const readinessSchema = JSON.stringify(readinessTool.parameters);
+
+    expect(evidenceTool.description).toContain("task_review (default), pr_readiness, handoff");
+    expect(evidenceSchema).toContain("Valid values: task_review");
+    expect(evidenceSchema).toContain("pr_readiness");
+    expect(evidenceSchema).toContain("handoff");
+    expect(readinessTool.description).toContain("task_review, pr_readiness");
+    expect(readinessSchema).toContain("Valid values: task_review");
+    await expect(
+      evidenceTool.execute?.("tool-call-purpose", { taskId: "task-1", purpose: "review" }, undefined, undefined, {
+        cwd: repoDir,
+      }),
+    ).rejects.toThrow(/Accepted values: task_review, pr_readiness, handoff/);
   });
 
   it("forwards runtimeMode through registered start, run, retry, and delegate tools", async () => {

--- a/packages/pi-conductor/extensions/purpose-values.ts
+++ b/packages/pi-conductor/extensions/purpose-values.ts
@@ -1,0 +1,34 @@
+import { Type } from "typebox";
+
+export const EVIDENCE_BUNDLE_PURPOSES = ["task_review", "pr_readiness", "handoff"] as const;
+export const READINESS_PURPOSES = ["task_review", "pr_readiness"] as const;
+
+export type EvidenceBundlePurpose = (typeof EVIDENCE_BUNDLE_PURPOSES)[number];
+export type ReadinessPurpose = (typeof READINESS_PURPOSES)[number];
+
+export function acceptedPurposeValues(values: readonly string[]): string {
+  return values.join(", ");
+}
+
+export function isEvidenceBundlePurpose(value: unknown): value is EvidenceBundlePurpose {
+  return EVIDENCE_BUNDLE_PURPOSES.includes(value as EvidenceBundlePurpose);
+}
+
+export function isReadinessPurpose(value: unknown): value is ReadinessPurpose {
+  return READINESS_PURPOSES.includes(value as ReadinessPurpose);
+}
+
+export function evidenceBundlePurposeSchema(description: string) {
+  return Type.Union(
+    [
+      Type.Literal(EVIDENCE_BUNDLE_PURPOSES[0]),
+      Type.Literal(EVIDENCE_BUNDLE_PURPOSES[1]),
+      Type.Literal(EVIDENCE_BUNDLE_PURPOSES[2]),
+    ],
+    { description },
+  );
+}
+
+export function readinessPurposeSchema(description: string) {
+  return Type.Union([Type.Literal(READINESS_PURPOSES[0]), Type.Literal(READINESS_PURPOSES[1])], { description });
+}

--- a/packages/pi-conductor/extensions/tools/evidence-tools.ts
+++ b/packages/pi-conductor/extensions/tools/evidence-tools.ts
@@ -1,19 +1,21 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import * as conductor from "../conductor.js";
+import {
+  acceptedPurposeValues,
+  evidenceBundlePurposeSchema as buildEvidenceBundlePurposeSchema,
+  readinessPurposeSchema as buildReadinessPurposeSchema,
+  EVIDENCE_BUNDLE_PURPOSES,
+  isEvidenceBundlePurpose,
+  isReadinessPurpose,
+  READINESS_PURPOSES,
+} from "../purpose-values.js";
 import * as storage from "../storage.js";
 
-const evidenceBundlePurposeDescription =
-  "Purpose of the evidence bundle. Valid values: task_review (default, for task review), pr_readiness (for PR readiness), handoff (for general handoff/human review).";
-const readinessPurposeDescription =
-  "Purpose of the readiness check. Valid values: task_review (task review readiness) or pr_readiness (PR publication readiness).";
-const evidenceBundlePurposeSchema = Type.Union(
-  [Type.Literal("task_review"), Type.Literal("pr_readiness"), Type.Literal("handoff")],
-  { description: evidenceBundlePurposeDescription },
-);
-const readinessPurposeSchema = Type.Union([Type.Literal("task_review"), Type.Literal("pr_readiness")], {
-  description: readinessPurposeDescription,
-});
+const evidenceBundlePurposeDescription = `Purpose of the evidence bundle. Valid values: ${acceptedPurposeValues(EVIDENCE_BUNDLE_PURPOSES)}. Use task_review for task review evidence, pr_readiness for PR publication readiness, or handoff for general handoff/human review. Default: task_review. If invalid, retry with one of these values.`;
+const readinessPurposeDescription = `Purpose of the readiness check. Valid values: ${acceptedPurposeValues(READINESS_PURPOSES)}. Use task_review for task review readiness or pr_readiness for PR publication readiness. If invalid, retry with one of these values.`;
+const evidenceBundlePurposeSchema = buildEvidenceBundlePurposeSchema(evidenceBundlePurposeDescription);
+const readinessPurposeSchema = buildReadinessPurposeSchema(readinessPurposeDescription);
 
 const artifactTypeSchema = Type.Union([
   Type.Literal("note"),
@@ -97,8 +99,7 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "conductor_build_evidence_bundle",
     label: "Conductor Build Evidence Bundle",
-    description:
-      "Build a task/worker-scoped evidence bundle for review or PR readiness. purpose values: task_review (default), pr_readiness, handoff.",
+    description: `Build a task/worker-scoped evidence bundle for review or PR readiness. purpose values: ${acceptedPurposeValues(EVIDENCE_BUNDLE_PURPOSES)}. Default: task_review. If invalid, retry with one of these values.`,
     parameters: Type.Object({
       workerId: Type.Optional(Type.String()),
       workerName: Type.Optional(Type.String()),
@@ -110,8 +111,10 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
       persistArtifact: Type.Optional(Type.Boolean()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      if (params.purpose && !["task_review", "pr_readiness", "handoff"].includes(params.purpose)) {
-        throw new Error("Invalid purpose. Accepted values: task_review, pr_readiness, handoff. Default: task_review.");
+      if (params.purpose !== undefined && !isEvidenceBundlePurpose(params.purpose)) {
+        throw new Error(
+          `Invalid purpose. Accepted values: ${acceptedPurposeValues(EVIDENCE_BUNDLE_PURPOSES)}. Default: task_review.`,
+        );
       }
       const bundle = conductor.buildEvidenceBundleForRepo(ctx.cwd, params);
       return {
@@ -129,8 +132,7 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "conductor_check_readiness",
     label: "Conductor Check Readiness",
-    description:
-      "Evaluate whether a task or worker is ready for review or PR publication. purpose values: task_review, pr_readiness.",
+    description: `Evaluate whether a task or worker is ready for review or PR publication. purpose values: ${acceptedPurposeValues(READINESS_PURPOSES)}. If invalid, retry with one of these values.`,
     parameters: Type.Object({
       workerId: Type.Optional(Type.String()),
       workerName: Type.Optional(Type.String()),
@@ -144,8 +146,8 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
       requireApprovedReadyForPrGate: Type.Optional(Type.Boolean()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      if (!["task_review", "pr_readiness"].includes(params.purpose)) {
-        throw new Error("Invalid purpose. Accepted values: task_review, pr_readiness.");
+      if (!isReadinessPurpose(params.purpose)) {
+        throw new Error(`Invalid purpose. Accepted values: ${acceptedPurposeValues(READINESS_PURPOSES)}.`);
       }
       const readiness = conductor.checkReadinessForRepo(ctx.cwd, params);
       return {

--- a/packages/pi-conductor/extensions/tools/evidence-tools.ts
+++ b/packages/pi-conductor/extensions/tools/evidence-tools.ts
@@ -3,6 +3,18 @@ import { Type } from "typebox";
 import * as conductor from "../conductor.js";
 import * as storage from "../storage.js";
 
+const evidenceBundlePurposeDescription =
+  "Purpose of the evidence bundle. Valid values: task_review (default, for task review), pr_readiness (for PR readiness), handoff (for general handoff/human review).";
+const readinessPurposeDescription =
+  "Purpose of the readiness check. Valid values: task_review (task review readiness) or pr_readiness (PR publication readiness).";
+const evidenceBundlePurposeSchema = Type.Union(
+  [Type.Literal("task_review"), Type.Literal("pr_readiness"), Type.Literal("handoff")],
+  { description: evidenceBundlePurposeDescription },
+);
+const readinessPurposeSchema = Type.Union([Type.Literal("task_review"), Type.Literal("pr_readiness")], {
+  description: readinessPurposeDescription,
+});
+
 const artifactTypeSchema = Type.Union([
   Type.Literal("note"),
   Type.Literal("test_result"),
@@ -85,20 +97,22 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "conductor_build_evidence_bundle",
     label: "Conductor Build Evidence Bundle",
-    description: "Build a task/worker-scoped evidence bundle for review or PR readiness",
+    description:
+      "Build a task/worker-scoped evidence bundle for review or PR readiness. purpose values: task_review (default), pr_readiness, handoff.",
     parameters: Type.Object({
       workerId: Type.Optional(Type.String()),
       workerName: Type.Optional(Type.String()),
       objectiveId: Type.Optional(Type.String()),
       taskId: Type.Optional(Type.String()),
       runId: Type.Optional(Type.String()),
-      purpose: Type.Optional(
-        Type.Union([Type.Literal("task_review"), Type.Literal("pr_readiness"), Type.Literal("handoff")]),
-      ),
+      purpose: Type.Optional(evidenceBundlePurposeSchema),
       includeEvents: Type.Optional(Type.Boolean()),
       persistArtifact: Type.Optional(Type.Boolean()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      if (params.purpose && !["task_review", "pr_readiness", "handoff"].includes(params.purpose)) {
+        throw new Error("Invalid purpose. Accepted values: task_review, pr_readiness, handoff. Default: task_review.");
+      }
       const bundle = conductor.buildEvidenceBundleForRepo(ctx.cwd, params);
       return {
         content: [
@@ -115,12 +129,13 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "conductor_check_readiness",
     label: "Conductor Check Readiness",
-    description: "Evaluate whether a task or worker is ready for review or PR publication",
+    description:
+      "Evaluate whether a task or worker is ready for review or PR publication. purpose values: task_review, pr_readiness.",
     parameters: Type.Object({
       workerId: Type.Optional(Type.String()),
       workerName: Type.Optional(Type.String()),
       taskId: Type.Optional(Type.String()),
-      purpose: Type.Union([Type.Literal("task_review"), Type.Literal("pr_readiness")]),
+      purpose: readinessPurposeSchema,
       requireCompletionReport: Type.Optional(Type.Boolean()),
       requireTestEvidence: Type.Optional(Type.Boolean()),
       requireNoOpenGates: Type.Optional(Type.Boolean()),
@@ -129,6 +144,9 @@ export function registerEvidenceTools(pi: ExtensionAPI): void {
       requireApprovedReadyForPrGate: Type.Optional(Type.Boolean()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      if (!["task_review", "pr_readiness"].includes(params.purpose)) {
+        throw new Error("Invalid purpose. Accepted values: task_review, pr_readiness.");
+      }
       const readiness = conductor.checkReadinessForRepo(ctx.cwd, params);
       return {
         content: [

--- a/packages/pi-conductor/extensions/types.ts
+++ b/packages/pi-conductor/extensions/types.ts
@@ -1,3 +1,5 @@
+import type { EvidenceBundlePurpose, ReadinessPurpose } from "./purpose-values.js";
+
 export const CONDUCTOR_SCHEMA_VERSION = 1;
 
 export type WorkerLifecycleState = "idle" | "running" | "broken" | "archived";
@@ -91,8 +93,7 @@ export interface ConductorNextAction {
   confidence: "high" | "medium" | "low";
 }
 
-export type EvidenceBundlePurpose = "task_review" | "pr_readiness" | "handoff";
-export type ReadinessPurpose = "task_review" | "pr_readiness";
+export type { EvidenceBundlePurpose, ReadinessPurpose } from "./purpose-values.js";
 export type ReadinessStatus = "ready" | "blocked" | "needs_review" | "not_ready";
 
 export interface EvidenceBundle {

--- a/packages/pi-conductor/skills/conductor-gate-review/SKILL.md
+++ b/packages/pi-conductor/skills/conductor-gate-review/SKILL.md
@@ -24,7 +24,9 @@ Use this workflow to inspect conductor gates without weakening the trusted-human
 2. Build context for the relevant gate/task/objective:
    - `conductor_prepare_human_review({ taskId })` or `conductor_prepare_human_review({ objectiveId })`
    - `conductor_check_readiness({ taskId, purpose: "task_review" })` or `conductor_check_readiness({ taskId, purpose: "pr_readiness" })`
-   - `conductor_build_evidence_bundle({ taskId, includeEvents: true })`
+   - `conductor_build_evidence_bundle({ taskId, purpose: "task_review", includeEvents: true })` for task review evidence
+   - `conductor_build_evidence_bundle({ taskId, purpose: "pr_readiness", includeEvents: true })` for `ready_for_pr` / PR publication gates
+   - `conductor_build_evidence_bundle({ taskId, purpose: "handoff", includeEvents: true })` for general handoff or human review packets
    - `conductor_resource_timeline({ taskId, gateId, includeArtifacts: true })`
 3. Summarize what is being decided:
    - gate type and requested decision


### PR DESCRIPTION
## Summary
- Document accepted evidence bundle purpose values in the tool description and schema.
- Add explicit invalid-purpose diagnostics for `conductor_build_evidence_bundle` and `conductor_check_readiness`.
- Update README examples to pass an explicit valid purpose value.

## Issues
- Closes #75

## Validation
- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/pi-conductor/__tests__/tool-runtime-contract.test.ts packages/pi-conductor/__tests__/readiness.test.ts packages/pi-conductor/__tests__/static-safety.test.ts`