### PR TITLE
feat(pi-exa): add stateful research planner tools

### DIFF
--- a/docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md
+++ b/docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md
@@ -91,11 +91,11 @@ The implementation should keep stable in-memory IDs for criteria, sources, and g
 ### Negative
 
 - Users lose active planning state when the extension runtime ends.
-  - Mitigation: `exa_research_summary(mode: "handoff")` can produce a copyable handoff packet.
+  - Mitigation: `exa_research_summary(mode: "execution_plan")` and `exa_research_summary(mode: "source_pack")` can produce copyable summaries for manual handoff until explicit handoff/export modes exist.
 - Long research workflows cannot be resumed automatically.
   - Mitigation: add export/import or persistence later if this becomes a real usage need.
 - Automated audit trails are limited to the current session transcript.
-  - Mitigation: Source Pack and handoff summaries preserve the most important state in user-visible output.
+  - Mitigation: Source Pack and execution-plan summaries preserve the most important state in user-visible output.
 
 ### Neutral
 

--- a/docs/architecture/plan-pi-exa-research-planning-tools.md
+++ b/docs/architecture/plan-pi-exa-research-planning-tools.md
@@ -3,7 +3,7 @@ title: "pi-exa Research Planning Tools"
 prd: "PRD-008-pi-exa-research-planning-tools"
 date: 2026-05-03
 author: "pi"
-status: Draft
+status: Implemented
 ---
 
 # Plan: pi-exa Research Planning Tools

--- a/docs/architecture/plan-pi-exa-research-planning-tools.md
+++ b/docs/architecture/plan-pi-exa-research-planning-tools.md
@@ -23,6 +23,8 @@ Add stateful research-planning tools to `packages/pi-exa` that mirror the ergono
 - one tool summarizes the accumulated plan,
 - one tool resets the session.
 
+V1 uses one active in-memory planning session at a time. Planning tools are default-enabled local tools and do not require an Exa API key because they do not perform network calls.
+
 These tools do **not** replace Exa retrieval tools. Instead, they orchestrate how the model should use existing tools such as `web_search_exa`, `web_fetch_exa`, `web_research_exa`, `web_answer_exa`, and `web_find_similar_exa`.
 
 The main shift is from a prompt-only skill to a stateful workflow where the model externalizes:
@@ -98,17 +100,16 @@ Includes:
 
 ### 3. `exa_research_summary`
 
-Generates a human-readable plan or handoff packet from current state.
+Generates a human-readable plan, Source Pack, or optional implementation payload from current state.
 
 | Mode | Output |
 |---|---|
 | `brief` | Short plan with objective, coverage areas, source strategy, next action. |
 | `execution_plan` | Detailed multi-round research plan suitable for user review. |
-| `payload` | Optional implementation payload for `web_research_exa`, derived from the readable plan. |
 | `source_pack` | Table of discovered/fetched sources with retrieval status. |
-| `handoff` | Complete packet for another agent/session. |
+| `payload` | Optional implementation payload for `web_research_exa`, derived from the readable plan. |
 
-Default output must be human-readable. JSON payloads should be labeled **Implementation payload** and shown only after the readable plan or when requested.
+Default output must be human-readable. JSON payloads should be labeled **Implementation payload** and shown only after the readable plan or when requested. V1 payload mode generates only `web_research_exa` payloads; search/fetch calls remain plain next-action recommendations.
 
 ### 4. `exa_research_reset`
 
@@ -128,7 +129,7 @@ Fields:
 - `description`: what this criterion covers.
 - `priority`: `high`, `medium`, `low`.
 - `status`: `proposed`, `searched`, `supported`, `conflicting`, `missing`, `excluded`.
-- `evidenceRefs`: source IDs or tool-call notes.
+- `evidenceRefs`: source IDs or tool-call notes. Refs must resolve to known sources or explicit tool-call notes before the criterion is counted as covered.
 
 #### Source Record
 
@@ -141,6 +142,7 @@ Fields:
 - `url`.
 - `sourceType`: `paper`, `white_paper`, `pdf`, `official_doc`, `filing`, `news`, `blog`, `github`, `forum`, `analyst_report`, `other`.
 - `retrievalStatus`: `discovered_only`, `fetched`, `fetch_failed`, `unavailable`.
+- `retrievalEvidence`: optional reference to fetched URL, tool-call/result ID, or other evidence that content was directly inspected.
 - `usedFor`: criteria IDs.
 - `contentNotes`: methods, claims, data, limitations, or relevant excerpts.
 - `qualityNotes`: bias, recency, sample size, vendor framing, peer review status.
@@ -192,7 +194,7 @@ For white papers, academic papers, technical reports, standards, filings, or PDF
 
 - discover actual paper/report URLs,
 - fetch the contents with `web_fetch_exa` when available,
-- track retrieval status in the Source Pack,
+- track retrieval status and retrieval evidence in the Source Pack,
 - synthesize from fetched contents, not only from `web_research_exa`,
 - mark unfetched items as `discovered_only`,
 - prefer directly inspected source text over broader synthesis when they conflict.
@@ -201,9 +203,9 @@ For white papers, academic papers, technical reports, standards, filings, or PDF
 
 | Phase | Component | Change | Dependencies | Estimated Scope | Files | Verification |
 |---:|---|---|---|---|---|---|
-| 1 | Research planner state | Add research planning types and in-memory tracker. | None | Medium | `packages/pi-exa/extensions/research-planner.ts`, `packages/pi-exa/extensions/research-planner-types.ts` | Unit tests for add/reset/status. |
-| 2 | Tool registration | Register `exa_research_step`, `exa_research_status`, `exa_research_summary`, `exa_research_reset`. | Phase 1 | Medium | `packages/pi-exa/extensions/index.ts`, `packages/pi-exa/extensions/schemas.ts` | Extension registration tests. |
-| 3 | Coverage model | Implement criteria/source/gap aggregation. | Phase 1 | Medium | `packages/pi-exa/extensions/research-planner.ts` | Tests for coverage and source pack summaries. |
+| 1 | Research planner state | Add research planning types and in-memory tracker with one active session and topic-mismatch warnings. | None | Medium | `packages/pi-exa/extensions/research-planner.ts`, `packages/pi-exa/extensions/research-planner-types.ts` | Unit tests for add/reset/status. |
+| 2 | Tool registration | Register default-enabled, no-auth `exa_research_step`, `exa_research_status`, `exa_research_summary`, `exa_research_reset`. | Phase 1 | Medium | `packages/pi-exa/extensions/index.ts`, `packages/pi-exa/extensions/schemas.ts` | Extension registration tests. |
+| 3 | Coverage model | Implement criteria/source/gap aggregation, evidence-ref validation, and retrieval-evidence flags. | Phase 1 | Medium | `packages/pi-exa/extensions/research-planner.ts` | Tests for coverage and source pack summaries. |
 | 4 | Branching model | Add branch/revision validation. | Phase 1 | Small | `packages/pi-exa/extensions/research-planner.ts` | Tests mirroring code-reasoning branch/revision behavior. |
 | 5 | Skill integration | Update `exa-research-planner` skill to require the tools. | Phases 2-4 | Small | `packages/pi-exa/skills/exa-research-planner/SKILL.md` | Skill text tests. |
 | 6 | Documentation | Document tools in README. | Phases 2-5 | Small | `packages/pi-exa/README.md` | README/package tests. |
@@ -220,11 +222,11 @@ For white papers, academic papers, technical reports, standards, filings, or PDF
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| Tool surface area grows too large. | More prompt/tool-selection overhead. | Keep planning tools clearly prefixed with `exa_research_`; consider gating behind config if needed. |
+| Tool surface area grows too large. | More prompt/tool-selection overhead. | Keep planning tools clearly prefixed with `exa_research_`, default-enabled because they are local-only, and document their orchestration role. |
 | Planning tool duplicates existing Exa tools. | Confusing workflow and accidental hidden costs. | Planning tools only recommend next actions; existing Exa tools perform retrieval/synthesis explicitly. |
 | State becomes too verbose. | Poor model usability and truncated outputs. | Summaries should compress criteria/source/gap state and support output truncation limits. |
 | Model still shows JSON-first drafts. | User experience regresses. | Add tests and skill guidance requiring human-readable summaries before implementation payloads. |
-| Paper retrieval creates false confidence when fetch fails. | Weak evidence may be overused. | Track `retrievalStatus` and mark unfetched sources as `discovered_only`. |
+| Paper retrieval creates false confidence when fetch fails. | Weak evidence may be overused. | Track `retrievalStatus`, `retrievalEvidence`, and mark unfetched sources as `discovered_only`. |
 
 ## Example Flow
 
@@ -246,5 +248,5 @@ Expected flow:
 
 1. **Resolved:** Planning sessions start in-memory, as captured in `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`.
 2. Should `exa_research_step` allow arbitrary source metadata, or should source records be strictly typed from day one?
-3. Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads, or also recommended `web_search_exa` / `web_fetch_exa` calls?
-4. Should research planning tools be enabled by default, or gated behind a flag to avoid adding tool surface area for users who only need basic search?
+3. **Resolved:** V1 `exa_research_summary(mode: "payload")` generates only `web_research_exa` payloads; recommended search/fetch calls remain plain next-action text.
+4. **Resolved:** Research planning tools are default-enabled in V1 because they are local-only and non-cost-incurring; retrieval tools keep existing gating.

--- a/docs/prd/PRD-008-pi-exa-research-planning-tools.md
+++ b/docs/prd/PRD-008-pi-exa-research-planning-tools.md
@@ -26,8 +26,8 @@ The immediate design plan exists at `docs/architecture/plan-pi-exa-research-plan
 
 | Goal | Metric | Target |
 |------|--------|--------|
-| **Stateful research planning** | New planning tools registered and callable | `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset` are available |
-| **Criteria coverage** | Planning state tracks discovered criteria | Criteria records include category, priority, status, and evidence refs |
+| **Stateful research planning** | New planning tools registered and callable | `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset` are default-enabled and work without an Exa API key |
+| **Criteria coverage** | Planning state tracks discovered criteria | Criteria records include category, priority, status, and validated evidence refs |
 | **Multi-round discovery** | Tool output recommends next research action | Step results can recommend search, fetch, clarify, draft, execute, or finalize |
 | **Source retrieval accountability** | Source Pack tracks retrieval state | Sources distinguish `discovered_only`, `fetched`, `fetch_failed`, and `unavailable` |
 | **Human-readable planning** | Summary defaults to readable plan | `exa_research_summary` leads with objective, coverage, source strategy, assumptions, and next action before any payload |
@@ -39,6 +39,7 @@ The immediate design plan exists at `docs/architecture/plan-pi-exa-research-plan
 - Planning tools do not hide Exa network calls or costs; they recommend next actions, while the model explicitly calls retrieval tools.
 - Existing package checks continue to pass.
 - `web_research_exa` remains opt-in according to existing config behavior.
+- Planning tools are default-enabled but never require an Exa API key because they do not perform network calls.
 
 ---
 
@@ -68,7 +69,7 @@ The immediate design plan exists at `docs/architecture/plan-pi-exa-research-plan
 
 1. **Research planning step tool** — record topic, stage, notes, criteria, sources, gaps, assumptions, branch/revision metadata, and recommended next action.
 2. **Research planning status tool** — report current session state, criteria coverage, source pack summary, open gaps, branches, and last next action.
-3. **Research planning summary tool** — generate human-readable briefs, execution plans, source packs, handoff packets, and optional implementation payloads.
+3. **Research planning summary tool** — generate human-readable briefs, execution plans, source packs, and optional implementation payloads.
 4. **Research planning reset tool** — clear the in-memory planning session.
 5. **Criteria model** — track discovered search/evaluation angles and their evidence coverage.
 6. **Source model** — track source type, URL, retrieval status, content notes, and quality notes.
@@ -80,15 +81,16 @@ The immediate design plan exists at `docs/architecture/plan-pi-exa-research-plan
 
 | What | Why | Tracked in |
 |------|-----|------------|
-| Persistent research sessions | In-memory state is enough for first implementation and matches `pi-code-reasoning` simplicity | Open question |
+| Persistent research sessions | In-memory state is enough for first implementation and matches `pi-code-reasoning` simplicity | ADR-0017 |
 | Automatic execution of recommended Exa tool calls | Hidden network calls would obscure cost and user/model control | N/A |
 | Full citation manager | Source Pack is sufficient for planning; citation management is a larger product | TBD |
 | New Exa API endpoints | This work orchestrates existing tools only | N/A |
 | UI rendering beyond normal tool text output | Useful later, not required for behavior | TBD |
+| Handoff/import/export workflows | V1 can produce readable summaries, but durable handoff is weak without persistence/import/export | TBD |
 
 ### Design for future (build with awareness)
 
-The state model should keep stable IDs for criteria (`C1`), sources (`S1`), and gaps (`G1`) so future import/export, richer UI, or external handoff can reference them without re-parsing prose. The summary mode should be extensible so later modes such as `audit` or `cost_report` can be added without changing step state shape.
+The state model should keep stable IDs for criteria (`C1`), sources (`S1`), and gaps (`G1`) so future import/export, richer UI, or external handoff can reference them without re-parsing prose. The summary mode should be extensible so later modes such as `handoff`, `audit`, or `cost_report` can be added without changing step state shape.
 
 ---
 
@@ -96,7 +98,7 @@ The state model should keep stable IDs for criteria (`C1`), sources (`S1`), and 
 
 ### FR-1: Record research planning steps
 
-The extension must expose `exa_research_step` to record one step in a stateful research planning session.
+The extension must expose `exa_research_step` to record one step in a stateful research planning session. V1 supports one active in-memory planning session at a time. The first recorded topic becomes the active topic until reset; later steps with a different topic should produce a topic-mismatch warning rather than silently mixing sessions.
 
 **Acceptance criteria:**
 
@@ -105,6 +107,8 @@ Given no research planning session exists
 When the model calls exa_research_step with topic "computer vision jump analysis", stage "framing", thought_number 1, total_thoughts 5, and next_step_needed true
 Then the tool records the step
 And the result includes progress, current stage, open gaps, and recommended next action fields
+When the model calls exa_research_step with a different topic before reset
+Then the result includes a topic-mismatch warning
 ```
 
 **Files:**
@@ -114,9 +118,30 @@ And the result includes progress, current stage, open gaps, and recommended next
 - `packages/pi-exa/extensions/schemas.ts` — define TypeBox schema for `exa_research_step`.
 - `packages/pi-exa/extensions/index.ts` — register the tool.
 
-### FR-2: Track autodiscovered criteria coverage
 
-The planning state must track criteria discovered by the model, including category, priority, status, and evidence references.
+### FR-2: Report research planning status
+
+The extension must expose `exa_research_status` to report the current active research planning session without mutating state.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a research planning session exists with recorded steps, criteria, sources, gaps, and assumptions
+When the model calls exa_research_status
+Then the result includes the active topic, step count, active stage, criteria coverage summary, source pack summary, open gaps, branches, and last recommended next action
+And the tool works when no Exa API key is configured
+```
+
+**Files:**
+
+- `packages/pi-exa/extensions/research-planner.ts` — implement status generation.
+- `packages/pi-exa/extensions/schemas.ts` — define TypeBox schema for `exa_research_status`.
+- `packages/pi-exa/extensions/index.ts` — register the tool without Exa API-key gating.
+- `packages/pi-exa/__tests__/research-planner.test.ts` — test status output and no-auth behavior.
+
+### FR-3: Track autodiscovered criteria coverage
+
+The planning state must track criteria discovered by the model, including category, priority, status, and validated evidence references. Evidence refs must resolve to known source IDs or explicit tool-call notes; criteria marked `supported` must have at least one resolvable evidence ref.
 
 **Acceptance criteria:**
 
@@ -125,6 +150,7 @@ Given a research planning session exists
 When the model records criteria for "force plate validation" and "camera angle sensitivity"
 Then exa_research_status lists both criteria
 And each criterion includes category, priority, status, and evidence reference fields when provided
+And unsupported or unresolved evidence refs are flagged instead of counted as covered
 ```
 
 **Files:**
@@ -133,9 +159,9 @@ And each criterion includes category, priority, status, and evidence reference f
 - `packages/pi-exa/extensions/research-planner.ts` — aggregate and update criteria across steps.
 - `packages/pi-exa/__tests__/research-planner.test.ts` — test criteria aggregation.
 
-### FR-3: Track source pack and retrieval status
+### FR-4: Track source pack and retrieval status
 
-The planning state must track discovered/fetched sources and distinguish source retrieval state.
+The planning state must track discovered/fetched sources and distinguish source retrieval state. Fetched sources should include retrieval evidence such as the fetched URL and a tool-call/result reference when available. `contentNotes` on non-fetched sources must be labeled as metadata/snippet-derived rather than directly inspected content.
 
 **Acceptance criteria:**
 
@@ -144,6 +170,7 @@ Given a paper-heavy research session exists
 When the model records one source with retrievalStatus "discovered_only" and another with retrievalStatus "fetched"
 Then exa_research_summary with mode "source_pack" shows both sources
 And the fetched source is distinguishable from the discovered-only source
+And content notes on discovered-only sources are flagged as not directly inspected
 ```
 
 **Files:**
@@ -152,7 +179,7 @@ And the fetched source is distinguishable from the discovered-only source
 - `packages/pi-exa/extensions/research-planner.ts` — aggregate source records and source pack output.
 - `packages/pi-exa/__tests__/research-planner.test.ts` — test source pack summaries.
 
-### FR-4: Track gaps and clarification policy
+### FR-5: Track gaps and clarification policy
 
 The planning state must track gaps and indicate when user clarification is warranted.
 
@@ -171,9 +198,9 @@ And the status includes the blocking gap description
 - `packages/pi-exa/extensions/research-planner.ts` — compute clarification recommendation.
 - `packages/pi-exa/__tests__/research-planner.test.ts` — test gap behavior.
 
-### FR-5: Support branch and revision metadata
+### FR-6: Support branch and revision metadata
 
-The planning step tool must support revision and branching metadata similar to `pi-code-reasoning`.
+The planning step tool must support revision and branching metadata similar to `pi-code-reasoning` for cases where research strategy forks or earlier criteria need correction. Branching is a V1 requirement because paper-first, market-first, contrarian-first, and source-retrieval-first strategies can produce materially different plans.
 
 **Acceptance criteria:**
 
@@ -191,9 +218,9 @@ Then exa_research_status lists the "paper-first" branch
 - `packages/pi-exa/extensions/schemas.ts` — include branch/revision fields.
 - `packages/pi-exa/__tests__/research-planner.test.ts` — test branch/revision flows.
 
-### FR-6: Generate human-readable summaries before payloads
+### FR-7: Generate human-readable summaries before payloads
 
-`exa_research_summary` must default to human-readable plans. Raw JSON payloads are optional and labeled as implementation payloads.
+`exa_research_summary` must default to human-readable plans. Raw JSON payloads are optional and labeled as implementation payloads. V1 `payload` mode generates only a `web_research_exa` payload; search/fetch recommendations remain plain next-action text.
 
 **Acceptance criteria:**
 
@@ -202,6 +229,8 @@ Given a research planning session has objective, criteria, source strategy, and 
 When the model calls exa_research_summary with mode "execution_plan"
 Then the output starts with a human-readable research objective and coverage plan
 And raw web_research_exa JSON is absent unless mode "payload" is requested
+When the model calls exa_research_summary with mode "payload"
+Then the output contains a labeled suggested web_research_exa payload and does not execute any retrieval tool
 ```
 
 **Files:**
@@ -210,7 +239,7 @@ And raw web_research_exa JSON is absent unless mode "payload" is requested
 - `packages/pi-exa/extensions/schemas.ts` — define summary mode schema.
 - `packages/pi-exa/__tests__/research-planner.test.ts` — test human-readable output ordering.
 
-### FR-7: Reset research planning state
+### FR-8: Reset research planning state
 
 The extension must expose `exa_research_reset` to clear state.
 
@@ -228,7 +257,7 @@ Then exa_research_status reports zero steps and no active topic
 - `packages/pi-exa/extensions/index.ts` — register reset tool.
 - `packages/pi-exa/__tests__/research-planner.test.ts` — test reset.
 
-### FR-8: Update skill and README guidance
+### FR-9: Update skill and README guidance
 
 The Exa research planner skill and README must document the new stateful workflow.
 
@@ -237,7 +266,8 @@ The Exa research planner skill and README must document the new stateful workflo
 ```gherkin
 Given the package documentation is updated
 When a reader opens packages/pi-exa/skills/exa-research-planner/SKILL.md
-Then it instructs the model to use exa_research_step for iterative planning
+Then it instructs the model to use exa_research_step for non-trivial research planning
+And it explains when to skip the full planner for simple or explicit deep-research requests
 And packages/pi-exa/README.md lists the research planning tools
 ```
 
@@ -254,11 +284,13 @@ And packages/pi-exa/README.md lists the research planning tools
 | Category | Requirement |
 |----------|-------------|
 | **Cost transparency** | Planning tools must not call Exa network APIs internally. They recommend explicit existing Exa tool calls. |
+| **Auth independence** | Planning tools must work without an Exa API key and must not reuse the API-key-gated Exa retrieval helper. |
 | **Output quality** | Summaries must lead with human-readable plans, not raw JSON payloads. |
 | **Type safety** | Tool schemas must avoid `Type.Unknown()` and use typed objects or flexible object schemas with `additionalProperties`. |
 | **Performance** | In-memory operations should be fast enough to add/status/summarize sessions with at least 50 steps, 100 criteria, and 100 sources. |
-| **Testability** | State aggregation, reset, branch/revision validation, and summary output must be unit-testable without Exa network access. |
+| **Testability** | State aggregation, reset, branch/revision validation, evidence-ref validation, topic-switch warnings, no-auth behavior, and summary output must be unit-testable without Exa network access. |
 | **Compatibility** | Existing Exa tools and config behavior must remain backward compatible. |
+| **Adoption control** | Planning tools are default-enabled in V1 because they are local-only and non-cost-incurring; retrieval tools keep existing gating. |
 
 ---
 
@@ -268,15 +300,16 @@ And packages/pi-exa/README.md lists the research planning tools
 
 | Risk | Severity | Likelihood | Mitigation |
 |------|----------|------------|------------|
-| Tool surface area becomes confusing | Medium | Medium | Prefix planning tools with `exa_research_` and document their orchestration role separately from web retrieval tools. |
-| The model still skips planning tools | Medium | Medium | Update `exa-research-planner` skill and prompt guidance to require tool use for non-trivial research. |
+| Tool surface area becomes confusing | Medium | Medium | Prefix planning tools with `exa_research_`, make them default-enabled but local-only, and document their orchestration role separately from web retrieval tools. |
+| The model still skips planning tools | Medium | Medium | Update `exa-research-planner` skill and prompt guidance to require tool use for non-trivial research, while acknowledging tools make behavior inspectable when used rather than impossible to bypass. |
 | State output becomes too verbose | Medium | Medium | Add concise status/summary formats and reuse package output truncation patterns if needed. |
 | Planning tools are mistaken for retrieval tools | Low | Medium | Make descriptions explicit: planning tools do not perform network search. |
-| Source Pack gives false confidence for unfetched papers | High | Medium | Track retrieval status and require summaries to label `discovered_only` sources clearly. |
+| Source Pack gives false confidence for unfetched papers | High | Medium | Track retrieval status, require retrieval evidence for fetched sources, validate evidence refs, and label `discovered_only` sources clearly. |
 
 ### Assumptions
 
 - In-memory state is acceptable for the first implementation.
+- V1 supports one active research planning session at a time; topic switches before reset should warn instead of silently mixing state.
 - Existing Exa tools remain responsible for network calls and cost-incurring operations.
 - Research planning state belongs in `packages/pi-exa` rather than a new package because it is Exa-specific and tied to Exa tool workflows.
 - Human-readable plans are more useful to users than raw `web_research_exa` payloads, but payloads remain useful as optional implementation detail.
@@ -326,15 +359,15 @@ And packages/pi-exa/README.md lists the research planning tools
 
 | File | Change type | FR | Description |
 |------|-------------|-----|-------------|
-| `packages/pi-exa/extensions/research-planner-types.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5 | Types for steps, criteria, sources, gaps, summary state, and branch/revision metadata. |
-| `packages/pi-exa/extensions/research-planner.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7 | In-memory tracker, aggregation, validation, status, summary, reset. |
-| `packages/pi-exa/extensions/schemas.ts` | Modify | FR-1, FR-5, FR-6, FR-7 | TypeBox schemas for new tools. |
-| `packages/pi-exa/extensions/index.ts` | Modify | FR-1, FR-6, FR-7 | Register planning tools and wire handlers. |
-| `packages/pi-exa/skills/exa-research-planner/SKILL.md` | Modify | FR-8 | Require stateful tools for non-trivial research planning. |
-| `packages/pi-exa/README.md` | Modify | FR-8 | Document research planning tools and workflow. |
-| `packages/pi-exa/__tests__/research-planner.test.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7 | Focused unit coverage for planner state and summaries. |
-| `packages/pi-exa/__tests__/extension.test.ts` | Modify | FR-1, FR-6, FR-7 | Tool registration and execute behavior coverage. |
-| `packages/pi-exa/__tests__/index.test.ts` | Modify | FR-8 | README/skill reference tests. |
+| `packages/pi-exa/extensions/research-planner-types.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6 | Types for steps, criteria, sources, gaps, summary state, and branch/revision metadata. |
+| `packages/pi-exa/extensions/research-planner.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7, FR-8 | In-memory tracker, aggregation, validation, status, summary, reset. |
+| `packages/pi-exa/extensions/schemas.ts` | Modify | FR-1, FR-2, FR-6, FR-7, FR-8 | TypeBox schemas for new tools. |
+| `packages/pi-exa/extensions/index.ts` | Modify | FR-1, FR-2, FR-7, FR-8 | Register planning tools and wire handlers. |
+| `packages/pi-exa/skills/exa-research-planner/SKILL.md` | Modify | FR-9 | Require stateful tools for non-trivial research planning. |
+| `packages/pi-exa/README.md` | Modify | FR-9 | Document research planning tools and workflow. |
+| `packages/pi-exa/__tests__/research-planner.test.ts` | New | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7, FR-8 | Focused unit coverage for planner state and summaries. |
+| `packages/pi-exa/__tests__/extension.test.ts` | Modify | FR-1, FR-2, FR-7, FR-8 | Tool registration and execute behavior coverage. |
+| `packages/pi-exa/__tests__/index.test.ts` | Modify | FR-9 | README/skill reference tests. |
 
 ---
 
@@ -351,11 +384,11 @@ And packages/pi-exa/README.md lists the research planning tools
 ## 11. Rollout Plan
 
 1. Implement planner state and tests behind new tool names.
-2. Register tools and verify default package behavior.
+2. Register tools as default-enabled local planning tools and verify they work without an Exa API key.
 3. Update `exa-research-planner` skill to route non-trivial workflows through the stateful tools.
 4. Update README and skill tests.
 5. Run package checks.
-6. Optionally create an ADR for the stateful-tool decision before or during implementation.
+6. Reference ADR-0016 and ADR-0017 during implementation.
 
 ---
 
@@ -364,8 +397,8 @@ And packages/pi-exa/README.md lists the research planning tools
 | # | Question | Owner | Due | Status |
 |---|----------|-------|-----|--------|
 | Q1 | Should research planning sessions persist to disk or stay in-memory initially? | Sebastian | Before implementation | **Resolved:** Start in-memory; see `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`. |
-| Q2 | Should planning tools be enabled by default or gated behind config? | Sebastian | Before implementation | Open |
-| Q3 | Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads or also suggested search/fetch calls? | Sebastian | During implementation | Open |
+| Q2 | Should planning tools be enabled by default or gated behind config? | Sebastian | Before implementation | **Resolved:** Default-enabled in V1 because tools are local-only and non-cost-incurring; retrieval tools keep existing gating. |
+| Q3 | Should `exa_research_summary(mode: "payload")` generate only `web_research_exa` payloads or also suggested search/fetch calls? | Sebastian | During implementation | **Resolved:** V1 payload mode generates only `web_research_exa` payloads; search/fetch remain plain next-action recommendations. |
 | Q4 | Should this require an ADR before implementation? | Sebastian | Before implementation | **Resolved:** ADRs drafted; see `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md` and `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`. |
 
 ---
@@ -399,3 +432,6 @@ Post-implementation checks:
 4. Record a blocking gap with `resolution: "ask_user"` and confirm status recommends user clarification.
 5. Generate `exa_research_summary(mode: "execution_plan")` and confirm it is human-readable and does not lead with JSON.
 6. Generate `exa_research_summary(mode: "payload")` and confirm the implementation payload derives from the recorded criteria and source strategy.
+7. Call `exa_research_step` and `exa_research_status` without an Exa API key configured and confirm both work.
+8. Record a source with `contentNotes` but `retrievalStatus: "discovered_only"` and confirm the Source Pack flags it as not directly inspected.
+9. Start a second topic before reset and confirm the step result warns about topic mismatch.

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -28,6 +28,8 @@ pi -e npm:@feniix/pi-exa
 
 You need an Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys) for retrieval tools. The local `exa_research_*` planning tools work without an API key because they do not call Exa network APIs.
 
+If you configure `enabledTools`, it acts as a strict allowlist. Include the `exa_research_*` names if you want the planner tools available with an explicit allowlist.
+
 ### Recommended: environment variable
 
 ```bash
@@ -177,6 +179,6 @@ PI_EXA_LIVE=1 EXA_API_KEY=your-key npx vitest run packages/pi-exa/__tests__/inte
 
 ## Notes
 
-- `exa_research_*` planning tools are enabled by default, local-only, and do not require an Exa API key.
+- `exa_research_*` planning tools are enabled by default when no explicit `enabledTools` allowlist is configured, local-only, and do not require an Exa API key.
 - `web_search_advanced_exa` and `web_research_exa` are opt-in and disabled by default.
 - Research/tool output may include both `text` and `details.parsedOutput` depending on `outputSchema.type`.

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -10,6 +10,7 @@
 - **web_research_exa**: deep-research synthesis (disabled by default).
 - **web_answer_exa**: quick grounded answers.
 - **web_find_similar_exa**: discover related URLs.
+- **exa_research_step/status/summary/reset**: local, stateful research-planning tools that recommend explicit Exa retrieval calls without executing them.
 
 ## Install
 
@@ -25,7 +26,7 @@ pi -e npm:@feniix/pi-exa
 
 ## Configuration
 
-You need an Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys).
+You need an Exa API key from [dashboard.exa.ai/api-keys](https://dashboard.exa.ai/api-keys) for retrieval tools. The local `exa_research_*` planning tools work without an API key because they do not call Exa network APIs.
 
 ### Recommended: environment variable
 
@@ -40,7 +41,16 @@ Use a private config file when you want to store an API key outside shared proje
 ```json
 {
   "apiKey": "your-key",
-  "enabledTools": ["web_search_exa", "web_fetch_exa", "web_answer_exa", "web_find_similar_exa"],
+  "enabledTools": [
+    "exa_research_step",
+    "exa_research_status",
+    "exa_research_summary",
+    "exa_research_reset",
+    "web_search_exa",
+    "web_fetch_exa",
+    "web_answer_exa",
+    "web_find_similar_exa"
+  ],
   "advancedEnabled": false,
   "researchEnabled": false
 }
@@ -64,7 +74,16 @@ Example:
 ```json
 {
   "pi-exa": {
-    "enabledTools": ["web_search_exa", "web_fetch_exa", "web_answer_exa", "web_find_similar_exa"],
+    "enabledTools": [
+      "exa_research_step",
+      "exa_research_status",
+      "exa_research_summary",
+      "exa_research_reset",
+      "web_search_exa",
+      "web_fetch_exa",
+      "web_answer_exa",
+      "web_find_similar_exa"
+    ],
     "advancedEnabled": false,
     "researchEnabled": false
   }
@@ -82,6 +101,22 @@ Example:
 - `--exa-config <path>` (deprecated alias for `--exa-config-file`).
 
 ## Tools
+
+### exa_research_step
+
+Records one step in an in-memory research-planning session. Params include `topic`, `stage`, `note`, optional `criteria`, `sources`, `gaps`, `assumptions`, `nextAction`, branch/revision metadata, `thought_number`, `total_thoughts`, and `next_step_needed`.
+
+### exa_research_status
+
+Reports the current local planning state: topic, step count, active stage, branches, criteria coverage, source pack summary, open gaps, assumptions, and recommended next action.
+
+### exa_research_summary
+
+Generates human-readable research planning output. Modes: `brief`, `execution_plan`, `source_pack`, and `payload`. Payload mode suggests a `web_research_exa` payload only; it does not run retrieval.
+
+### exa_research_reset
+
+Clears the active in-memory planning session.
 
 ### web_search_exa
 
@@ -142,5 +177,6 @@ PI_EXA_LIVE=1 EXA_API_KEY=your-key npx vitest run packages/pi-exa/__tests__/inte
 
 ## Notes
 
+- `exa_research_*` planning tools are enabled by default, local-only, and do not require an Exa API key.
 - `web_search_advanced_exa` and `web_research_exa` are opt-in and disabled by default.
 - Research/tool output may include both `text` and `details.parsedOutput` depending on `outputSchema.type`.

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -177,6 +177,19 @@ describe("pi-exa extension", () => {
 
     expect(statusResult?.content[0].text).toContain("local planner");
     expect(statusResult?.details.tool).toBe("exa_research_status");
+
+    const summaryTool = getRegisteredTool(mockPi, "exa_research_summary");
+    const summaryResult = await summaryTool?.execute(
+      "call-summary",
+      { mode: "execution_plan" },
+      { aborted: false } as AbortSignal,
+      undefined,
+      undefined as never,
+    );
+
+    expect(summaryResult?.content[0].text).toContain("# Research Execution Plan");
+    expect(summaryResult?.details.tool).toBe("exa_research_summary");
+    expect(mockExaConstructor).not.toHaveBeenCalled();
   });
 
   it("honors enabledTools allowlists for research planning tools", () => {

--- a/packages/pi-exa/__tests__/extension.test.ts
+++ b/packages/pi-exa/__tests__/extension.test.ts
@@ -131,8 +131,61 @@ describe("pi-exa extension", () => {
     expect(toolNames).toContain("web_fetch_exa");
     expect(toolNames).toContain("web_answer_exa");
     expect(toolNames).toContain("web_find_similar_exa");
+    expect(toolNames).toContain("exa_research_step");
+    expect(toolNames).toContain("exa_research_status");
+    expect(toolNames).toContain("exa_research_summary");
+    expect(toolNames).toContain("exa_research_reset");
     expect(toolNames).not.toContain("web_search_advanced_exa");
     expect(toolNames).not.toContain("web_research_exa");
+  });
+
+  it("executes research planning tools without an Exa API key", async () => {
+    const mockPi = createMockPi();
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const resetTool = getRegisteredTool(mockPi, "exa_research_reset");
+    await resetTool?.execute("call-reset", {}, { aborted: false } as AbortSignal, undefined, undefined as never);
+
+    const stepTool = getRegisteredTool(mockPi, "exa_research_step");
+    const stepResult = await stepTool?.execute(
+      "call-step",
+      {
+        topic: "local planner",
+        stage: "framing",
+        note: "Plan locally without authentication.",
+        thought_number: 1,
+        total_thoughts: 2,
+        next_step_needed: true,
+      },
+      { aborted: false } as AbortSignal,
+      undefined,
+      undefined as never,
+    );
+
+    expect(stepResult?.isError).toBeUndefined();
+    expect(stepResult?.content[0].text).toContain("local planner");
+    expect(mockExaConstructor).not.toHaveBeenCalled();
+
+    const statusTool = getRegisteredTool(mockPi, "exa_research_status");
+    const statusResult = await statusTool?.execute(
+      "call-status",
+      {},
+      { aborted: false } as AbortSignal,
+      undefined,
+      undefined as never,
+    );
+
+    expect(statusResult?.content[0].text).toContain("local planner");
+    expect(statusResult?.details.tool).toBe("exa_research_status");
+  });
+
+  it("honors enabledTools allowlists for research planning tools", () => {
+    const configPath = writeTempConfig({ enabledTools: ["web_search_exa"] });
+    const mockPi = createMockPi({ "--exa-config-file": configPath });
+    exaExtension(mockPi as unknown as ExtensionAPI);
+
+    const toolNames = mockPi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toEqual(["web_search_exa"]);
   });
 
   it("registers web_search_advanced_exa when config enables it", () => {
@@ -735,6 +788,10 @@ describe("pi-exa extension", () => {
   it("adds cross-tool prompt guidance for all registered tools", () => {
     const configPath = writeTempConfig({
       enabledTools: [
+        "exa_research_step",
+        "exa_research_status",
+        "exa_research_summary",
+        "exa_research_reset",
         "web_search_exa",
         "web_fetch_exa",
         "web_search_advanced_exa",
@@ -748,11 +805,13 @@ describe("pi-exa extension", () => {
     exaExtension(mockPi as unknown as ExtensionAPI);
 
     const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    expect(tools).toHaveLength(6);
+    const webTools = tools.filter((tool) => tool.name.startsWith("web_"));
+    expect(webTools).toHaveLength(6);
+    expect(tools).toEqual(expect.arrayContaining([expect.objectContaining({ name: "exa_research_step" })]));
 
     const exaToolNamePattern = /web_(search|fetch|search_advanced|research|answer|find_similar)_exa/g;
 
-    for (const tool of tools) {
+    for (const tool of webTools) {
       expect(tool.promptSnippet).toBeTypeOf("string");
       expect(tool.promptSnippet.length).toBeLessThan(100);
       expect(tool.promptSnippet).not.toContain("\n");

--- a/packages/pi-exa/__tests__/helpers.test.ts
+++ b/packages/pi-exa/__tests__/helpers.test.ts
@@ -392,6 +392,10 @@ describe("pi-exa tool enablement helpers", () => {
     const pi = { getFlag: () => undefined } as { getFlag: (flag: string) => unknown };
     expect(isToolEnabledForConfig(pi as never, null, "web_search_exa")).toBe(true);
     expect(isToolEnabledForConfig(pi as never, null, "web_fetch_exa")).toBe(true);
+    expect(isToolEnabledForConfig(pi as never, null, "exa_research_step")).toBe(true);
+    expect(isToolEnabledForConfig(pi as never, null, "exa_research_status")).toBe(true);
+    expect(isToolEnabledForConfig(pi as never, null, "exa_research_summary")).toBe(true);
+    expect(isToolEnabledForConfig(pi as never, null, "exa_research_reset")).toBe(true);
   });
 
   it("respects advanced tool flag override", () => {

--- a/packages/pi-exa/__tests__/index.test.ts
+++ b/packages/pi-exa/__tests__/index.test.ts
@@ -153,12 +153,17 @@ describe("pi-exa", () => {
       expect(skill).toContain("Do not lead with raw JSON");
     });
 
-    it("exa-research-planner does not reference unimplemented planning tools", () => {
+    it("exa-research-planner references implemented planning tools", () => {
       const skill = readFileSync(join(__dirname, "../skills/exa-research-planner/SKILL.md"), "utf-8");
+      const readme = readFileSync(join(__dirname, "../README.md"), "utf-8");
 
       expect(skill).not.toContain("PRD-008");
-      expect(skill).not.toContain("exa_research_step");
-      expect(skill).not.toContain("exa_research_summary");
+      expect(skill).toContain("exa_research_step");
+      expect(skill).toContain("exa_research_status");
+      expect(skill).toContain("exa_research_summary");
+      expect(skill).toContain("exa_research_reset");
+      expect(readme).toContain("exa_research_step");
+      expect(readme).toContain("local-only");
     });
   });
 });

--- a/packages/pi-exa/__tests__/research-planner.test.ts
+++ b/packages/pi-exa/__tests__/research-planner.test.ts
@@ -79,6 +79,25 @@ describe("research planner state", () => {
     expect(status.openGaps.map((gap) => gap.id)).toEqual(["G1", "G2"]);
   });
 
+  it("keeps same-title sources with different URLs separate", () => {
+    recordResearchStep({
+      topic: "source identity",
+      stage: "cheap_discovery",
+      note: "Record generic page titles from different URLs.",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_step_needed: false,
+      sources: [
+        { title: "Introduction", url: "https://example.com/a", retrievalStatus: "discovered_only" },
+        { title: "Introduction", url: "https://example.com/b", retrievalStatus: "discovered_only" },
+      ],
+    });
+
+    const status = getResearchStatus();
+    expect(status.sources).toHaveLength(2);
+    expect(status.sources.map((source) => source.url)).toEqual(["https://example.com/a", "https://example.com/b"]);
+  });
+
   it("aggregates criteria and validates evidence references", () => {
     recordResearchStep({
       topic: "computer vision jump analysis",
@@ -122,6 +141,29 @@ describe("research planner state", () => {
     expect(status.criteriaCoverage.supported).toBe(1);
     expect(status.criteriaCoverage.unresolvedEvidence).toBe(1);
     expect(status.criteria[1].evidenceIssues).toContain("Unresolved evidence ref: S404");
+  });
+
+  it("does not count malformed tool evidence as supported coverage", () => {
+    recordResearchStep({
+      topic: "evidence validation",
+      stage: "coverage_analysis",
+      note: "Record malformed evidence refs.",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_step_needed: false,
+      criteria: [
+        { id: "C1", label: "Bare tool prefix", status: "supported", evidenceRefs: ["tool:"] },
+        { id: "C2", label: "Unknown tool", status: "supported", evidenceRefs: ["tool:made-up call-1"] },
+        { id: "C3", label: "No evidence", status: "supported" },
+      ],
+    });
+
+    const status = getResearchStatus();
+    expect(status.criteriaCoverage.supported).toBe(0);
+    expect(status.criteriaCoverage.unresolvedEvidence).toBe(3);
+    expect(status.criteria[0].evidenceIssues).toContain("Unresolved evidence ref: tool:");
+    expect(status.criteria[1].evidenceIssues).toContain("Unresolved evidence ref: tool:made-up call-1");
+    expect(status.criteria[2].evidenceIssues).toContain("Supported criterion has no evidence refs.");
   });
 
   it("updates existing records without exposing mutable state", () => {
@@ -264,10 +306,46 @@ describe("research planner state", () => {
       branch_id: "still-bad",
     });
 
+    expect(uniqueInvalid.warnings).toContain("Revision steps cannot also define branch metadata.");
     expect(uniqueInvalid.warnings).toContain("Revision references unknown step 99.");
     expect(uniqueInvalid.warnings).toContain("Branch references unknown step 99.");
     expect(getResearchStatus().stepCount).toBe(1);
     expect(getResearchStatus().branches).not.toContain("still-bad");
+
+    const missingBranchId = recordResearchStep({
+      topic: "invalid references",
+      stage: "criteria_discovery",
+      note: "Missing branch ID.",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_step_needed: true,
+      branch_from_step: 1,
+    });
+    expect(missingBranchId.warnings).toContain("branch_from_step requires branch_id.");
+    expect(getResearchStatus().stepCount).toBe(1);
+
+    const outOfOrder = recordResearchStep({
+      topic: "invalid references",
+      stage: "criteria_discovery",
+      note: "Step three.",
+      thought_number: 3,
+      total_thoughts: 3,
+      next_step_needed: true,
+    });
+    expect(outOfOrder.stepCount).toBe(2);
+
+    const regressed = recordResearchStep({
+      topic: "invalid references",
+      stage: "criteria_discovery",
+      note: "Regressed thought number.",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_step_needed: true,
+    });
+    expect(regressed.warnings).toContain(
+      "Out-of-order thought_number 2; last recorded thought_number is 3. Step was not recorded.",
+    );
+    expect(getResearchStatus().stepCount).toBe(2);
   });
 
   it("tracks gaps, branches, and revisions", () => {
@@ -291,12 +369,20 @@ describe("research planner state", () => {
     recordResearchStep({
       topic: "strategy comparison",
       stage: "coverage_analysis",
-      note: "Paper-first branch.",
+      note: "Revision to initial framing.",
       thought_number: 3,
-      total_thoughts: 3,
-      next_step_needed: false,
+      total_thoughts: 4,
+      next_step_needed: true,
       is_revision: true,
       revises_step: 1,
+    });
+    recordResearchStep({
+      topic: "strategy comparison",
+      stage: "coverage_analysis",
+      note: "Paper-first branch.",
+      thought_number: 4,
+      total_thoughts: 4,
+      next_step_needed: false,
       branch_from_step: 2,
       branch_id: "paper-first",
     });
@@ -369,8 +455,22 @@ describe("research planner state", () => {
       stage: "framing",
       note: "Temporary state.",
       thought_number: 1,
-      total_thoughts: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      criteria: [{ id: "C5", label: "Temporary criterion" }],
+      sources: [{ id: "S5", title: "Temporary source" }],
+      gaps: [{ id: "G5", description: "Temporary gap", severity: "blocking", resolution: "ask_user" }],
+      assumptions: ["temporary assumption"],
+    });
+    recordResearchStep({
+      topic: "reset me",
+      stage: "coverage_analysis",
+      note: "Temporary branch.",
+      thought_number: 2,
+      total_thoughts: 2,
       next_step_needed: false,
+      branch_from_step: 1,
+      branch_id: "temporary",
     });
 
     resetResearchPlanner();
@@ -378,5 +478,27 @@ describe("research planner state", () => {
     const status = getResearchStatus();
     expect(status.stepCount).toBe(0);
     expect(status.topic).toBeUndefined();
+    expect(status.criteria).toEqual([]);
+    expect(status.sources).toEqual([]);
+    expect(status.openGaps).toEqual([]);
+    expect(status.assumptions).toEqual([]);
+    expect(status.branches).toEqual([]);
+    expect(status.clarificationWarranted).toBe(false);
+
+    recordResearchStep({
+      topic: "after reset",
+      stage: "framing",
+      note: "IDs restart.",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_step_needed: false,
+      criteria: [{ label: "Fresh criterion" }],
+      sources: [{ title: "Fresh source" }],
+      gaps: [{ description: "Fresh gap" }],
+    });
+    const fresh = getResearchStatus();
+    expect(fresh.criteria[0].id).toBe("C1");
+    expect(fresh.sources[0].id).toBe("S1");
+    expect(fresh.openGaps[0].id).toBe("G1");
   });
 });

--- a/packages/pi-exa/__tests__/research-planner.test.ts
+++ b/packages/pi-exa/__tests__/research-planner.test.ts
@@ -9,6 +9,40 @@ import {
   recordResearchStep,
   resetResearchPlanner,
 } from "../extensions/research-planner.js";
+import {
+  CRITERION_CATEGORIES,
+  CRITERION_STATUSES,
+  GAP_RESOLUTIONS,
+  GAP_SEVERITIES,
+  RESEARCH_NEXT_ACTIONS,
+  RESEARCH_STAGES,
+  RETRIEVAL_STATUSES,
+  SOURCE_TYPES,
+  SUMMARY_MODES,
+} from "../extensions/research-planner-types.js";
+import { exaResearchStepParams, exaResearchSummaryParams } from "../extensions/schemas.js";
+
+const literalValues = (schema: { anyOf?: Array<{ const: string }> }) => schema.anyOf?.map((entry) => entry.const) ?? [];
+
+describe("research planner schemas", () => {
+  it("keeps schema enum literals aligned with planner constants", () => {
+    const stepProperties = exaResearchStepParams.properties;
+    const criterionProperties = stepProperties.criteria.items.properties;
+    const sourceProperties = stepProperties.sources.items.properties;
+    const gapProperties = stepProperties.gaps.items.properties;
+
+    expect(literalValues(stepProperties.stage)).toEqual([...RESEARCH_STAGES]);
+    expect(literalValues(stepProperties.nextAction)).toEqual([...RESEARCH_NEXT_ACTIONS]);
+    expect(literalValues(criterionProperties.category)).toEqual([...CRITERION_CATEGORIES]);
+    expect(literalValues(criterionProperties.status)).toEqual([...CRITERION_STATUSES]);
+    expect(literalValues(criterionProperties.priority)).toEqual(["high", "medium", "low"]);
+    expect(literalValues(sourceProperties.sourceType)).toEqual([...SOURCE_TYPES]);
+    expect(literalValues(sourceProperties.retrievalStatus)).toEqual([...RETRIEVAL_STATUSES]);
+    expect(literalValues(gapProperties.severity)).toEqual([...GAP_SEVERITIES]);
+    expect(literalValues(gapProperties.resolution)).toEqual([...GAP_RESOLUTIONS]);
+    expect(literalValues(exaResearchSummaryParams.properties.mode)).toEqual([...SUMMARY_MODES]);
+  });
+});
 
 describe("research planner state", () => {
   beforeEach(() => {
@@ -96,6 +130,87 @@ describe("research planner state", () => {
     const status = getResearchStatus();
     expect(status.sources).toHaveLength(2);
     expect(status.sources.map((source) => source.url)).toEqual(["https://example.com/a", "https://example.com/b"]);
+  });
+
+  it("preserves stable source IDs when merging by URL", () => {
+    recordResearchStep({
+      topic: "source id stability",
+      stage: "source_retrieval",
+      note: "Record initial source and evidence.",
+      thought_number: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      sources: [{ id: "S1", title: "Initial", url: "https://example.com/a", retrievalStatus: "fetched" }],
+      criteria: [{ id: "C1", label: "Evidence", status: "supported", evidenceRefs: ["S1"] }],
+    });
+
+    recordResearchStep({
+      topic: "source id stability",
+      stage: "source_retrieval",
+      note: "Record the same URL with a conflicting explicit ID.",
+      thought_number: 2,
+      total_thoughts: 2,
+      next_step_needed: false,
+      sources: [
+        {
+          id: "S2",
+          title: "Updated",
+          url: "https://example.com/a",
+          retrievalStatus: "fetched",
+          retrievalEvidence: "tool:web_fetch_exa call-2",
+        },
+      ],
+    });
+
+    const status = getResearchStatus();
+    expect(status.sources).toHaveLength(1);
+    expect(status.sources[0].id).toBe("S1");
+    expect(status.sources[0].title).toBe("Updated");
+    expect(status.criteria[0].evidenceIssues).toEqual([]);
+    expect(status.criteriaCoverage.supported).toBe(1);
+  });
+
+  it("warns instead of rewriting conflicting stable IDs", () => {
+    recordResearchStep({
+      topic: "conflict handling",
+      stage: "source_retrieval",
+      note: "Record initial stable IDs.",
+      thought_number: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      criteria: [
+        { id: "C1", label: "Original criterion", status: "supported", evidenceRefs: ["tool:web_search_exa call-1"] },
+      ],
+      sources: [{ id: "S1", title: "Original source", url: "https://example.com/a" }],
+      gaps: [{ id: "G1", description: "Original gap" }],
+    });
+
+    const result = recordResearchStep({
+      topic: "conflict handling",
+      stage: "coverage_analysis",
+      note: "Try conflicting stable IDs.",
+      thought_number: 2,
+      total_thoughts: 2,
+      next_step_needed: false,
+      criteria: [{ id: "C1", label: "Different criterion" }],
+      sources: [{ id: "S1", title: "Different source", url: "https://example.com/b" }],
+      gaps: [{ id: "G1", description: "Different gap" }],
+    });
+
+    expect(result.warnings).toContain(
+      'Criterion C1 already exists as "Original criterion"; conflicting label "Different criterion" was ignored.',
+    );
+    expect(result.warnings).toContain(
+      "Source S1 already exists for https://example.com/a; conflicting URL https://example.com/b was ignored.",
+    );
+    expect(result.warnings).toContain(
+      'Gap G1 already exists as "Original gap"; conflicting description "Different gap" was ignored.',
+    );
+
+    const status = getResearchStatus();
+    expect(status.criteria[0].label).toBe("Original criterion");
+    expect(status.sources[0].url).toBe("https://example.com/a");
+    expect(status.openGaps[0].description).toBe("Original gap");
   });
 
   it("aggregates criteria and validates evidence references", () => {

--- a/packages/pi-exa/__tests__/research-planner.test.ts
+++ b/packages/pi-exa/__tests__/research-planner.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Stateful research-planner tests for pi-exa.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getResearchStatus,
+  getResearchSummary,
+  recordResearchStep,
+  resetResearchPlanner,
+} from "../extensions/research-planner.js";
+
+describe("research planner state", () => {
+  beforeEach(() => {
+    resetResearchPlanner();
+  });
+
+  it("records steps, progress, and topic mismatch warnings", () => {
+    const first = recordResearchStep({
+      topic: "computer vision jump analysis",
+      stage: "framing",
+      note: "Frame the research objective and baseline assumptions.",
+      thought_number: 1,
+      total_thoughts: 5,
+      next_step_needed: true,
+      nextAction: "web_search_exa",
+      nextActionReason: "Cheap discovery should come before deep synthesis.",
+    });
+
+    expect(first.stepCount).toBe(1);
+    expect(first.progress.percent).toBe(20);
+    expect(first.recommendedNextAction?.action).toBe("web_search_exa");
+
+    const second = recordResearchStep({
+      topic: "enterprise AI market sizing",
+      stage: "framing",
+      note: "This is a different topic.",
+      thought_number: 2,
+      total_thoughts: 5,
+      next_step_needed: true,
+    });
+
+    expect(second.warnings).toContain(
+      'Topic mismatch: active topic is "computer vision jump analysis"; received "enterprise AI market sizing". Call exa_research_reset before starting a new topic. Step was not recorded.',
+    );
+    const status = getResearchStatus();
+    expect(status.topic).toBe("computer vision jump analysis");
+    expect(status.stepCount).toBe(1);
+    expect(status.activeStage).toBe("framing");
+  });
+
+  it("advances generated IDs after explicit IDs", () => {
+    recordResearchStep({
+      topic: "id generation",
+      stage: "framing",
+      note: "Record explicit IDs.",
+      thought_number: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      criteria: [{ id: "C1", label: "Explicit criterion" }],
+      sources: [{ id: "S1", title: "Explicit source" }],
+      gaps: [{ id: "G1", description: "Explicit gap" }],
+    });
+    recordResearchStep({
+      topic: "id generation",
+      stage: "criteria_discovery",
+      note: "Record generated IDs.",
+      thought_number: 2,
+      total_thoughts: 2,
+      next_step_needed: false,
+      criteria: [{ label: "Generated criterion" }],
+      sources: [{ title: "Generated source" }],
+      gaps: [{ description: "Generated gap" }],
+    });
+
+    const status = getResearchStatus();
+    expect(status.criteria.map((criterion) => criterion.id)).toEqual(["C1", "C2"]);
+    expect(status.sources.map((source) => source.id)).toEqual(["S1", "S2"]);
+    expect(status.openGaps.map((gap) => gap.id)).toEqual(["G1", "G2"]);
+  });
+
+  it("aggregates criteria and validates evidence references", () => {
+    recordResearchStep({
+      topic: "computer vision jump analysis",
+      stage: "source_retrieval",
+      note: "Fetched the validation paper and mapped it to criteria.",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_step_needed: true,
+      sources: [
+        {
+          id: "S1",
+          title: "Validation paper",
+          url: "https://example.com/paper",
+          sourceType: "paper",
+          retrievalStatus: "fetched",
+          retrievalEvidence: "tool:web_fetch_exa call-1",
+        },
+      ],
+      criteria: [
+        {
+          id: "C1",
+          label: "Force plate validation",
+          category: "method",
+          priority: "high",
+          status: "supported",
+          evidenceRefs: ["S1"],
+        },
+        {
+          id: "C2",
+          label: "Camera angle sensitivity",
+          category: "metric",
+          priority: "medium",
+          status: "supported",
+          evidenceRefs: ["S404"],
+        },
+      ],
+    });
+
+    const status = getResearchStatus();
+    expect(status.criteria).toHaveLength(2);
+    expect(status.criteriaCoverage.supported).toBe(1);
+    expect(status.criteriaCoverage.unresolvedEvidence).toBe(1);
+    expect(status.criteria[1].evidenceIssues).toContain("Unresolved evidence ref: S404");
+  });
+
+  it("updates existing records without exposing mutable state", () => {
+    recordResearchStep({
+      topic: "record updates",
+      stage: "framing",
+      note: "Initial records.",
+      thought_number: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      criteria: [{ id: "C1", label: "Validation", evidenceRefs: ["tool:web_search_exa call-1"] }],
+      sources: [{ id: "S1", title: "Source", usedFor: ["C1"] }],
+      gaps: [{ id: "G1", description: "Gap", severity: "important" }],
+    });
+    recordResearchStep({
+      topic: "record updates",
+      stage: "coverage_analysis",
+      note: "Update records.",
+      thought_number: 2,
+      total_thoughts: 2,
+      next_step_needed: false,
+      criteria: [{ id: "C1", label: "Validation", status: "supported", evidenceRefs: ["tool:web_fetch_exa call-2"] }],
+      sources: [
+        { id: "S1", title: "Source", retrievalStatus: "fetched", retrievalEvidence: "tool:web_fetch_exa call-2" },
+      ],
+      gaps: [{ id: "G1", description: "Gap", severity: "minor" }],
+    });
+
+    const status = getResearchStatus();
+    expect(status.criteria).toHaveLength(1);
+    expect(status.sources).toHaveLength(1);
+    expect(status.openGaps).toHaveLength(1);
+    expect(status.criteria[0].evidenceRefs).toEqual(["tool:web_search_exa call-1", "tool:web_fetch_exa call-2"]);
+    expect(status.sources[0].retrievalStatus).toBe("fetched");
+    expect(status.openGaps[0].severity).toBe("minor");
+
+    status.criteria[0].evidenceRefs.push("mutated");
+    expect(getResearchStatus().criteria[0].evidenceRefs).not.toContain("mutated");
+  });
+
+  it("labels unverified sources as not directly inspected in source packs", () => {
+    recordResearchStep({
+      topic: "paper retrieval policy",
+      stage: "cheap_discovery",
+      note: "Discovered candidate source snippets.",
+      thought_number: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      sources: [
+        {
+          id: "S1",
+          title: "Snippet-only paper",
+          url: "https://example.com/snippet",
+          sourceType: "paper",
+          retrievalStatus: "discovered_only",
+          contentNotes: "Claims a strong correlation.",
+        },
+        {
+          id: "S2",
+          title: "Fetched paper",
+          url: "https://example.com/fetched",
+          sourceType: "paper",
+          retrievalStatus: "fetched",
+          retrievalEvidence: "tool:web_fetch_exa call-2",
+          contentNotes: "Directly inspected methods section.",
+        },
+        {
+          id: "S3",
+          title: "Unverified fetched paper",
+          sourceType: "paper",
+          retrievalStatus: "fetched",
+        },
+      ],
+    });
+
+    const sourcePack = getResearchSummary({ mode: "source_pack" });
+    expect(sourcePack).toContain("Snippet-only paper");
+    expect(sourcePack).toContain("not directly inspected");
+    expect(sourcePack).toContain("Fetched paper");
+    expect(sourcePack).toContain("Unverified fetched paper");
+    expect(sourcePack).toContain("Fetched source is missing retrieval evidence");
+    const status = getResearchStatus();
+    expect(status.sourcePackSummary.fetched).toBe(1);
+    expect(status.sourcePackSummary.notDirectlyInspected).toBe(2);
+  });
+
+  it("warns without recording invalid branch, revision, and sequence references", () => {
+    const invalidFirst = recordResearchStep({
+      topic: "invalid first",
+      stage: "framing",
+      note: "Invalid first step.",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_step_needed: true,
+      is_revision: true,
+      revises_step: 99,
+    });
+
+    expect(invalidFirst.warnings).toContain("Revision references unknown step 99.");
+    expect(getResearchStatus().topic).toBeUndefined();
+    expect(getResearchStatus().stepCount).toBe(0);
+
+    recordResearchStep({
+      topic: "invalid references",
+      stage: "framing",
+      note: "Initial step.",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_step_needed: true,
+    });
+
+    const result = recordResearchStep({
+      topic: "invalid references",
+      stage: "criteria_discovery",
+      note: "Invalid duplicate and references.",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_step_needed: true,
+      is_revision: true,
+      revises_step: 99,
+      branch_from_step: 99,
+      branch_id: "bad-branch",
+    });
+
+    expect(result.warnings).toContain("Duplicate thought_number 1; step was not recorded.");
+    expect(result.warnings).toContain("Revision references unknown step 99.");
+    expect(result.warnings).toContain("Branch references unknown step 99.");
+    expect(getResearchStatus().stepCount).toBe(1);
+
+    const uniqueInvalid = recordResearchStep({
+      topic: "invalid references",
+      stage: "criteria_discovery",
+      note: "Invalid references with a unique thought number.",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_step_needed: true,
+      is_revision: true,
+      revises_step: 99,
+      branch_from_step: 99,
+      branch_id: "still-bad",
+    });
+
+    expect(uniqueInvalid.warnings).toContain("Revision references unknown step 99.");
+    expect(uniqueInvalid.warnings).toContain("Branch references unknown step 99.");
+    expect(getResearchStatus().stepCount).toBe(1);
+    expect(getResearchStatus().branches).not.toContain("still-bad");
+  });
+
+  it("tracks gaps, branches, and revisions", () => {
+    recordResearchStep({
+      topic: "strategy comparison",
+      stage: "framing",
+      note: "Initial strategy.",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_step_needed: true,
+    });
+    recordResearchStep({
+      topic: "strategy comparison",
+      stage: "criteria_discovery",
+      note: "Criteria pass.",
+      thought_number: 2,
+      total_thoughts: 3,
+      next_step_needed: true,
+      gaps: [{ id: "G1", description: "Need geography", severity: "blocking", resolution: "ask_user" }],
+    });
+    recordResearchStep({
+      topic: "strategy comparison",
+      stage: "coverage_analysis",
+      note: "Paper-first branch.",
+      thought_number: 3,
+      total_thoughts: 3,
+      next_step_needed: false,
+      is_revision: true,
+      revises_step: 1,
+      branch_from_step: 2,
+      branch_id: "paper-first",
+    });
+
+    const status = getResearchStatus();
+    expect(status.branches).toContain("paper-first");
+    expect(status.clarificationWarranted).toBe(true);
+    expect(status.openGaps[0].description).toBe("Need geography");
+    expect(status.revisions).toEqual([{ step: 3, revisesStep: 1 }]);
+  });
+
+  it("does not expose stored step objects through record results", () => {
+    const result = recordResearchStep({
+      topic: "step immutability",
+      stage: "framing",
+      note: "Initial step.",
+      thought_number: 1,
+      total_thoughts: 2,
+      next_step_needed: true,
+      nextAction: "web_search_exa",
+    });
+
+    result.step.thought_number = 99;
+    result.step.nextAction = "finalize";
+    result.step.warnings.push("mutated");
+
+    const status = getResearchStatus();
+    expect(status.progress.current).toBe(1);
+    expect(status.recommendedNextAction?.action).toBe("web_search_exa");
+    expect(status.warnings).not.toContain("mutated");
+  });
+
+  it("generates human-readable execution plans and labeled payloads without executing retrieval", () => {
+    recordResearchStep({
+      topic: "computer vision jump analysis",
+      stage: "deep_research_plan",
+      note: "Plan should compare pose-estimation methods against validation targets.",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_step_needed: false,
+      assumptions: ["Focus on peer-reviewed validation before vendor claims."],
+      criteria: [
+        {
+          id: "C1",
+          label: "Validation metrics",
+          category: "metric",
+          priority: "high",
+          status: "proposed",
+        },
+      ],
+      nextAction: "web_research_exa",
+      nextActionReason: "The plan is ready for explicit deep synthesis.",
+    });
+
+    const executionPlan = getResearchSummary({ mode: "execution_plan" });
+    expect(executionPlan.startsWith("# Research Execution Plan")).toBe(true);
+    expect(executionPlan).toContain("computer vision jump analysis");
+    expect(executionPlan).not.toContain('"query"');
+
+    const payload = getResearchSummary({ mode: "payload" });
+    expect(payload).toContain("# Research Execution Plan");
+    expect(payload).toContain("## Implementation payload");
+    expect(payload).toContain('"query"');
+    expect(payload).toContain("This payload is a suggestion only; no Exa retrieval call was executed.");
+  });
+
+  it("resets all planner state", () => {
+    recordResearchStep({
+      topic: "reset me",
+      stage: "framing",
+      note: "Temporary state.",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_step_needed: false,
+    });
+
+    resetResearchPlanner();
+
+    const status = getResearchStatus();
+    expect(status.stepCount).toBe(0);
+    expect(status.topic).toBeUndefined();
+  });
+});

--- a/packages/pi-exa/extensions/config.ts
+++ b/packages/pi-exa/extensions/config.ts
@@ -255,7 +255,11 @@ export function isToolEnabledForConfig(pi: ExtensionAPI, config: ExaConfig | nul
     toolName === "web_search_exa" ||
     toolName === "web_fetch_exa" ||
     toolName === "web_answer_exa" ||
-    toolName === "web_find_similar_exa"
+    toolName === "web_find_similar_exa" ||
+    toolName === "exa_research_step" ||
+    toolName === "exa_research_status" ||
+    toolName === "exa_research_summary" ||
+    toolName === "exa_research_reset"
   ) {
     return true;
   }

--- a/packages/pi-exa/extensions/index.ts
+++ b/packages/pi-exa/extensions/index.ts
@@ -8,7 +8,12 @@ import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { Static, TSchema } from "typebox";
 import { getResolvedConfig, isToolEnabledForConfig, resolveAuth } from "./config.js";
 import type { ToolPerformResult } from "./formatters.js";
+import { getResearchStatus, getResearchSummary, recordResearchStep, resetResearchPlanner } from "./research-planner.js";
 import {
+  exaResearchResetParams,
+  exaResearchStatusParams,
+  exaResearchStepParams,
+  exaResearchSummaryParams,
   webAnswerParams,
   webFetchParams,
   webFindSimilarParams,
@@ -52,6 +57,16 @@ type ExaToolSpec<TParams extends TSchema> = {
   perform: (apiKey: string, params: Static<TParams>) => Promise<ToolPerformResult>;
 };
 
+type LocalToolSpec<TParams extends TSchema> = {
+  name: string;
+  label: string;
+  description: string;
+  promptSnippet: string;
+  promptGuidelines: string[];
+  parameters: TParams;
+  perform: (params: Static<TParams>) => unknown;
+};
+
 function toolDetails(toolName: string): { tool: string } {
   return { tool: toolName };
 }
@@ -75,6 +90,40 @@ function cancelledResult(toolName: string) {
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function toText(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value, null, 2);
+}
+
+function registerLocalTool<TParams extends TSchema>(pi: ExtensionAPI, spec: LocalToolSpec<TParams>): void {
+  pi.registerTool(
+    defineTool({
+      name: spec.name,
+      label: spec.label,
+      description: spec.description,
+      promptSnippet: spec.promptSnippet,
+      promptGuidelines: spec.promptGuidelines,
+      parameters: spec.parameters,
+      async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+        if (signal?.aborted) {
+          return cancelledResult(spec.name);
+        }
+
+        try {
+          const result = spec.perform(params);
+          return { content: [{ type: "text" as const, text: toText(result) }], details: toolDetails(spec.name) };
+        } catch (error) {
+          const message = toErrorMessage(error);
+          return {
+            content: [{ type: "text" as const, text: `${spec.label} error: ${message}` }],
+            isError: true,
+            details: { ...toolDetails(spec.name), error: message },
+          };
+        }
+      },
+    }),
+  );
 }
 
 function registerExaTool<TParams extends TSchema>(pi: ExtensionAPI, spec: ExaToolSpec<TParams>): void {
@@ -117,6 +166,64 @@ function registerExaTool<TParams extends TSchema>(pi: ExtensionAPI, spec: ExaToo
   );
 }
 
+function registerResearchPlannerTools(pi: ExtensionAPI, isToolEnabled: (toolName: string) => boolean): void {
+  const plannerGuidelines = [
+    "Use exa_research_step to externalize non-trivial Exa research planning before expensive retrieval.",
+    "Planning tools recommend Exa retrieval calls but never execute network or cost-incurring operations internally.",
+    "Use exa_research_summary for human-readable plans before requesting payload mode.",
+  ];
+
+  if (isToolEnabled("exa_research_step")) {
+    registerLocalTool(pi, {
+      name: "exa_research_step",
+      label: "Exa Research Step",
+      description: "Record one step in a stateful, local Exa research planning session without calling Exa APIs.",
+      promptSnippet: "Record iterative research-planning state before retrieval.",
+      promptGuidelines: plannerGuidelines,
+      parameters: exaResearchStepParams,
+      perform: recordResearchStep,
+    });
+  }
+
+  if (isToolEnabled("exa_research_status")) {
+    registerLocalTool(pi, {
+      name: "exa_research_status",
+      label: "Exa Research Status",
+      description:
+        "Report current local Exa research planning state, criteria coverage, sources, gaps, and next action.",
+      promptSnippet: "Inspect current research-planning state.",
+      promptGuidelines: plannerGuidelines,
+      parameters: exaResearchStatusParams,
+      perform: () => getResearchStatus(),
+    });
+  }
+
+  if (isToolEnabled("exa_research_summary")) {
+    registerLocalTool(pi, {
+      name: "exa_research_summary",
+      label: "Exa Research Summary",
+      description:
+        "Generate a human-readable Exa research plan, Source Pack, or optional suggested web_research_exa payload.",
+      promptSnippet: "Summarize the accumulated Exa research plan.",
+      promptGuidelines: plannerGuidelines,
+      parameters: exaResearchSummaryParams,
+      perform: getResearchSummary,
+    });
+  }
+
+  if (isToolEnabled("exa_research_reset")) {
+    registerLocalTool(pi, {
+      name: "exa_research_reset",
+      label: "Exa Research Reset",
+      description: "Clear the current in-memory Exa research planning session.",
+      promptSnippet: "Reset local Exa research-planning state.",
+      promptGuidelines: plannerGuidelines,
+      parameters: exaResearchResetParams,
+      perform: () => resetResearchPlanner(),
+    });
+  }
+}
+
 function registerFlags(pi: ExtensionAPI): void {
   pi.registerFlag("--exa-api-key", {
     description: "Exa AI API key for search operations",
@@ -149,6 +256,7 @@ export default function exaExtension(pi: ExtensionAPI) {
 
   const resolvedConfig = getResolvedConfig(pi);
   const isToolEnabled = (toolName: string): boolean => isToolEnabledForConfig(pi, resolvedConfig, toolName);
+  registerResearchPlannerTools(pi, isToolEnabled);
 
   if (isToolEnabled("web_search_exa")) {
     registerExaTool(pi, {

--- a/packages/pi-exa/extensions/research-planner-types.ts
+++ b/packages/pi-exa/extensions/research-planner-types.ts
@@ -1,0 +1,216 @@
+/**
+ * Types for stateful Exa research planning tools.
+ */
+
+export const RESEARCH_STAGES = [
+  "framing",
+  "criteria_discovery",
+  "cheap_discovery",
+  "source_retrieval",
+  "coverage_analysis",
+  "deep_research_plan",
+  "synthesis_plan",
+  "conclusion",
+] as const;
+
+export type ResearchStage = (typeof RESEARCH_STAGES)[number];
+
+export const RESEARCH_NEXT_ACTIONS = [
+  "ask_user",
+  "web_search_exa",
+  "web_search_advanced_exa",
+  "web_fetch_exa",
+  "web_find_similar_exa",
+  "web_answer_exa",
+  "web_research_exa",
+  "draft_plan",
+  "finalize",
+] as const;
+
+export type ResearchNextAction = (typeof RESEARCH_NEXT_ACTIONS)[number];
+
+export const CRITERION_CATEGORIES = [
+  "method",
+  "metric",
+  "source_class",
+  "population",
+  "market",
+  "risk",
+  "contrarian",
+  "timeframe",
+  "geography",
+  "use_case",
+  "other",
+] as const;
+
+export type CriterionCategory = (typeof CRITERION_CATEGORIES)[number];
+
+export const PRIORITIES = ["high", "medium", "low"] as const;
+export type ResearchPriority = (typeof PRIORITIES)[number];
+
+export const CRITERION_STATUSES = ["proposed", "searched", "supported", "conflicting", "missing", "excluded"] as const;
+
+export type CriterionStatus = (typeof CRITERION_STATUSES)[number];
+
+export const SOURCE_TYPES = [
+  "paper",
+  "white_paper",
+  "pdf",
+  "official_doc",
+  "filing",
+  "news",
+  "blog",
+  "github",
+  "forum",
+  "analyst_report",
+  "other",
+] as const;
+
+export type ResearchSourceType = (typeof SOURCE_TYPES)[number];
+
+export const RETRIEVAL_STATUSES = ["discovered_only", "fetched", "fetch_failed", "unavailable"] as const;
+export type RetrievalStatus = (typeof RETRIEVAL_STATUSES)[number];
+
+export const GAP_SEVERITIES = ["blocking", "important", "minor"] as const;
+export type GapSeverity = (typeof GAP_SEVERITIES)[number];
+
+export const GAP_RESOLUTIONS = ["ask_user", "search_more", "fetch_source", "carry_assumption", "exclude"] as const;
+export type GapResolution = (typeof GAP_RESOLUTIONS)[number];
+
+export const SUMMARY_MODES = ["brief", "execution_plan", "source_pack", "payload"] as const;
+export type ResearchSummaryMode = (typeof SUMMARY_MODES)[number];
+
+export interface ResearchCriterionInput {
+  id?: string;
+  label: string;
+  category?: CriterionCategory;
+  description?: string;
+  priority?: ResearchPriority;
+  status?: CriterionStatus;
+  evidenceRefs?: string[];
+}
+
+export interface ResearchCriterion
+  extends Required<Omit<ResearchCriterionInput, "id" | "description" | "evidenceRefs">> {
+  id: string;
+  description?: string;
+  evidenceRefs: string[];
+  evidenceIssues: string[];
+}
+
+export interface ResearchSourceInput {
+  id?: string;
+  title: string;
+  url?: string;
+  sourceType?: ResearchSourceType;
+  retrievalStatus?: RetrievalStatus;
+  retrievalEvidence?: string;
+  usedFor?: string[];
+  contentNotes?: string;
+  qualityNotes?: string;
+}
+
+export interface ResearchSource
+  extends Required<
+    Omit<ResearchSourceInput, "id" | "url" | "retrievalEvidence" | "usedFor" | "contentNotes" | "qualityNotes">
+  > {
+  id: string;
+  url?: string;
+  retrievalEvidence?: string;
+  usedFor: string[];
+  contentNotes?: string;
+  qualityNotes?: string;
+  inspectionIssues: string[];
+}
+
+export interface ResearchGapInput {
+  id?: string;
+  description: string;
+  severity?: GapSeverity;
+  resolution?: GapResolution;
+}
+
+export interface ResearchGap extends Required<Omit<ResearchGapInput, "id">> {
+  id: string;
+}
+
+export interface ResearchStepInput {
+  topic: string;
+  stage: ResearchStage;
+  note: string;
+  criteria?: ResearchCriterionInput[];
+  sources?: ResearchSourceInput[];
+  gaps?: ResearchGapInput[];
+  assumptions?: string[];
+  nextAction?: ResearchNextAction;
+  nextActionReason?: string;
+  thought_number: number;
+  total_thoughts: number;
+  next_step_needed: boolean;
+  is_revision?: boolean;
+  revises_step?: number;
+  branch_from_step?: number;
+  branch_id?: string;
+}
+
+export interface ResearchStep extends ResearchStepInput {
+  sequence: number;
+  warnings: string[];
+}
+
+export interface RecommendedNextAction {
+  action: ResearchNextAction;
+  reason?: string;
+}
+
+export interface CriteriaCoverage {
+  total: number;
+  supported: number;
+  missing: number;
+  conflicting: number;
+  proposed: number;
+  searched: number;
+  excluded: number;
+  unresolvedEvidence: number;
+}
+
+export interface SourcePackSummary {
+  total: number;
+  fetched: number;
+  discoveredOnly: number;
+  fetchFailed: number;
+  unavailable: number;
+  notDirectlyInspected: number;
+}
+
+export interface ResearchRevision {
+  step: number;
+  revisesStep: number;
+}
+
+export interface ResearchStatus {
+  topic?: string;
+  stepCount: number;
+  activeStage?: ResearchStage;
+  progress: { current: number; total: number; percent: number; complete: boolean };
+  branches: string[];
+  revisions: ResearchRevision[];
+  criteriaCoverage: CriteriaCoverage;
+  sourcePackSummary: SourcePackSummary;
+  criteria: ResearchCriterion[];
+  sources: ResearchSource[];
+  openGaps: ResearchGap[];
+  assumptions: string[];
+  recommendedNextAction?: RecommendedNextAction;
+  clarificationWarranted: boolean;
+  warnings: string[];
+}
+
+export interface ResearchStepResult extends ResearchStatus {
+  step: ResearchStep;
+  planFragment: string;
+}
+
+export interface ResearchSummaryParams {
+  mode?: ResearchSummaryMode;
+}

--- a/packages/pi-exa/extensions/research-planner.ts
+++ b/packages/pi-exa/extensions/research-planner.ts
@@ -1,0 +1,547 @@
+/**
+ * In-memory stateful Exa research planner.
+ *
+ * These helpers intentionally never call Exa network APIs. They only track and
+ * summarize planning state so the model can decide which explicit retrieval
+ * tool to call next.
+ */
+
+import type {
+  CriteriaCoverage,
+  RecommendedNextAction,
+  ResearchCriterion,
+  ResearchCriterionInput,
+  ResearchGap,
+  ResearchGapInput,
+  ResearchSource,
+  ResearchSourceInput,
+  ResearchStatus,
+  ResearchStep,
+  ResearchStepInput,
+  ResearchStepResult,
+  ResearchSummaryParams,
+  SourcePackSummary,
+} from "./research-planner-types.js";
+
+interface PlannerState {
+  topic?: string;
+  steps: ResearchStep[];
+  criteria: ResearchCriterion[];
+  sources: ResearchSource[];
+  gaps: ResearchGap[];
+  assumptions: string[];
+  branches: Map<string, number>;
+  warnings: string[];
+  nextCriterionId: number;
+  nextSourceId: number;
+  nextGapId: number;
+}
+
+const state: PlannerState = createEmptyState();
+
+function createEmptyState(): PlannerState {
+  return {
+    steps: [],
+    criteria: [],
+    sources: [],
+    gaps: [],
+    assumptions: [],
+    branches: new Map(),
+    warnings: [],
+    nextCriterionId: 1,
+    nextSourceId: 1,
+    nextGapId: 1,
+  };
+}
+
+function replaceState(next: PlannerState): void {
+  state.topic = next.topic;
+  state.steps = next.steps;
+  state.criteria = next.criteria;
+  state.sources = next.sources;
+  state.gaps = next.gaps;
+  state.assumptions = next.assumptions;
+  state.branches = next.branches;
+  state.warnings = next.warnings;
+  state.nextCriterionId = next.nextCriterionId;
+  state.nextSourceId = next.nextSourceId;
+  state.nextGapId = next.nextGapId;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
+}
+
+function nextId(prefix: "C" | "S" | "G"): string {
+  if (prefix === "C") {
+    return `${prefix}${state.nextCriterionId++}`;
+  }
+  if (prefix === "S") {
+    return `${prefix}${state.nextSourceId++}`;
+  }
+  return `${prefix}${state.nextGapId++}`;
+}
+
+function reserveExplicitId(prefix: "C" | "S" | "G", id?: string): void {
+  if (!id?.startsWith(prefix)) {
+    return;
+  }
+  const numericSuffix = Number(id.slice(1));
+  if (!Number.isInteger(numericSuffix) || numericSuffix < 1) {
+    return;
+  }
+  if (prefix === "C") {
+    state.nextCriterionId = Math.max(state.nextCriterionId, numericSuffix + 1);
+  } else if (prefix === "S") {
+    state.nextSourceId = Math.max(state.nextSourceId, numericSuffix + 1);
+  } else {
+    state.nextGapId = Math.max(state.nextGapId, numericSuffix + 1);
+  }
+}
+
+function findCriterion(input: ResearchCriterionInput): ResearchCriterion | undefined {
+  return state.criteria.find((criterion) => criterion.id === input.id || criterion.label === input.label);
+}
+
+function normalizeCriterion(input: ResearchCriterionInput, existing?: ResearchCriterion): ResearchCriterion {
+  reserveExplicitId("C", input.id);
+  return {
+    id: input.id ?? existing?.id ?? nextId("C"),
+    label: input.label,
+    category: input.category ?? existing?.category ?? "other",
+    description: input.description ?? existing?.description,
+    priority: input.priority ?? existing?.priority ?? "medium",
+    status: input.status ?? existing?.status ?? "proposed",
+    evidenceRefs: uniqueStrings([...(existing?.evidenceRefs ?? []), ...(input.evidenceRefs ?? [])]),
+    evidenceIssues: [],
+  };
+}
+
+function findSource(input: ResearchSourceInput): ResearchSource | undefined {
+  return state.sources.find(
+    (source) => source.id === input.id || (input.url && source.url === input.url) || source.title === input.title,
+  );
+}
+
+function normalizeSource(input: ResearchSourceInput, existing?: ResearchSource): ResearchSource {
+  reserveExplicitId("S", input.id);
+  return {
+    id: input.id ?? existing?.id ?? nextId("S"),
+    title: input.title,
+    url: input.url ?? existing?.url,
+    sourceType: input.sourceType ?? existing?.sourceType ?? "other",
+    retrievalStatus: input.retrievalStatus ?? existing?.retrievalStatus ?? "discovered_only",
+    retrievalEvidence: input.retrievalEvidence ?? existing?.retrievalEvidence,
+    usedFor: uniqueStrings([...(existing?.usedFor ?? []), ...(input.usedFor ?? [])]),
+    contentNotes: input.contentNotes ?? existing?.contentNotes,
+    qualityNotes: input.qualityNotes ?? existing?.qualityNotes,
+    inspectionIssues: [],
+  };
+}
+
+function findGap(input: ResearchGapInput): ResearchGap | undefined {
+  return state.gaps.find((gap) => gap.id === input.id || gap.description === input.description);
+}
+
+function normalizeGap(input: ResearchGapInput, existing?: ResearchGap): ResearchGap {
+  reserveExplicitId("G", input.id);
+  return {
+    id: input.id ?? existing?.id ?? nextId("G"),
+    description: input.description,
+    severity: input.severity ?? existing?.severity ?? "important",
+    resolution: input.resolution ?? existing?.resolution ?? "search_more",
+  };
+}
+
+function isExplicitToolEvidence(ref: string): boolean {
+  return /^tool[:#-]/i.test(ref) || /^web_[a-z_]+_exa[:#\s]/i.test(ref);
+}
+
+function validateEvidence(): void {
+  const sourceIds = new Set(state.sources.map((source) => source.id));
+  for (const criterion of state.criteria) {
+    criterion.evidenceIssues = criterion.evidenceRefs
+      .filter((ref) => !sourceIds.has(ref) && !isExplicitToolEvidence(ref))
+      .map((ref) => `Unresolved evidence ref: ${ref}`);
+
+    if (criterion.status === "supported" && criterion.evidenceRefs.length === 0) {
+      criterion.evidenceIssues.push("Supported criterion has no evidence refs.");
+    }
+  }
+}
+
+function validateSources(): void {
+  for (const source of state.sources) {
+    source.inspectionIssues = [];
+    if (source.retrievalStatus === "discovered_only" && source.contentNotes) {
+      source.inspectionIssues.push(
+        "Content notes are metadata/snippet-derived; source content was not directly inspected.",
+      );
+    }
+    if (source.retrievalStatus === "fetched" && !source.retrievalEvidence) {
+      source.inspectionIssues.push("Fetched source is missing retrieval evidence.");
+    }
+  }
+}
+
+function mergeCriteria(inputs: ResearchCriterionInput[] = []): void {
+  for (const input of inputs) {
+    const existing = findCriterion(input);
+    const normalized = normalizeCriterion(input, existing);
+    if (existing) {
+      Object.assign(existing, normalized);
+    } else {
+      state.criteria.push(normalized);
+    }
+  }
+}
+
+function mergeSources(inputs: ResearchSourceInput[] = []): void {
+  for (const input of inputs) {
+    const existing = findSource(input);
+    const normalized = normalizeSource(input, existing);
+    if (existing) {
+      Object.assign(existing, normalized);
+    } else {
+      state.sources.push(normalized);
+    }
+  }
+}
+
+function mergeGaps(inputs: ResearchGapInput[] = []): void {
+  for (const input of inputs) {
+    const existing = findGap(input);
+    const normalized = normalizeGap(input, existing);
+    if (existing) {
+      Object.assign(existing, normalized);
+    } else {
+      state.gaps.push(normalized);
+    }
+  }
+}
+
+function validateStepReferences(input: ResearchStepInput): string[] {
+  const warnings: string[] = [];
+  const knownSteps = new Set(state.steps.map((step) => step.thought_number));
+  const lastStep = state.steps.at(-1);
+
+  if (knownSteps.has(input.thought_number)) {
+    warnings.push(`Duplicate thought_number ${input.thought_number}; step was not recorded.`);
+  }
+  if (lastStep && input.thought_number < lastStep.thought_number) {
+    warnings.push(
+      `Out-of-order thought_number ${input.thought_number}; last recorded thought_number is ${lastStep.thought_number}. Step was not recorded.`,
+    );
+  }
+
+  if (input.is_revision && input.revises_step !== undefined && !knownSteps.has(input.revises_step)) {
+    warnings.push(`Revision references unknown step ${input.revises_step}.`);
+  }
+  if (input.branch_from_step !== undefined && !knownSteps.has(input.branch_from_step)) {
+    warnings.push(`Branch references unknown step ${input.branch_from_step}.`);
+  }
+  return warnings;
+}
+
+function coverageSummary(): CriteriaCoverage {
+  return {
+    total: state.criteria.length,
+    supported: state.criteria.filter(
+      (criterion) => criterion.status === "supported" && criterion.evidenceIssues.length === 0,
+    ).length,
+    missing: state.criteria.filter((criterion) => criterion.status === "missing").length,
+    conflicting: state.criteria.filter((criterion) => criterion.status === "conflicting").length,
+    proposed: state.criteria.filter((criterion) => criterion.status === "proposed").length,
+    searched: state.criteria.filter((criterion) => criterion.status === "searched").length,
+    excluded: state.criteria.filter((criterion) => criterion.status === "excluded").length,
+    unresolvedEvidence: state.criteria.filter((criterion) => criterion.evidenceIssues.length > 0).length,
+  };
+}
+
+function sourceSummary(): SourcePackSummary {
+  return {
+    total: state.sources.length,
+    fetched: state.sources.filter((source) => source.retrievalStatus === "fetched" && source.retrievalEvidence).length,
+    discoveredOnly: state.sources.filter((source) => source.retrievalStatus === "discovered_only").length,
+    fetchFailed: state.sources.filter((source) => source.retrievalStatus === "fetch_failed").length,
+    unavailable: state.sources.filter((source) => source.retrievalStatus === "unavailable").length,
+    notDirectlyInspected: state.sources.filter(
+      (source) => source.retrievalStatus !== "fetched" || !source.retrievalEvidence,
+    ).length,
+  };
+}
+
+function lastRecommendedAction(): RecommendedNextAction | undefined {
+  for (const step of [...state.steps].reverse()) {
+    if (step.nextAction) {
+      return { action: step.nextAction, reason: step.nextActionReason };
+    }
+  }
+  return undefined;
+}
+
+function currentProgress() {
+  const last = state.steps.at(-1);
+  const current = last?.thought_number ?? 0;
+  const total = Math.max(last?.total_thoughts ?? 0, current);
+  return {
+    current,
+    total,
+    percent: total > 0 ? Math.min(100, Math.round((current / total) * 100)) : 0,
+    complete: last ? !last.next_step_needed : false,
+  };
+}
+
+function snapshotStep(step: ResearchStep): ResearchStep {
+  return {
+    ...step,
+    criteria: step.criteria?.map((criterion) => ({
+      ...criterion,
+      evidenceRefs: criterion.evidenceRefs ? [...criterion.evidenceRefs] : undefined,
+    })),
+    sources: step.sources?.map((source) => ({
+      ...source,
+      usedFor: source.usedFor ? [...source.usedFor] : undefined,
+    })),
+    gaps: step.gaps?.map((gap) => ({ ...gap })),
+    assumptions: step.assumptions ? [...step.assumptions] : undefined,
+    warnings: [...step.warnings],
+  };
+}
+
+function planFragment(status: ResearchStatus): string {
+  const next = status.recommendedNextAction
+    ? `${status.recommendedNextAction.action}${status.recommendedNextAction.reason ? ` — ${status.recommendedNextAction.reason}` : ""}`
+    : "record the next planning step";
+  return [
+    `Topic: ${status.topic ?? "(none)"}`,
+    `Stage: ${status.activeStage ?? "not started"}`,
+    `Progress: ${status.progress.percent}% (${status.progress.current}/${status.progress.total})`,
+    `Criteria: ${status.criteriaCoverage.supported}/${status.criteriaCoverage.total} supported`,
+    `Sources: ${status.sourcePackSummary.fetched}/${status.sourcePackSummary.total} fetched`,
+    `Next action: ${next}`,
+  ].join("\n");
+}
+
+export function recordResearchStep(input: ResearchStepInput): ResearchStepResult {
+  const warnings = validateStepReferences(input);
+  const isTopicMismatch = Boolean(state.topic && state.topic !== input.topic);
+  const isInvalidReference = warnings.some(
+    (warning) => warning.startsWith("Revision references unknown") || warning.startsWith("Branch references unknown"),
+  );
+  const isInvalidSequence = warnings.some((warning) => warning.includes("step was not recorded"));
+
+  if (isTopicMismatch) {
+    warnings.push(
+      `Topic mismatch: active topic is "${state.topic}"; received "${input.topic}". Call exa_research_reset before starting a new topic. Step was not recorded.`,
+    );
+  }
+
+  const step: ResearchStep = { ...input, sequence: state.steps.length + 1, warnings };
+  if (isTopicMismatch || isInvalidSequence || isInvalidReference) {
+    const status = getResearchStatus();
+    const resultStatus = { ...status, warnings: uniqueStrings([...status.warnings, ...warnings]) };
+    return { ...resultStatus, step: snapshotStep(step), planFragment: planFragment(resultStatus) };
+  }
+
+  if (!state.topic) {
+    state.topic = input.topic;
+  }
+
+  mergeSources(input.sources);
+  mergeCriteria(input.criteria);
+  mergeGaps(input.gaps);
+  state.assumptions = uniqueStrings([...state.assumptions, ...(input.assumptions ?? [])]);
+
+  if (input.branch_id && input.branch_from_step !== undefined) {
+    state.branches.set(input.branch_id, input.branch_from_step);
+  }
+
+  state.steps.push(snapshotStep(step));
+  state.warnings = uniqueStrings([...state.warnings, ...warnings]);
+
+  validateEvidence();
+  validateSources();
+
+  const status = getResearchStatus();
+  return { ...status, step: snapshotStep(step), planFragment: planFragment(status) };
+}
+
+function snapshotCriteria(): ResearchCriterion[] {
+  return state.criteria.map((criterion) => ({
+    ...criterion,
+    evidenceRefs: [...criterion.evidenceRefs],
+    evidenceIssues: [...criterion.evidenceIssues],
+  }));
+}
+
+function snapshotSources(): ResearchSource[] {
+  return state.sources.map((source) => ({
+    ...source,
+    usedFor: [...source.usedFor],
+    inspectionIssues: [...source.inspectionIssues],
+  }));
+}
+
+export function getResearchStatus(): ResearchStatus {
+  validateEvidence();
+  validateSources();
+  const openGaps = state.gaps.filter((gap) => gap.resolution !== "exclude");
+  return {
+    topic: state.topic,
+    stepCount: state.steps.length,
+    activeStage: state.steps.at(-1)?.stage,
+    progress: currentProgress(),
+    branches: [...state.branches.keys()],
+    revisions: state.steps
+      .filter((step) => step.is_revision && step.revises_step !== undefined)
+      .map((step) => ({ step: step.thought_number, revisesStep: step.revises_step as number })),
+    criteriaCoverage: coverageSummary(),
+    sourcePackSummary: sourceSummary(),
+    criteria: snapshotCriteria(),
+    sources: snapshotSources(),
+    openGaps: openGaps.map((gap) => ({ ...gap })),
+    assumptions: [...state.assumptions],
+    recommendedNextAction: lastRecommendedAction(),
+    clarificationWarranted: openGaps.some((gap) => gap.severity === "blocking" && gap.resolution === "ask_user"),
+    warnings: [...state.warnings],
+  };
+}
+
+function formatCriteria(status: ResearchStatus): string {
+  if (status.criteria.length === 0) {
+    return "- No criteria recorded yet.";
+  }
+  return status.criteria
+    .map((criterion) => {
+      const evidence = criterion.evidenceRefs.length > 0 ? criterion.evidenceRefs.join(", ") : "none";
+      const issues = criterion.evidenceIssues.length > 0 ? ` Issues: ${criterion.evidenceIssues.join("; ")}` : "";
+      return `- ${criterion.id} ${criterion.label} (${criterion.priority}, ${criterion.status}, ${criterion.category}) — evidence: ${evidence}.${issues}`;
+    })
+    .join("\n");
+}
+
+function formatSources(status: ResearchStatus): string {
+  if (status.sources.length === 0) {
+    return "- No sources recorded yet.";
+  }
+  return status.sources
+    .map((source) => {
+      const inspected =
+        source.retrievalStatus === "fetched" && source.retrievalEvidence
+          ? "directly inspected"
+          : "not directly inspected";
+      const issues = source.inspectionIssues.length > 0 ? ` Issues: ${source.inspectionIssues.join("; ")}` : "";
+      const url = source.url ? ` — ${source.url}` : "";
+      const notes = source.contentNotes ? ` Notes: ${source.contentNotes}` : "";
+      return `- ${source.id} ${source.title} (${source.sourceType}, ${source.retrievalStatus}, ${inspected})${url}.${notes}${issues}`;
+    })
+    .join("\n");
+}
+
+function formatGaps(status: ResearchStatus): string {
+  if (status.openGaps.length === 0) {
+    return "- No open gaps recorded.";
+  }
+  return status.openGaps
+    .map((gap) => `- ${gap.id} ${gap.description} (${gap.severity}, resolution: ${gap.resolution})`)
+    .join("\n");
+}
+
+function executionPlan(status: ResearchStatus): string {
+  const next = status.recommendedNextAction
+    ? `${status.recommendedNextAction.action}${status.recommendedNextAction.reason ? ` — ${status.recommendedNextAction.reason}` : ""}`
+    : "Record another planning step or finalize the research plan.";
+
+  return [
+    "# Research Execution Plan",
+    "",
+    `## Objective\n${status.topic ?? "No active research topic."}`,
+    "",
+    `## Progress\n${status.progress.percent}% complete (${status.progress.current}/${status.progress.total} steps). Active stage: ${status.activeStage ?? "not started"}.`,
+    "",
+    "## Criteria Coverage",
+    formatCriteria(status),
+    "",
+    "## Source Strategy",
+    formatSources(status),
+    "",
+    "## Open Gaps",
+    formatGaps(status),
+    "",
+    "## Assumptions",
+    status.assumptions.length > 0
+      ? status.assumptions.map((assumption) => `- ${assumption}`).join("\n")
+      : "- None recorded.",
+    "",
+    "## Recommended Next Action",
+    next,
+  ].join("\n");
+}
+
+function brief(status: ResearchStatus): string {
+  return [
+    "# Research Planning Brief",
+    "",
+    `- Objective: ${status.topic ?? "No active research topic."}`,
+    `- Stage: ${status.activeStage ?? "not started"}`,
+    `- Criteria: ${status.criteriaCoverage.supported}/${status.criteriaCoverage.total} supported; ${status.criteriaCoverage.unresolvedEvidence} with evidence issues`,
+    `- Sources: ${status.sourcePackSummary.fetched}/${status.sourcePackSummary.total} fetched; ${status.sourcePackSummary.notDirectlyInspected} not directly inspected`,
+    `- Open gaps: ${status.openGaps.length}`,
+    `- Next action: ${status.recommendedNextAction?.action ?? "record next step"}`,
+  ].join("\n");
+}
+
+function sourcePack(status: ResearchStatus): string {
+  return ["# Source Pack", "", `Topic: ${status.topic ?? "No active research topic."}`, "", formatSources(status)].join(
+    "\n",
+  );
+}
+
+function payload(status: ResearchStatus): string {
+  const systemPrompt = [
+    "Use the recorded criteria, assumptions, source strategy, and gaps from the human-reviewed research plan.",
+    "Prefer directly inspected fetched sources over discovered-only metadata when claims conflict.",
+  ].join(" ");
+  const queryParts = [
+    status.topic ?? "",
+    ...status.criteria.map((criterion) => criterion.label),
+    ...status.openGaps.filter((gap) => gap.resolution !== "ask_user").map((gap) => gap.description),
+  ].filter((part) => part.length > 0);
+  const suggestedPayload = {
+    query: queryParts.join("; ") || "Research the recorded topic.",
+    systemPrompt,
+    additionalQueries: status.criteria.slice(0, 5).map((criterion) => criterion.label),
+    numResults: Math.min(20, Math.max(5, status.criteria.length + status.sources.length)),
+  };
+
+  return [
+    executionPlan(status),
+    "",
+    "## Implementation payload",
+    "This payload is a suggestion only; no Exa retrieval call was executed.",
+    "",
+    "```json",
+    JSON.stringify(suggestedPayload, null, 2),
+    "```",
+  ].join("\n");
+}
+
+export function getResearchSummary(params: ResearchSummaryParams = {}): string {
+  const status = getResearchStatus();
+  switch (params.mode ?? "brief") {
+    case "execution_plan":
+      return executionPlan(status);
+    case "source_pack":
+      return sourcePack(status);
+    case "payload":
+      return payload(status);
+    default:
+      return brief(status);
+  }
+}
+
+export function resetResearchPlanner(): ResearchStatus {
+  replaceState(createEmptyState());
+  return getResearchStatus();
+}

--- a/packages/pi-exa/extensions/research-planner.ts
+++ b/packages/pi-exa/extensions/research-planner.ts
@@ -118,9 +118,7 @@ function normalizeCriterion(input: ResearchCriterionInput, existing?: ResearchCr
 }
 
 function findSource(input: ResearchSourceInput): ResearchSource | undefined {
-  return state.sources.find(
-    (source) => source.id === input.id || (input.url && source.url === input.url) || source.title === input.title,
-  );
+  return state.sources.find((source) => source.id === input.id || (input.url && source.url === input.url));
 }
 
 function normalizeSource(input: ResearchSourceInput, existing?: ResearchSource): ResearchSource {
@@ -154,7 +152,7 @@ function normalizeGap(input: ResearchGapInput, existing?: ResearchGap): Research
 }
 
 function isExplicitToolEvidence(ref: string): boolean {
-  return /^tool[:#-]/i.test(ref) || /^web_[a-z_]+_exa[:#\s]/i.test(ref);
+  return /^tool:(web_[a-z_]+_exa|exa_research_[a-z_]+)[:#\s]+\S+/i.test(ref) || /^web_[a-z_]+_exa[:#\s]+\S+/i.test(ref);
 }
 
 function validateEvidence(): void {
@@ -234,6 +232,21 @@ function validateStepReferences(input: ResearchStepInput): string[] {
     );
   }
 
+  if (input.is_revision && input.revises_step === undefined) {
+    warnings.push("Revision steps require revises_step.");
+  }
+  if (!input.is_revision && input.revises_step !== undefined) {
+    warnings.push("revises_step requires is_revision true.");
+  }
+  if (input.is_revision && (input.branch_from_step !== undefined || input.branch_id !== undefined)) {
+    warnings.push("Revision steps cannot also define branch metadata.");
+  }
+  if (input.branch_from_step !== undefined && input.branch_id === undefined) {
+    warnings.push("branch_from_step requires branch_id.");
+  }
+  if (input.branch_id !== undefined && input.branch_from_step === undefined) {
+    warnings.push("branch_id requires branch_from_step.");
+  }
   if (input.is_revision && input.revises_step !== undefined && !knownSteps.has(input.revises_step)) {
     warnings.push(`Revision references unknown step ${input.revises_step}.`);
   }
@@ -327,9 +340,16 @@ export function recordResearchStep(input: ResearchStepInput): ResearchStepResult
   const warnings = validateStepReferences(input);
   const isTopicMismatch = Boolean(state.topic && state.topic !== input.topic);
   const isInvalidReference = warnings.some(
-    (warning) => warning.startsWith("Revision references unknown") || warning.startsWith("Branch references unknown"),
+    (warning) =>
+      warning.startsWith("Revision references unknown") ||
+      warning.startsWith("Branch references unknown") ||
+      warning === "Revision steps require revises_step." ||
+      warning === "revises_step requires is_revision true." ||
+      warning === "Revision steps cannot also define branch metadata." ||
+      warning === "branch_from_step requires branch_id." ||
+      warning === "branch_id requires branch_from_step.",
   );
-  const isInvalidSequence = warnings.some((warning) => warning.includes("step was not recorded"));
+  const isInvalidSequence = warnings.some((warning) => warning.toLowerCase().includes("step was not recorded"));
 
   if (isTopicMismatch) {
     warnings.push(
@@ -384,8 +404,6 @@ function snapshotSources(): ResearchSource[] {
 }
 
 export function getResearchStatus(): ResearchStatus {
-  validateEvidence();
-  validateSources();
   const openGaps = state.gaps.filter((gap) => gap.resolution !== "exclude");
   return {
     topic: state.topic,
@@ -393,9 +411,11 @@ export function getResearchStatus(): ResearchStatus {
     activeStage: state.steps.at(-1)?.stage,
     progress: currentProgress(),
     branches: [...state.branches.keys()],
-    revisions: state.steps
-      .filter((step) => step.is_revision && step.revises_step !== undefined)
-      .map((step) => ({ step: step.thought_number, revisesStep: step.revises_step as number })),
+    revisions: state.steps.flatMap((step) =>
+      step.is_revision && step.revises_step !== undefined
+        ? [{ step: step.thought_number, revisesStep: step.revises_step }]
+        : [],
+    ),
     criteriaCoverage: coverageSummary(),
     sourcePackSummary: sourceSummary(),
     criteria: snapshotCriteria(),

--- a/packages/pi-exa/extensions/research-planner.ts
+++ b/packages/pi-exa/extensions/research-planner.ts
@@ -106,7 +106,7 @@ function findCriterion(input: ResearchCriterionInput): ResearchCriterion | undef
 function normalizeCriterion(input: ResearchCriterionInput, existing?: ResearchCriterion): ResearchCriterion {
   reserveExplicitId("C", input.id);
   return {
-    id: input.id ?? existing?.id ?? nextId("C"),
+    id: existing?.id ?? input.id ?? nextId("C"),
     label: input.label,
     category: input.category ?? existing?.category ?? "other",
     description: input.description ?? existing?.description,
@@ -124,7 +124,7 @@ function findSource(input: ResearchSourceInput): ResearchSource | undefined {
 function normalizeSource(input: ResearchSourceInput, existing?: ResearchSource): ResearchSource {
   reserveExplicitId("S", input.id);
   return {
-    id: input.id ?? existing?.id ?? nextId("S"),
+    id: existing?.id ?? input.id ?? nextId("S"),
     title: input.title,
     url: input.url ?? existing?.url,
     sourceType: input.sourceType ?? existing?.sourceType ?? "other",
@@ -144,7 +144,7 @@ function findGap(input: ResearchGapInput): ResearchGap | undefined {
 function normalizeGap(input: ResearchGapInput, existing?: ResearchGap): ResearchGap {
   reserveExplicitId("G", input.id);
   return {
-    id: input.id ?? existing?.id ?? nextId("G"),
+    id: existing?.id ?? input.id ?? nextId("G"),
     description: input.description,
     severity: input.severity ?? existing?.severity ?? "important",
     resolution: input.resolution ?? existing?.resolution ?? "search_more",
@@ -182,9 +182,16 @@ function validateSources(): void {
   }
 }
 
-function mergeCriteria(inputs: ResearchCriterionInput[] = []): void {
+function mergeCriteria(inputs: ResearchCriterionInput[] = []): string[] {
+  const warnings: string[] = [];
   for (const input of inputs) {
     const existing = findCriterion(input);
+    if (existing && input.id !== undefined && existing.id === input.id && existing.label !== input.label) {
+      warnings.push(
+        `Criterion ${existing.id} already exists as "${existing.label}"; conflicting label "${input.label}" was ignored.`,
+      );
+      continue;
+    }
     const normalized = normalizeCriterion(input, existing);
     if (existing) {
       Object.assign(existing, normalized);
@@ -192,11 +199,26 @@ function mergeCriteria(inputs: ResearchCriterionInput[] = []): void {
       state.criteria.push(normalized);
     }
   }
+  return warnings;
 }
 
-function mergeSources(inputs: ResearchSourceInput[] = []): void {
+function mergeSources(inputs: ResearchSourceInput[] = []): string[] {
+  const warnings: string[] = [];
   for (const input of inputs) {
     const existing = findSource(input);
+    if (
+      existing &&
+      input.id !== undefined &&
+      existing.id === input.id &&
+      existing.url &&
+      input.url &&
+      existing.url !== input.url
+    ) {
+      warnings.push(
+        `Source ${existing.id} already exists for ${existing.url}; conflicting URL ${input.url} was ignored.`,
+      );
+      continue;
+    }
     const normalized = normalizeSource(input, existing);
     if (existing) {
       Object.assign(existing, normalized);
@@ -204,11 +226,19 @@ function mergeSources(inputs: ResearchSourceInput[] = []): void {
       state.sources.push(normalized);
     }
   }
+  return warnings;
 }
 
-function mergeGaps(inputs: ResearchGapInput[] = []): void {
+function mergeGaps(inputs: ResearchGapInput[] = []): string[] {
+  const warnings: string[] = [];
   for (const input of inputs) {
     const existing = findGap(input);
+    if (existing && input.id !== undefined && existing.id === input.id && existing.description !== input.description) {
+      warnings.push(
+        `Gap ${existing.id} already exists as "${existing.description}"; conflicting description "${input.description}" was ignored.`,
+      );
+      continue;
+    }
     const normalized = normalizeGap(input, existing);
     if (existing) {
       Object.assign(existing, normalized);
@@ -216,6 +246,7 @@ function mergeGaps(inputs: ResearchGapInput[] = []): void {
       state.gaps.push(normalized);
     }
   }
+  return warnings;
 }
 
 function validateStepReferences(input: ResearchStepInput): string[] {
@@ -368,9 +399,9 @@ export function recordResearchStep(input: ResearchStepInput): ResearchStepResult
     state.topic = input.topic;
   }
 
-  mergeSources(input.sources);
-  mergeCriteria(input.criteria);
-  mergeGaps(input.gaps);
+  warnings.push(...mergeSources(input.sources));
+  warnings.push(...mergeCriteria(input.criteria));
+  warnings.push(...mergeGaps(input.gaps));
   state.assumptions = uniqueStrings([...state.assumptions, ...(input.assumptions ?? [])]);
 
   if (input.branch_id && input.branch_from_step !== undefined) {

--- a/packages/pi-exa/extensions/schemas.ts
+++ b/packages/pi-exa/extensions/schemas.ts
@@ -22,6 +22,125 @@ const advancedSearchType = Type.Union([
   Type.Literal("instant"),
 ]);
 
+const researchStage = Type.Union([
+  Type.Literal("framing"),
+  Type.Literal("criteria_discovery"),
+  Type.Literal("cheap_discovery"),
+  Type.Literal("source_retrieval"),
+  Type.Literal("coverage_analysis"),
+  Type.Literal("deep_research_plan"),
+  Type.Literal("synthesis_plan"),
+  Type.Literal("conclusion"),
+]);
+
+const researchNextAction = Type.Union([
+  Type.Literal("ask_user"),
+  Type.Literal("web_search_exa"),
+  Type.Literal("web_search_advanced_exa"),
+  Type.Literal("web_fetch_exa"),
+  Type.Literal("web_find_similar_exa"),
+  Type.Literal("web_answer_exa"),
+  Type.Literal("web_research_exa"),
+  Type.Literal("draft_plan"),
+  Type.Literal("finalize"),
+]);
+
+const criterionCategory = Type.Union([
+  Type.Literal("method"),
+  Type.Literal("metric"),
+  Type.Literal("source_class"),
+  Type.Literal("population"),
+  Type.Literal("market"),
+  Type.Literal("risk"),
+  Type.Literal("contrarian"),
+  Type.Literal("timeframe"),
+  Type.Literal("geography"),
+  Type.Literal("use_case"),
+  Type.Literal("other"),
+]);
+
+const priority = Type.Union([Type.Literal("high"), Type.Literal("medium"), Type.Literal("low")]);
+
+const criterionStatus = Type.Union([
+  Type.Literal("proposed"),
+  Type.Literal("searched"),
+  Type.Literal("supported"),
+  Type.Literal("conflicting"),
+  Type.Literal("missing"),
+  Type.Literal("excluded"),
+]);
+
+const sourceType = Type.Union([
+  Type.Literal("paper"),
+  Type.Literal("white_paper"),
+  Type.Literal("pdf"),
+  Type.Literal("official_doc"),
+  Type.Literal("filing"),
+  Type.Literal("news"),
+  Type.Literal("blog"),
+  Type.Literal("github"),
+  Type.Literal("forum"),
+  Type.Literal("analyst_report"),
+  Type.Literal("other"),
+]);
+
+const retrievalStatus = Type.Union([
+  Type.Literal("discovered_only"),
+  Type.Literal("fetched"),
+  Type.Literal("fetch_failed"),
+  Type.Literal("unavailable"),
+]);
+
+const gapSeverity = Type.Union([Type.Literal("blocking"), Type.Literal("important"), Type.Literal("minor")]);
+
+const gapResolution = Type.Union([
+  Type.Literal("ask_user"),
+  Type.Literal("search_more"),
+  Type.Literal("fetch_source"),
+  Type.Literal("carry_assumption"),
+  Type.Literal("exclude"),
+]);
+
+const researchCriterion = Type.Object(
+  {
+    id: Type.Optional(Type.String({ description: "Stable criterion ID, e.g. C1" })),
+    label: Type.String({ description: "Short criterion label" }),
+    category: Type.Optional(criterionCategory),
+    description: Type.Optional(Type.String({ description: "What this criterion covers" })),
+    priority: Type.Optional(priority),
+    status: Type.Optional(criterionStatus),
+    evidenceRefs: Type.Optional(Type.Array(Type.String({ description: "Source IDs or explicit tool-call notes" }))),
+  },
+  { additionalProperties: true },
+);
+
+const researchSource = Type.Object(
+  {
+    id: Type.Optional(Type.String({ description: "Stable source ID, e.g. S1" })),
+    title: Type.String({ description: "Source title" }),
+    url: Type.Optional(Type.String({ description: "Source URL when known" })),
+    sourceType: Type.Optional(sourceType),
+    retrievalStatus: Type.Optional(retrievalStatus),
+    retrievalEvidence: Type.Optional(
+      Type.String({ description: "Fetched URL, tool-call/result ref, or direct inspection note" }),
+    ),
+    usedFor: Type.Optional(Type.Array(Type.String({ description: "Criterion IDs this source supports" }))),
+    contentNotes: Type.Optional(Type.String({ description: "Content notes or snippet-derived notes" })),
+    qualityNotes: Type.Optional(Type.String({ description: "Bias, recency, sample size, or quality notes" })),
+  },
+  { additionalProperties: true },
+);
+
+const researchGap = Type.Object(
+  {
+    id: Type.Optional(Type.String({ description: "Stable gap ID, e.g. G1" })),
+    description: Type.String({ description: "Ambiguity, missing evidence, conflict, or decision needed" }),
+    severity: Type.Optional(gapSeverity),
+    resolution: Type.Optional(gapResolution),
+  },
+  { additionalProperties: true },
+);
+
 export const webSearchParams = Type.Object(
   {
     query: Type.String({
@@ -125,3 +244,45 @@ export const webFindSimilarParams = Type.Object(
   },
   { additionalProperties: true },
 );
+
+export const exaResearchStepParams = Type.Object(
+  {
+    topic: Type.String({ description: "User-facing research topic or question" }),
+    stage: researchStage,
+    note: Type.String({ description: "What was learned, decided, or proposed in this step" }),
+    criteria: Type.Optional(Type.Array(researchCriterion)),
+    sources: Type.Optional(Type.Array(researchSource)),
+    gaps: Type.Optional(Type.Array(researchGap)),
+    assumptions: Type.Optional(Type.Array(Type.String({ description: "Assumptions carried unless corrected" }))),
+    nextAction: Type.Optional(researchNextAction),
+    nextActionReason: Type.Optional(Type.String({ description: "Why this is the cheapest useful next move" })),
+    thought_number: Type.Integer({ description: "Current step number", minimum: 1 }),
+    total_thoughts: Type.Integer({ description: "Estimated total planning steps", minimum: 1 }),
+    next_step_needed: Type.Boolean({ description: "Set false only when planning is complete" }),
+    is_revision: Type.Optional(Type.Boolean({ description: "Marks a correction to earlier planning" })),
+    revises_step: Type.Optional(Type.Integer({ description: "Step number being revised", minimum: 1 })),
+    branch_from_step: Type.Optional(
+      Type.Integer({ description: "Step number where an alternative strategy branches", minimum: 1 }),
+    ),
+    branch_id: Type.Optional(Type.String({ description: "Identifier for the branch" })),
+  },
+  { additionalProperties: true },
+);
+
+export const exaResearchStatusParams = Type.Object({}, { additionalProperties: true });
+
+export const exaResearchSummaryParams = Type.Object(
+  {
+    mode: Type.Optional(
+      Type.Union([
+        Type.Literal("brief"),
+        Type.Literal("execution_plan"),
+        Type.Literal("source_pack"),
+        Type.Literal("payload"),
+      ]),
+    ),
+  },
+  { additionalProperties: true },
+);
+
+export const exaResearchResetParams = Type.Object({}, { additionalProperties: true });

--- a/packages/pi-exa/extensions/schemas.ts
+++ b/packages/pi-exa/extensions/schemas.ts
@@ -3,6 +3,18 @@
  */
 
 import { Type } from "typebox";
+import {
+  CRITERION_CATEGORIES,
+  CRITERION_STATUSES,
+  GAP_RESOLUTIONS,
+  GAP_SEVERITIES,
+  PRIORITIES,
+  RESEARCH_NEXT_ACTIONS,
+  RESEARCH_STAGES,
+  RETRIEVAL_STATUSES,
+  SOURCE_TYPES,
+  SUMMARY_MODES,
+} from "./research-planner-types.js";
 
 const outputSchemaType = Type.Union([Type.Literal("object"), Type.Literal("text")]);
 
@@ -23,82 +35,78 @@ const advancedSearchType = Type.Union([
 ]);
 
 const researchStage = Type.Union([
-  Type.Literal("framing"),
-  Type.Literal("criteria_discovery"),
-  Type.Literal("cheap_discovery"),
-  Type.Literal("source_retrieval"),
-  Type.Literal("coverage_analysis"),
-  Type.Literal("deep_research_plan"),
-  Type.Literal("synthesis_plan"),
-  Type.Literal("conclusion"),
+  Type.Literal(RESEARCH_STAGES[0]),
+  Type.Literal(RESEARCH_STAGES[1]),
+  Type.Literal(RESEARCH_STAGES[2]),
+  Type.Literal(RESEARCH_STAGES[3]),
+  Type.Literal(RESEARCH_STAGES[4]),
+  Type.Literal(RESEARCH_STAGES[5]),
+  Type.Literal(RESEARCH_STAGES[6]),
+  Type.Literal(RESEARCH_STAGES[7]),
 ]);
-
 const researchNextAction = Type.Union([
-  Type.Literal("ask_user"),
-  Type.Literal("web_search_exa"),
-  Type.Literal("web_search_advanced_exa"),
-  Type.Literal("web_fetch_exa"),
-  Type.Literal("web_find_similar_exa"),
-  Type.Literal("web_answer_exa"),
-  Type.Literal("web_research_exa"),
-  Type.Literal("draft_plan"),
-  Type.Literal("finalize"),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[0]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[1]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[2]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[3]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[4]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[5]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[6]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[7]),
+  Type.Literal(RESEARCH_NEXT_ACTIONS[8]),
 ]);
-
 const criterionCategory = Type.Union([
-  Type.Literal("method"),
-  Type.Literal("metric"),
-  Type.Literal("source_class"),
-  Type.Literal("population"),
-  Type.Literal("market"),
-  Type.Literal("risk"),
-  Type.Literal("contrarian"),
-  Type.Literal("timeframe"),
-  Type.Literal("geography"),
-  Type.Literal("use_case"),
-  Type.Literal("other"),
+  Type.Literal(CRITERION_CATEGORIES[0]),
+  Type.Literal(CRITERION_CATEGORIES[1]),
+  Type.Literal(CRITERION_CATEGORIES[2]),
+  Type.Literal(CRITERION_CATEGORIES[3]),
+  Type.Literal(CRITERION_CATEGORIES[4]),
+  Type.Literal(CRITERION_CATEGORIES[5]),
+  Type.Literal(CRITERION_CATEGORIES[6]),
+  Type.Literal(CRITERION_CATEGORIES[7]),
+  Type.Literal(CRITERION_CATEGORIES[8]),
+  Type.Literal(CRITERION_CATEGORIES[9]),
+  Type.Literal(CRITERION_CATEGORIES[10]),
 ]);
-
-const priority = Type.Union([Type.Literal("high"), Type.Literal("medium"), Type.Literal("low")]);
-
+const priority = Type.Union([Type.Literal(PRIORITIES[0]), Type.Literal(PRIORITIES[1]), Type.Literal(PRIORITIES[2])]);
 const criterionStatus = Type.Union([
-  Type.Literal("proposed"),
-  Type.Literal("searched"),
-  Type.Literal("supported"),
-  Type.Literal("conflicting"),
-  Type.Literal("missing"),
-  Type.Literal("excluded"),
+  Type.Literal(CRITERION_STATUSES[0]),
+  Type.Literal(CRITERION_STATUSES[1]),
+  Type.Literal(CRITERION_STATUSES[2]),
+  Type.Literal(CRITERION_STATUSES[3]),
+  Type.Literal(CRITERION_STATUSES[4]),
+  Type.Literal(CRITERION_STATUSES[5]),
 ]);
-
 const sourceType = Type.Union([
-  Type.Literal("paper"),
-  Type.Literal("white_paper"),
-  Type.Literal("pdf"),
-  Type.Literal("official_doc"),
-  Type.Literal("filing"),
-  Type.Literal("news"),
-  Type.Literal("blog"),
-  Type.Literal("github"),
-  Type.Literal("forum"),
-  Type.Literal("analyst_report"),
-  Type.Literal("other"),
+  Type.Literal(SOURCE_TYPES[0]),
+  Type.Literal(SOURCE_TYPES[1]),
+  Type.Literal(SOURCE_TYPES[2]),
+  Type.Literal(SOURCE_TYPES[3]),
+  Type.Literal(SOURCE_TYPES[4]),
+  Type.Literal(SOURCE_TYPES[5]),
+  Type.Literal(SOURCE_TYPES[6]),
+  Type.Literal(SOURCE_TYPES[7]),
+  Type.Literal(SOURCE_TYPES[8]),
+  Type.Literal(SOURCE_TYPES[9]),
+  Type.Literal(SOURCE_TYPES[10]),
 ]);
-
 const retrievalStatus = Type.Union([
-  Type.Literal("discovered_only"),
-  Type.Literal("fetched"),
-  Type.Literal("fetch_failed"),
-  Type.Literal("unavailable"),
+  Type.Literal(RETRIEVAL_STATUSES[0]),
+  Type.Literal(RETRIEVAL_STATUSES[1]),
+  Type.Literal(RETRIEVAL_STATUSES[2]),
+  Type.Literal(RETRIEVAL_STATUSES[3]),
 ]);
-
-const gapSeverity = Type.Union([Type.Literal("blocking"), Type.Literal("important"), Type.Literal("minor")]);
-
+const gapSeverity = Type.Union([
+  Type.Literal(GAP_SEVERITIES[0]),
+  Type.Literal(GAP_SEVERITIES[1]),
+  Type.Literal(GAP_SEVERITIES[2]),
+]);
 const gapResolution = Type.Union([
-  Type.Literal("ask_user"),
-  Type.Literal("search_more"),
-  Type.Literal("fetch_source"),
-  Type.Literal("carry_assumption"),
-  Type.Literal("exclude"),
+  Type.Literal(GAP_RESOLUTIONS[0]),
+  Type.Literal(GAP_RESOLUTIONS[1]),
+  Type.Literal(GAP_RESOLUTIONS[2]),
+  Type.Literal(GAP_RESOLUTIONS[3]),
+  Type.Literal(GAP_RESOLUTIONS[4]),
 ]);
 
 const researchCriterion = Type.Object(
@@ -275,10 +283,10 @@ export const exaResearchSummaryParams = Type.Object(
   {
     mode: Type.Optional(
       Type.Union([
-        Type.Literal("brief"),
-        Type.Literal("execution_plan"),
-        Type.Literal("source_pack"),
-        Type.Literal("payload"),
+        Type.Literal(SUMMARY_MODES[0]),
+        Type.Literal(SUMMARY_MODES[1]),
+        Type.Literal(SUMMARY_MODES[2]),
+        Type.Literal(SUMMARY_MODES[3]),
       ]),
     ),
   },

--- a/packages/pi-exa/skills/exa-research-planner/SKILL.md
+++ b/packages/pi-exa/skills/exa-research-planner/SKILL.md
@@ -10,7 +10,7 @@ Use this skill to turn a vague or broad research request into a high-quality Exa
 
 This skill has two jobs:
 
-1. **Research planning** — sharpen the question, decide whether cheap discovery is useful, and draft a strong deep-research payload.
+1. **Research planning** — sharpen the question, decide whether cheap discovery is useful, track criteria/source/gap state with the local `exa_research_*` planning tools, and draft a strong deep-research payload.
 2. **Explicit deep-research execution** — when the user directly asks for deep research or approves a draft, run `web_research_exa` and return a source-grounded synthesis.
 
 ## Operating Modes
@@ -29,7 +29,14 @@ Do not force an explicit deep-research request through a long planning loop. If 
 
 Build the workflow only from tools actually available in the current session.
 
-Common default tools:
+Local planning tools, enabled by default and safe to use without an Exa API key:
+
+- `exa_research_step` — record one planning step with criteria, sources, gaps, assumptions, and next action.
+- `exa_research_status` — inspect current planning state without mutating it.
+- `exa_research_summary` — produce a human-readable brief, execution plan, source pack, or labeled optional payload.
+- `exa_research_reset` — clear the active in-memory planning session.
+
+Common default retrieval tools:
 
 - `web_search_exa`
 - `web_fetch_exa`
@@ -47,7 +54,7 @@ Warn clearly when an important tool is unavailable:
 - If `web_search_advanced_exa` is unavailable, say advanced filters are unavailable and fall back to `web_search_exa` with better query wording.
 - If a common default tool is missing, mention it briefly and adapt without dwelling on it.
 
-Never suggest unavailable tools as if they can be used.
+Never suggest unavailable tools as if they can be used. The `exa_research_*` planning tools do not execute network calls; they recommend explicit retrieval calls that the model must invoke separately.
 
 ## Fast Path: Explicit Deep Research
 
@@ -68,7 +75,7 @@ A direct user request to run deep research counts as approval. Do not ask “sho
 
 ## Cost-Aware Planning Workflow
 
-Use this staged flow when the user has not clearly asked to run deep research yet, or when the topic would benefit from reconnaissance.
+Use this staged flow when the user has not clearly asked to run deep research yet, or when the topic would benefit from reconnaissance. For non-trivial planning, call `exa_research_step` before retrieval to record the objective, assumptions, initial criteria, and cheapest useful next action. Skip the full planner only for simple lookups or explicit deep-research requests where the brief is already usable.
 
 ### Phase 1: Clarify the Goal
 
@@ -116,7 +123,7 @@ Use available tools selectively:
 | Expand from one strong seed URL | `web_find_similar_exa` | Use only with a clearly representative source. |
 | Resolve a narrow sub-question cheaply | `web_answer_exa` | Use when it may avoid deeper research. |
 
-Each discovery round must have a purpose. After each round, summarize what changed:
+Each discovery round must have a purpose. After each round, call `exa_research_step` to record what changed:
 
 - better terminology,
 - stronger candidate sources,
@@ -126,7 +133,7 @@ Each discovery round must have a purpose. After each round, summarize what chang
 
 ## Iterative Discovery and Clarification Loop
 
-Run multiple cheap discovery rounds when each round changes the plan. The planner should behave like an active research lead: discover criteria, search for evidence, revise the coverage map, and only then draft or execute deep synthesis.
+Run multiple cheap discovery rounds when each round changes the plan. The planner should behave like an active research lead: discover criteria, search for evidence, revise the coverage map in `exa_research_step`, inspect it with `exa_research_status`, and only then draft or execute deep synthesis.
 
 Use this loop for broad, ambiguous, or high-stakes research:
 
@@ -189,7 +196,7 @@ In the final report, explicitly identify which findings came from directly fetch
 
 ### Phase 4: Draft the Deep Research Plan
 
-Show the user the research plan in human-consumable form first. Do not lead with raw JSON.
+Show the user the research plan in human-consumable form first. Use `exa_research_summary` for stateful plans. Do not lead with raw JSON.
 
 #### Human-Readable Drafts First
 

--- a/packages/pi-exa/skills/exa-research-planner/SKILL.md
+++ b/packages/pi-exa/skills/exa-research-planner/SKILL.md
@@ -29,7 +29,7 @@ Do not force an explicit deep-research request through a long planning loop. If 
 
 Build the workflow only from tools actually available in the current session.
 
-Local planning tools, enabled by default and safe to use without an Exa API key:
+Local planning tools, enabled by default when no explicit `enabledTools` allowlist is configured and safe to use without an Exa API key:
 
 - `exa_research_step` — record one planning step with criteria, sources, gaps, assumptions, and next action.
 - `exa_research_status` — inspect current planning state without mutating it.


### PR DESCRIPTION
## Summary

Implements PRD-008 for `packages/pi-exa` with local, stateful research-planning tools:

- adds `exa_research_step`, `exa_research_status`, `exa_research_summary`, and `exa_research_reset`
- tracks planning steps, criteria coverage, source retrieval status, gaps, assumptions, branch/revision metadata, and recommended next actions
- keeps planning tools local-only/no-auth while preserving explicit Exa retrieval calls for cost transparency
- updates schemas, README, and the `exa-research-planner` skill now that the tools exist
- marks the implementation plan as implemented

## Testing

- `npx vitest run packages/pi-exa/__tests__`
- `npx tsc --noEmit --project packages/pi-exa/tsconfig.json`
- `npx biome ci packages/pi-exa`
- `specdocs_validate`
- Multi-agent code review with follow-up targeted checks; residual actionable work: none

## Post-Deploy Monitoring & Validation

No additional production monitoring required because this is a local pi extension tool change with no server-side deployment or background runtime.

Validation after install/release:

- Run `pi -e packages/pi-exa` and verify the four `exa_research_*` tools are registered by default.
- Call `exa_research_step` and `exa_research_status` without `EXA_API_KEY`; expected healthy signal: tools work and no Exa client is constructed.
- Call `exa_research_summary({ mode: "payload" })`; expected healthy signal: output labels the suggested payload and does not execute retrieval.
- Failure signals: planner tools missing from tool list, missing-API-key errors from planner tools, or summaries leading with raw JSON.

Rollback/mitigation trigger: revert this PR if planner tool registration breaks default Exa tool loading or causes API-key gating regressions.