### PR TITLE
fix: load pi-conductor from root extension config

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   "pi": {
     "extensions": [
       "./packages/pi-code-reasoning/extensions/index.ts",
-      "./packages/pi-conductor/extensions/index.ts",
       "./packages/pi-devtools/extensions/index.ts",
       "./packages/pi-exa/extensions/index.ts",
       "./packages/pi-notion/extensions/index.ts",
       "./packages/pi-ref-tools/extensions/index.ts",
       "./packages/pi-sequential-thinking/extensions/index.ts",
       "./packages/pi-specdocs/extensions/index.ts",
-      "./packages/pi-statusline/extensions/index.ts"
+      "./packages/pi-statusline/extensions/index.ts",
+      "./packages/pi-conductor/extensions/index.ts"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "pi": {
     "extensions": [
       "./packages/pi-code-reasoning/extensions/index.ts",
+      "./packages/pi-conductor/extensions/index.ts",
       "./packages/pi-devtools/extensions/index.ts",
       "./packages/pi-exa/extensions/index.ts",
       "./packages/pi-notion/extensions/index.ts",

--- a/packages/pi-conductor/__tests__/package-smoke.test.ts
+++ b/packages/pi-conductor/__tests__/package-smoke.test.ts
@@ -49,6 +49,12 @@ function parseFrontmatter(markdown: string): Record<string, string> {
 }
 
 describe("pi-conductor package smoke", () => {
+  it("is loaded by root pi -e . extension configuration", () => {
+    const rootPackageJson = JSON.parse(readFileSync(join(packageRoot, "../../package.json"), "utf-8"));
+
+    expect(rootPackageJson.pi.extensions).toContain("./packages/pi-conductor/extensions/index.ts");
+  });
+
   it("publishes and registers packaged skills", () => {
     const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf-8"));
     const skillsRoot = join(packageRoot, "skills");

--- a/packages/pi-conductor/__tests__/package-smoke.test.ts
+++ b/packages/pi-conductor/__tests__/package-smoke.test.ts
@@ -49,9 +49,17 @@ function parseFrontmatter(markdown: string): Record<string, string> {
 }
 
 describe("pi-conductor package smoke", () => {
-  it("is loaded by root pi -e . extension configuration", () => {
-    const rootPackageJson = JSON.parse(readFileSync(join(packageRoot, "../../package.json"), "utf-8"));
+  it("keeps root pi -e . extension configuration aligned with workspace extensions", () => {
+    const repoRoot = join(packageRoot, "../..");
+    const rootPackageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8"));
+    const packagesRoot = join(repoRoot, "packages");
+    const expectedExtensionPaths = readdirSync(packagesRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `./packages/${entry.name}/extensions/index.ts`)
+      .filter((extensionPath) => existsSync(join(repoRoot, extensionPath)))
+      .sort();
 
+    expect(rootPackageJson.pi.extensions).toEqual(expect.arrayContaining(expectedExtensionPaths));
     expect(rootPackageJson.pi.extensions).toContain("./packages/pi-conductor/extensions/index.ts");
   });
 


### PR DESCRIPTION
## Summary
- Add `pi-conductor` to the root `pi.extensions` list so `pi -e .` loads it from the workspace root.
- Add package smoke coverage to keep the root extension configuration aligned.

## Issues
- Closes #77

## Validation
- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/pi-conductor/__tests__/package-smoke.test.ts packages/pi-conductor/__tests__/static-safety.test.ts`