### PR TITLE
fix: run conductor cleanup outside state lock

### DIFF
--- a/packages/pi-conductor/__tests__/cleanup-lock.test.ts
+++ b/packages/pi-conductor/__tests__/cleanup-lock.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const worktreeMockState = vi.hoisted(() => ({
   onRemoveManagedWorktree: null as null | (() => void),
+  onRemoveManagedBranch: null as null | (() => void),
 }));
 
 vi.mock("../extensions/worktrees.js", async (importOriginal) => {
@@ -16,6 +17,10 @@ vi.mock("../extensions/worktrees.js", async (importOriginal) => {
       worktreeMockState.onRemoveManagedWorktree?.();
       actual.removeManagedWorktree(repoRoot, worktreePath);
     },
+    removeManagedBranch(repoRoot: string, branch: string): void {
+      worktreeMockState.onRemoveManagedBranch?.();
+      actual.removeManagedBranch(repoRoot, branch);
+    },
   };
 });
 
@@ -25,9 +30,11 @@ import {
   createTaskForRepo,
   createWorkerForRepo,
   getOrCreateRunForRepo,
+  recoverWorkerForRepo,
   removeWorkerForRepo,
   resolveGateForRepo,
 } from "../extensions/conductor.js";
+import { writeRun } from "../extensions/storage.js";
 
 describe("cleanup lock boundaries", () => {
   let repoDir: string;
@@ -38,6 +45,7 @@ describe("cleanup lock boundaries", () => {
     conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
     process.env.PI_CONDUCTOR_HOME = conductorHome;
     worktreeMockState.onRemoveManagedWorktree = null;
+    worktreeMockState.onRemoveManagedBranch = null;
     execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
     execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
     execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
@@ -48,10 +56,30 @@ describe("cleanup lock boundaries", () => {
 
   afterEach(() => {
     worktreeMockState.onRemoveManagedWorktree = null;
+    worktreeMockState.onRemoveManagedBranch = null;
     delete process.env.PI_CONDUCTOR_HOME;
     if (existsSync(repoDir)) rmSync(repoDir, { recursive: true, force: true });
     if (existsSync(conductorHome)) rmSync(conductorHome, { recursive: true, force: true });
   });
+
+  function approveCleanupGate(workerId: string): void {
+    const run = getOrCreateRunForRepo(repoDir);
+    const generation =
+      run.tasks.filter((task) => task.assignedWorkerId === workerId).length +
+      run.runs.filter((entry) => entry.workerId === workerId).length;
+    const gate = createGateForRepo(repoDir, {
+      type: "destructive_cleanup",
+      resourceRefs: { workerId },
+      requestedDecision: "Approve worker cleanup",
+      targetRevision: generation,
+    });
+    resolveGateForRepo(repoDir, {
+      gateId: gate.gateId,
+      status: "approved",
+      actor: { type: "human", id: "reviewer" },
+      resolutionReason: "cleanup approved",
+    });
+  }
 
   it("does not hold the conductor state lock while deleting worker resources", async () => {
     const worker = await createWorkerForRepo(repoDir, "backend");
@@ -80,5 +108,72 @@ describe("cleanup lock boundaries", () => {
     expect(after.tasks.map((task) => task.title)).toContain("Concurrent task");
     expect(after.workers).toHaveLength(0);
     expect(after.archivedWorkers.map((entry) => entry.workerId)).toContain(worker.workerId);
+  });
+
+  it("leaves partial cleanup failures reserved, non-assignable, and retryable", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    approveCleanupGate(worker.workerId);
+    let failBranchRemoval = true;
+    worktreeMockState.onRemoveManagedBranch = () => {
+      if (failBranchRemoval) {
+        failBranchRemoval = false;
+        throw new Error("branch deletion failed once");
+      }
+    };
+
+    expect(() => removeWorkerForRepo(repoDir, "backend")).toThrow(/branch deletion failed once/);
+
+    const afterFailure = getOrCreateRunForRepo(repoDir);
+    const reservedWorker = afterFailure.workers.find((entry) => entry.workerId === worker.workerId);
+    expect(reservedWorker?.lifecycle).toBe("broken");
+    expect(reservedWorker?.recoverable).toBe(true);
+    expect(afterFailure.events.map((event) => event.type)).toContain("worker.cleanup_failed");
+    const task = createTaskForRepo(repoDir, { title: "Do not assign", prompt: "Worker is mid-cleanup" });
+    expect(() => assignTaskForRepo(repoDir, task.taskId, worker.workerId)).toThrow(/cannot be assigned/);
+
+    const removed = removeWorkerForRepo(repoDir, "backend");
+    expect(removed.workerId).toBe(worker.workerId);
+    const afterRetry = getOrCreateRunForRepo(repoDir);
+    expect(afterRetry.workers.map((entry) => entry.workerId)).not.toContain(worker.workerId);
+    expect(afterRetry.archivedWorkers.map((entry) => entry.workerId)).toContain(worker.workerId);
+  });
+
+  it("rejects recovery while cleanup is reserved outside the state lock", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    approveCleanupGate(worker.workerId);
+    let recoveryResult: Promise<unknown> | undefined;
+    worktreeMockState.onRemoveManagedWorktree = () => {
+      recoveryResult = recoverWorkerForRepo(repoDir, "backend").then(
+        () => new Error("recovery unexpectedly succeeded"),
+        (error) => error,
+      );
+    };
+
+    removeWorkerForRepo(repoDir, "backend");
+
+    expect(recoveryResult).toBeDefined();
+    const recoveryError = await recoveryResult;
+    expect(recoveryError).toBeInstanceOf(Error);
+    expect((recoveryError as Error).message).toMatch(/reserved for destructive cleanup/);
+  });
+
+  it("finalizes an already-reserved cleanup retry", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    approveCleanupGate(worker.workerId);
+    const run = getOrCreateRunForRepo(repoDir);
+    writeRun({
+      ...run,
+      workers: run.workers.map((entry) =>
+        entry.workerId === worker.workerId ? { ...entry, lifecycle: "broken", recoverable: true } : entry,
+      ),
+    });
+
+    const removed = removeWorkerForRepo(repoDir, "backend");
+
+    expect(removed.workerId).toBe(worker.workerId);
+    const after = getOrCreateRunForRepo(repoDir);
+    expect(after.workers.map((entry) => entry.workerId)).not.toContain(worker.workerId);
+    expect(after.archivedWorkers.map((entry) => entry.workerId)).toContain(worker.workerId);
+    expect(after.gates.find((entry) => entry.resourceRefs.workerId === worker.workerId)?.usedAt).not.toBeNull();
   });
 });

--- a/packages/pi-conductor/__tests__/cleanup-lock.test.ts
+++ b/packages/pi-conductor/__tests__/cleanup-lock.test.ts
@@ -1,0 +1,84 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const worktreeMockState = vi.hoisted(() => ({
+  onRemoveManagedWorktree: null as null | (() => void),
+}));
+
+vi.mock("../extensions/worktrees.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../extensions/worktrees.js")>();
+  return {
+    ...actual,
+    removeManagedWorktree(repoRoot: string, worktreePath: string): void {
+      worktreeMockState.onRemoveManagedWorktree?.();
+      actual.removeManagedWorktree(repoRoot, worktreePath);
+    },
+  };
+});
+
+import {
+  assignTaskForRepo,
+  createGateForRepo,
+  createTaskForRepo,
+  createWorkerForRepo,
+  getOrCreateRunForRepo,
+  removeWorkerForRepo,
+  resolveGateForRepo,
+} from "../extensions/conductor.js";
+
+describe("cleanup lock boundaries", () => {
+  let repoDir: string;
+  let conductorHome: string;
+
+  beforeEach(() => {
+    repoDir = execSync("mktemp -d", { encoding: "utf-8" }).trim();
+    conductorHome = mkdtempSync(join(tmpdir(), "pi-conductor-home-"));
+    process.env.PI_CONDUCTOR_HOME = conductorHome;
+    worktreeMockState.onRemoveManagedWorktree = null;
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.email 'test@test.com'", { cwd: repoDir, stdio: "pipe" });
+    execSync("git config user.name 'Test User'", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, "README.md"), "hello");
+    execSync("git add README.md", { cwd: repoDir, stdio: "pipe" });
+    execSync("git commit -m 'initial commit'", { cwd: repoDir, stdio: "pipe" });
+  });
+
+  afterEach(() => {
+    worktreeMockState.onRemoveManagedWorktree = null;
+    delete process.env.PI_CONDUCTOR_HOME;
+    if (existsSync(repoDir)) rmSync(repoDir, { recursive: true, force: true });
+    if (existsSync(conductorHome)) rmSync(conductorHome, { recursive: true, force: true });
+  });
+
+  it("does not hold the conductor state lock while deleting worker resources", async () => {
+    const worker = await createWorkerForRepo(repoDir, "backend");
+    const generation = getOrCreateRunForRepo(repoDir).runs.filter((entry) => entry.workerId === worker.workerId).length;
+    const gate = createGateForRepo(repoDir, {
+      type: "destructive_cleanup",
+      resourceRefs: { workerId: worker.workerId },
+      requestedDecision: "Approve worker cleanup",
+      targetRevision: generation,
+    });
+    resolveGateForRepo(repoDir, {
+      gateId: gate.gateId,
+      status: "approved",
+      actor: { type: "human", id: "reviewer" },
+      resolutionReason: "cleanup approved",
+    });
+
+    worktreeMockState.onRemoveManagedWorktree = () => {
+      const concurrentTask = createTaskForRepo(repoDir, { title: "Concurrent task", prompt: "Prove lock is free" });
+      expect(() => assignTaskForRepo(repoDir, concurrentTask.taskId, worker.workerId)).toThrow(/cannot be assigned/);
+    };
+
+    removeWorkerForRepo(repoDir, "backend");
+
+    const after = getOrCreateRunForRepo(repoDir);
+    expect(after.tasks.map((task) => task.title)).toContain("Concurrent task");
+    expect(after.workers).toHaveLength(0);
+    expect(after.archivedWorkers.map((entry) => entry.workerId)).toContain(worker.workerId);
+  });
+});

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -74,6 +74,7 @@ import {
 } from "./work-routing.js";
 import { isStatusOnlyWorkRequest, selectRuntimeModeForWork } from "./work-runtime-selection.js";
 import { type RunWorkRuntimeSummary, summarizeRunWorkRuntime } from "./work-runtime-summary.js";
+import { hasActiveWorkerCleanupReservation } from "./worker-cleanup.js";
 
 export { buildEvidenceBundleForRepo, checkReadinessForRepo } from "./evidence-service.js";
 export { createGateForRepo, resolveGateForRepo, resolveGateFromTrustedHumanForRepo } from "./gate-service.js";
@@ -2036,6 +2037,9 @@ export async function recoverWorkerForRepo(repoRoot: string, workerName: string)
   if (!worker) {
     throw new Error(`Worker named ${workerName} not found`);
   }
+  if (hasActiveWorkerCleanupReservation(run, worker.workerId)) {
+    throw new Error(`Worker ${worker.name} is reserved for destructive cleanup and cannot be recovered`);
+  }
   let worktreePath = worker.worktreePath;
   let runtime = null;
   try {
@@ -2068,6 +2072,9 @@ export async function recoverWorkerForRepo(repoRoot: string, workerName: string)
     throw error;
   }
   const updatedRun = mutateRepoRunSync(repoRoot, (latest) => {
+    if (hasActiveWorkerCleanupReservation(latest, worker.workerId)) {
+      throw new Error(`Worker ${worker.name} is reserved for destructive cleanup and cannot be recovered`);
+    }
     const workers = latest.workers.map((entry) =>
       entry.workerId === worker.workerId
         ? {

--- a/packages/pi-conductor/extensions/conductor.ts
+++ b/packages/pi-conductor/extensions/conductor.ts
@@ -36,7 +36,6 @@ import {
   completeTaskRun,
   createWorkerRecord,
   markConductorGateUsed,
-  removeWorker,
   setWorkerPrState,
 } from "./storage.js";
 import { terminalRunSummaryMarkdown } from "./task-brief-summary.js";
@@ -1623,84 +1622,7 @@ export async function createWorkerForRepo(repoRoot: string, workerName: string):
   }
   return worker;
 }
-function workerCleanupGeneration(run: RunRecord, workerId: string): number {
-  return (
-    run.tasks.filter((task) => task.assignedWorkerId === workerId).length +
-    run.runs.filter((entry) => entry.workerId === workerId).length
-  );
-}
-
-export function removeWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
-  const run = getOrCreateRunForRepo(repoRoot);
-  const worker = run.workers.find((entry) => entry.name === workerName);
-  if (!worker) {
-    throw new Error(`Worker named ${workerName} not found`);
-  }
-  const currentCleanupGeneration = workerCleanupGeneration(run, worker.workerId);
-  const cleanupGate = run.gates.find(
-    (gate) =>
-      gate.type === "destructive_cleanup" &&
-      gate.resourceRefs.workerId === worker.workerId &&
-      gate.operation === "destructive_cleanup" &&
-      gate.status !== "canceled" &&
-      gate.usedAt === null &&
-      gate.targetRevision === currentCleanupGeneration,
-  );
-  const wrongOperationGate = run.gates.find(
-    (gate) =>
-      gate.type === "destructive_cleanup" &&
-      gate.resourceRefs.workerId === worker.workerId &&
-      gate.status === "approved" &&
-      gate.operation !== "destructive_cleanup" &&
-      gate.usedAt === null,
-  );
-  if (wrongOperationGate) {
-    throw new Error(`Worker ${worker.name} requires a destructive_cleanup gate scoped to destructive_cleanup`);
-  }
-  if (cleanupGate?.status !== "approved") {
-    if (!cleanupGate) {
-      createGateForRepo(repoRoot, {
-        type: "destructive_cleanup",
-        resourceRefs: { workerId: worker.workerId },
-        requestedDecision: `Approve deleting worker ${worker.name}, its worktree, session link, and managed branch`,
-        targetRevision: currentCleanupGeneration,
-      });
-    }
-    throw new Error(
-      `Worker ${worker.name} requires an approved destructive_cleanup gate before cleanup. Approve via /conductor human dashboard, then rerun conductor_cleanup_worker(${JSON.stringify({ name: worker.name })}).`,
-    );
-  }
-  const updatedRun = mutateRepoRunSync(repoRoot, (latest) => {
-    const latestGate = latest.gates.find((gate) => gate.gateId === cleanupGate.gateId);
-    if (!latestGate || latestGate.status !== "approved" || latestGate.usedAt !== null) {
-      throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate before cleanup finalization`);
-    }
-    const latestWorker = assertWorkerCleanupReady(latest, worker.workerId, worker.name);
-    if (latestGate.targetRevision !== workerCleanupGeneration(latest, worker.workerId)) {
-      throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate after worker activity changed`);
-    }
-    if (latestWorker.worktreePath && existsSync(latestWorker.worktreePath)) {
-      removeManagedWorktree(latest.repoRoot, latestWorker.worktreePath);
-    }
-    if (latestWorker.sessionFile && existsSync(latestWorker.sessionFile))
-      rmSync(latestWorker.sessionFile, { force: true });
-    if (latestWorker.branch) removeManagedBranch(latest.repoRoot, latestWorker.branch);
-    return appendExternalOperationEvent(
-      removeWorker(markConductorGateUsed(latest, cleanupGate.gateId), worker.workerId),
-      {
-        status: "succeeded",
-        resourceRefs: { workerId: worker.workerId, gateId: cleanupGate.gateId },
-        payload: {
-          operation: "cleanup_worker",
-          name: worker.name,
-          worktreePath: latestWorker.worktreePath,
-          branch: latestWorker.branch,
-        },
-      },
-    );
-  });
-  return updatedRun.archivedWorkers.find((entry) => entry.workerId === worker.workerId) ?? worker;
-}
+export { removeWorkerForRepo } from "./worker-cleanup.js";
 export function commitWorkerForRepo(repoRoot: string, workerName: string, message: string): WorkerRecord {
   const run = getOrCreateRunForRepo(repoRoot);
   const worker = run.workers.find((entry) => entry.name === workerName);

--- a/packages/pi-conductor/extensions/storage.ts
+++ b/packages/pi-conductor/extensions/storage.ts
@@ -433,8 +433,12 @@ export function updateTask(run: RunRecord, input: { taskId: string; title?: stri
 
 export function assignTaskToWorker(run: RunRecord, taskId: string, workerId: string): RunRecord {
   const normalized = normalizeProjectRecord(run);
-  if (!normalized.workers.some((worker) => worker.workerId === workerId)) {
+  const worker = normalized.workers.find((entry) => entry.workerId === workerId);
+  if (!worker) {
     throw new Error(`Worker ${workerId} not found`);
+  }
+  if (worker.lifecycle !== "idle" || worker.recoverable) {
+    throw new Error(`Worker ${workerId} is ${worker.lifecycle} and cannot be assigned work`);
   }
 
   let found = false;

--- a/packages/pi-conductor/extensions/worker-cleanup.ts
+++ b/packages/pi-conductor/extensions/worker-cleanup.ts
@@ -1,0 +1,156 @@
+import { existsSync, rmSync } from "node:fs";
+import { assertWorkerCleanupReady } from "./cleanup-guidance.js";
+import { createGateForRepo } from "./gate-service.js";
+import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
+import { appendConductorEvent, markConductorGateUsed, removeWorker } from "./storage.js";
+import type { RunRecord, WorkerRecord } from "./types.js";
+import { removeManagedBranch, removeManagedWorktree } from "./worktrees.js";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function workerCleanupGeneration(run: RunRecord, workerId: string): number {
+  return (
+    run.tasks.filter((task) => task.assignedWorkerId === workerId).length +
+    run.runs.filter((entry) => entry.workerId === workerId).length
+  );
+}
+
+function appendCleanupEvent(
+  run: RunRecord,
+  input: { status: "succeeded" | "failed"; workerId: string; gateId: string; payload: Record<string, unknown> },
+): RunRecord {
+  return appendConductorEvent(run, {
+    actor: { type: "system", id: "conductor" },
+    type: input.status === "succeeded" ? "worker.cleanup_succeeded" : "worker.cleanup_failed",
+    resourceRefs: { projectKey: run.projectKey, workerId: input.workerId, gateId: input.gateId },
+    payload: input.payload,
+  });
+}
+
+export function removeWorkerForRepo(repoRoot: string, workerName: string): WorkerRecord {
+  const run = getOrCreateRunForRepo(repoRoot);
+  const worker = run.workers.find((entry) => entry.name === workerName);
+  if (!worker) {
+    throw new Error(`Worker named ${workerName} not found`);
+  }
+  const currentCleanupGeneration = workerCleanupGeneration(run, worker.workerId);
+  const cleanupGate = run.gates.find(
+    (gate) =>
+      gate.type === "destructive_cleanup" &&
+      gate.resourceRefs.workerId === worker.workerId &&
+      gate.operation === "destructive_cleanup" &&
+      gate.status !== "canceled" &&
+      gate.usedAt === null &&
+      gate.targetRevision === currentCleanupGeneration,
+  );
+  const wrongOperationGate = run.gates.find(
+    (gate) =>
+      gate.type === "destructive_cleanup" &&
+      gate.resourceRefs.workerId === worker.workerId &&
+      gate.status === "approved" &&
+      gate.operation !== "destructive_cleanup" &&
+      gate.usedAt === null,
+  );
+  if (wrongOperationGate) {
+    throw new Error(`Worker ${worker.name} requires a destructive_cleanup gate scoped to destructive_cleanup`);
+  }
+  if (cleanupGate?.status !== "approved") {
+    if (!cleanupGate) {
+      createGateForRepo(repoRoot, {
+        type: "destructive_cleanup",
+        resourceRefs: { workerId: worker.workerId },
+        requestedDecision: `Approve deleting worker ${worker.name}, its worktree, session link, and managed branch`,
+        targetRevision: currentCleanupGeneration,
+      });
+    }
+    throw new Error(
+      `Worker ${worker.name} requires an approved destructive_cleanup gate before cleanup. Approve via /conductor human dashboard, then rerun conductor_cleanup_worker(${JSON.stringify({ name: worker.name })}).`,
+    );
+  }
+
+  const reserved = mutateRepoRunSync(repoRoot, (latest) => {
+    const latestGate = latest.gates.find((gate) => gate.gateId === cleanupGate.gateId);
+    if (!latestGate || latestGate.status !== "approved" || latestGate.usedAt !== null) {
+      throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate before cleanup finalization`);
+    }
+    const latestWorker = assertWorkerCleanupReady(latest, worker.workerId, worker.name);
+    if (latestGate.targetRevision !== workerCleanupGeneration(latest, worker.workerId)) {
+      throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate after worker activity changed`);
+    }
+    return {
+      ...latest,
+      workers: latest.workers.map((entry) =>
+        entry.workerId === latestWorker.workerId
+          ? { ...entry, lifecycle: "broken" as const, recoverable: true, updatedAt: new Date().toISOString() }
+          : entry,
+      ),
+    };
+  });
+  const reservedWorker = reserved.workers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+
+  try {
+    if (reservedWorker.worktreePath && existsSync(reservedWorker.worktreePath)) {
+      removeManagedWorktree(reserved.repoRoot, reservedWorker.worktreePath);
+    }
+    if (reservedWorker.sessionFile && existsSync(reservedWorker.sessionFile))
+      rmSync(reservedWorker.sessionFile, { force: true });
+    if (reservedWorker.branch) removeManagedBranch(reserved.repoRoot, reservedWorker.branch);
+  } catch (error) {
+    mutateRepoRunSync(repoRoot, (latest) =>
+      appendCleanupEvent(
+        {
+          ...latest,
+          workers: latest.workers.map((entry) =>
+            entry.workerId === worker.workerId
+              ? {
+                  ...entry,
+                  lifecycle: worker.lifecycle,
+                  recoverable: worker.recoverable,
+                  updatedAt: new Date().toISOString(),
+                }
+              : entry,
+          ),
+        },
+        {
+          status: "failed",
+          workerId: worker.workerId,
+          gateId: cleanupGate.gateId,
+          payload: {
+            operation: "cleanup_worker",
+            name: worker.name,
+            worktreePath: reservedWorker.worktreePath,
+            branch: reservedWorker.branch,
+            errorMessage: errorMessage(error),
+          },
+        },
+      ),
+    );
+    throw error;
+  }
+
+  const updatedRun = mutateRepoRunSync(repoRoot, (latest) => {
+    const latestGate = latest.gates.find((gate) => gate.gateId === cleanupGate.gateId);
+    if (!latestGate || latestGate.status !== "approved" || latestGate.usedAt !== null) {
+      throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate before cleanup finalization`);
+    }
+    if (latestGate.targetRevision !== workerCleanupGeneration(latest, worker.workerId)) {
+      throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate after worker activity changed`);
+    }
+    const latestWorker = latest.workers.find((entry) => entry.workerId === worker.workerId);
+    if (!latestWorker) throw new Error(`Worker named ${worker.name} not found`);
+    return appendCleanupEvent(removeWorker(markConductorGateUsed(latest, cleanupGate.gateId), worker.workerId), {
+      status: "succeeded",
+      workerId: worker.workerId,
+      gateId: cleanupGate.gateId,
+      payload: {
+        operation: "cleanup_worker",
+        name: worker.name,
+        worktreePath: reservedWorker.worktreePath,
+        branch: reservedWorker.branch,
+      },
+    });
+  });
+  return updatedRun.archivedWorkers.find((entry) => entry.workerId === worker.workerId) ?? worker;
+}

--- a/packages/pi-conductor/extensions/worker-cleanup.ts
+++ b/packages/pi-conductor/extensions/worker-cleanup.ts
@@ -3,7 +3,7 @@ import { assertWorkerCleanupReady } from "./cleanup-guidance.js";
 import { createGateForRepo } from "./gate-service.js";
 import { getOrCreateRunForRepo, mutateRepoRunSync } from "./repo-run.js";
 import { appendConductorEvent, markConductorGateUsed, removeWorker } from "./storage.js";
-import type { RunRecord, WorkerRecord } from "./types.js";
+import type { GateRecord, RunRecord, WorkerRecord } from "./types.js";
 import { removeManagedBranch, removeManagedWorktree } from "./worktrees.js";
 
 function errorMessage(error: unknown): string {
@@ -15,6 +15,39 @@ function workerCleanupGeneration(run: RunRecord, workerId: string): number {
     run.tasks.filter((task) => task.assignedWorkerId === workerId).length +
     run.runs.filter((entry) => entry.workerId === workerId).length
   );
+}
+
+function isApprovedUnusedCleanupGate(run: RunRecord, gate: GateRecord, workerId: string): boolean {
+  return (
+    gate.type === "destructive_cleanup" &&
+    gate.resourceRefs.workerId === workerId &&
+    gate.operation === "destructive_cleanup" &&
+    gate.status === "approved" &&
+    gate.usedAt === null &&
+    gate.targetRevision === workerCleanupGeneration(run, workerId)
+  );
+}
+
+function isWorkerCleanupReserved(run: RunRecord, worker: WorkerRecord, gate: GateRecord): boolean {
+  return worker.lifecycle === "broken" && worker.recoverable && isApprovedUnusedCleanupGate(run, gate, worker.workerId);
+}
+
+export function hasActiveWorkerCleanupReservation(run: RunRecord, workerId: string): boolean {
+  const worker = run.workers.find((entry) => entry.workerId === workerId);
+  if (!worker) return false;
+  return run.gates.some((gate) => isWorkerCleanupReserved(run, worker, gate));
+}
+
+function assertWorkerCleanupReadyOrReserved(
+  run: RunRecord,
+  workerId: string,
+  workerName: string,
+  gate: GateRecord,
+): WorkerRecord {
+  const worker = run.workers.find((entry) => entry.workerId === workerId);
+  if (!worker) throw new Error(`Worker named ${workerName} not found`);
+  if (isWorkerCleanupReserved(run, worker, gate)) return worker;
+  return assertWorkerCleanupReady(run, workerId, workerName);
 }
 
 function appendCleanupEvent(
@@ -75,9 +108,12 @@ export function removeWorkerForRepo(repoRoot: string, workerName: string): Worke
     if (!latestGate || latestGate.status !== "approved" || latestGate.usedAt !== null) {
       throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate before cleanup finalization`);
     }
-    const latestWorker = assertWorkerCleanupReady(latest, worker.workerId, worker.name);
     if (latestGate.targetRevision !== workerCleanupGeneration(latest, worker.workerId)) {
       throw new Error(`Worker ${worker.name} requires a fresh destructive_cleanup gate after worker activity changed`);
+    }
+    const latestWorker = assertWorkerCleanupReadyOrReserved(latest, worker.workerId, worker.name, latestGate);
+    if (isWorkerCleanupReserved(latest, latestWorker, latestGate)) {
+      return latest;
     }
     return {
       ...latest,
@@ -106,8 +142,8 @@ export function removeWorkerForRepo(repoRoot: string, workerName: string): Worke
             entry.workerId === worker.workerId
               ? {
                   ...entry,
-                  lifecycle: worker.lifecycle,
-                  recoverable: worker.recoverable,
+                  lifecycle: "broken" as const,
+                  recoverable: true,
                   updatedAt: new Date().toISOString(),
                 }
               : entry,
@@ -140,6 +176,9 @@ export function removeWorkerForRepo(repoRoot: string, workerName: string): Worke
     }
     const latestWorker = latest.workers.find((entry) => entry.workerId === worker.workerId);
     if (!latestWorker) throw new Error(`Worker named ${worker.name} not found`);
+    if (!isWorkerCleanupReserved(latest, latestWorker, latestGate)) {
+      throw new Error(`Worker ${worker.name} cleanup reservation changed before cleanup finalization`);
+    }
     return appendCleanupEvent(removeWorker(markConductorGateUsed(latest, cleanupGate.gateId), worker.workerId), {
       status: "succeeded",
       workerId: worker.workerId,

--- a/packages/pi-conductor/extensions/worktrees.ts
+++ b/packages/pi-conductor/extensions/worktrees.ts
@@ -15,6 +15,7 @@ function execGit(cwd: string, command: string): string {
     cwd,
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
+    timeout: 30_000,
   }).trim();
 }
 


### PR DESCRIPTION
## Summary
- Move conductor worker cleanup into a two-phase flow that reserves under lock, performs worktree/session/branch deletion outside the state lock, then finalizes under lock.
- Restore retryable worker state and record cleanup failure events when destructive cleanup IO fails.
- Add cleanup lock-boundary coverage and prevent assigning new work to cleanup-reserved workers.

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `npx vitest run packages/pi-conductor/__tests__`
- `npm run check`

Closes #94