### PR TITLE
docs(pi-exa): define research planning tools

### DIFF
--- a/docs/adr/ADR-0016-stateful-exa-research-planning-tools.md
+++ b/docs/adr/ADR-0016-stateful-exa-research-planning-tools.md
@@ -1,0 +1,114 @@
+---
+title: "Stateful Exa Research Planning Tools"
+adr: ADR-0016
+status: Proposed
+date: 2026-05-03
+prd: "PRD-008-pi-exa-research-planning-tools"
+decision: "Add stateful exa_research_* planning tools that recommend explicit Exa retrieval calls"
+---
+
+# ADR-0016: Stateful Exa Research Planning Tools
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-03
+
+## Requirement Source
+
+- **PRD**: `docs/prd/PRD-008-pi-exa-research-planning-tools.md`
+- **Plan**: `docs/architecture/plan-pi-exa-research-planning-tools.md`
+- **Decision Point**: PRD-008 FR-1 through FR-8 require a reliable research-planning workflow that tracks criteria, sources, gaps, assumptions, branches, revisions, and human-readable summaries.
+
+## Context
+
+`packages/pi-exa/skills/exa-research-planner/SKILL.md` currently describes an iterative research workflow in markdown. It can tell the model to discover many search criteria, run cheap discovery rounds, fetch paper contents, and produce human-readable plans. However, prompt-only guidance does not reliably preserve state across a long research process.
+
+The desired behavior resembles existing stateful reasoning packages in this repository:
+
+- `packages/pi-sequential-thinking` records staged thoughts and summarizes progress.
+- `packages/pi-code-reasoning` records sequential thoughts with branch and revision support.
+
+PRD-008 asks for the same kind of externalized process state for Exa research planning: criteria coverage, Source Pack status, open gaps, assumptions, recommended next actions, and optional payload generation.
+
+The decision is whether `pi-exa` should keep improving the markdown skill only, add stateful planning tools, or create a separate package for research planning.
+
+## Decision Drivers
+
+- PRD-008 requires multi-step criteria and source tracking that a prompt-only skill cannot reliably enforce.
+- Exa deep research has cost and latency implications; the workflow must keep retrieval/synthesis tool calls explicit.
+- Existing repository patterns already support stateful thinking tools with reset/status/summary ergonomics.
+- The research planner must produce human-readable plans before implementation payloads.
+- The workflow should remain specific to Exa tool usage and Source Pack behavior.
+
+## Considered Options
+
+### Option 1: Keep improving `SKILL.md` only
+
+Continue encoding all behavior in `packages/pi-exa/skills/exa-research-planner/SKILL.md`.
+
+- Good, because it has the lowest implementation cost.
+- Good, because it adds no new tool surface area.
+- Bad, because the model can still skip steps, forget discovered criteria, lose source status, or show raw payloads too early.
+- Bad, because there is no structured status or reset mechanism.
+- Bad, because branch/revision behavior cannot be validated or summarized consistently.
+
+### Option 2: Add stateful `exa_research_*` planning tools inside `pi-exa`
+
+Add tools such as `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset` to `packages/pi-exa`.
+
+- Good, because it follows the successful stateful-process pattern from `pi-sequential-thinking` and `pi-code-reasoning`.
+- Good, because it makes criteria, sources, gaps, and assumptions explicit and inspectable.
+- Good, because it can recommend next Exa retrieval calls without hiding network cost.
+- Good, because it keeps Exa-specific planning close to Exa retrieval tools and skills.
+- Bad, because it increases tool surface area.
+- Bad, because it requires new state management, schemas, tests, and documentation.
+
+### Option 3: Create a separate research-planning package
+
+Build a new package dedicated to generic research planning, independent of `pi-exa`.
+
+- Good, because the concept could apply beyond Exa.
+- Good, because it avoids increasing `pi-exa` tool count for users who only want search.
+- Bad, because PRD-008 behavior is tightly coupled to Exa tools, Exa source retrieval, and `web_research_exa` payload generation.
+- Bad, because a second package adds installation and coordination complexity.
+- Bad, because cross-package prompt/tool routing would be harder to document and test.
+
+## Decision
+
+Chosen option: **"Add stateful `exa_research_*` planning tools inside `pi-exa`"**, because PRD-008 requires reliable, inspectable process state while preserving explicit Exa retrieval calls. Keeping the tools inside `pi-exa` matches the Exa-specific nature of the source strategy, Source Pack, and deep-research payload workflow.
+
+The planning tools will recommend next actions such as `web_search_exa`, `web_fetch_exa`, or `web_research_exa`, but they will not call Exa network tools internally.
+
+## Consequences
+
+### Positive
+
+- Research planning becomes auditable: criteria, sources, gaps, and assumptions are visible in tool state.
+- The model gets a durable workflow similar to sequential/code reasoning instead of relying on prompt compliance.
+- User-facing plans can be generated from accumulated state, improving review quality before deep research runs.
+- Exa cost transparency is preserved because retrieval and synthesis remain explicit tool calls.
+
+### Negative
+
+- `pi-exa` gains additional tools, increasing prompt/tool-selection surface area.
+  - Mitigation: prefix tools with `exa_research_` and describe them clearly as planning/orchestration tools.
+- Implementation becomes more complex than a markdown-only skill.
+  - Mitigation: follow existing `pi-code-reasoning` and `pi-sequential-thinking` state/status/reset patterns.
+- The model may still skip the planning tools unless the skill strongly routes non-trivial research through them.
+  - Mitigation: update `packages/pi-exa/skills/exa-research-planner/SKILL.md` and tests to require the tools.
+
+### Neutral
+
+- The stateful planning tools do not replace `web_research_exa`; they sit above it as orchestration.
+- Future generic research-planning functionality could still be extracted into another package if non-Exa use cases emerge.
+
+## Related
+
+- **PRD**: `docs/prd/PRD-008-pi-exa-research-planning-tools.md`
+- **Plan**: `docs/architecture/plan-pi-exa-research-planning-tools.md`
+- **ADRs**: `docs/adr/ADR-0005-exa-deep-search-tool-strategy.md`
+- **Implementation**: `packages/pi-exa/extensions/`, `packages/pi-exa/skills/exa-research-planner/SKILL.md`

--- a/docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md
+++ b/docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md
@@ -1,0 +1,110 @@
+---
+title: "In-Memory Exa Research Planning Sessions"
+adr: ADR-0017
+status: Proposed
+date: 2026-05-03
+prd: "PRD-008-pi-exa-research-planning-tools"
+decision: "Start with in-memory research planning sessions; defer persistence"
+---
+
+# ADR-0017: In-Memory Exa Research Planning Sessions
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-03
+
+## Requirement Source
+
+- **PRD**: `docs/prd/PRD-008-pi-exa-research-planning-tools.md`
+- **Plan**: `docs/architecture/plan-pi-exa-research-planning-tools.md`
+- **Decision Point**: PRD-008 lists persistence as an open question. The implementation plan needs a first-session storage strategy for `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset`.
+
+## Context
+
+PRD-008 requires stateful research-planning tools that accumulate steps, criteria, sources, gaps, assumptions, branches, and revisions. That state must live somewhere.
+
+The repository has two relevant precedents:
+
+- `packages/pi-code-reasoning` uses in-memory tracking for code reasoning thoughts, branches, and resets.
+- `packages/pi-sequential-thinking` includes persistent session storage and import/export capabilities.
+
+Exa research planning could eventually benefit from persistence, especially for long-running research projects or handoffs. However, the first implementation primarily needs reliable intra-session state so the model can complete one research workflow without losing criteria/source/gap context.
+
+## Decision Drivers
+
+- PRD-008 can be satisfied initially with state that lasts for the active pi extension runtime/session.
+- Simpler implementation reduces risk while adding several new planning tools.
+- Persistent storage introduces config, path resolution, import/export, privacy, and cleanup concerns.
+- Research planning state may contain URLs, source notes, and user research intent, so persistence should be intentional.
+- Existing `pi-code-reasoning` provides an in-memory precedent for branch/revision workflows.
+
+## Considered Options
+
+### Option 1: In-memory session state only
+
+Store research planning state in module-level memory for the current extension runtime. `exa_research_reset` clears it.
+
+- Good, because it is simple and matches the first implementation's needs.
+- Good, because it avoids new config, file paths, and persistence privacy concerns.
+- Good, because it follows the `pi-code-reasoning` pattern for branch/revision state.
+- Bad, because state is lost when the pi session/runtime restarts.
+- Bad, because users cannot resume a long research plan across sessions without copying a summary.
+
+### Option 2: Persist sessions to disk from day one
+
+Store research planning sessions under a configurable directory, similar to `pi-sequential-thinking`.
+
+- Good, because users can resume long-running research workflows.
+- Good, because handoff and audit trails become easier.
+- Bad, because it adds config, import/export, migration, and cleanup complexity before the core workflow is proven.
+- Bad, because persisted research state may include sensitive topics, URLs, or source notes.
+- Bad, because PRD-008 does not require persistence for the initial user-facing behavior.
+
+### Option 3: Hybrid in-memory with explicit export/import
+
+Keep default state in memory, but add export/import tools in the first implementation.
+
+- Good, because persistence is user-controlled rather than automatic.
+- Good, because handoff becomes possible without always writing local state.
+- Bad, because it still expands scope and schemas for the first implementation.
+- Bad, because PRD-008 already has several new tools and state models to ship.
+
+## Decision
+
+Chosen option: **"In-memory session state only"**, because it satisfies PRD-008's initial requirements with the least complexity and least persistence/privacy risk. Persistence should be deferred until real usage shows that cross-session resume or durable research audit trails are needed.
+
+The implementation should keep stable in-memory IDs for criteria, sources, and gaps so future persistence or export/import can be added without changing the conceptual model.
+
+## Consequences
+
+### Positive
+
+- First implementation stays focused on stateful planning behavior rather than storage infrastructure.
+- No new storage directory, config file, or persistence lifecycle is required.
+- Research topics and source notes are not silently written to disk.
+- The design remains compatible with future export/import or disk persistence.
+
+### Negative
+
+- Users lose active planning state when the extension runtime ends.
+  - Mitigation: `exa_research_summary(mode: "handoff")` can produce a copyable handoff packet.
+- Long research workflows cannot be resumed automatically.
+  - Mitigation: add export/import or persistence later if this becomes a real usage need.
+- Automated audit trails are limited to the current session transcript.
+  - Mitigation: Source Pack and handoff summaries preserve the most important state in user-visible output.
+
+### Neutral
+
+- This decision does not affect Exa retrieval tools or their caching behavior.
+- If persistence is added later, it should likely follow `pi-sequential-thinking` config conventions.
+
+## Related
+
+- **PRD**: `docs/prd/PRD-008-pi-exa-research-planning-tools.md`
+- **Plan**: `docs/architecture/plan-pi-exa-research-planning-tools.md`
+- **ADRs**: `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md`
+- **Implementation**: `packages/pi-exa/extensions/research-planner.ts`, `packages/pi-exa/extensions/research-planner-types.ts`

--- a/docs/architecture/plan-pi-exa-research-planning-tools.md
+++ b/docs/architecture/plan-pi-exa-research-planning-tools.md
@@ -1,0 +1,250 @@
+---
+title: "pi-exa Research Planning Tools"
+prd: "PRD-008-pi-exa-research-planning-tools"
+date: 2026-05-03
+author: "pi"
+status: Draft
+---
+
+# Plan: pi-exa Research Planning Tools
+
+## Source
+
+- **Package**: `packages/pi-exa`
+- **Prompt**: User wants `packages/pi-exa/skills/exa-research-planner/` to behave more like `packages/pi-sequential-thinking` and `packages/pi-code-reasoning`.
+- **Context**: The current Exa research planner is a markdown skill. It can recommend iterative discovery, criteria expansion, paper retrieval, and human-readable planning, but it cannot reliably track state or enforce the process across multiple tool calls.
+
+## Architecture Overview
+
+Add stateful research-planning tools to `packages/pi-exa` that mirror the ergonomics of sequential/code reasoning tools:
+
+- one tool records each research-planning step,
+- one tool reports current status,
+- one tool summarizes the accumulated plan,
+- one tool resets the session.
+
+These tools do **not** replace Exa retrieval tools. Instead, they orchestrate how the model should use existing tools such as `web_search_exa`, `web_fetch_exa`, `web_research_exa`, `web_answer_exa`, and `web_find_similar_exa`.
+
+The main shift is from a prompt-only skill to a stateful workflow where the model externalizes:
+
+- autodiscovered search criteria,
+- discovery rounds,
+- coverage gaps,
+- source retrieval status,
+- paper-content inspection notes,
+- assumptions,
+- recommended next actions.
+
+The user-facing draft should remain human-readable. Raw `web_research_exa` payloads are optional implementation details shown after the readable plan or on request.
+
+## Components
+
+### 1. `exa_research_step`
+
+Records one research-planning step and returns updated state plus the recommended next action.
+
+**Purpose**
+
+- Force the model to externalize the research process.
+- Track criteria discovery and revisions.
+- Track source discovery/fetching and evidence quality.
+- Decide whether to search more, fetch sources, ask the user, draft a plan, or execute deep research.
+
+**Key parameters**
+
+| Field | Type | Required | Purpose |
+|---|---|---:|---|
+| `topic` | string | yes | User-facing research topic or question. |
+| `stage` | enum | yes | `framing`, `criteria_discovery`, `cheap_discovery`, `source_retrieval`, `coverage_analysis`, `deep_research_plan`, `synthesis_plan`, `conclusion`. |
+| `note` | string | yes | What was learned, decided, or proposed in this step. |
+| `criteria` | array | no | Search/evaluation criteria discovered or revised in this step. |
+| `sources` | array | no | Source records discovered or fetched in this step. |
+| `gaps` | array | no | Missing evidence, ambiguity, conflicts, or user decisions needed. |
+| `assumptions` | array | no | Assumptions carried unless corrected. |
+| `nextAction` | enum | no | `ask_user`, `web_search_exa`, `web_search_advanced_exa`, `web_fetch_exa`, `web_find_similar_exa`, `web_answer_exa`, `web_research_exa`, `draft_plan`, `finalize`. |
+| `nextActionReason` | string | no | Why this is the cheapest useful next move. |
+| `thought_number` | integer | yes | Step number, matching sequential-thinking ergonomics. |
+| `total_thoughts` | integer | yes | Estimated total steps; can change as scope changes. |
+| `next_step_needed` | boolean | yes | Set false only when planning is complete. |
+| `is_revision` | boolean | no | Marks a correction to earlier planning. |
+| `revises_step` | integer | no | Step number being revised. |
+| `branch_from_step` | integer | no | Step number where an alternative strategy branches. |
+| `branch_id` | string | no | Identifier for the branch. |
+
+**Return shape**
+
+- current stage and progress,
+- criteria coverage matrix,
+- source pack summary,
+- open gaps,
+- recommended next action,
+- whether user clarification is warranted,
+- concise human-readable plan fragment.
+
+### 2. `exa_research_status`
+
+Returns current planning session state.
+
+Includes:
+
+- topic,
+- step count,
+- active stage,
+- branches,
+- criteria coverage summary,
+- source pack summary,
+- open gaps,
+- last recommended next action.
+
+### 3. `exa_research_summary`
+
+Generates a human-readable plan or handoff packet from current state.
+
+| Mode | Output |
+|---|---|
+| `brief` | Short plan with objective, coverage areas, source strategy, next action. |
+| `execution_plan` | Detailed multi-round research plan suitable for user review. |
+| `payload` | Optional implementation payload for `web_research_exa`, derived from the readable plan. |
+| `source_pack` | Table of discovered/fetched sources with retrieval status. |
+| `handoff` | Complete packet for another agent/session. |
+
+Default output must be human-readable. JSON payloads should be labeled **Implementation payload** and shown only after the readable plan or when requested.
+
+### 4. `exa_research_reset`
+
+Clears the current planning session.
+
+### 5. Core Data Model
+
+#### Research Criterion
+
+A criterion represents one search/evaluation angle the model discovered.
+
+Fields:
+
+- `id`: stable identifier, e.g. `C1`.
+- `label`: short name, e.g. `Force plate validation`.
+- `category`: `method`, `metric`, `source_class`, `population`, `market`, `risk`, `contrarian`, `timeframe`, `geography`, `use_case`, `other`.
+- `description`: what this criterion covers.
+- `priority`: `high`, `medium`, `low`.
+- `status`: `proposed`, `searched`, `supported`, `conflicting`, `missing`, `excluded`.
+- `evidenceRefs`: source IDs or tool-call notes.
+
+#### Source Record
+
+A source record tracks source retrieval and whether content was actually inspected.
+
+Fields:
+
+- `id`: stable identifier, e.g. `S1`.
+- `title`.
+- `url`.
+- `sourceType`: `paper`, `white_paper`, `pdf`, `official_doc`, `filing`, `news`, `blog`, `github`, `forum`, `analyst_report`, `other`.
+- `retrievalStatus`: `discovered_only`, `fetched`, `fetch_failed`, `unavailable`.
+- `usedFor`: criteria IDs.
+- `contentNotes`: methods, claims, data, limitations, or relevant excerpts.
+- `qualityNotes`: bias, recency, sample size, vendor framing, peer review status.
+
+#### Gap Record
+
+A gap captures ambiguity or missing evidence.
+
+Fields:
+
+- `id`: stable identifier, e.g. `G1`.
+- `description`.
+- `severity`: `blocking`, `important`, `minor`.
+- `resolution`: `ask_user`, `search_more`, `fetch_source`, `carry_assumption`, `exclude`.
+
+### 6. Planning Loop
+
+The tools should encourage this workflow:
+
+1. **Frame** — record objective and assumptions.
+2. **Autodiscover criteria** — infer many possible search angles before deep synthesis.
+3. **Broad cheap discovery** — use `web_search_exa` to learn vocabulary, source classes, and named entities.
+4. **Revise criteria** — update priorities based on discovery.
+5. **Targeted cheap discovery** — use advanced search, similar search, or answer when helpful.
+6. **Retrieve sources** — fetch representative URLs, especially papers, white papers, reports, PDFs, standards, and filings.
+7. **Analyze coverage** — decide what is covered, missing, contradictory, or out of scope.
+8. **Clarify only if needed** — ask one focused user question only when a gap changes objective or criteria.
+9. **Produce human-readable plan** — show objective, coverage, source strategy, assumptions, output shape.
+10. **Optional payload** — derive `web_research_exa` JSON after the readable plan.
+11. **Optional synthesis** — if deep research runs, use fetched source contents as first-class evidence.
+
+### 7. Clarification Policy
+
+Ask the user only when ambiguity materially changes the research.
+
+Ask when:
+
+- several domains require different source strategies,
+- evaluation criteria conflict,
+- timeframe/geography materially changes results,
+- the user must choose between source classes,
+- optimization target is unclear.
+
+Do not ask when the ambiguity can be safely carried as an assumption.
+
+### 8. Source Retrieval Policy
+
+For white papers, academic papers, technical reports, standards, filings, or PDFs:
+
+- discover actual paper/report URLs,
+- fetch the contents with `web_fetch_exa` when available,
+- track retrieval status in the Source Pack,
+- synthesize from fetched contents, not only from `web_research_exa`,
+- mark unfetched items as `discovered_only`,
+- prefer directly inspected source text over broader synthesis when they conflict.
+
+## Implementation Order
+
+| Phase | Component | Change | Dependencies | Estimated Scope | Files | Verification |
+|---:|---|---|---|---|---|---|
+| 1 | Research planner state | Add research planning types and in-memory tracker. | None | Medium | `packages/pi-exa/extensions/research-planner.ts`, `packages/pi-exa/extensions/research-planner-types.ts` | Unit tests for add/reset/status. |
+| 2 | Tool registration | Register `exa_research_step`, `exa_research_status`, `exa_research_summary`, `exa_research_reset`. | Phase 1 | Medium | `packages/pi-exa/extensions/index.ts`, `packages/pi-exa/extensions/schemas.ts` | Extension registration tests. |
+| 3 | Coverage model | Implement criteria/source/gap aggregation. | Phase 1 | Medium | `packages/pi-exa/extensions/research-planner.ts` | Tests for coverage and source pack summaries. |
+| 4 | Branching model | Add branch/revision validation. | Phase 1 | Small | `packages/pi-exa/extensions/research-planner.ts` | Tests mirroring code-reasoning branch/revision behavior. |
+| 5 | Skill integration | Update `exa-research-planner` skill to require the tools. | Phases 2-4 | Small | `packages/pi-exa/skills/exa-research-planner/SKILL.md` | Skill text tests. |
+| 6 | Documentation | Document tools in README. | Phases 2-5 | Small | `packages/pi-exa/README.md` | README/package tests. |
+| 7 | Quality gate | Run package checks. | All prior phases | Small | N/A | `npx tsc --noEmit --project packages/pi-exa/tsconfig.json`, `npx vitest run packages/pi-exa/__tests__`, `npx biome ci packages/pi-exa`. |
+
+## ADR Index
+
+| ADR | Title | Status | Notes |
+|---|---|---|---|
+| ADR-TBD | Stateful Exa Research Planning Tools | Proposed | Decide prompt-only skill vs stateful tools and whether planning tools should auto-call retrieval tools. |
+| ADR-TBD | Exa Research Session Persistence | Optional | Decide in-memory vs persisted sessions if persistence becomes necessary. |
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Tool surface area grows too large. | More prompt/tool-selection overhead. | Keep planning tools clearly prefixed with `exa_research_`; consider gating behind config if needed. |
+| Planning tool duplicates existing Exa tools. | Confusing workflow and accidental hidden costs. | Planning tools only recommend next actions; existing Exa tools perform retrieval/synthesis explicitly. |
+| State becomes too verbose. | Poor model usability and truncated outputs. | Summaries should compress criteria/source/gap state and support output truncation limits. |
+| Model still shows JSON-first drafts. | User experience regresses. | Add tests and skill guidance requiring human-readable summaries before implementation payloads. |
+| Paper retrieval creates false confidence when fetch fails. | Weak evidence may be overused. | Track `retrievalStatus` and mark unfetched sources as `discovered_only`. |
+
+## Example Flow
+
+User asks: “Research computer vision jump analysis.”
+
+Expected flow:
+
+1. `exa_research_step(stage: "framing")` records objective and assumptions.
+2. `exa_research_step(stage: "criteria_discovery")` proposes criteria: pose method, validation target, metrics, camera setup, population, field deployment, limitations.
+3. Model calls `web_search_exa` for broad discovery.
+4. `exa_research_step(stage: "cheap_discovery")` records found terms and papers.
+5. Model calls `web_fetch_exa` on strongest paper URLs.
+6. `exa_research_step(stage: "source_retrieval")` records fetched source contents and Source Pack status.
+7. `exa_research_step(stage: "coverage_analysis")` identifies gaps and whether user clarification is needed.
+8. `exa_research_summary(mode: "execution_plan")` returns a readable plan.
+9. User approves execution or asks for refinements.
+
+## Open Questions
+
+1. Should planning sessions persist to disk like `packages/pi-sequential-thinking`, or remain in-memory like `packages/pi-code-reasoning`?
+2. Should `exa_research_step` allow arbitrary source metadata, or should source records be strictly typed from day one?
+3. Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads, or also recommended `web_search_exa` / `web_fetch_exa` calls?
+4. Should research planning tools be enabled by default, or gated behind a flag to avoid adding tool surface area for users who only need basic search?

--- a/docs/architecture/plan-pi-exa-research-planning-tools.md
+++ b/docs/architecture/plan-pi-exa-research-planning-tools.md
@@ -213,8 +213,8 @@ For white papers, academic papers, technical reports, standards, filings, or PDF
 
 | ADR | Title | Status | Notes |
 |---|---|---|---|
-| ADR-TBD | Stateful Exa Research Planning Tools | Proposed | Decide prompt-only skill vs stateful tools and whether planning tools should auto-call retrieval tools. |
-| ADR-TBD | Exa Research Session Persistence | Optional | Decide in-memory vs persisted sessions if persistence becomes necessary. |
+| `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md` | Stateful Exa Research Planning Tools | Proposed | Chooses stateful `exa_research_*` planning tools inside `pi-exa`; planning tools recommend but do not execute Exa retrieval calls. |
+| `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md` | In-Memory Exa Research Planning Sessions | Proposed | Chooses in-memory planning sessions for the first implementation and defers persistence. |
 
 ## Risks and Mitigations
 
@@ -244,7 +244,7 @@ Expected flow:
 
 ## Open Questions
 
-1. Should planning sessions persist to disk like `packages/pi-sequential-thinking`, or remain in-memory like `packages/pi-code-reasoning`?
+1. **Resolved:** Planning sessions start in-memory, as captured in `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`.
 2. Should `exa_research_step` allow arbitrary source metadata, or should source records be strictly typed from day one?
 3. Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads, or also recommended `web_search_exa` / `web_fetch_exa` calls?
 4. Should research planning tools be enabled by default, or gated behind a flag to avoid adding tool surface area for users who only need basic search?

--- a/docs/prd/PRD-008-pi-exa-research-planning-tools.md
+++ b/docs/prd/PRD-008-pi-exa-research-planning-tools.md
@@ -363,10 +363,10 @@ And packages/pi-exa/README.md lists the research planning tools
 
 | # | Question | Owner | Due | Status |
 |---|----------|-------|-----|--------|
-| Q1 | Should research planning sessions persist to disk or stay in-memory initially? | Sebastian | Before implementation | Open |
+| Q1 | Should research planning sessions persist to disk or stay in-memory initially? | Sebastian | Before implementation | **Resolved:** Start in-memory; see `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`. |
 | Q2 | Should planning tools be enabled by default or gated behind config? | Sebastian | Before implementation | Open |
 | Q3 | Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads or also suggested search/fetch calls? | Sebastian | During implementation | Open |
-| Q4 | Should this require an ADR before implementation? | Sebastian | Before implementation | Open |
+| Q4 | Should this require an ADR before implementation? | Sebastian | Before implementation | **Resolved:** ADRs drafted; see `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md` and `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`. |
 
 ---
 

--- a/docs/prd/PRD-008-pi-exa-research-planning-tools.md
+++ b/docs/prd/PRD-008-pi-exa-research-planning-tools.md
@@ -1,0 +1,401 @@
+---
+title: "pi-exa Research Planning Tools"
+prd: PRD-008
+status: Draft
+owner: "Sebastian Otaegui"
+issue: "N/A"
+date: 2026-05-03
+version: "1.0"
+---
+
+# PRD: pi-exa Research Planning Tools
+
+---
+
+## 1. Problem & Context
+
+`packages/pi-exa/skills/exa-research-planner/SKILL.md` currently describes an iterative research workflow, but it is still only prompt guidance. A prompt-only skill cannot reliably enforce or track the behavior the user wants: multi-round criteria discovery, source retrieval, paper-content inspection, gap analysis, human-readable plan drafts, and optional deep-research execution.
+
+This is the same class of problem solved by `packages/pi-sequential-thinking` and `packages/pi-code-reasoning`: stateful tools force the model to externalize each step, track sequence state, branch/revise when scope changes, and produce summaries from accumulated state. `pi-exa` needs a similar stateful workflow for research planning.
+
+The immediate design plan exists at `docs/architecture/plan-pi-exa-research-planning-tools.md`. This PRD formalizes the product requirements that plan should implement.
+
+---
+
+## 2. Goals & Success Metrics
+
+| Goal | Metric | Target |
+|------|--------|--------|
+| **Stateful research planning** | New planning tools registered and callable | `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset` are available |
+| **Criteria coverage** | Planning state tracks discovered criteria | Criteria records include category, priority, status, and evidence refs |
+| **Multi-round discovery** | Tool output recommends next research action | Step results can recommend search, fetch, clarify, draft, execute, or finalize |
+| **Source retrieval accountability** | Source Pack tracks retrieval state | Sources distinguish `discovered_only`, `fetched`, `fetch_failed`, and `unavailable` |
+| **Human-readable planning** | Summary defaults to readable plan | `exa_research_summary` leads with objective, coverage, source strategy, assumptions, and next action before any payload |
+| **Paper-content evidence discipline** | Fetched source contents are tracked separately from synthesized output | Source records can store content notes and quality notes |
+
+**Guardrails (must not regress):**
+
+- Existing web retrieval tools (`web_search_exa`, `web_fetch_exa`, `web_research_exa`, `web_answer_exa`, `web_find_similar_exa`) continue to work unchanged.
+- Planning tools do not hide Exa network calls or costs; they recommend next actions, while the model explicitly calls retrieval tools.
+- Existing package checks continue to pass.
+- `web_research_exa` remains opt-in according to existing config behavior.
+
+---
+
+## 3. Users & Use Cases
+
+### Primary: Research-oriented pi user
+
+> As a pi user, I want the Exa research planner to walk through multi-round discovery and source coverage so that final research is broader, more auditable, and less dependent on one deep-research call.
+
+**Preconditions:** `@feniix/pi-exa` is installed and configured with an Exa API key for retrieval tools that require network access.
+
+### Secondary: LLM using pi-exa skills
+
+> As the model executing an Exa research workflow, I want stateful tools for criteria, sources, gaps, and next actions so that I do not lose track of the plan across multiple searches and fetches.
+
+**Preconditions:** Research planning tools are registered in the current pi session.
+
+### Future: Automation / handoff consumer
+
+> As an automation or downstream agent, I want a structured research plan summary so that I can continue research, review source coverage, or execute the recommended payload later.
+
+---
+
+## 4. Scope
+
+### In scope
+
+1. **Research planning step tool** — record topic, stage, notes, criteria, sources, gaps, assumptions, branch/revision metadata, and recommended next action.
+2. **Research planning status tool** — report current session state, criteria coverage, source pack summary, open gaps, branches, and last next action.
+3. **Research planning summary tool** — generate human-readable briefs, execution plans, source packs, handoff packets, and optional implementation payloads.
+4. **Research planning reset tool** — clear the in-memory planning session.
+5. **Criteria model** — track discovered search/evaluation angles and their evidence coverage.
+6. **Source model** — track source type, URL, retrieval status, content notes, and quality notes.
+7. **Gap model** — track ambiguity, missing evidence, and whether to ask the user, search more, fetch, assume, or exclude.
+8. **Skill update** — update `exa-research-planner` to use these tools instead of relying only on prompt instructions.
+9. **Tests and docs** — cover tool registration, state tracking, reset, summaries, branch/revision behavior, and README documentation.
+
+### Out of scope / later
+
+| What | Why | Tracked in |
+|------|-----|------------|
+| Persistent research sessions | In-memory state is enough for first implementation and matches `pi-code-reasoning` simplicity | Open question |
+| Automatic execution of recommended Exa tool calls | Hidden network calls would obscure cost and user/model control | N/A |
+| Full citation manager | Source Pack is sufficient for planning; citation management is a larger product | TBD |
+| New Exa API endpoints | This work orchestrates existing tools only | N/A |
+| UI rendering beyond normal tool text output | Useful later, not required for behavior | TBD |
+
+### Design for future (build with awareness)
+
+The state model should keep stable IDs for criteria (`C1`), sources (`S1`), and gaps (`G1`) so future import/export, richer UI, or external handoff can reference them without re-parsing prose. The summary mode should be extensible so later modes such as `audit` or `cost_report` can be added without changing step state shape.
+
+---
+
+## 5. Functional Requirements
+
+### FR-1: Record research planning steps
+
+The extension must expose `exa_research_step` to record one step in a stateful research planning session.
+
+**Acceptance criteria:**
+
+```gherkin
+Given no research planning session exists
+When the model calls exa_research_step with topic "computer vision jump analysis", stage "framing", thought_number 1, total_thoughts 5, and next_step_needed true
+Then the tool records the step
+And the result includes progress, current stage, open gaps, and recommended next action fields
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner.ts` — implement in-memory tracker and step handling.
+- `packages/pi-exa/extensions/research-planner-types.ts` — define step, criterion, source, gap, summary, and status types.
+- `packages/pi-exa/extensions/schemas.ts` — define TypeBox schema for `exa_research_step`.
+- `packages/pi-exa/extensions/index.ts` — register the tool.
+
+### FR-2: Track autodiscovered criteria coverage
+
+The planning state must track criteria discovered by the model, including category, priority, status, and evidence references.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a research planning session exists
+When the model records criteria for "force plate validation" and "camera angle sensitivity"
+Then exa_research_status lists both criteria
+And each criterion includes category, priority, status, and evidence reference fields when provided
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner-types.ts` — define `ResearchCriterion`.
+- `packages/pi-exa/extensions/research-planner.ts` — aggregate and update criteria across steps.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test criteria aggregation.
+
+### FR-3: Track source pack and retrieval status
+
+The planning state must track discovered/fetched sources and distinguish source retrieval state.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a paper-heavy research session exists
+When the model records one source with retrievalStatus "discovered_only" and another with retrievalStatus "fetched"
+Then exa_research_summary with mode "source_pack" shows both sources
+And the fetched source is distinguishable from the discovered-only source
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner-types.ts` — define `ResearchSource`.
+- `packages/pi-exa/extensions/research-planner.ts` — aggregate source records and source pack output.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test source pack summaries.
+
+### FR-4: Track gaps and clarification policy
+
+The planning state must track gaps and indicate when user clarification is warranted.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a research planning session has a gap with severity "blocking" and resolution "ask_user"
+When the model calls exa_research_status
+Then the result identifies that user clarification is warranted
+And the status includes the blocking gap description
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner-types.ts` — define `ResearchGap`.
+- `packages/pi-exa/extensions/research-planner.ts` — compute clarification recommendation.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test gap behavior.
+
+### FR-5: Support branch and revision metadata
+
+The planning step tool must support revision and branching metadata similar to `pi-code-reasoning`.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a research planning session has two recorded steps
+When the model records a third step with is_revision true and revises_step 1
+Then the step is accepted and marked as a revision
+When the model records a branch with branch_from_step 2 and branch_id "paper-first"
+Then exa_research_status lists the "paper-first" branch
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner.ts` — validate revision and branch references.
+- `packages/pi-exa/extensions/schemas.ts` — include branch/revision fields.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test branch/revision flows.
+
+### FR-6: Generate human-readable summaries before payloads
+
+`exa_research_summary` must default to human-readable plans. Raw JSON payloads are optional and labeled as implementation payloads.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a research planning session has objective, criteria, source strategy, and assumptions
+When the model calls exa_research_summary with mode "execution_plan"
+Then the output starts with a human-readable research objective and coverage plan
+And raw web_research_exa JSON is absent unless mode "payload" is requested
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner.ts` — implement summary modes.
+- `packages/pi-exa/extensions/schemas.ts` — define summary mode schema.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test human-readable output ordering.
+
+### FR-7: Reset research planning state
+
+The extension must expose `exa_research_reset` to clear state.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a research planning session has recorded steps, criteria, sources, and gaps
+When the model calls exa_research_reset
+Then exa_research_status reports zero steps and no active topic
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner.ts` — implement reset.
+- `packages/pi-exa/extensions/index.ts` — register reset tool.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test reset.
+
+### FR-8: Update skill and README guidance
+
+The Exa research planner skill and README must document the new stateful workflow.
+
+**Acceptance criteria:**
+
+```gherkin
+Given the package documentation is updated
+When a reader opens packages/pi-exa/skills/exa-research-planner/SKILL.md
+Then it instructs the model to use exa_research_step for iterative planning
+And packages/pi-exa/README.md lists the research planning tools
+```
+
+**Files:**
+
+- `packages/pi-exa/skills/exa-research-planner/SKILL.md` — require stateful planning tools.
+- `packages/pi-exa/README.md` — document tools and intended workflow.
+- `packages/pi-exa/__tests__/index.test.ts` — test docs/skill references.
+
+---
+
+## 6. Non-Functional Requirements
+
+| Category | Requirement |
+|----------|-------------|
+| **Cost transparency** | Planning tools must not call Exa network APIs internally. They recommend explicit existing Exa tool calls. |
+| **Output quality** | Summaries must lead with human-readable plans, not raw JSON payloads. |
+| **Type safety** | Tool schemas must avoid `Type.Unknown()` and use typed objects or flexible object schemas with `additionalProperties`. |
+| **Performance** | In-memory operations should be fast enough to add/status/summarize sessions with at least 50 steps, 100 criteria, and 100 sources. |
+| **Testability** | State aggregation, reset, branch/revision validation, and summary output must be unit-testable without Exa network access. |
+| **Compatibility** | Existing Exa tools and config behavior must remain backward compatible. |
+
+---
+
+## 7. Risks & Assumptions
+
+### Risks
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|------------|------------|
+| Tool surface area becomes confusing | Medium | Medium | Prefix planning tools with `exa_research_` and document their orchestration role separately from web retrieval tools. |
+| The model still skips planning tools | Medium | Medium | Update `exa-research-planner` skill and prompt guidance to require tool use for non-trivial research. |
+| State output becomes too verbose | Medium | Medium | Add concise status/summary formats and reuse package output truncation patterns if needed. |
+| Planning tools are mistaken for retrieval tools | Low | Medium | Make descriptions explicit: planning tools do not perform network search. |
+| Source Pack gives false confidence for unfetched papers | High | Medium | Track retrieval status and require summaries to label `discovered_only` sources clearly. |
+
+### Assumptions
+
+- In-memory state is acceptable for the first implementation.
+- Existing Exa tools remain responsible for network calls and cost-incurring operations.
+- Research planning state belongs in `packages/pi-exa` rather than a new package because it is Exa-specific and tied to Exa tool workflows.
+- Human-readable plans are more useful to users than raw `web_research_exa` payloads, but payloads remain useful as optional implementation detail.
+
+---
+
+## 8. Design Decisions
+
+### D1: Stateful tools instead of prompt-only skill
+
+**Options considered:**
+
+1. Keep improving `SKILL.md` only — low implementation cost, but behavior remains unreliable and untracked.
+2. Add stateful planning tools — more implementation work, but mirrors successful `pi-sequential-thinking` / `pi-code-reasoning` patterns.
+
+**Decision:** Add stateful planning tools.
+
+**Rationale:** The desired workflow depends on accumulated state: criteria, discoveries, fetched sources, gaps, assumptions, branches, and revisions. A prompt-only skill cannot reliably preserve or expose that state.
+
+**Future path:** The tool state can later support import/export, richer UI, or automated handoff.
+
+### D2: Planning tools recommend, but do not execute, Exa searches
+
+**Options considered:**
+
+1. Planning tools auto-call Exa retrieval tools — convenient, but hides network cost and blends orchestration with retrieval.
+2. Planning tools recommend next actions — explicit, auditable, and consistent with existing tool boundaries.
+
+**Decision:** Planning tools recommend next tool calls; the model explicitly calls existing Exa tools.
+
+**Rationale:** `web_research_exa` is intentionally cost/latency transparent. Keeping retrieval calls explicit preserves that design.
+
+### D3: Human-readable summaries before implementation payloads
+
+**Options considered:**
+
+1. Show raw JSON payloads by default — precise for tools, but poor for user review.
+2. Show readable plans first and payloads only as optional implementation details — better for user decisions.
+
+**Decision:** Human-readable summaries first.
+
+**Rationale:** Users need to review scope, criteria, source strategy, and assumptions. JSON payloads are derived implementation details.
+
+---
+
+## 9. File Breakdown
+
+| File | Change type | FR | Description |
+|------|-------------|-----|-------------|
+| `packages/pi-exa/extensions/research-planner-types.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5 | Types for steps, criteria, sources, gaps, summary state, and branch/revision metadata. |
+| `packages/pi-exa/extensions/research-planner.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7 | In-memory tracker, aggregation, validation, status, summary, reset. |
+| `packages/pi-exa/extensions/schemas.ts` | Modify | FR-1, FR-5, FR-6, FR-7 | TypeBox schemas for new tools. |
+| `packages/pi-exa/extensions/index.ts` | Modify | FR-1, FR-6, FR-7 | Register planning tools and wire handlers. |
+| `packages/pi-exa/skills/exa-research-planner/SKILL.md` | Modify | FR-8 | Require stateful tools for non-trivial research planning. |
+| `packages/pi-exa/README.md` | Modify | FR-8 | Document research planning tools and workflow. |
+| `packages/pi-exa/__tests__/research-planner.test.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7 | Focused unit coverage for planner state and summaries. |
+| `packages/pi-exa/__tests__/extension.test.ts` | Modify | FR-1, FR-6, FR-7 | Tool registration and execute behavior coverage. |
+| `packages/pi-exa/__tests__/index.test.ts` | Modify | FR-8 | README/skill reference tests. |
+
+---
+
+## 10. Dependencies & Constraints
+
+- Must follow existing TypeScript, Biome, and Vitest conventions in this repo.
+- Must not introduce divergent package-specific TypeScript compiler options.
+- Must avoid `Type.Unknown()` in tool schemas.
+- Should follow state/truncation patterns from `packages/pi-code-reasoning` and `packages/pi-sequential-thinking` where appropriate.
+- Must keep existing Exa API key/config behavior unchanged.
+
+---
+
+## 11. Rollout Plan
+
+1. Implement planner state and tests behind new tool names.
+2. Register tools and verify default package behavior.
+3. Update `exa-research-planner` skill to route non-trivial workflows through the stateful tools.
+4. Update README and skill tests.
+5. Run package checks.
+6. Optionally create an ADR for the stateful-tool decision before or during implementation.
+
+---
+
+## 12. Open Questions
+
+| # | Question | Owner | Due | Status |
+|---|----------|-------|-----|--------|
+| Q1 | Should research planning sessions persist to disk or stay in-memory initially? | Sebastian | Before implementation | Open |
+| Q2 | Should planning tools be enabled by default or gated behind config? | Sebastian | Before implementation | Open |
+| Q3 | Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads or also suggested search/fetch calls? | Sebastian | During implementation | Open |
+| Q4 | Should this require an ADR before implementation? | Sebastian | Before implementation | Open |
+
+---
+
+## 13. Related
+
+| Issue | Relationship |
+|-------|-------------|
+| `docs/architecture/plan-pi-exa-research-planning-tools.md` | Initial architecture plan for this PRD |
+| `docs/adr/ADR-0005-exa-deep-search-tool-strategy.md` | Existing decision that deep synthesis stays in `web_research_exa` |
+| `packages/pi-sequential-thinking` | Pattern source for staged stateful thinking tools |
+| `packages/pi-code-reasoning` | Pattern source for branch/revision process tools |
+
+---
+
+## 14. Changelog
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-05-03 | Initial draft | pi |
+
+---
+
+## 15. Verification (Appendix)
+
+Post-implementation checks:
+
+1. Start a planning session for “computer vision jump analysis” and confirm `exa_research_step` records criteria before any deep research payload is shown.
+2. Run broad discovery with `web_search_exa`, then record updated criteria and sources with `exa_research_step`.
+3. Fetch a paper URL with `web_fetch_exa`, then record it as `retrievalStatus: "fetched"` and confirm `exa_research_summary(mode: "source_pack")` shows it.
+4. Record a blocking gap with `resolution: "ask_user"` and confirm status recommends user clarification.
+5. Generate `exa_research_summary(mode: "execution_plan")` and confirm it is human-readable and does not lead with JSON.
+6. Generate `exa_research_summary(mode: "payload")` and confirm the implementation payload derives from the recorded criteria and source strategy.

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -87,5 +87,70 @@ describe("pi-exa", () => {
       expect(skill).toContain("web_find_similar_exa");
       expect(skill).toContain("web_search_exa");
     });
+
+    it("skills only mention supported tool parameters", () => {
+      const skillFiles = [
+        "code-search",
+        "company-research",
+        "exa-research-planner",
+        "financial-report-search",
+        "people-research",
+        "personal-site-search",
+        "research-paper-search",
+      ];
+
+      for (const skillName of skillFiles) {
+        const skill = readFileSync(join(__dirname, `../skills/${skillName}/SKILL.md`), "utf-8");
+        expect(skill).not.toContain("excludeText");
+      }
+    });
+
+    it("structured outputSchema skill examples define array items", () => {
+      const financialSkill = readFileSync(join(__dirname, "../skills/financial-report-search/SKILL.md"), "utf-8");
+      const peopleSkill = readFileSync(join(__dirname, "../skills/people-research/SKILL.md"), "utf-8");
+
+      expect(financialSkill).toContain('"risks": { "type": "array", "items": { "type": "string" } }');
+      expect(peopleSkill).toContain('"experts": { "type": "array", "items": { "type": "object" } }');
+    });
+
+    it("exa-research-planner supports explicit deep research execution", () => {
+      const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+
+      expect(skill).toContain("Explicit deep-research execution");
+      expect(skill).toContain("A direct user request to run deep research counts as approval");
+      expect(skill).toContain("web_research_exa");
+    });
+
+    it("exa-research-planner requires paper retrieval for white paper sources", () => {
+      const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+
+      expect(skill).toContain("White Papers and Source Retrieval");
+      expect(skill).toContain("return the actual paper URLs");
+      expect(skill).toContain("web_fetch_exa");
+    });
+
+    it("exa-research-planner requires paper contents to inform synthesis", () => {
+      const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+
+      expect(skill).toContain("Paper Content Synthesis Rule");
+      expect(skill).toContain("Do not rely only on `web_research_exa` synthesis");
+      expect(skill).toContain("Use fetched paper contents as first-class evidence");
+    });
+
+    it("exa-research-planner supports iterative discovery and clarification", () => {
+      const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+
+      expect(skill).toContain("Iterative Discovery and Clarification Loop");
+      expect(skill).toContain("Run multiple cheap discovery rounds when each round changes the plan");
+      expect(skill).toContain("Ask the user one focused clarification question");
+    });
+
+    it("exa-research-planner presents human-readable drafts before payloads", () => {
+      const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+
+      expect(skill).toContain("Human-Readable Drafts First");
+      expect(skill).toContain("Show the user the research plan in human-consumable form first");
+      expect(skill).toContain("Do not lead with raw JSON");
+    });
   });
 });

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -153,12 +153,12 @@ describe("pi-exa", () => {
       expect(skill).toContain("Do not lead with raw JSON");
     });
 
-    it("exa-research-planner references planned stateful research tools", () => {
+    it("exa-research-planner does not reference unimplemented planning tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
 
-      expect(skill).toContain("Stateful Planning Tools");
-      expect(skill).toContain("exa_research_step");
-      expect(skill).toContain("stateful planning is unavailable");
+      expect(skill).not.toContain("PRD-008");
+      expect(skill).not.toContain("exa_research_step");
+      expect(skill).not.toContain("exa_research_summary");
     });
   });
 });

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -152,5 +152,13 @@ describe("pi-exa", () => {
       expect(skill).toContain("Show the user the research plan in human-consumable form first");
       expect(skill).toContain("Do not lead with raw JSON");
     });
+
+    it("exa-research-planner references planned stateful research tools", () => {
+      const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+
+      expect(skill).toContain("Stateful Planning Tools");
+      expect(skill).toContain("exa_research_step");
+      expect(skill).toContain("stateful planning is unavailable");
+    });
   });
 });

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -4,8 +4,10 @@
  * Provides Exa search tools via native TypeScript using the Exa API directly.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Static, TSchema } from "typebox";
 import { getResolvedConfig, isToolEnabledForConfig, resolveAuth } from "./config.js";
+import type { ToolPerformResult } from "./formatters.js";
 import {
   webAnswerParams,
   webFetchParams,
@@ -35,11 +37,87 @@ export { DEFAULT_MAX_CHARACTERS } from "./web-fetch.js";
 export { DEFAULT_NUM_RESULTS } from "./web-search.js";
 
 // =============================================================================
-// Extension Entry Point
+// Tool Registration Helpers
 // =============================================================================
 
-export default function exaExtension(pi: ExtensionAPI) {
-  // Register CLI flags
+type ExaToolSpec<TParams extends TSchema> = {
+  name: string;
+  label: string;
+  description: string;
+  promptSnippet: string;
+  promptGuidelines: string[];
+  parameters: TParams;
+  pendingMessage: string;
+  errorPrefix: string;
+  perform: (apiKey: string, params: Static<TParams>) => Promise<ToolPerformResult>;
+};
+
+function toolDetails(toolName: string): { tool: string } {
+  return { tool: toolName };
+}
+
+function missingApiKeyResult(toolName: string) {
+  return {
+    content: [
+      { type: "text" as const, text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." },
+    ],
+    isError: true,
+    details: { ...toolDetails(toolName), error: "missing_api_key" },
+  };
+}
+
+function cancelledResult(toolName: string) {
+  return {
+    content: [{ type: "text" as const, text: "Cancelled." }],
+    details: { ...toolDetails(toolName), cancelled: true },
+  };
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function registerExaTool<TParams extends TSchema>(pi: ExtensionAPI, spec: ExaToolSpec<TParams>): void {
+  pi.registerTool(
+    defineTool({
+      name: spec.name,
+      label: spec.label,
+      description: spec.description,
+      promptSnippet: spec.promptSnippet,
+      promptGuidelines: spec.promptGuidelines,
+      parameters: spec.parameters,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const apiKey = resolveAuth(pi).apiKey;
+        if (!apiKey) {
+          return missingApiKeyResult(spec.name);
+        }
+
+        if (signal?.aborted) {
+          return cancelledResult(spec.name);
+        }
+
+        onUpdate?.({
+          content: [{ type: "text", text: spec.pendingMessage }],
+          details: { status: "pending" },
+        });
+
+        try {
+          const result = await spec.perform(apiKey, params);
+          return { content: [{ type: "text", text: result.text }], details: result.details };
+        } catch (error) {
+          const message = toErrorMessage(error);
+          return {
+            content: [{ type: "text", text: `${spec.errorPrefix}: ${message}` }],
+            isError: true,
+            details: { ...toolDetails(spec.name), error: message },
+          };
+        }
+      },
+    }),
+  );
+}
+
+function registerFlags(pi: ExtensionAPI): void {
   pi.registerFlag("--exa-api-key", {
     description: "Exa AI API key for search operations",
     type: "string",
@@ -60,17 +138,20 @@ export default function exaExtension(pi: ExtensionAPI) {
     description: "Deprecated alias for --exa-config-file.",
     type: "string",
   });
+}
 
-  const getApiKey = (): string => resolveAuth(pi).apiKey;
-  const isToolEnabled = (toolName: string): boolean => isToolEnabledForConfig(pi, getResolvedConfig(pi), toolName);
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
 
-  function toolDetails(toolName: string): { tool: string } {
-    return { tool: toolName };
-  }
+export default function exaExtension(pi: ExtensionAPI) {
+  registerFlags(pi);
 
-  // Register web_search_exa tool
+  const resolvedConfig = getResolvedConfig(pi);
+  const isToolEnabled = (toolName: string): boolean => isToolEnabledForConfig(pi, resolvedConfig, toolName);
+
   if (isToolEnabled("web_search_exa")) {
-    pi.registerTool({
+    registerExaTool(pi, {
       name: "web_search_exa",
       label: "Exa Web Search",
       description:
@@ -83,47 +164,14 @@ export default function exaExtension(pi: ExtensionAPI) {
         "Use web_search_exa for retrieval; use web_research_exa for comparisons, synthesis, and recommendations.",
       ],
       parameters: webSearchParams,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const apiKey = getApiKey();
-        if (!apiKey) {
-          return {
-            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-            isError: true,
-            details: { tool: "web_search_exa", error: "missing_api_key" },
-          };
-        }
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled." }],
-            details: { ...toolDetails("web_search_exa"), cancelled: true },
-          };
-        }
-
-        onUpdate?.({
-          content: [{ type: "text", text: "Searching the web via Exa..." }],
-          details: { status: "pending" },
-        });
-
-        try {
-          const { query, numResults } = params;
-          const result = await performWebSearch(apiKey, query, numResults || DEFAULT_NUM_RESULTS);
-          return { content: [{ type: "text", text: result.text }], details: result.details };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: "text", text: `Exa search error: ${message}` }],
-            isError: true,
-            details: { ...toolDetails("web_search_exa"), error: message },
-          };
-        }
-      },
+      pendingMessage: "Searching the web via Exa...",
+      errorPrefix: "Exa search error",
+      perform: (apiKey, params) => performWebSearch(apiKey, params.query, params.numResults || DEFAULT_NUM_RESULTS),
     });
   }
 
-  // Register web_fetch_exa tool
   if (isToolEnabled("web_fetch_exa")) {
-    pi.registerTool({
+    registerExaTool(pi, {
       name: "web_fetch_exa",
       label: "Exa Web Fetch",
       description: "Read a webpage's full content as clean markdown. Best for extracting full content from known URLs.",
@@ -134,51 +182,20 @@ export default function exaExtension(pi: ExtensionAPI) {
         "Use web_fetch_exa to inspect returned pages; use web_find_similar_exa when you want more pages like a source URL.",
       ],
       parameters: webFetchParams,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const apiKey = getApiKey();
-        if (!apiKey) {
-          return {
-            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-            isError: true,
-            details: { ...toolDetails("web_fetch_exa"), error: "missing_api_key" },
-          };
-        }
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled." }],
-            details: { ...toolDetails("web_fetch_exa"), cancelled: true },
-          };
-        }
-
-        onUpdate?.({
-          content: [{ type: "text", text: "Fetching content via Exa..." }],
-          details: { status: "pending" },
-        });
-
-        try {
-          const result = await performWebFetch(apiKey, params.urls, {
-            maxCharacters: params.maxCharacters,
-            highlights: params.highlights,
-            summary: params.summary,
-            maxAgeHours: params.maxAgeHours,
-          });
-          return { content: [{ type: "text", text: result.text }], details: result.details };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: "text", text: `Exa fetch error: ${message}` }],
-            isError: true,
-            details: { ...toolDetails("web_fetch_exa"), error: message },
-          };
-        }
-      },
+      pendingMessage: "Fetching content via Exa...",
+      errorPrefix: "Exa fetch error",
+      perform: (apiKey, params) =>
+        performWebFetch(apiKey, params.urls, {
+          maxCharacters: params.maxCharacters,
+          highlights: params.highlights,
+          summary: params.summary,
+          maxAgeHours: params.maxAgeHours,
+        }),
     });
   }
 
-  // Register web_search_advanced_exa tool (disabled by default)
   if (isToolEnabled("web_search_advanced_exa")) {
-    pi.registerTool({
+    registerExaTool(pi, {
       name: "web_search_advanced_exa",
       label: "Exa Advanced Search",
       description:
@@ -190,57 +207,26 @@ export default function exaExtension(pi: ExtensionAPI) {
         "Use web_search_advanced_exa to find filtered result sets; use web_fetch_exa to read the selected URLs.",
       ],
       parameters: webSearchAdvancedParams,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const apiKey = getApiKey();
-        if (!apiKey) {
-          return {
-            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-            isError: true,
-            details: { ...toolDetails("web_search_advanced_exa"), error: "missing_api_key" },
-          };
-        }
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled." }],
-            details: { ...toolDetails("web_search_advanced_exa"), cancelled: true },
-          };
-        }
-
-        onUpdate?.({
-          content: [{ type: "text", text: "Performing advanced search via Exa..." }],
-          details: { status: "pending" },
-        });
-
-        try {
-          const result = await performAdvancedSearch(apiKey, params.query, {
-            numResults: params.numResults,
-            category: params.category,
-            type: params.type,
-            startPublishedDate: params.startPublishedDate,
-            endPublishedDate: params.endPublishedDate,
-            includeDomains: params.includeDomains,
-            excludeDomains: params.excludeDomains,
-            textMaxCharacters: params.textMaxCharacters,
-            enableHighlights: params.enableHighlights,
-            highlightsNumSentences: params.highlightsNumSentences,
-          });
-          return { content: [{ type: "text", text: result.text }], details: result.details };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: "text", text: `Exa advanced search error: ${message}` }],
-            isError: true,
-            details: { ...toolDetails("web_search_advanced_exa"), error: message },
-          };
-        }
-      },
+      pendingMessage: "Performing advanced search via Exa...",
+      errorPrefix: "Exa advanced search error",
+      perform: (apiKey, params) =>
+        performAdvancedSearch(apiKey, params.query, {
+          numResults: params.numResults,
+          category: params.category,
+          type: params.type,
+          startPublishedDate: params.startPublishedDate,
+          endPublishedDate: params.endPublishedDate,
+          includeDomains: params.includeDomains,
+          excludeDomains: params.excludeDomains,
+          textMaxCharacters: params.textMaxCharacters,
+          enableHighlights: params.enableHighlights,
+          highlightsNumSentences: params.highlightsNumSentences,
+        }),
     });
   }
 
-  // Register web_research_exa tool (disabled by default, opt-in)
   if (isToolEnabled("web_research_exa")) {
-    pi.registerTool({
+    registerExaTool(pi, {
       name: "web_research_exa",
       label: "Exa Deep Research",
       description: "Deep-reasoning Exa search with synthesized, grounded output for complex research topics.",
@@ -251,58 +237,27 @@ export default function exaExtension(pi: ExtensionAPI) {
         "Use web_research_exa when a systemPrompt or outputSchema is needed; use web_search_advanced_exa for filtered retrieval only.",
       ],
       parameters: webResearchParams,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const apiKey = getApiKey();
-        if (!apiKey) {
-          return {
-            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-            isError: true,
-            details: { ...toolDetails("web_research_exa"), error: "missing_api_key" },
-          };
-        }
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled." }],
-            details: { ...toolDetails("web_research_exa"), cancelled: true },
-          };
-        }
-
-        onUpdate?.({
-          content: [{ type: "text", text: "Performing deep research via Exa..." }],
-          details: { status: "pending" },
-        });
-
-        try {
-          const result = await performResearch(apiKey, {
-            query: params.query,
-            type: params.type,
-            systemPrompt: params.systemPrompt,
-            textMaxCharacters: params.textMaxCharacters,
-            outputSchema: params.outputSchema,
-            additionalQueries: params.additionalQueries,
-            numResults: params.numResults,
-            includeDomains: params.includeDomains,
-            excludeDomains: params.excludeDomains,
-            startPublishedDate: params.startPublishedDate,
-            endPublishedDate: params.endPublishedDate,
-          });
-          return { content: [{ type: "text", text: result.text }], details: result.details };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: "text", text: `Exa research error: ${message}` }],
-            isError: true,
-            details: { ...toolDetails("web_research_exa"), error: message },
-          };
-        }
-      },
+      pendingMessage: "Performing deep research via Exa...",
+      errorPrefix: "Exa research error",
+      perform: (apiKey, params) =>
+        performResearch(apiKey, {
+          query: params.query,
+          type: params.type,
+          systemPrompt: params.systemPrompt,
+          textMaxCharacters: params.textMaxCharacters,
+          outputSchema: params.outputSchema,
+          additionalQueries: params.additionalQueries,
+          numResults: params.numResults,
+          includeDomains: params.includeDomains,
+          excludeDomains: params.excludeDomains,
+          startPublishedDate: params.startPublishedDate,
+          endPublishedDate: params.endPublishedDate,
+        }),
     });
   }
 
-  // Register web_answer_exa tool
   if (isToolEnabled("web_answer_exa")) {
-    pi.registerTool({
+    registerExaTool(pi, {
       name: "web_answer_exa",
       label: "Exa Answer",
       description: "Get a grounded answer with source citations and optional structured output.",
@@ -313,51 +268,20 @@ export default function exaExtension(pi: ExtensionAPI) {
         "Use web_answer_exa for a cited response; use web_fetch_exa when you need the full source text.",
       ],
       parameters: webAnswerParams,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const apiKey = getApiKey();
-        if (!apiKey) {
-          return {
-            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-            isError: true,
-            details: { ...toolDetails("web_answer_exa"), error: "missing_api_key" },
-          };
-        }
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled." }],
-            details: { ...toolDetails("web_answer_exa"), cancelled: true },
-          };
-        }
-
-        onUpdate?.({
-          content: [{ type: "text", text: "Fetching answer from Exa..." }],
-          details: { status: "pending" },
-        });
-
-        try {
-          const result = await performAnswer(apiKey, {
-            query: params.query,
-            systemPrompt: params.systemPrompt,
-            text: params.text,
-            outputSchema: params.outputSchema,
-          });
-          return { content: [{ type: "text", text: result.text }], details: result.details };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: "text", text: `Exa answer error: ${message}` }],
-            isError: true,
-            details: { ...toolDetails("web_answer_exa"), error: message },
-          };
-        }
-      },
+      pendingMessage: "Fetching answer from Exa...",
+      errorPrefix: "Exa answer error",
+      perform: (apiKey, params) =>
+        performAnswer(apiKey, {
+          query: params.query,
+          systemPrompt: params.systemPrompt,
+          text: params.text,
+          outputSchema: params.outputSchema,
+        }),
     });
   }
 
-  // Register web_find_similar_exa tool
   if (isToolEnabled("web_find_similar_exa")) {
-    pi.registerTool({
+    registerExaTool(pi, {
       name: "web_find_similar_exa",
       label: "Exa Similar Pages",
       description: "Find web pages similar to a given URL.",
@@ -368,49 +292,19 @@ export default function exaExtension(pi: ExtensionAPI) {
         "Use web_find_similar_exa to discover related pages; use web_fetch_exa to inspect the returned URLs in full.",
       ],
       parameters: webFindSimilarParams,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const apiKey = getApiKey();
-        if (!apiKey) {
-          return {
-            content: [{ type: "text", text: "Exa API key not configured. Set EXA_API_KEY or use --exa-api-key flag." }],
-            isError: true,
-            details: { ...toolDetails("web_find_similar_exa"), error: "missing_api_key" },
-          };
-        }
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled." }],
-            details: { ...toolDetails("web_find_similar_exa"), cancelled: true },
-          };
-        }
-
-        onUpdate?.({
-          content: [{ type: "text", text: "Finding similar pages via Exa..." }],
-          details: { status: "pending" },
-        });
-
-        try {
-          const result = await performFindSimilar(apiKey, {
-            url: params.url,
-            numResults: params.numResults,
-            textMaxCharacters: params.textMaxCharacters,
-            excludeSourceDomain: params.excludeSourceDomain,
-            startPublishedDate: params.startPublishedDate,
-            endPublishedDate: params.endPublishedDate,
-            includeDomains: params.includeDomains,
-            excludeDomains: params.excludeDomains,
-          });
-          return { content: [{ type: "text", text: result.text }], details: result.details };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: "text", text: `Exa similar search error: ${message}` }],
-            isError: true,
-            details: { ...toolDetails("web_find_similar_exa"), error: message },
-          };
-        }
-      },
+      pendingMessage: "Finding similar pages via Exa...",
+      errorPrefix: "Exa similar search error",
+      perform: (apiKey, params) =>
+        performFindSimilar(apiKey, {
+          url: params.url,
+          numResults: params.numResults,
+          textMaxCharacters: params.textMaxCharacters,
+          excludeSourceDomain: params.excludeSourceDomain,
+          startPublishedDate: params.startPublishedDate,
+          endPublishedDate: params.endPublishedDate,
+          includeDomains: params.includeDomains,
+          excludeDomains: params.excludeDomains,
+        }),
     });
   }
 }

--- a/packages/pi-exa/skills/code-search/SKILL.md
+++ b/packages/pi-exa/skills/code-search/SKILL.md
@@ -6,31 +6,41 @@ context: fork
 
 # Code Search (Exa)
 
+Use this skill when the user needs external coding context: official docs, API examples, error explanations, library comparisons, or implementation references that are not already in the repo.
+
 ## Tool Selection
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Find code examples / API syntax | `web_search_exa` | Start with query + `numResults` |
-| Need grounded short answer or explanation | `web_answer_exa` | Use `systemPrompt` + optional `outputSchema` |
-| Need deep, synthesis-style comparison across sources | `web_research_exa` | Set `systemPrompt`, pass `additionalQueries`, prefer `outputSchema` |
-| Read a page after discovery | `web_fetch_exa` | Use on 1-3 URLs from search result |
+| Find docs, examples, API syntax, or error reports | `web_search_exa` | Start here for most lookups; include language/library/version in the query. |
+| Read official docs or a promising result | `web_fetch_exa` | Fetch 1-3 high-signal URLs after discovery. |
+| Need a concise grounded explanation | `web_answer_exa` | Best for direct questions; ask for citations and short code snippets. |
+| Compare libraries or approaches across sources | `web_research_exa` | Use only when enabled and the answer needs synthesis, not a quick lookup. |
+| Find similar docs or examples from one strong page | `web_find_similar_exa` | Use when a seed URL is clearly relevant. |
+
+If `web_research_exa` or `web_search_advanced_exa` is unavailable, do not pretend it can be used. Fall back to `web_search_exa` plus selective `web_fetch_exa`.
 
 ## Query Writing
 
-- Include **language** and **version** (e.g., `TypeScript 5`, `React 19`, `Python 3.12`).
-- Prefer short, high-signal phrasing and exact identifiers when available.
+- Include the **language, framework/library, and version** when known: `TypeScript 5.7 TypeBox Object additionalProperties`.
+- Include exact identifiers, error strings, function names, or package names when available.
+- Prefer official docs, release notes, issue trackers, and maintainer-authored examples before blogs.
+- For debugging, include the error class/message and runtime context.
 
 ## Recommended Parameters
 
-- **web_search_exa**
-  - `{ "query": "...", "numResults": 5 }`
-- **web_answer_exa**
-  - `{ "query": "...", "systemPrompt": "Prefer official docs and short code snippets" }`
-- **web_research_exa**
-  - `{ "query": "...,", "systemPrompt": "Focus on official references and compare approaches", "outputSchema": { "type": "text" } }`
+- `web_search_exa`
+  - `{ "query": "TypeScript 5.7 TypeBox additionalProperties examples", "numResults": 5 }`
+- `web_fetch_exa`
+  - `{ "urls": ["https://example.com/docs/page"], "maxCharacters": 5000 }`
+- `web_answer_exa`
+  - `{ "query": "How does TypeBox validate additionalProperties in TypeScript?", "systemPrompt": "Prefer official docs and concise code snippets." }`
+- `web_research_exa`
+  - `{ "query": "Compare TypeScript runtime validation libraries for backend APIs, focusing on schema reuse, performance, and ergonomics.", "systemPrompt": "Prefer official docs, maintainer posts, and recent benchmarks. Call out uncertainty.", "outputSchema": { "type": "text" } }`
 
 ## Output Guidance
 
-1) Return concise snippets first.
-2) Cite source URLs where decisions came from.
-3) Keep follow-up calls minimal and focused.
+1. Lead with the answer or snippet the user can use immediately.
+2. Cite source URLs for claims that affect implementation decisions.
+3. Separate confirmed facts from inferred guidance.
+4. Keep follow-up tool calls minimal and targeted.

--- a/packages/pi-exa/skills/company-research/SKILL.md
+++ b/packages/pi-exa/skills/company-research/SKILL.md
@@ -6,53 +6,47 @@ context: fork
 
 # Company Research (Exa)
 
+Use this skill for company discovery, competitor scans, vendor profiles, funding or hiring signals, market maps, and quick diligence.
+
 ## Tool Selection
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Company discovery / competitive list | `web_search_exa` | Use category filters when needed |
-| Company page metadata or focused category search | `web_search_advanced_exa` | `category: "company"`, use domain filters |
-| Comparative write-up across multiple companies | `web_research_exa` | Requires `systemPrompt`, `additionalQueries`, optionally `outputSchema.type: "object"` |
-| Direct question about a company topic | `web_answer_exa` | Prefer `outputSchema` for downstream processing |
-| Follow-up deep reading | `web_fetch_exa` | Pulls content from selected URLs |
+| Broad company or competitor discovery | `web_search_exa` | Best first pass when terminology, category fit, or target companies are unclear. |
+| Company-profile style results | `web_search_advanced_exa` with `category: "company"` | Use when available; do not use deep search types here. |
+| Comparative write-up across companies | `web_research_exa` | Use when enabled and the user needs synthesis or recommendations. |
+| Direct factual question about one company | `web_answer_exa` | Good for concise cited answers. |
+| Read selected company pages, filings, or posts | `web_fetch_exa` | Fetch 1-3 high-signal URLs after discovery. |
+| Find companies or pages similar to one strong source | `web_find_similar_exa` | Use when a seed URL is clearly representative. |
+
+If `web_search_advanced_exa` is unavailable, use `web_search_exa` with stronger query wording. If `web_research_exa` is unavailable, stop at discovery plus a concise manual synthesis.
 
 ## Category Behavior
 
 - `category: "company"` focuses on company-facing pages and profile-like structure.
-- Deep search (`deep`, `deep-lite`) belongs to **`web_research_exa`**, not `web_search_advanced_exa`.
+- Deep search types (`deep-reasoning`, `deep-lite`, `deep`) belong to `web_research_exa`, not `web_search_advanced_exa`.
 
 ## Filter Restrictions
 
 When using `web_search_advanced_exa` with `category: "company"`, avoid:
-- `includeDomains`
+
+- `excludeDomains`
 - `startPublishedDate` / `endPublishedDate`
 
-These filters commonly trigger Exa `400` errors for this category. Prefer running a broader query first, then post-filtering results locally if needed.
+These combinations are rejected by the extension before reaching Exa. If you need freshness or exclusions, run broader discovery first and filter locally.
 
-## Recommended settings
+## Recommended Settings
 
-```json
-{
-  "web_search_exa": { "query": "AI infrastructure startups in 2025", "numResults": 20 },
-  "web_search_advanced_exa": {
-    "category": "company",
-    "type": "auto",
-    "numResults": 12
-  },
-  "web_research_exa": {
-    "systemPrompt": "Prefer official sources and filings; return concise competitive summary.",
-    "outputSchema": {
-      "type": "object",
-      "properties": {
-        "summary": { "type": "string" }
-      }
-    }
-  }
-}
-```
+- Broad discovery
+  - `{ "query": "AI infrastructure startups serving enterprise developers 2025", "numResults": 10 }`
+- Company category search
+  - `{ "query": "AI infrastructure developer tools startups", "category": "company", "type": "auto", "numResults": 12 }`
+- Comparative synthesis
+  - `{ "query": "Compare AI infrastructure startups serving enterprise developer teams, focusing on product positioning, traction signals, and differentiation.", "systemPrompt": "Prefer official sources, filings, funding announcements, customer pages, and reputable news. Avoid overclaiming from sparse data.", "outputSchema": { "type": "text" } }`
 
 ## Output Guidance
 
-1) Return structured findings list first (name, signals, links).
-2) Note assumptions or data gaps.
-3) Avoid overclaiming on incomplete information.
+1. Return a structured findings list first: company, what they do, signals, and links.
+2. Distinguish direct evidence from interpretation.
+3. Call out stale, sparse, or conflicting data.
+4. Avoid implying private traction or revenue unless sourced.

--- a/packages/pi-exa/skills/exa-research-planner/SKILL.md
+++ b/packages/pi-exa/skills/exa-research-planner/SKILL.md
@@ -49,6 +49,19 @@ Warn clearly when an important tool is unavailable:
 
 Never suggest unavailable tools as if they can be used.
 
+## Stateful Planning Tools
+
+`PRD-008` defines planned stateful research-planning tools: `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset`.
+
+When these tools are available, use them for non-trivial research planning:
+
+1. Call `exa_research_step` for framing, criteria discovery, each meaningful discovery round, source retrieval, coverage analysis, and conclusion.
+2. Call `exa_research_status` when you need to inspect current criteria, source pack, gaps, branches, or recommended next action.
+3. Call `exa_research_summary` before showing a final plan, payload, handoff, or Source Pack to the user.
+4. Call `exa_research_reset` when starting a separate research topic.
+
+If these tools are not available in the current session, continue with the prompt-guided workflow below and be explicit that stateful planning is unavailable. Do not claim criteria, source-pack status, gaps, or revisions are durably tracked unless the `exa_research_*` tools are actually present.
+
 ## Fast Path: Explicit Deep Research
 
 When the user explicitly asks for deep research:

--- a/packages/pi-exa/skills/exa-research-planner/SKILL.md
+++ b/packages/pi-exa/skills/exa-research-planner/SKILL.md
@@ -1,308 +1,291 @@
 ---
 name: exa-research-planner
-description: Plan and refine Exa research workflows before expensive execution. Use whenever the user wants to scope or sharpen a research task, compare options, explore a market or technical landscape, gather sources cheaply before deep synthesis, iterate on search criteria, or decide whether deep research is even necessary. Make sure to use this skill when the user is asking for staged, cost-aware research planning rather than an immediate final answer, even if they do not mention Exa or specific Exa tools explicitly.
+description: Plan, draft, and execute Exa deep-research workflows. Use when the user wants staged research planning, cost-aware discovery before deep synthesis, or an explicit deep-research report. Also use when the user asks to refine a research question, compare options, explore a market or technical landscape, gather sources cheaply before synthesis, or decide whether deep research is necessary.
 context: fork
 ---
 
 # Exa Research Planner
 
-Use this skill when the user wants to **design a strong research workflow before running expensive deep research**.
+Use this skill to turn a vague or broad research request into a high-quality Exa research workflow, then optionally execute `web_research_exa` when the user clearly wants deep synthesis.
 
-This skill is for a **plan-first, optionally-discover, execute-last** workflow.
+This skill has two jobs:
 
-The goal is not merely to run Exa tools. The goal is to help the user arrive at a better research brief, better sources, and better escalation decisions with less cost and less wasted deep-search work.
+1. **Research planning** — sharpen the question, decide whether cheap discovery is useful, and draft a strong deep-research payload.
+2. **Explicit deep-research execution** — when the user directly asks for deep research or approves a draft, run `web_research_exa` and return a source-grounded synthesis.
 
-## Core Rules
+## Operating Modes
 
-Start by checking which Exa tools are actually available in the current session. Build the workflow only from tools that exist.
+Choose the mode from the user's request.
 
-The point of this skill is to reduce wasted work. Prefer the lightest step that is likely to improve the brief or answer a key uncertainty.
+| Mode | Use When | Behavior |
+|---|---|---|
+| **Plan-only** | User asks to design/refine a research prompt, scope a landscape, or reduce cost | Clarify, optionally do cheap discovery, draft a payload, and ask before execution. |
+| **Recon-first** | Topic is broad, terminology is unclear, or trusted sources are unknown | Run cheap discovery with available search/fetch tools, then refine the deep-research spec. |
+| **Explicit deep-research execution** | User says “do deep research,” “run deep research,” “deeply research,” or equivalent | Clarify only missing essentials, then run `web_research_exa` if available. A direct user request to run deep research counts as approval. |
 
-Treat tool availability in two groups:
-- **Common default tools**: `web_search_exa`, `web_fetch_exa`, `web_answer_exa`, and `web_find_similar_exa` are usually available by default, unless the session uses an explicit `enabledTools` allowlist
-- **Opt-in tools**: `web_search_advanced_exa` and `web_research_exa` are commonly unavailable unless explicitly enabled
+Do not force an explicit deep-research request through a long planning loop. If the user has already asked to run deep research and the brief is usable, execute the deep research rather than asking for another confirmation.
 
-Warn clearly when a relevant tool is unavailable:
-- if `web_research_exa` is unavailable, say that deep synthesis cannot be executed in this session and fall back to planning plus cheaper discovery
-- if `web_search_advanced_exa` is unavailable, say that advanced filtering by category, domain, or date is unavailable and fall back to `web_search_exa` plus more selective query wording and fetches
-- if one of the common default tools is missing, mention it as an unusual constraint and adapt gracefully without overemphasizing it
-- only offer `web_find_similar_exa` or `web_answer_exa` when they are both available and clearly useful
+## Tool Availability Rules
 
-Do **not** call `web_research_exa` immediately unless the user clearly asks to skip planning and run it now.
+Build the workflow only from tools actually available in the current session.
 
-Prefer a staged workflow:
-1. clarify the research goal
-2. identify scope, evaluation criteria, and source preferences
-3. decide whether to do cheap discovery first
-4. if useful, run one or more rounds of cheap discovery with the available tools
-5. optionally offer `web_find_similar_exa` or `web_answer_exa` only when they clearly fit the current stage and are available
-6. summarize what was learned and refine the research brief
-7. draft a proposed `web_research_exa` payload only if deep synthesis is still needed and the tool is available, or draft it for later use if unavailable
-8. ask for confirmation before any expensive deep-research execution
+Common default tools:
 
-Cheap discovery can happen in **multiple rounds**. Use iterative low-cost searches to improve terminology, source selection, filters, and query shape before escalating.
+- `web_search_exa`
+- `web_fetch_exa`
+- `web_answer_exa`
+- `web_find_similar_exa`
 
-The important idea is that each round should teach you something: better search language, better domains, better criteria, or evidence that deep research is unnecessary.
+Opt-in tools:
 
-Only run `web_research_exa` after the user explicitly confirms they want to execute the polished draft, unless they have already made that preference unambiguous.
+- `web_search_advanced_exa`
+- `web_research_exa`
 
-## When to Use This Skill
+Warn clearly when an important tool is unavailable:
 
-Use it when the user asks for help with:
-- drafting a research query
-- refining a comparison or evaluation prompt
-- planning a market scan or landscape review
-- doing low-cost reconnaissance before deep research
-- defining source preferences or exclusions
-- setting time bounds for fast-moving topics
-- choosing between prose vs structured output
-- iterating on search criteria before running research
+- If `web_research_exa` is unavailable, say deep synthesis cannot be executed in this session. Fall back to cheap discovery and a polished draft payload for later use.
+- If `web_search_advanced_exa` is unavailable, say advanced filters are unavailable and fall back to `web_search_exa` with better query wording.
+- If a common default tool is missing, mention it briefly and adapt without dwelling on it.
 
-## Workflow
+Never suggest unavailable tools as if they can be used.
 
-### Phase 1: Clarify the goal
+## Fast Path: Explicit Deep Research
 
-Ask enough questions to produce a high-quality search brief.
+When the user explicitly asks for deep research:
 
-Useful dimensions to clarify:
-- **topic**: what is being researched?
-- **decision**: what decision should the research support?
-- **task type**: comparison, recommendation, scan, due diligence, summary, evaluation
-- **criteria**: what factors matter most?
-- **source preference**: official docs, maintainers, GitHub, academic sources, news, practitioner blogs
-- **time horizon**: current snapshot, last 12 months, historical context
-- **filters**: include or exclude domains
-- **output shape**: narrative report or structured object
-- **depth vs speed**: prefer `deep-reasoning`, `deep`, or `deep-lite`
-- **cost sensitivity**: should we minimize cost and do reconnaissance first?
+1. Check that `web_research_exa` is available.
+2. If the request is usable, draft the payload internally and run it.
+3. Ask at most one clarifying question only if a missing constraint would materially change the result, such as:
+   - the target decision,
+   - source type preference,
+   - timeframe,
+   - comparison criteria,
+   - output format.
+4. Use `deep-reasoning` by default for careful synthesis; use `deep-lite` for exploratory or cost-sensitive requests; use `deep` when speed matters more than maximum reasoning depth.
+5. Return a concise report with sources, uncertainty, and practical next steps.
 
-If the user already gave enough detail, do not over-question. Move quickly to drafting a plan.
+A direct user request to run deep research counts as approval. Do not ask “should I run it?” again unless the request is dangerously ambiguous or the tool may incur unexpected scope/cost.
 
-A good default is to ask only the smallest set of questions that will meaningfully improve the plan. Avoid turning the interaction into an intake form when the user already gave a usable brief.
+## Cost-Aware Planning Workflow
 
-### Phase 2: Choose a cost-aware plan
+Use this staged flow when the user has not clearly asked to run deep research yet, or when the topic would benefit from reconnaissance.
 
-Decide between:
-- **draft-only**: refine the brief without running tools yet
-- **cheap discovery**: use lower-cost search/fetch tools to learn before drafting deep research
-- **deep synthesis**: draft `web_research_exa` only after enough reconnaissance or when the user clearly wants it
+### Phase 1: Clarify the Goal
+
+Ask the smallest number of questions that will meaningfully improve the research. Useful dimensions:
+
+- **Topic:** what is being researched?
+- **Decision:** what decision should the research support?
+- **Task type:** comparison, recommendation, scan, diligence, summary, evaluation.
+- **Criteria:** what factors matter most?
+- **Sources:** official docs, filings, GitHub, academic papers, news, practitioner blogs, company pages.
+- **Time horizon:** current snapshot, last 12 months, historical context.
+- **Filters:** domains to include or exclude.
+- **Output shape:** narrative report or structured object.
+- **Depth/speed/cost:** `deep-reasoning`, `deep`, or `deep-lite`.
+
+If the user already gave enough detail, move directly to a plan or execution.
+
+### Phase 2: Choose the Cheapest Useful Next Step
+
+Choose one:
+
+- **Draft-only:** refine the brief and proposed `web_research_exa` payload without running tools.
+- **Cheap discovery:** use search/fetch tools to learn terminology, candidate sources, and filters.
+- **Deep synthesis:** run or prepare `web_research_exa` when cheaper steps are unnecessary or already done.
 
 Prefer cheap discovery first when:
-- the topic is broad or ambiguous
-- the best terminology is unclear
-- trusted domains are not yet known
-- the user wants to reduce cost
-- you need candidate sources before committing to deep synthesis
 
-Adapt the plan to the available tools.
-For example:
-- without `web_search_advanced_exa`, prefer extra rounds of `web_search_exa` and better query wording instead of filtered search
-- without `web_research_exa`, stop at planning, cheap discovery, and draft preparation rather than pretending execution is possible
-- if a normally available default tool is missing, mention it briefly and choose the nearest workable fallback
+- the topic is broad or ambiguous,
+- trusted domains are unknown,
+- terminology is unclear,
+- the user wants to minimize cost,
+- you need candidate sources before committing to synthesis.
 
-When proposing a plan, explain *why this next step is the cheapest useful move*. That explanation helps the user trust the workflow and makes it easier to decide whether to continue iterating.
+Explain why the proposed next step is the cheapest useful move.
 
-### Phase 3: Run cheap discovery in one or more rounds when useful
+### Phase 3: Run Cheap Discovery When It Earns Its Keep
 
-Cheap discovery may use the available tools:
-- `web_search_exa` for broad discovery and terminology gathering
-- `web_search_advanced_exa` for category, domain, or date-constrained discovery when available
-- `web_fetch_exa` for inspecting a small number of promising URLs when available
-- `web_find_similar_exa` only when a clearly high-quality seed URL has already been identified and the tool is available
-- `web_answer_exa` only when a quick grounded answer might resolve the question cheaply or test whether deep research is even needed, and the tool is available
+Use available tools selectively:
 
-If `web_search_advanced_exa` is unavailable, say so and continue with `web_search_exa`-driven discovery rather than presenting advanced filtering as an option.
+| Goal | Preferred Tool | Notes |
+|---|---|---|
+| Broad discovery and vocabulary | `web_search_exa` | Best first pass for reconnaissance. |
+| Domain/category/date constrained discovery | `web_search_advanced_exa` | Use when available and constraints are known. |
+| Inspect a few strong URLs | `web_fetch_exa` | Fetch 1-3 high-signal pages. |
+| Expand from one strong seed URL | `web_find_similar_exa` | Use only with a clearly representative source. |
+| Resolve a narrow sub-question cheaply | `web_answer_exa` | Use when it may avoid deeper research. |
 
-Multiple rounds are allowed and encouraged when they improve the final brief, but each round should have a purpose. Do not keep searching just because searching is possible.
+Each discovery round must have a purpose. After each round, summarize what changed:
 
-Examples of iterative cheap discovery:
-- round 1: broad search to find key vocabulary, vendors, or frameworks
-- round 2: narrowed search using the vocabulary from round 1
-- round 3: advanced search with filters for trusted domains, categories, or dates
-- selective fetches: inspect 1-3 strong sources to validate assumptions and refine criteria
-- similar-source expansion: use `web_find_similar_exa` from a strong seed page when adjacent sources are likely to be useful
-- cheap answer check: use `web_answer_exa` when a concise grounded answer may settle a sub-question without deep synthesis
+- better terminology,
+- stronger candidate sources,
+- trusted domains to include,
+- low-signal domains to exclude,
+- whether deep research still appears necessary.
 
-After each round, summarize what changed:
-- better terminology
-- clearer evaluation criteria
-- trusted domains to include
-- low-signal domains to exclude
-- whether deep research still appears necessary
+## Iterative Discovery and Clarification Loop
 
-Before starting another round, explain why it is useful.
-Before escalating to `web_research_exa`, summarize what the cheap rounds already established.
+Run multiple cheap discovery rounds when each round changes the plan. The planner should behave like an active research lead: discover criteria, search for evidence, revise the coverage map, and only then draft or execute deep synthesis.
 
-### Phase 4: Draft the deep research spec only if needed
+Use this loop for broad, ambiguous, or high-stakes research:
 
-Produce a proposed `web_research_exa` call with these fields when relevant:
+1. **Seed criteria:** infer initial search dimensions from the user's topic.
+2. **Round 1 broad discovery:** identify vocabulary, source classes, named entities, and candidate criteria the user did not mention.
+3. **Revise criteria:** add, remove, or reprioritize search criteria based on what the first round revealed.
+4. **Round 2 targeted discovery:** search the strongest criteria, domains, papers, vendors, methods, or contrarian evidence.
+5. **Fetch representative sources:** use `web_fetch_exa` for the strongest URLs when source contents matter.
+6. **Gap check:** identify missing evidence, conflicting evidence, or decisions that require user input.
+7. **Clarify or continue:** Ask the user one focused clarification question if the gap changes the research objective, scope, or evaluation criteria. Otherwise run another cheap discovery round or draft the deep-research payload.
+8. **Stop condition:** stop iterating when a new round is unlikely to change query wording, source filters, criteria, or the final synthesis.
+
+Ask the user one focused clarification question when discovery reveals a materially different interpretation of the request. Good clarification triggers include:
+
+- the topic has multiple domains with different source strategies,
+- discovery finds several incompatible evaluation frames,
+- the answer depends on a timeframe or geography the user did not specify,
+- source classes conflict, such as vendor white papers versus peer-reviewed papers,
+- the research could optimize for different outcomes, such as accuracy, deployability, cost, safety, or market adoption.
+
+Do not ask for clarification just because more detail would be nice. If the missing detail can be handled as an assumption, state the assumption and continue.
+
+## White Papers and Source Retrieval
+
+When white papers, academic papers, technical reports, standards documents, filings, or PDFs are important source classes, the research plan must include source retrieval, not just synthesis.
+
+Requirements:
+
+- Use discovery to find the paper landing pages or PDF URLs.
+- Use `web_fetch_exa` on the strongest paper URLs when available, especially before relying on claims from abstracts, snippets, or secondary summaries.
+- In the final report, return the actual paper URLs alongside the synthesized findings.
+- Distinguish paper types: vendor white paper, academic paper, standards document, government report, analyst report, or marketing collateral.
+- Call out when the full paper could not be fetched and the synthesis relies only on metadata, snippets, abstracts, or secondary discussion.
+
+For paper-heavy research, include a **Source Pack** section in the output:
+
+| Source | Type | URL | Used For | Retrieval Status |
+|---|---|---|---|---|
+| Paper title | academic paper / white paper / PDF | direct URL | evidence area | fetched / discovered only / unavailable |
+
+If the user asks for white papers as sources, treat the actual papers as deliverables. Do not only cite them indirectly through the deep synthesis.
+
+### Paper Content Synthesis Rule
+
+Do not rely only on `web_research_exa` synthesis when paper sources are part of the evidence base. Use fetched paper contents as first-class evidence in the final answer.
+
+Required workflow for paper-heavy research:
+
+1. Run discovery/deep research to identify candidate papers and reports.
+2. Select the strongest papers that materially support or challenge the answer.
+3. Fetch the paper contents with `web_fetch_exa` when available.
+4. Read the fetched contents for methods, claims, data, limitations, and conclusions.
+5. Synthesize across both:
+   - the `web_research_exa` synthesized output, and
+   - the fetched paper contents you directly inspected.
+6. If fetched paper contents disagree with the deep-research synthesis, prefer the directly inspected paper text and call out the discrepancy.
+7. If a paper cannot be fetched, mark it as `discovered only` and do not treat it as equally strong evidence.
+
+In the final report, explicitly identify which findings came from directly fetched paper contents versus broader Exa synthesis. This is especially important for vendor white papers and analyst reports, where summaries may inherit marketing framing.
+
+### Phase 4: Draft the Deep Research Plan
+
+Show the user the research plan in human-consumable form first. Do not lead with raw JSON.
+
+#### Human-Readable Drafts First
+
+When presenting a draft to the user, lead with a readable research plan that explains what will be studied, why those criteria matter, which sources will be prioritized, and what the output will contain. Raw tool payloads are implementation details; include them only after the human-readable plan, in a collapsed/optional section, or when the user specifically asks for the exact JSON.
+
+A user-facing draft should include:
+
+- **Research objective:** one sentence describing the decision or question.
+- **Coverage areas:** the criteria the research will cover.
+- **Discovery rounds:** what cheap searches or fetches will happen before deep synthesis.
+- **Source strategy:** source classes, trusted domains, source retrieval requirements, and exclusions.
+- **Paper/source pack plan:** when papers, white papers, reports, PDFs, or standards are deliverables.
+- **Expected output:** report shape, comparison table, recommendation, source pack, or structured data.
+- **Assumptions:** what the planner will assume unless the user corrects it.
+- **Open clarification:** at most one focused question if needed.
+
+The internal `web_research_exa` payload still matters, but it should be derived from the readable plan. If shown, label it as **Implementation payload** after the readable plan.
+
+Produce a proposed `web_research_exa` call when useful. Include relevant fields:
+
 - `query`
 - `type`
 - `systemPrompt`
 - `additionalQueries`
 - `numResults`
+- `textMaxCharacters`
 - `includeDomains`
 - `excludeDomains`
 - `startPublishedDate`
 - `endPublishedDate`
 - `outputSchema`
 
-Always make the `query` a **clear research objective**, not just keywords.
-Use what was learned from cheap discovery to sharpen the draft.
-
-### Phase 5: Review the draft with the user
-
-Present:
-1. a short plain-English summary of the research plan
-2. what the cheap discovery rounds found, if any
-3. the proposed JSON payload
-4. a small set of suggested refinements
-
-Then ask for confirmation, for example:
-- `Want me to run this as-is?`
-- `Should I do one more cheap discovery pass first?`
-- `Should I narrow the source set or timeframe first?`
-- `Do you want text output or a structured result?`
-
-If the user appears unsure, give a recommendation rather than only asking open-ended questions. For example: `I think one more cheap pass on official docs and pricing pages will improve the final deep-research prompt. Want me to do that first?`
-
-If `web_research_exa` is unavailable, replace the execution question with a planning-oriented one such as: `I can prepare this as a polished draft and keep exploring cheaply, but I can't run deep synthesis in this session. Want me to refine the draft further or continue discovery?`
-
-### Phase 6: Execute only after approval
-
-Only once the user explicitly confirms, call `web_research_exa` with the approved draft.
-
-## Cost-Aware Tool Strategy
-
-Use the cheapest available tool that can move the work forward.
-
-| Goal | Preferred Tool | Notes |
-|---|---|---|
-| Broad discovery, vocabulary, candidate sources | `web_search_exa` | Best first pass for cheap reconnaissance; normally available by default |
-| Filter by domain, category, or dates | `web_search_advanced_exa` | Use after a broad pass or when constraints are already known; warn and fall back if unavailable |
-| Inspect a few known URLs | `web_fetch_exa` | Use selectively on 1-3 promising results; normally available by default |
-| Expand from a strong seed URL | `web_find_similar_exa` | Offer only when a clearly high-signal source has already been found and the tool is available; normally available by default |
-| Cheap grounded answer or sub-question check | `web_answer_exa` | Offer only when a concise cited answer may avoid deeper research and the tool is available; normally available by default |
-| Deep synthesis and recommendations | `web_research_exa` | Use only when cheaper rounds are not enough; warn and stop at draft preparation if unavailable |
-
-When the user wants to minimize cost, prefer multiple rounds of `web_search_exa` / `web_search_advanced_exa` before escalating.
-Do not suggest `web_find_similar_exa` or `web_answer_exa` by default; offer them only when they clearly fit the current stage of the workflow.
-Focus warnings primarily on opt-in tools that are commonly missing, especially `web_search_advanced_exa` and `web_research_exa`.
-Do not suggest unavailable tools as if they can be used.
-
-## Drafting Guidance
-
-### Query writing
-
-Write the query as a research objective with evaluation dimensions.
+Make `query` a clear research objective, not keywords.
 
 Good:
-- `Compare TypeScript runtime validation libraries for backend APIs, focusing on ergonomics, performance, ecosystem adoption, and schema reuse.`
-- `Evaluate MCP tooling options for local agent development, including extensibility, documentation quality, stability, and production readiness.`
-- `Assess current open-source vector databases suitable for small production deployments, emphasizing operational simplicity, maturity, and cost.`
+
+```json
+{
+  "query": "Compare TypeScript runtime validation libraries for backend APIs, focusing on ergonomics, performance, ecosystem adoption, and schema reuse."
+}
+```
 
 Avoid:
-- `typescript validation libraries`
-- `mcp tools`
-- `vector dbs`
-
-### Choosing search type
-
-Default guidance:
-- `deep-reasoning`: best for comparisons, recommendations, and careful trade-off analysis
-- `deep`: best when faster turnaround is more important than maximum reasoning depth
-- `deep-lite`: best for lighter exploratory passes or early iteration
-
-When unsure, draft with:
 
 ```json
 {
-  "type": "deep-reasoning"
+  "query": "typescript validation libraries"
 }
 ```
 
-### System prompt guidance
+### Phase 5: Execute or Hand Back the Draft
+
+- In **Plan-only** and **Recon-first** modes, ask for confirmation before execution.
+- In **Explicit deep-research execution** mode, execute once the brief is usable because the user already approved deep research by asking for it.
+- If `web_research_exa` is unavailable, present the payload as a polished draft for later execution and offer cheap discovery instead.
+
+## Deep Research Defaults
+
+### Search Type
+
+- `deep-reasoning`: default for comparisons, recommendations, careful trade-off analysis, market scans, and due diligence.
+- `deep`: use when faster turnaround matters more than maximum reasoning depth.
+- `deep-lite`: use for exploratory passes, lower-cost iteration, or when the user asks for a lighter scan.
+
+### System Prompt
 
 Use `systemPrompt` to specify:
-- source quality preferences
-- evaluation lens
-- how to handle disagreement or uncertainty
-- what kinds of evidence to prioritize
 
-Good patterns:
-- `Prefer official docs, maintainer-authored sources, and reputable engineering writeups.`
-- `Focus on trade-offs, maturity, operational complexity, and production suitability.`
-- `Call out uncertainty, conflicting evidence, and missing data.`
-- `Prefer recent sources for fast-moving topics.`
+- source quality preferences,
+- evidence standards,
+- evaluation criteria,
+- how to handle disagreement,
+- recency requirements,
+- what to avoid.
 
-### Additional queries
-
-Use `additionalQueries` when alternate phrasing will improve coverage.
-
-Good uses:
-- synonyms
-- competitor names
-- alternate terminology
-- explicit comparison variants
-
-Keep `additionalQueries` short and high-signal. The current `web_research_exa` schema allows **at most 5 items**, so prefer the best alternate phrasings rather than exhaustive coverage.
-
-Do not exceed 5 entries in `additionalQueries`. If you have more candidates, keep the strongest 3–5 and fold the rest into the main `query` or `systemPrompt`.
-
-Example:
+Good pattern:
 
 ```json
 {
-  "additionalQueries": [
-    "TypeScript runtime schema validation comparison",
-    "Zod vs Valibot vs TypeBox backend API",
-    "best validation library for Node.js APIs"
-  ]
+  "systemPrompt": "Prefer official docs, maintainer-authored sources, reputable technical writeups, and recent primary sources. Focus on trade-offs, quality of evidence, and practical recommendations. Call out uncertainty and conflicting evidence."
 }
 ```
 
-### Domain filters
+### Additional Queries
 
-Use filters to improve signal.
+Use `additionalQueries` for alternate terminology, competitor names, synonyms, and comparison variants.
 
-- `includeDomains` for official or trusted sources
-- `excludeDomains` for low-signal content
+Rules:
 
-Examples:
+- Maximum 5 entries.
+- Prefer the strongest 3-5, not exhaustive lists.
+- Fold extra variants into `query` or `systemPrompt`.
 
-```json
-{
-  "includeDomains": ["github.com", "npmjs.com", "zod.dev"]
-}
-```
+### Output Schema
 
-```json
-{
-  "excludeDomains": ["medium.com"]
-}
-```
-
-### Date filters
-
-Use `startPublishedDate` / `endPublishedDate` for time-sensitive topics:
-- AI tooling
-- framework changes
-- product or vendor comparisons
-- recent market developments
-
-Example:
-
-```json
-{
-  "startPublishedDate": "2025-01-01"
-}
-```
-
-### Output shape
-
-Default to text unless the user clearly wants structured output.
-
-Use:
+Default to text:
 
 ```json
 {
@@ -310,25 +293,15 @@ Use:
 }
 ```
 
-Prefer text output unless the user clearly benefits from structured downstream consumption, because structured schemas are easier to make invalid and require more careful drafting.
+Use structured output only when downstream processing or comparison clearly benefits. Keep schemas shallow.
 
-Use structured output only when it will clearly help comparison or downstream use.
-Keep schemas simple and shallow.
-Do not manually add citation or confidence fields.
-
-If `outputSchema` contains array fields, each array must include an explicit `items` definition. For simple lists, use `"items": { "type": "string" }`.
-
-Example:
+If `outputSchema` contains arrays, every array must include `items`:
 
 ```json
 {
   "outputSchema": {
     "type": "object",
     "properties": {
-      "options": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
       "recommendation": { "type": "string" },
       "risks": {
         "type": "array",
@@ -339,124 +312,83 @@ Example:
 }
 ```
 
-### Tool schema pitfalls
+Do not manually add citation or confidence fields unless the user specifically needs them; Exa grounding already provides citation context.
 
-When drafting `web_research_exa` payloads:
-- `additionalQueries` may contain **at most 5 entries**
-- any array in `outputSchema` must define `items`
-- if you do not need structured output, prefer `{ "type": "text" }` to reduce schema errors
-
-## Default Draft Template
-
-Use this as a starting point when the user asks for help building a deep research query:
+## Default Payload Template
 
 ```json
 {
-  "query": "<clear research objective>",
+  "query": "<clear research objective with evaluation criteria>",
   "type": "deep-reasoning",
-  "systemPrompt": "Prefer official docs, maintainers, and reputable sources. Focus on trade-offs, quality of evidence, and practical recommendations.",
+  "systemPrompt": "Prefer primary sources, official docs, reputable reporting, and expert writeups. Focus on trade-offs, quality of evidence, practical recommendations, uncertainty, and conflicting evidence.",
   "additionalQueries": [],
   "numResults": 10,
   "outputSchema": { "type": "text" }
 }
 ```
 
-## Response Pattern
+## Report Format After Running Deep Research
 
-When using this skill, structure your response like this:
+Return:
 
-### 1. Research plan
-A short explanation of what the overall workflow is trying to answer.
+1. **Executive summary** — 3-6 bullets.
+2. **Findings** — grouped by the user's criteria.
+3. **Evidence and sources** — cite URLs inline or under each finding.
+4. **Uncertainty / conflicts** — what the sources do not settle.
+5. **Recommendation or next steps** — if the request implies a decision.
 
-### 2. Proposed next step
-Show the cheapest useful next step using only available tools:
-- a draft-only refinement
-- a cheap discovery query
-- a filtered advanced search when `web_search_advanced_exa` is available
-- a selective fetch when `web_fetch_exa` is available
-- optionally a similar-source expansion when a strong seed URL exists and `web_find_similar_exa` is available
-- optionally a cheap grounded answer when it may resolve a narrow question and `web_answer_exa` is available
-- or a deep-research draft if the work is already mature enough
+Keep the report concise unless the user asked for a long-form research memo.
 
-### 3. Why this step makes sense now
-Explain what uncertainty this step will reduce or what evidence it should gather.
-If a stronger opt-in tool is unavailable, explain the fallback and its limitation in one or two sentences.
-If a normally available default tool is missing, note it briefly as an unusual constraint and continue with the best available fallback.
+## Response Patterns
 
-### 4. What we learned so far
-If one or more discovery rounds already happened, summarize the main findings and how they changed the plan.
+### Planning Response
 
-### 5. Proposed deep research draft
-When appropriate, show the candidate `web_research_exa` JSON.
-If deep research is unavailable, show the polished draft anyway and label it clearly as a draft for later execution.
+Use this structure when not executing yet:
 
-### 6. Suggested refinements
-Offer 2-4 concrete improvements, such as:
-- narrow to official sources
-- add a recency window
-- do another cheap pass with refined terminology
-- convert output to a comparison object
-- split one broad topic into two passes
+- **Research objective:** what the research should answer.
+- **Coverage plan:** human-readable criteria, source strategy, and discovery rounds.
+- **Next step:** the cheapest useful move.
+- **Why:** what uncertainty it reduces.
+- **Implementation payload:** optional JSON only after the human-readable plan, or when the user asks for it.
+- **Question:** one clear confirmation or refinement question.
 
-### 7. Confirmation question
-Ask whether to:
-- refine further
-- do another cheap discovery round
-- run the deep-research draft as-is
-- broaden or narrow scope
+### Execution Response
 
-## Output Format
+Use this structure when executing deep research:
 
-Prefer concise, decision-oriented responses.
+- **Research objective:** one sentence.
+- **Payload:** show the important parameters briefly when useful.
+- Call `web_research_exa`.
+- **Synthesis:** return the report format above.
 
-A good default structure is:
-- **Plan:** one short paragraph
-- **Next step:** one concrete recommendation
-- **Why:** one short paragraph
-- **Draft:** JSON only when a concrete payload is useful
-- **Question:** one clear choice for the user
+## Examples
 
-Do not bury the user in long checklists if the situation is simple.
+### Explicit deep-research request
 
-## Example Interaction Pattern
+User: `Do deep research on observability platforms for startups.`
 
-User intent:
-- `Help me design a deep research query to compare observability tools for startups.`
+Behavior:
 
-Good response pattern:
-1. clarify whether they care most about cost, ease of setup, or product depth
-2. propose a cheap first-pass search to discover vendors and criteria
-3. explain why that first pass is cheaper and more useful than jumping straight to deep research
-4. optionally do a second cheap pass with filters or better terminology
-5. draft a query and `systemPrompt` only after the brief is sharper
-6. propose optional source/date filters
-7. ask whether to execute deep research now or keep iterating cheaply
+- Do not ask whether to run deep research again.
+- Ask one clarifying question only if needed, such as whether cost or ease of setup matters most.
+- Otherwise run `web_research_exa` with a clear comparison query and `outputSchema: { "type": "text" }`.
 
-## Example Draft
+### Plan-first request
 
-```json
-{
-  "query": "Compare observability platforms suitable for startups, focusing on ease of setup, pricing transparency, core monitoring coverage, alerting quality, and team scalability.",
-  "type": "deep-reasoning",
-  "systemPrompt": "Prefer official docs, pricing pages, GitHub repos where relevant, and credible engineering evaluations. Focus on trade-offs, startup suitability, and uncertainty in pricing or feature claims.",
-  "additionalQueries": [
-    "best observability tools for startups",
-    "Datadog vs Grafana Cloud vs New Relic startup teams",
-    "startup-friendly application monitoring platforms"
-  ],
-  "numResults": 10,
-  "outputSchema": { "type": "text" }
-}
-```
+User: `Help me design a deep research query to compare observability tools for startups.`
 
-Do not run this automatically. Ask the user whether they want to refine it, do another cheap discovery round, or execute it.
+Behavior:
 
-## Skill Quality Notes
+- Clarify key criteria if missing.
+- Optionally run cheap discovery to identify vendors and terms.
+- Draft a payload.
+- Ask whether to execute, refine, or do one more cheap discovery pass.
 
-Keep this skill practical and lean:
-- prefer short, high-signal plans over long generic advice
-- explain why a step is useful instead of giving rigid commands without context
-- avoid suggesting expensive deep research before cheap evidence-gathering has had a fair chance
-- do not force every workflow through every tool; skip steps that are not earning their keep
-- be proactive about recommending the next best move when the user seems uncertain
-- when the user already has a strong brief, move quickly from clarification to a concrete plan instead of repeating generic planning advice
+## Quality Notes
+
+- Prefer short, high-signal plans over generic checklists.
+- Do not spend tools on discovery that will not change the final research prompt.
+- Do not block explicit deep-research requests behind unnecessary confirmation.
+- Be transparent when deep research cannot run because `web_research_exa` is unavailable.
+- Favor primary sources and dated materials for fast-moving topics.
+- Call out uncertainty instead of smoothing over source disagreement.

--- a/packages/pi-exa/skills/exa-research-planner/SKILL.md
+++ b/packages/pi-exa/skills/exa-research-planner/SKILL.md
@@ -49,19 +49,6 @@ Warn clearly when an important tool is unavailable:
 
 Never suggest unavailable tools as if they can be used.
 
-## Stateful Planning Tools
-
-`PRD-008` defines planned stateful research-planning tools: `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset`.
-
-When these tools are available, use them for non-trivial research planning:
-
-1. Call `exa_research_step` for framing, criteria discovery, each meaningful discovery round, source retrieval, coverage analysis, and conclusion.
-2. Call `exa_research_status` when you need to inspect current criteria, source pack, gaps, branches, or recommended next action.
-3. Call `exa_research_summary` before showing a final plan, payload, handoff, or Source Pack to the user.
-4. Call `exa_research_reset` when starting a separate research topic.
-
-If these tools are not available in the current session, continue with the prompt-guided workflow below and be explicit that stateful planning is unavailable. Do not claim criteria, source-pack status, gaps, or revisions are durably tracked unless the `exa_research_*` tools are actually present.
-
 ## Fast Path: Explicit Deep Research
 
 When the user explicitly asks for deep research:

--- a/packages/pi-exa/skills/financial-report-search/SKILL.md
+++ b/packages/pi-exa/skills/financial-report-search/SKILL.md
@@ -6,33 +6,32 @@ context: fork
 
 # Financial Report Search (Exa)
 
+Use this skill for SEC filings, annual reports, earnings materials, investor presentations, risk factors, financial metrics, and company-by-company filing comparisons.
+
 ## Tool Selection
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Discovery of filings / reports | `web_search_advanced_exa` with `category: "financial report"` | Use date filters and domain filters |
-| Compare filings across firms | `web_research_exa` | Use `systemPrompt` and `outputSchema` for structured output |
-| Explain one metric or line item | `web_answer_exa` | Fast direct answers with citations |
-| Read full filing text | `web_fetch_exa` | Fetch 1-3 URLs only |
+| Discover filings, annual reports, or investor materials | `web_search_advanced_exa` with `category: "financial report"` | Use when available; date and domain filters are useful here. |
+| Broad filing discovery when advanced search is unavailable | `web_search_exa` | Add company name, filing type, fiscal year, and source domain terms. |
+| Compare filings across firms or periods | `web_research_exa` | Use when enabled; require evidence-backed statements. |
+| Explain one metric, line item, or disclosure | `web_answer_exa` | Good for narrow cited explanations. |
+| Read full filing or report text | `web_fetch_exa` | Fetch 1-3 selected URLs only. |
 
-## Filter Restrictions
+If `web_search_advanced_exa` is unavailable, fall back to `web_search_exa` with explicit terms like `10-K`, `10-Q`, `annual report`, `investor relations`, `site:sec.gov`, or the company ticker.
 
-When using `web_search_advanced_exa` with `category: "financial report"`, avoid:
-- `excludeText`
+## Recommended Settings
 
-This option is rejected for this category by Exa and may return `400`.
-
-## Recommended settings
-
-- `web_search_advanced_exa`
-  - `{ "query": "10-K AI company", "category": "financial report", "startPublishedDate": "2025-01-01", "numResults": 20 }`
-- `web_search_advanced_exa` for SEC-only domain filtering
-  - `{ "includeDomains": ["sec.report", "sec.gov"], "category": "financial report" }`
-- `web_research_exa`
-  - `{ "query": "Compare risk factors and revenue trend in latest reports", "systemPrompt": "Return only evidence-backed statements", "outputSchema": { "type": "object", "properties": { "risks": { "type": "array" } } } }`
+- Filing discovery
+  - `{ "query": "NVIDIA 10-K 2025 risk factors", "category": "financial report", "startPublishedDate": "2025-01-01", "numResults": 10 }`
+- SEC-focused discovery
+  - `{ "query": "NVIDIA latest 10-K", "category": "financial report", "includeDomains": ["sec.gov", "sec.report"], "numResults": 10 }`
+- Comparative synthesis
+  - `{ "query": "Compare risk factors and revenue trend disclosures in the latest annual reports for NVIDIA, AMD, and Intel.", "systemPrompt": "Return only evidence-backed statements. Separate reported numbers from interpretation and cite source URLs for every numeric claim.", "outputSchema": { "type": "object", "properties": { "summary": { "type": "string" }, "risks": { "type": "array", "items": { "type": "string" } } } } }`
 
 ## Output Guidance
 
-1) Separate numbers from interpretations.
-2) Include source links for every numeric claim.
-3) Call out filing periods clearly.
+1. Separate reported numbers from interpretations.
+2. Include source links for every numeric claim.
+3. Call out filing type, period, and publication date.
+4. Flag stale filings, amended filings, and source ambiguity.

--- a/packages/pi-exa/skills/people-research/SKILL.md
+++ b/packages/pi-exa/skills/people-research/SKILL.md
@@ -6,33 +6,42 @@ context: fork
 
 # People Research (Exa)
 
+Use this skill for finding experts, candidates, speakers, authors, investors, founders, maintainers, or other public professional profiles.
+
 ## Tool Selection
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Professional profile discovery | `web_search_advanced_exa` with `category: "people"` | Use `query` for role/location/industry |
-| Compare multiple candidates | `web_research_exa` | Use `additionalQueries` + `systemPrompt` |
-| Direct answer about one person | `web_answer_exa` | Good for short factual checks |
-| Read profile details | `web_fetch_exa` | Fetch selected profile URLs |
+| Professional profile discovery | `web_search_advanced_exa` with `category: "people"` | Use when available; put role, domain, company, or location in `query`. |
+| Broad discovery when advanced search is unavailable | `web_search_exa` | Use precise role/company/topic terms and public-profile keywords. |
+| Compare multiple people or build a shortlist | `web_research_exa` | Use when enabled; include selection criteria in `systemPrompt`. |
+| Direct factual question about one person | `web_answer_exa` | Good for short cited checks. |
+| Read selected profile pages or bios | `web_fetch_exa` | Fetch only high-signal URLs. |
+| Find similar profiles from a strong seed page | `web_find_similar_exa` | Use when one public profile is an ideal example. |
+
+If `web_search_advanced_exa` is unavailable, fall back to `web_search_exa`. If `web_research_exa` is unavailable, provide a sourced shortlist without deep synthesis.
 
 ## Filter Restrictions
 
 When using `web_search_advanced_exa` with `category: "people"`, avoid:
-- `excludeText`
+
 - `excludeDomains`
 - `startPublishedDate` / `endPublishedDate`
 
-These filters are rejected for this category by Exa and typically return `400`.
+For `includeDomains`, only LinkedIn domains are accepted by the extension for `category: "people"`, such as `linkedin.com` or `www.linkedin.com`.
 
-## Recommended settings
+## Recommended Settings
 
 - People discovery
-  - `web_search_advanced_exa` with `category: "people"`, `numResults: 20`
-- Deep compare
-  - `web_research_exa` with `outputSchema`: `{ "type": "object", "properties": { "experts": { "type": "array" } } }`
+  - `{ "query": "distributed systems database engineer San Francisco", "category": "people", "numResults": 10 }`
+- LinkedIn-scoped people discovery
+  - `{ "query": "AI infrastructure startup founder", "category": "people", "includeDomains": ["linkedin.com"], "numResults": 10 }`
+- Deep shortlist comparison
+  - `{ "query": "Find public experts in database internals and distributed systems who write about production engineering trade-offs.", "systemPrompt": "Prefer public bios, personal sites, talks, publications, and reputable profiles. Flag common-name ambiguity and sparse evidence.", "outputSchema": { "type": "object", "properties": { "experts": { "type": "array", "items": { "type": "object" } }, "caveats": { "type": "array", "items": { "type": "string" } } } } }`
 
 ## Output Guidance
 
-1) Return one row per person with source URL.
-2) Include role, company, and recency signals.
-3) Flag potential uncertainty (common-name collisions, sparse profiles).
+1. Return one row per person with source URL.
+2. Include role, company/affiliation, expertise signal, and recency signal.
+3. Flag uncertainty: common-name collisions, outdated profiles, or sparse evidence.
+4. Avoid private, sensitive, or unsourced personal claims.

--- a/packages/pi-exa/skills/personal-site-search/SKILL.md
+++ b/packages/pi-exa/skills/personal-site-search/SKILL.md
@@ -6,42 +6,47 @@ context: fork
 
 # Personal Site Search (Exa)
 
+Use this skill to find practitioner blogs, independent analysis, personal websites, technical essays, field notes, and non-corporate perspectives.
+
 ## Tool Selection
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Find practitioner blogs by topic | `web_search_exa` | Start broad with a keyword query when you do not already know a source site |
-| Filter to personal sites only | `web_search_advanced_exa` with `category: "personal site"` | Add date filters for freshness or domain filters for specific ecosystems |
-| Find more like this / recommend similar sites | `web_find_similar_exa` | Use when you already have one strong post or blog URL and want adjacent personal sites |
-| Distill viewpoints across multiple posts | `web_research_exa` | Requires `--exa-enable-research`; provide a strong `systemPrompt` and optional `outputSchema` |
-| Direct one-off answer from discovered sources | `web_answer_exa` | Use for concise cited answers after the topic is clear |
-| Pull full article bodies | `web_fetch_exa` | Use after discovery when snippets are not enough |
+| Find practitioner blogs by topic | `web_search_exa` | Start here when you do not already know a source site. |
+| Filter to personal sites only | `web_search_advanced_exa` with `category: "personal site"` | Use when available; add date or domain filters when useful. |
+| Find more like this / recommend similar sites | `web_find_similar_exa` | Use when you already have one strong post or blog URL. |
+| Distill viewpoints across multiple posts | `web_research_exa` | Use when enabled and synthesis is worth the cost. |
+| Direct one-off answer from discovered sources | `web_answer_exa` | Use for concise cited answers after the topic is clear. |
+| Pull full article bodies | `web_fetch_exa` | Fetch selected URLs when snippets are not enough. |
 
-## When to use find-similar vs search
+If `web_search_advanced_exa` is unavailable, use `web_search_exa` with terms like `blog`, `personal site`, `independent write-up`, or `practitioner perspective`.
+
+## When to Use Find-Similar vs Search
 
 - Use `web_find_similar_exa` for **find more like this** workflows when you already have a canonical URL that matches the taste, style, or niche you want.
 - Use `web_search_exa` for **keyword-based discovery** when you are starting from a topic, technology, or opinion and do not yet have a seed URL.
 - Use `web_search_advanced_exa` instead of `web_find_similar_exa` when you need explicit controls like `category: "personal site"`, domain constraints, or date filtering.
 
-## Recommended settings
+## Recommended Settings
 
-- `web_search_exa`
+- Topic discovery
   - `{ "query": "Rust async architecture practitioner blog", "numResults": 10 }`
-- `web_search_advanced_exa`
+- Personal-site category search
   - `{ "query": "Rust async architecture", "category": "personal site", "excludeDomains": ["medium.com", "substack.com"], "numResults": 15 }`
-- `web_find_similar_exa`
+- Similar-source expansion
   - `{ "url": "https://example.dev/posts/rust-async-architecture", "excludeSourceDomain": true, "numResults": 8 }`
-- `web_research_exa` *(requires `--exa-enable-research`)*
-  - `{ "query": "Compare recommendations from practitioner blogs", "systemPrompt": "Prioritize dated posts, independent authors, and call out opinion vs facts", "outputSchema": { "type": "text" } }`
+- Synthesis
+  - `{ "query": "Compare recommendations from practitioner blogs about Rust async architecture trade-offs.", "systemPrompt": "Prioritize dated posts and independent authors. Distinguish opinion from verified facts and call out disagreement.", "outputSchema": { "type": "text" } }`
 
 ## Query Writing
 
-- Include the topic, ecosystem, and audience: e.g. `postgres indexing practitioner blog`, `react compiler migration personal blog`.
+- Include topic, ecosystem, and audience: `postgres indexing practitioner blog`, `react compiler migration personal blog`.
 - Prefer wording like `blog`, `personal site`, `independent write-up`, or `practitioner perspective` when using `web_search_exa`.
-- After finding one excellent source, pivot to `web_find_similar_exa` instead of repeating broader keyword searches.
+- After finding one excellent source, pivot to `web_find_similar_exa` instead of repeating broad keyword searches.
 
 ## Output Guidance
 
-1) Identify author perspective and date.
-2) Distinguish opinion claims from verifiable facts.
-3) Return the top 3–5 strongest links with a short rationale for each.
+1. Identify author perspective and date.
+2. Distinguish opinion claims from verifiable facts.
+3. Return the top 3-5 strongest links with a short rationale for each.
+4. Call out if results are mostly corporate blogs, content farms, or undated posts.

--- a/packages/pi-exa/skills/research-paper-search/SKILL.md
+++ b/packages/pi-exa/skills/research-paper-search/SKILL.md
@@ -6,23 +6,39 @@ context: fork
 
 # Research Paper Search (Exa)
 
+Use this skill for discovering academic papers, arXiv/preprint work, methods comparisons, literature scans, and evidence-weighted technical summaries.
+
 ## Tool Selection
 
 | Intent | Primary Tool | Notes |
 |---|---|---|
-| Paper discovery | `web_search_advanced_exa` | `category: "research paper"`, optional `includeDomains` (e.g., `arxiv.org`) |
-| Evidence-weighted synthesis across papers | `web_research_exa` | Use `systemPrompt`, optional structured `outputSchema` |
-| One-off definition / quick answer | `web_answer_exa` | Keep it concise and citation-focused |
+| Paper discovery | `web_search_advanced_exa` with `category: "research paper"` | Use when available; domain filters such as `arxiv.org` can improve signal. |
+| Broad discovery when advanced search is unavailable | `web_search_exa` | Include topic, method names, and paper/source terms. |
+| Evidence-weighted synthesis across papers | `web_research_exa` | Use when enabled; specify evidence quality and caveat requirements. |
+| One-off definition or quick answer | `web_answer_exa` | Keep it concise and citation-focused. |
+| Read abstracts or paper pages | `web_fetch_exa` | Fetch selected paper URLs when snippets are insufficient. |
+| Find related papers from one seed paper | `web_find_similar_exa` | Use when a seed URL is clearly on-topic. |
 
-## Recommended settings
+If opt-in tools are unavailable, use `web_search_exa` plus selective `web_fetch_exa` and produce a smaller sourced summary.
 
-- `web_search_advanced_exa`
-  - `{ "query": "LLM fine-tuning methods", "category": "research paper", "includeDomains": ["arxiv.org"], "numResults": 20 }`
-- `web_research_exa`
-  - `{ "query": "Summarize methodological differences between X and Y", "systemPrompt": "Prioritize peer-reviewed sources and methods sections", "outputSchema": { "type": "text" } }`
+## Recommended Settings
+
+- Paper discovery
+  - `{ "query": "LLM fine-tuning methods instruction tuning preference optimization", "category": "research paper", "includeDomains": ["arxiv.org"], "numResults": 10 }`
+- Related-paper expansion
+  - `{ "url": "https://arxiv.org/abs/2305.18290", "excludeSourceDomain": false, "numResults": 8 }`
+- Evidence-weighted synthesis
+  - `{ "query": "Summarize methodological differences between instruction tuning, RLHF, DPO, and newer preference optimization methods for large language models.", "systemPrompt": "Prioritize peer-reviewed papers, arXiv papers with clear methods sections, and papers with empirical comparisons. Separate findings from speculation and call out methodology limits.", "outputSchema": { "type": "text" } }`
+
+## Query Writing
+
+- Include method names, task/domain, and publication terms: `paper`, `arXiv`, `benchmark`, `survey`, `method`.
+- Use date filters for fast-moving areas when the user asks for recent work.
+- Prefer direct paper sources over secondary summaries unless the user wants a high-level introduction.
 
 ## Output Guidance
 
-1) Return paper title, venue, and year.
-2) Prefer direct quotations for claims.
-3) Provide caveats for methodology limits.
+1. Return paper title, venue/source, year, and URL.
+2. Separate claims about results from claims about methods.
+3. Prefer direct quotations only when wording matters; otherwise summarize concisely with citation URLs.
+4. Provide caveats for limited benchmarks, small sample sizes, or non-comparable evaluations.


### PR DESCRIPTION
## Summary

This updates `pi-exa` so its research guidance is clearer today and its next research-planning feature has a durable spec path. The existing Exa skills now give more consistent tool-routing guidance, stronger fallbacks for unavailable opt-in tools, and safer examples for structured output schemas.

The branch also captures the next step for Exa research planning: stateful `exa_research_*` tools modeled after the sequential/code reasoning packages. Those tools are specified in a new PRD, implementation plan, and ADRs so the implementation can happen in a focused follow-up.

```mermaid
flowchart TB
  Skill[exa-research-planner skill]
  Plan[PRD-008 + architecture plan]
  ADR1[ADR-0016 stateful planning tools]
  ADR2[ADR-0017 in-memory sessions]
  Future[future exa_research_* implementation]

  Skill --> Plan
  Plan --> ADR1
  Plan --> ADR2
  ADR1 --> Future
  ADR2 --> Future
```

## What changed

| Area | Change |
|---|---|
| Extension internals | Consolidated duplicated Exa tool execution flow in `packages/pi-exa/extensions/index.ts`. |
| Skill guidance | Audited and tightened all `packages/pi-exa/skills/*/SKILL.md` docs. |
| Research planner skill | Added explicit deep-research execution, iterative discovery, paper/source retrieval, paper-content synthesis, and human-readable draft guidance. |
| Tests | Added guardrails so skills do not mention unsupported parameters, structured array schemas include `items`, and the research planner retains the new behavior guidance. |
| Specs | Added PRD-008, an architecture plan, and ADRs for stateful research planning tools and in-memory sessions. |

## Design notes

The skill remains prompt-based in this PR, but the new specs define the stateful tool layer needed to make research planning reliable. The planned tools will track criteria, sources, gaps, assumptions, branches, and revisions while keeping Exa network calls explicit for cost transparency.

The extension refactor is intentionally behavior-preserving. It centralizes shared API-key checks, cancellation handling, pending updates, and error formatting without changing the individual Exa tool contracts.

## Validation

- `npx vitest run packages/pi-exa/__tests__/index.test.ts`
- `npx vitest run packages/pi-exa/__tests__`
- `npx tsc --noEmit --project packages/pi-exa/tsconfig.json`
- `npx biome ci packages/pi-exa`
- `specdocs_validate`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/pi-coding_agent-10b981?logo=typescript&logoColor=white)