### PR TITLE
fix(pi-statusline): skip statusline in non-UI sessions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -24,9 +24,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/arben-adm/mcp-sequential-thinking@f3727d858769495befaf56e6b4f2e84509dc6456",
-        "--with",
-        "portalocker",
+        "sequential-thinking@0.7.0",
         "mcp-sequential-thinking"
       ]
     },
@@ -41,13 +39,12 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/oraios/serena@66cbe31045107ddcd3851886f8b5854f625e4638",
+        "git+https://github.com/oraios/serena@v1.3.0",
         "serena",
         "start-mcp-server",
         "--context",
-        "ide-assistant",
-        "--project",
-        "${PROJECT_ROOT}"
+        "claude-code",
+        "--project-from-cwd"
       ]
     }
   }

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,5 +1,4 @@
 {
-  "lastChangelogVersion": "0.70.0",
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.5",
   "pi-code-reasoning": {

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,24 +3,26 @@ project_name: "pidev"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  ansible             bash                clojure             cpp
-#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
-#   elixir              elm                 erlang              fortran             fsharp
-#   go                  groovy              haskell             haxe                hlsl
-#   java                json                julia               kotlin              lean4
-#   lua                 luau                markdown            matlab              msl
-#   nix                 ocaml               pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         python_ty
-#   r                   rego                ruby                ruby_solargraph     rust
-#   scala               solidity            swift               systemverilog       terraform
-#   toml                typescript          typescript_vts      vue                 yaml
-#   zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -125,3 +127,14 @@ ls_specific_settings: {}
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/packages/pi-exa/docs/exa-api-findings.md
+++ b/packages/pi-exa/docs/exa-api-findings.md
@@ -1,0 +1,275 @@
+# Exa API Findings — 2026-05-15
+
+Empirical findings from cross-comparing Exa's `/search` and `/research` endpoints on a single fact-retrieval task (Notion database property types). Cost, latency, accuracy, and failure-mode data — useful when deciding which Exa surface to call from `pi-exa` and how to configure it.
+
+The test prompt across all runs was a comprehensive catalog request: "list every property type Notion's database API supports — for each, the API type identifier, writable status, JSON wire shape, and gotchas." A known-correct answer existed (Notion's own docs at `developers.notion.com`), making this a clean spec-correctness benchmark.
+
+---
+
+## TL;DR
+
+**`/research/v0` and `/research/v1` are being retired.** Replace them with `/search type=deep-reasoning` plus `additionalQueries` for fan-out discovery.
+
+**For spec lookup against a known authoritative source, `/search type=deep` + `includeDomains` is ~80× cheaper and faster than `/research/v1`, and the only configuration that didn't hallucinate** on the known-hallucination test case (Notion's `place` property).
+
+**Single highest-impact lever**: `includeDomains`. Setting it to an authoritative domain is the difference between accurate output and confident hallucination — observed identically across `/research/v0`, `/research/v1`, and `/search deep-reasoning` runs that lacked the filter.
+
+---
+
+## Endpoints tested
+
+### 1. `POST /research/v0/tasks` (retiring)
+
+- Async; POST returns task ID, GET polls until status=completed.
+- Returns structured JSON with auto-generated schema inferred from the prose instructions.
+- Embedded per-entry `sourceURLs[]` citations.
+- Has an `operations` field with internal-step trace.
+- **Field name gotcha**: schema field is `outputSchema` (camelCase), not `output_schema`.
+
+### 2. `POST /research/v1` (retiring)
+
+- Async; same poll-until-done pattern.
+- Returns prose markdown in `output.content` (no auto-schema).
+- Separate top-level `citations` array.
+- Adds `GET /research/v1` listing endpoint that returns all prior research tasks for an API key — useful side-channel for debugging, but **shared API keys leak prior prompt history** to anyone who can call this endpoint.
+- ID field is `researchId` (not `id`).
+- URL structure drops the `/tasks` segment.
+
+### 3. `POST /search` (current; replaces both research endpoints)
+
+- Sync; single request/response.
+- `type` parameter selects search depth: `instant`, `fast`, `auto`, `deep-lite`, `deep`, `deep-reasoning`.
+- Caller controls `outputSchema` directly (no auto-inference).
+- Returns `output.content` (string or structured) plus `output.grounding` with per-field citations.
+- Supports the steering levers: `includeDomains`, `excludeDomains`, `systemPrompt`, `additionalQueries`, `numResults`.
+
+---
+
+## Measurements (Notion property types task)
+
+Same prompt, same desired output, five different configurations:
+
+| Run | Endpoint | type | Steering | Latency | Cost | Types covered | `place` correct? | Easy cases correct? |
+|---|---|---|---|---|---|---|---|---|
+| A | `/research/v0/tasks` | n/a | (single query) | ~45s | $0.043 | 23 | ❌ writable + fabricated Reddit URL | ✅ |
+| B | `/research/v1` | n/a | (single query) | ~370s | $0.979 | 19 | ❌ writable + fabricated `{lat, lon, name, address}` | ✅ |
+| C | `/search` | `deep` | `includeDomains: [developers.notion.com]` + permissive systemPrompt + outputSchema | ~15s | $0.012 | 24 | ✅ unsupported | ✅ |
+| D | `/search` | `deep-reasoning` | `includeDomains: [developers.notion.com]` + **strict** systemPrompt + outputSchema | ~13s | $0.015 | 24 | ✅ unsupported (best detail) | ❌ over-classified title/date/checkbox/etc. as unsupported |
+| E | `/search` | `deep-reasoning` | No `includeDomains` + 7 `additionalQueries` + permissive systemPrompt + outputSchema | ~71s | $0.034 | 24 | ❌ writable + same Reddit-derived `{lat, lon}` shape as B | ✅ |
+
+**Cost ratios** (relative to cheapest run, C): A is 3.6×, B is 81×, D is 1.25×, E is 2.8×.
+
+**The cheapest accurate run was 80× cheaper than the most expensive inaccurate run.**
+
+---
+
+## Failure modes observed
+
+### Mode 1: Confident-wrong on a hallucination-magnet topic
+
+Runs A, B, and E all produced the same wrong answer about Notion's `place` property — classified it as writable, fabricated a wire shape (`{lat, lon, name, address}` or similar), and cited a Reddit URL that doesn't back up the claim. The hallucination is consistent across runs because the same misinformation exists in the model's training data / community-source pool, and broad-fan-out retrieval pulls it in alongside (or instead of) the authoritative docs.
+
+**The actual truth** (per `https://developers.notion.com/reference/page-property-values#unsupported-properties`): place is in the schema enum but reads return `null` and writes are unsupported. The docs explicitly say "Exclude these unsupported types when you are updating page properties."
+
+**Mitigation**: `includeDomains` filtered to the authoritative source (run C) — only run that got it right. Run D also got it right because of the same filter, but had a different failure mode (below).
+
+### Mode 2: Over-cautious collapse under strict systemPrompt + low numResults
+
+Run D used `type: "deep-reasoning"` with a strict systemPrompt ("don't fabricate wire shapes — omit if not in docs") and `numResults: 8`. The model couldn't find every property type's exact wire shape in the 8 retrieved pages and conservatively classified `title`, `date`, `checkbox`, `people`, `files`, and `verification` as unsupported — even though they're clearly writable per the same docs the filter was pointing at.
+
+**Insight**: `deep-reasoning`'s extra reasoning per step amplifies whatever the systemPrompt + retrieved-page corpus push it toward. With a "don't fabricate" instruction and limited retrieval, it pushes toward "I don't know → unsupported". With permissive instructions and broad retrieval, it pushes the other way (hallucination).
+
+**Mitigation**: when using `deep-reasoning` with strict steering, **raise `numResults` to 20-30** so the model has enough context to find the answers rather than defaulting to "unknown".
+
+### Mode 3: Source-pollution
+
+Run E used `deep-reasoning` + `additionalQueries` with no `includeDomains` — the closest behavioral match to `/research/v1`. The domain spread of retrieved pages was: 12 from `developers.notion.com`, 17 from `github.com`, `apidog.io`, `notionthings.com`, `latenode.com`, `n8n.io`, `youtube.com`, `hexdocs.pm`. The community sources contained the false claim that place is writable; the model defaulted to that consensus even though Notion's own docs (also retrieved) disagreed.
+
+**This is not a `/research`-specific bug.** Both `/research/v0`, `/research/v1`, and `/search deep-reasoning` fan-out runs reproduced it. It's a property of broad-fan-out retrieval without domain filtering.
+
+---
+
+## Parameter reference (from the `/search` docs)
+
+### `type` values
+
+| `type` | Latency | Use for |
+|---|---|---|
+| `instant` | ~250 ms | Real-time apps (chat, voice, autocomplete) |
+| `fast` | ~450 ms | Optimized search with good relevance |
+| `auto` (default) | ~1s | Router picks per-query; balanced default |
+| `deep-lite` | ~4s | Lightweight synthesis; cheaper than full `deep` |
+| `deep` | 4-15s | Multi-step planning with structured outputs |
+| `deep-reasoning` | 12-40s (more with `additionalQueries`) | Maximum reasoning capability per step |
+
+### Key steering levers
+
+| Parameter | When to use | Effect |
+|---|---|---|
+| `includeDomains` | Authoritative source is known | Restricts retrieval to listed domains. **Highest-leverage parameter for spec correctness.** |
+| `excludeDomains` | Known noise source | Filters out specific domains. Max 1200 entries. |
+| `systemPrompt` | Specific guidance on synthesis or source preference | Instructions for the synthesis step. Interacts with `type` — see Mode 2 above. |
+| `additionalQueries` | Discovery work; unknown sources | Extra query variations explored as parallel branches in `deep`/`deep-reasoning`. Multiplies cost and latency roughly linearly. |
+| `outputSchema` | Need structured JSON output | Caller-controlled JSON Schema. Max nesting depth 2, max 10 total properties. |
+| `numResults` | Trade off retrieval breadth vs cost | 1-100. Defaults to 10. Raise to 20-30 when using strict systemPrompts. |
+| `contents.highlights: true` | Agent workflows | ~10× fewer tokens than full `text`. **Recommended default for agents.** |
+| `contents.text.maxCharacters` | When full text needed | Caps text per result. Often unnecessary if `outputSchema` is set. |
+
+### Deprecated parameters
+
+Do not use:
+
+| Wrong | Correct |
+|---|---|
+| `useAutoprompt: true` | Remove. Deprecated, no-op. |
+| `includeUrls` / `excludeUrls` | Use `includeDomains` / `excludeDomains`. |
+| `text: true` (top-level) | Nest under `contents`. |
+| `summary: true` (top-level) | Nest under `contents`. |
+| `numSentences` (in highlights) | Deprecated. Use `highlights: true` for the best default. |
+| `highlightsPerUrl` | Deprecated. |
+| `livecrawl: "always"` | Use `contents.maxAgeHours: 0`. |
+| `excludeDomains` with `category: "company"` or `"people"` | Returns 400. These categories don't support it. |
+
+### Python SDK note
+
+The Python SDK uses snake_case for all parameter names, including inside `contents`: `num_results`, `max_age_hours`, `output_schema`, `contents={"text": {"max_characters": 4000}}`. JavaScript SDK and raw curl use camelCase.
+
+---
+
+## Recipes
+
+### Recipe 1: Spec lookup against known authoritative docs
+
+Best when: you know which docs site holds the answer, you want accurate output, cost matters.
+
+```json
+{
+  "query": "<focused question>",
+  "type": "deep",
+  "numResults": 8,
+  "includeDomains": ["developers.notion.com"],
+  "systemPrompt": "Prefer the official docs. Don't fabricate examples; cite specific docs pages.",
+  "contents": { "highlights": true },
+  "outputSchema": { "type": "object", "properties": { ... } }
+}
+```
+
+Expected: 10-15 seconds, ~$0.01-$0.02, accurate.
+
+### Recipe 2: Discovery (unknown sources)
+
+Best when: you don't know where the authoritative answer lives, or there isn't one consensus answer.
+
+```json
+{
+  "query": "<primary question>",
+  "type": "deep-reasoning",
+  "numResults": 30,
+  "additionalQueries": [
+    "<related angle 1>",
+    "<related angle 2>",
+    "<related angle 3>"
+  ],
+  "systemPrompt": "Search broadly. Prefer authoritative primary sources but include alternative perspectives. Cite specific URLs.",
+  "contents": { "highlights": true },
+  "outputSchema": { ... }
+}
+```
+
+Expected: 30-90 seconds, ~$0.03-$0.10, broad coverage with source-pollution risk.
+
+**Note**: do NOT include `includeDomains` here — that defeats the discovery goal.
+
+### Recipe 3: Hybrid two-pass (spec correctness + discovery breadth)
+
+Best when: you need both the authoritative answer AND awareness of what alternative sources claim.
+
+1. **Pass 1 (discovery)**: Recipe 2 to find candidate authoritative sources. Inspect the `output.grounding` citations.
+2. **Pass 2 (spec)**: Recipe 1 with `includeDomains` set to the authoritative sources discovered in pass 1. Use this for the final answer.
+
+Costs roughly 2× a single recipe-2 call but gives you the audit trail of "what does the web say" alongside the correct answer.
+
+### Recipe 4: Real-time / interactive
+
+Best when: latency is the constraint (chat, voice, autocomplete).
+
+```json
+{
+  "query": "<query>",
+  "type": "instant",
+  "contents": { "highlights": true }
+}
+```
+
+Expected: ~250 ms. No synthesis; you read results yourself.
+
+### Recipe 5: Read sources yourself (no synthesis)
+
+Best when: you'd rather inspect the actual pages than trust LLM synthesis.
+
+```json
+{
+  "query": "<query>",
+  "type": "auto",
+  "numResults": 10,
+  "contents": { "highlights": true }
+}
+```
+
+Then call `web_fetch_exa` on URLs that look promising for full text.
+
+---
+
+## Pitfalls
+
+1. **Source pollution from broad fan-out**. Without `includeDomains`, `deep`/`deep-reasoning` will pull from community blogs, forums, and YouTube transcripts alongside official docs. Confident-wrong hallucinations from training data or community misinformation can override authoritative sources. *Mitigation*: use `includeDomains` whenever an authoritative source exists.
+
+2. **Strict systemPrompt + low numResults collapses `deep-reasoning` into "everything is unknown"**. The extra reasoning per step amplifies caution under strict prompts. *Mitigation*: pair strict steering with `numResults: 20-30`.
+
+3. **Hallucination is consistent across endpoints**. The same wrong claim about Notion's `place` property showed up in `/research/v0`, `/research/v1`, and broad-fan-out `/search deep-reasoning`. Don't trust citations blindly — `/research/v1` cited 50 URLs including Notion's own docs and still hallucinated the answer. *Mitigation*: cross-check critical claims against primary sources directly.
+
+4. **`outputSchema` field name is camelCase**. `output_schema` returns `Unrecognized key(s) in object: 'output_schema'`. Python SDK callers use snake_case but raw curl / JS SDK callers use camelCase.
+
+5. **`/research/v1`'s GET listing leaks prior prompts**. `GET /research/v1` returns every research task ever run with an API key. Shared API keys expose prompt history to all key holders.
+
+6. **`additionalQueries` cost scales roughly linearly**. 7 additional queries roughly 5× cost vs. 0 additional queries (measured: $0.034 with 7 queries vs $0.012-$0.015 with 0). Don't fan out unless you actually need the breadth.
+
+7. **`deep-reasoning` is NOT uniformly better than `deep`**. More reasoning capability per step amplifies whatever the prompt + retrieval push it toward — can be better (more thorough on specific questions) or worse (more confident-wrong, more over-cautious collapse). Use `deep` as the default; reach for `deep-reasoning` when you specifically need maximum depth on a narrow question.
+
+---
+
+## Implications for `pi-exa`
+
+The package is structurally well-aligned with these findings. The deep types are routed through `web_research_exa` (separate from `web_search_advanced_exa`), all the steering levers are exposed, and the default `type` is `deep-reasoning`. The improvements worth making are mostly documentation and default tuning:
+
+1. **promptGuidelines on `web_research_exa`** should explicitly call out the `includeDomains` pattern for spec lookup against known authoritative sources. This is the single highest-leverage parameter and the current guidelines don't mention it.
+
+2. **Update `highlights` config**: `web-research.ts` and `web-search.ts` both use `numSentences: 3` or `4`, which the Exa docs flag as deprecated. Switch to `highlights: true` for the best-quality default.
+
+3. **Reconsider `textMaxCharacters: 12000` default** in `web-research.ts`. Per the Exa docs, agent workflows should prefer highlights over full text. With `outputSchema` set, the synthesized output is the load-bearing artifact and the raw text per result is mostly noise. Lower to 3000 or omit text entirely when `outputSchema` is provided.
+
+4. **Add a README section / parameter description** explaining the source-pollution gotcha and the `includeDomains` mitigation. Same warning that's in this doc — somewhere a downstream caller will encounter it.
+
+5. **Document the `additionalQueries` cost-scaling** in the schema description. Callers should understand that each query roughly multiplies cost.
+
+6. **Consider `stream: true` support** for long deep-reasoning calls. Quality-of-life improvement; lets pi show progress instead of a frozen pendingMessage during 30-70 second waits.
+
+7. **Verify `research-planner.ts`'s `additionalQueries.slice(0, 5)` cap is intentional**. 5-7 is a reasonable range; the Exa docs don't document an upper bound.
+
+---
+
+## References
+
+- Exa search API reference: https://exa.ai/docs/reference/search-api-guide-for-coding-agents
+- Exa research API (v0): `POST https://api.exa.ai/research/v0/tasks`, `GET https://api.exa.ai/research/v0/tasks/{id}`
+- Exa research API (v1): `POST https://api.exa.ai/research/v1`, `GET https://api.exa.ai/research/v1[/{researchId}]`
+- Authoritative Notion docs for the test case:
+  - https://developers.notion.com/reference/property-object (data source property types enum)
+  - https://developers.notion.com/reference/page-property-values (writable property shapes; unsupported subsection)
+
+## Test environment
+
+- Date: 2026-05-15
+- API key: `EXA_API_KEY` env var (single key used across all runs; no per-tier provisioning)
+- All curl invocations used `x-api-key` header (not Bearer)
+- `pi-exa` package version at time of measurement: 3.5.0 (per `package.json`)

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -2,9 +2,9 @@
 
 A fixed two-line status display for pi.
 
-By default it renders in the footer in interactive/RPC mode and logs to stdout in non-UI modes (`-p`, JSON mode).
+By default it renders in the footer in interactive/RPC mode and stays inert in non-UI modes (`-p`, JSON mode).
 It is not injected into model context and is not sent as messages.
-It also exposes a `/statusline` tool for explicit retrieval.
+In UI-capable sessions, it also exposes a `/statusline` tool for explicit retrieval.
 
 ## Display
 

--- a/packages/pi-statusline/__tests__/index.runtime.test.ts
+++ b/packages/pi-statusline/__tests__/index.runtime.test.ts
@@ -95,7 +95,7 @@ describe("pi-statusline extension runtime", () => {
     vi.restoreAllMocks();
   });
 
-  it("emits status lines on non-UI session start and updates footer in UI mode", async () => {
+  it("skips non-UI session starts and updates footer in UI mode", async () => {
     const mockPi = createMockPi();
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     statuslineExtension(mockPi as unknown as ExtensionAPI);
@@ -117,7 +117,9 @@ describe("pi-statusline extension runtime", () => {
       },
     );
 
-    expect(logSpy).toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(setFooter).not.toHaveBeenCalled();
+    expect(mockPi.registerTool).not.toHaveBeenCalled();
 
     await sessionStartHandler?.(
       {},
@@ -132,6 +134,7 @@ describe("pi-statusline extension runtime", () => {
     );
 
     expect(setFooter).toHaveBeenCalledTimes(1);
+    expect(mockPi.registerTool).toHaveBeenCalledTimes(1);
   });
 
   it("throttles footer rerenders during rapid streaming updates", async () => {
@@ -237,14 +240,172 @@ describe("pi-statusline extension runtime", () => {
     }).not.toThrow();
   });
 
+  it("ignores stale async session-start git refreshes", async () => {
+    vi.useRealTimers();
+    const mockPi = createMockPi();
+    let releaseSlowGit: (() => void) | undefined;
+    let slowGitReleased = false;
+
+    mockPi.exec.mockImplementation(async (_cmd: string, args: string[], options?: { cwd?: string }) => {
+      const cwd = options?.cwd ?? "/tmp/fast";
+      const joined = args.join(" ");
+      if (cwd === "/tmp/slow" && joined.includes("rev-parse --is-inside-work-tree") && !slowGitReleased) {
+        await new Promise<void>((resolve) => {
+          releaseSlowGit = () => {
+            slowGitReleased = true;
+            resolve();
+          };
+        });
+      }
+
+      if (joined.includes("rev-parse --is-inside-work-tree"))
+        return { code: 0, stdout: "true", stderr: "", killed: false };
+      if (joined.includes("rev-parse --show-toplevel")) {
+        return {
+          code: 0,
+          stdout: cwd === "/tmp/slow" ? "/tmp/slow-repo" : "/tmp/fast-repo",
+          stderr: "",
+          killed: false,
+        };
+      }
+      if (joined.includes("rev-parse --git-dir")) return { code: 0, stdout: ".git", stderr: "", killed: false };
+      if (joined.includes("branch --show-current")) {
+        return { code: 0, stdout: cwd === "/tmp/slow" ? "slow-branch" : "fast-branch", stderr: "", killed: false };
+      }
+      if (joined.includes("status --porcelain")) {
+        return { code: 0, stdout: cwd === "/tmp/slow" ? " M slow.ts\n" : "", stderr: "", killed: false };
+      }
+      if (joined.includes("worktree list --porcelain")) {
+        return {
+          code: 0,
+          stdout: `worktree ${cwd === "/tmp/slow" ? "/tmp/slow-repo" : "/tmp/fast-repo"}\nHEAD abc\nbranch refs/heads/main\n`,
+          stderr: "",
+          killed: false,
+        };
+      }
+      return { code: 1, stdout: "", stderr: "", killed: false };
+    });
+
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    const setFooter = vi.fn();
+    const slowStart = sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/slow",
+        hasUI: true,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 12 }),
+        ui: { setFooter },
+      },
+    );
+
+    for (let i = 0; i < 20 && !releaseSlowGit; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(releaseSlowGit).toBeDefined();
+
+    const fastStart = sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/fast",
+        hasUI: true,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 12 }),
+        ui: { setFooter },
+      },
+    );
+
+    await fastStart;
+    releaseSlowGit?.();
+    await slowStart;
+
+    const footerFactory = setFooter.mock.calls[0]?.[0];
+    const footer = footerFactory?.(
+      { requestRender: vi.fn() },
+      {},
+      {
+        getGitBranch: () => "fast-branch",
+        onBranchChange: () => vi.fn(),
+      },
+    );
+
+    const text = stripAnsi(footer?.render(120).join("\n") ?? "");
+    expect(text).toContain("fast-repo");
+    expect(text).not.toContain("slow-repo");
+  });
+
+  it("does not read session context after async agent-end refreshes", async () => {
+    const mockPi = createMockPi();
+    mockPi.exec.mockImplementation(async (_cmd: string, args: string[]) => {
+      await Promise.resolve();
+      const joined = args.join(" ");
+      if (joined.includes("rev-parse --is-inside-work-tree"))
+        return { code: 0, stdout: "true", stderr: "", killed: false };
+      if (joined.includes("rev-parse --show-toplevel"))
+        return { code: 0, stdout: "/tmp/project", stderr: "", killed: false };
+      if (joined.includes("rev-parse --git-dir")) return { code: 0, stdout: ".git", stderr: "", killed: false };
+      if (joined.includes("branch --show-current")) return { code: 0, stdout: "main", stderr: "", killed: false };
+      if (joined.includes("status --porcelain")) return { code: 0, stdout: " M file.ts\n", stderr: "", killed: false };
+      if (joined.includes("worktree list --porcelain")) {
+        return {
+          code: 0,
+          stdout: "worktree /tmp/project\nHEAD abc\nbranch refs/heads/main\n",
+          stderr: "",
+          killed: false,
+        };
+      }
+      return { code: 1, stdout: "", stderr: "", killed: false };
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const agentEndHandler = mockPi.on.mock.calls.find(([name]) => name === "agent_end")?.[1];
+
+    let stale = false;
+    const ctx = {
+      get cwd() {
+        if (stale) throw new Error("This extension ctx is stale after session replacement or reload");
+        return "/tmp/project";
+      },
+      get hasUI() {
+        if (stale) throw new Error("This extension ctx is stale after session replacement or reload");
+        return true;
+      },
+      get model() {
+        if (stale) throw new Error("This extension ctx is stale after session replacement or reload");
+        return { id: "opus", contextWindow: 1000000 };
+      },
+      sessionManager: {
+        getBranch: () => {
+          if (stale) throw new Error("This extension ctx is stale after session replacement or reload");
+          return [];
+        },
+      },
+      getContextUsage: () => {
+        if (stale) throw new Error("This extension ctx is stale after session replacement or reload");
+        return { percent: 12 };
+      },
+    };
+
+    const result = agentEndHandler?.({}, ctx);
+    stale = true;
+
+    await expect(result).resolves.not.toThrow();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
   it("tracks activity and live token usage during tool execution", async () => {
     const mockPi = createMockPi();
     statuslineExtension(mockPi as unknown as ExtensionAPI);
 
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
     const inputHandler = mockPi.on.mock.calls.find(([name]) => name === "input")?.[1];
     const messageUpdateHandler = mockPi.on.mock.calls.find(([name]) => name === "message_update")?.[1];
     const toolStartHandler = mockPi.on.mock.calls.find(([name]) => name === "tool_execution_start")?.[1];
-    const toolDef = mockPi.registerTool.mock.calls[0]?.[0];
 
     const branchEntries = [
       { type: "message", message: { role: "assistant", usage: { input: 100, output: 40 } } },
@@ -252,11 +413,15 @@ describe("pi-statusline extension runtime", () => {
     ];
     const ctx = {
       cwd: "/tmp/project",
-      hasUI: false,
+      hasUI: true,
       model: { id: "opus", contextWindow: 1000000 },
       sessionManager: { getBranch: () => branchEntries },
       getContextUsage: () => ({ percent: 12 }),
+      ui: { setFooter: vi.fn() },
     };
+
+    await sessionStartHandler?.({}, ctx);
+    const toolDef = mockPi.registerTool.mock.calls[0]?.[0];
 
     await inputHandler?.({ text: "/release" }, ctx);
     await messageUpdateHandler?.(

--- a/packages/pi-statusline/__tests__/index.runtime.test.ts
+++ b/packages/pi-statusline/__tests__/index.runtime.test.ts
@@ -338,6 +338,100 @@ describe("pi-statusline extension runtime", () => {
     expect(text).not.toContain("slow-repo");
   });
 
+  it("reinstalls the footer for repeated UI session starts", async () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    const setFooter = vi.fn();
+    const ctx = {
+      cwd: "/tmp/project",
+      hasUI: true,
+      model: { id: "opus", contextWindow: 1000000 },
+      sessionManager: { getBranch: () => [] },
+      getContextUsage: () => ({ percent: 12 }),
+      ui: { setFooter },
+    };
+
+    await sessionStartHandler?.({}, ctx);
+    await sessionStartHandler?.({}, ctx);
+
+    expect(setFooter).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not rerender when async agent-end refresh loses the session race", async () => {
+    vi.useRealTimers();
+    const mockPi = createMockPi();
+    let releaseGit: (() => void) | undefined;
+    let blockNextGitRefresh = false;
+
+    mockPi.exec.mockImplementation(async (_cmd: string, args: string[]) => {
+      const joined = args.join(" ");
+      if (joined.includes("rev-parse --is-inside-work-tree")) {
+        if (blockNextGitRefresh) {
+          await new Promise<void>((resolve) => {
+            releaseGit = resolve;
+          });
+        }
+        return { code: 0, stdout: "true", stderr: "", killed: false };
+      }
+      if (joined.includes("rev-parse --show-toplevel"))
+        return { code: 0, stdout: "/tmp/project", stderr: "", killed: false };
+      if (joined.includes("rev-parse --git-dir")) return { code: 0, stdout: ".git", stderr: "", killed: false };
+      if (joined.includes("branch --show-current")) return { code: 0, stdout: "main", stderr: "", killed: false };
+      if (joined.includes("status --porcelain")) return { code: 0, stdout: "", stderr: "", killed: false };
+      if (joined.includes("worktree list --porcelain")) {
+        return {
+          code: 0,
+          stdout: "worktree /tmp/project\nHEAD abc\nbranch refs/heads/main\n",
+          stderr: "",
+          killed: false,
+        };
+      }
+      return { code: 1, stdout: "", stderr: "", killed: false };
+    });
+
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    const sessionShutdownHandler = mockPi.on.mock.calls.find(([name]) => name === "session_shutdown")?.[1];
+    const agentEndHandler = mockPi.on.mock.calls.find(([name]) => name === "agent_end")?.[1];
+    const setFooter = vi.fn();
+    const ctx = {
+      cwd: "/tmp/project",
+      hasUI: true,
+      model: { id: "opus", contextWindow: 1000000 },
+      sessionManager: { getBranch: () => [] },
+      getContextUsage: () => ({ percent: 12 }),
+      ui: { setFooter },
+    };
+
+    await sessionStartHandler?.({}, ctx);
+    const footerFactory = setFooter.mock.calls[0]?.[0];
+    const requestRender = vi.fn();
+    footerFactory?.(
+      { requestRender },
+      {},
+      {
+        getGitBranch: () => "main",
+        onBranchChange: () => vi.fn(),
+      },
+    );
+
+    blockNextGitRefresh = true;
+    const result = agentEndHandler?.({}, ctx);
+    for (let i = 0; i < 20 && !releaseGit; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(releaseGit).toBeDefined();
+
+    await sessionShutdownHandler?.({}, ctx);
+    releaseGit?.();
+    await result;
+
+    expect(requestRender).not.toHaveBeenCalled();
+  });
+
   it("does not read session context after async agent-end refreshes", async () => {
     const mockPi = createMockPi();
     mockPi.exec.mockImplementation(async (_cmd: string, args: string[]) => {

--- a/packages/pi-statusline/__tests__/index.runtime.test.ts
+++ b/packages/pi-statusline/__tests__/index.runtime.test.ts
@@ -492,6 +492,59 @@ describe("pi-statusline extension runtime", () => {
     expect(logSpy).not.toHaveBeenCalled();
   });
 
+  it("continues input handling when the input context is stale", async () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const inputHandler = mockPi.on.mock.calls.find(([name]) => name === "input")?.[1];
+    const ctx = {
+      get hasUI() {
+        throw new Error("This extension ctx is stale after session replacement or reload");
+      },
+    };
+
+    await expect(Promise.resolve(inputHandler?.({ text: "/release" }, ctx))).resolves.toEqual({ action: "continue" });
+  });
+
+  it("keeps statusline tool inert in non-UI sessions after a UI session", async () => {
+    const mockPi = createMockPi();
+    statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    const setFooter = vi.fn();
+
+    await sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/project",
+        hasUI: true,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 12 }),
+        ui: { setFooter },
+      },
+    );
+    await sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/project",
+        hasUI: false,
+        model: { id: "opus", contextWindow: 1000000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 12 }),
+        ui: { setFooter },
+      },
+    );
+
+    const toolDef = mockPi.registerTool.mock.calls[0]?.[0];
+    const result = await toolDef.execute("tool-id", {}, new AbortController().signal, undefined, {
+      cwd: "/tmp/project",
+      hasUI: false,
+    });
+
+    expect(result.content[0]?.text).toContain("unavailable in non-UI sessions");
+  });
+
   it("tracks activity and live token usage during tool execution", async () => {
     const mockPi = createMockPi();
     statuslineExtension(mockPi as unknown as ExtensionAPI);

--- a/packages/pi-statusline/__tests__/index.test.ts
+++ b/packages/pi-statusline/__tests__/index.test.ts
@@ -35,9 +35,22 @@ describe("pi-statusline extension", () => {
     );
   });
 
-  it("registers /statusline tool", () => {
+  it("registers /statusline tool in UI mode", async () => {
     const mockPi = createMockPi();
     statuslineExtension(mockPi as unknown as ExtensionAPI);
+
+    const sessionStartHandler = mockPi.on.mock.calls.find(([name]) => name === "session_start")?.[1];
+    await sessionStartHandler?.(
+      {},
+      {
+        cwd: "/tmp/project",
+        hasUI: true,
+        model: { id: "opus", contextWindow: 1_000_000 },
+        sessionManager: { getBranch: () => [] },
+        getContextUsage: () => ({ percent: 11 }),
+        ui: { setFooter: vi.fn() },
+      },
+    );
 
     expect(mockPi.registerTool).toHaveBeenCalledTimes(1);
     expect(mockPi.registerTool).toHaveBeenCalledWith(

--- a/packages/pi-statusline/__tests__/lines.test.ts
+++ b/packages/pi-statusline/__tests__/lines.test.ts
@@ -25,11 +25,21 @@ describe("statusline line helpers", () => {
         activityLabel: "Act: responding",
       },
       "main",
-      30,
+      120,
     );
 
+    const text = stripAnsi(lines.join("\n"));
+    expect(text).toContain("Model: opus");
+    expect(text).toContain("Thinking: medium");
+    expect(text).toContain("Ctx: 10.0%");
+    expect(text).toContain("⎇ main");
+    expect(text).toContain("dirty: +3");
+    expect(text).toContain("project");
+    expect(text).toContain("𖠰 main");
+    expect(text).toContain("Skill: release");
+    expect(text).toContain("Act: responding");
     expect(lines).toHaveLength(2);
-    expect(stripAnsi(lines[0] ?? "").length).toBeLessThanOrEqual(30);
-    expect(stripAnsi(lines[1] ?? "").length).toBeLessThanOrEqual(30);
+    expect(stripAnsi(lines[0] ?? "").length).toBeLessThanOrEqual(120);
+    expect(stripAnsi(lines[1] ?? "").length).toBeLessThanOrEqual(120);
   });
 });

--- a/packages/pi-statusline/__tests__/lines.test.ts
+++ b/packages/pi-statusline/__tests__/lines.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsi } from "../extensions/format.js";
+import { buildLines, getBranchLabel, getDirtyLabel, getWorktreeLabel } from "../extensions/lines.js";
+import { createInitialState } from "../extensions/state.js";
+
+describe("statusline line helpers", () => {
+  it("formats git labels", () => {
+    expect(getBranchLabel("main")).toBe("⎇ main");
+    expect(getBranchLabel(null)).toBe("⎇ no git");
+    expect(getWorktreeLabel("feature")).toBe("𖠰 feature");
+    expect(getDirtyLabel(2)).toBe("dirty: +2");
+  });
+
+  it("builds bounded status lines from state", () => {
+    const lines = buildLines(
+      "/tmp/project",
+      {
+        ...createInitialState(),
+        modelLabel: "Model: opus",
+        thinkingLabel: "Thinking: medium",
+        contextLabel: "Ctx: 10.0%",
+        tokenLabel: "↑1.0k/↓2.0k",
+        gitSnapshot: { repoName: "project", branch: "main", dirtyCount: 3, worktreeLabel: "main" },
+        lastSkill: "release",
+        activityLabel: "Act: responding",
+      },
+      "main",
+      30,
+    );
+
+    expect(lines).toHaveLength(2);
+    expect(stripAnsi(lines[0] ?? "").length).toBeLessThanOrEqual(30);
+    expect(stripAnsi(lines[1] ?? "").length).toBeLessThanOrEqual(30);
+  });
+});

--- a/packages/pi-statusline/__tests__/render-scheduler.test.ts
+++ b/packages/pi-statusline/__tests__/render-scheduler.test.ts
@@ -40,4 +40,14 @@ describe("render scheduler", () => {
 
     expect(render).toHaveBeenCalledTimes(1);
   });
+
+  it("rethrows unrecoverable render callback failures", () => {
+    const render = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const scheduler = createRenderScheduler(100, () => false);
+    scheduler.setRenderCallback(render);
+
+    expect(() => scheduler.rerender(true)).toThrow("boom");
+  });
 });

--- a/packages/pi-statusline/__tests__/render-scheduler.test.ts
+++ b/packages/pi-statusline/__tests__/render-scheduler.test.ts
@@ -50,4 +50,18 @@ describe("render scheduler", () => {
 
     expect(() => scheduler.rerender(true)).toThrow("boom");
   });
+
+  it("cancels pending throttled renders on clear", async () => {
+    const render = vi.fn();
+    const scheduler = createRenderScheduler(100, () => false);
+    scheduler.setRenderCallback(render);
+
+    scheduler.rerender();
+    scheduler.rerender();
+    scheduler.clear();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(render).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/pi-statusline/__tests__/render-scheduler.test.ts
+++ b/packages/pi-statusline/__tests__/render-scheduler.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRenderScheduler } from "../extensions/render-scheduler.js";
+
+describe("render scheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("throttles render callbacks", async () => {
+    const render = vi.fn();
+    const scheduler = createRenderScheduler(100, () => false);
+    scheduler.setRenderCallback(render);
+
+    scheduler.rerender();
+    scheduler.rerender();
+    scheduler.rerender();
+
+    expect(render).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears recoverable stale render callbacks", () => {
+    const render = vi.fn(() => {
+      throw new Error("recoverable");
+    });
+    const scheduler = createRenderScheduler(100, (error) => error instanceof Error && error.message === "recoverable");
+    scheduler.setRenderCallback(render);
+
+    expect(() => scheduler.rerender(true)).not.toThrow();
+    scheduler.rerender(true);
+
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/pi-statusline/__tests__/state.test.ts
+++ b/packages/pi-statusline/__tests__/state.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createInitialGitSnapshot, createInitialState, getActivityLabel } from "../extensions/state.js";
+
+describe("statusline state helpers", () => {
+  it("creates initial git and runtime state", () => {
+    expect(createInitialGitSnapshot()).toEqual({
+      repoName: null,
+      branch: null,
+      dirtyCount: 0,
+      worktreeLabel: "no git",
+    });
+
+    expect(createInitialState()).toMatchObject({
+      modelLabel: "Model: none",
+      thinkingLabel: "Thinking: off",
+      contextLabel: "Ctx: n/a",
+      tokenLabel: "↑0/↓0",
+      lastSkill: null,
+      activityLabel: "Act: idle",
+      activityPhase: "idle",
+      activeToolCount: 0,
+      activeToolName: null,
+      liveAssistantUsage: null,
+    });
+  });
+
+  it("formats activity labels", () => {
+    expect(getActivityLabel("idle")).toBe("Act: idle");
+    expect(getActivityLabel("tool", "bash", 1)).toBe("Act: bash");
+    expect(getActivityLabel("tool", "bash", 2)).toBe("Act: bash x2");
+  });
+});

--- a/packages/pi-statusline/__tests__/ui-mode.test.ts
+++ b/packages/pi-statusline/__tests__/ui-mode.test.ts
@@ -21,4 +21,17 @@ describe("UI-mode event helpers", () => {
     expect(result).toBe("handled");
     expect(handler).toHaveBeenCalledOnce();
   });
+
+  it("treats stale context access like an unavailable UI", async () => {
+    const handler = vi.fn();
+    const uiOnly = createUiOnlyHandler(handler);
+    const staleCtx = {
+      get hasUI() {
+        throw new Error("This extension ctx is stale after session replacement or reload");
+      },
+    };
+
+    await expect(Promise.resolve(uiOnly({ type: "event" }, staleCtx))).resolves.toBeUndefined();
+    expect(handler).not.toHaveBeenCalled();
+  });
 });

--- a/packages/pi-statusline/__tests__/ui-mode.test.ts
+++ b/packages/pi-statusline/__tests__/ui-mode.test.ts
@@ -34,4 +34,37 @@ describe("UI-mode event helpers", () => {
     await expect(Promise.resolve(uiOnly({ type: "event" }, staleCtx))).resolves.toBeUndefined();
     expect(handler).not.toHaveBeenCalled();
   });
+
+  it("rethrows non-stale UI availability failures", async () => {
+    const handler = vi.fn();
+    const uiOnly = createUiOnlyHandler(handler);
+    const brokenCtx = {
+      get hasUI() {
+        throw new Error("boom");
+      },
+    };
+
+    await expect(uiOnly({ type: "event" }, brokenCtx)).rejects.toThrow("boom");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("swallows stale async handler failures", async () => {
+    const handler = vi.fn(async () => {
+      await Promise.resolve();
+      throw new Error("This extension ctx is stale after session replacement or reload");
+    });
+    const uiOnly = createUiOnlyHandler(handler);
+
+    await expect(uiOnly({ type: "event" }, { hasUI: true })).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("rethrows non-stale handler failures", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const uiOnly = createUiOnlyHandler(handler);
+
+    await expect(uiOnly({ type: "event" }, { hasUI: true })).rejects.toThrow("boom");
+  });
 });

--- a/packages/pi-statusline/__tests__/ui-mode.test.ts
+++ b/packages/pi-statusline/__tests__/ui-mode.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { createUiOnlyHandler } from "../extensions/ui-mode.js";
+
+describe("UI-mode event helpers", () => {
+  it("skips handlers when UI is unavailable", async () => {
+    const handler = vi.fn();
+    const uiOnly = createUiOnlyHandler(handler);
+
+    const result = await uiOnly({ type: "event" }, { hasUI: false });
+
+    expect(result).toBeUndefined();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("runs handlers when UI is available", async () => {
+    const handler = vi.fn(async () => "handled");
+    const uiOnly = createUiOnlyHandler(handler);
+
+    const result = await uiOnly({ type: "event" }, { hasUI: true });
+
+    expect(result).toBe("handled");
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/pi-statusline/extensions/git.ts
+++ b/packages/pi-statusline/extensions/git.ts
@@ -103,11 +103,13 @@ export async function getGitSnapshot(pi: ExtensionAPI, cwd: string): Promise<Git
     };
   }
 
-  const topLevel = await runGit(pi, cwd, ["rev-parse", "--show-toplevel"]);
-  const gitDir = await runGit(pi, cwd, ["rev-parse", "--git-dir"]);
-  const branch = await runGit(pi, cwd, ["branch", "--show-current"]);
-  const dirtyOutput = await runGit(pi, cwd, ["--no-optional-locks", "status", "--porcelain"]);
-  const worktreeOutput = await runGit(pi, cwd, ["worktree", "list", "--porcelain"]);
+  const [topLevel, gitDir, branch, dirtyOutput, worktreeOutput] = await Promise.all([
+    runGit(pi, cwd, ["rev-parse", "--show-toplevel"]),
+    runGit(pi, cwd, ["rev-parse", "--git-dir"]),
+    runGit(pi, cwd, ["branch", "--show-current"]),
+    runGit(pi, cwd, ["--no-optional-locks", "status", "--porcelain"]),
+    runGit(pi, cwd, ["worktree", "list", "--porcelain"]),
+  ]);
 
   const repoName = topLevel ? basename(topLevel) : null;
   const dirtyCount = dirtyOutput === null ? 0 : parseDirtyCountFromPorcelain(dirtyOutput);

--- a/packages/pi-statusline/extensions/index.ts
+++ b/packages/pi-statusline/extensions/index.ts
@@ -94,13 +94,17 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     };
   };
 
+  const readDynamicState = (ctx: Pick<ExtensionContext, "model" | "sessionManager" | "getContextUsage">) => ({
+    modelLabel: getModelLabel(ctx.model),
+    thinkingLabel: getThinkingLabel(pi.getThinkingLevel()),
+    contextLabel: getContextLabel(ctx.getContextUsage(), ctx.model),
+    tokenLabel: getTokenLabel(ctx.sessionManager.getBranch(), state.liveAssistantUsage),
+  });
+
   const refreshDynamicState = (ctx: Pick<ExtensionContext, "model" | "sessionManager" | "getContextUsage">) => {
     state = {
       ...state,
-      modelLabel: getModelLabel(ctx.model),
-      thinkingLabel: getThinkingLabel(pi.getThinkingLevel()),
-      contextLabel: getContextLabel(ctx.getContextUsage(), ctx.model),
-      tokenLabel: getTokenLabel(ctx.sessionManager.getBranch(), state.liveAssistantUsage),
+      ...readDynamicState(ctx),
     };
   };
 
@@ -151,12 +155,21 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     }
   };
 
-  const refreshState = async (ctx: ExtensionContext) => {
+  const refreshState = async (ctx: ExtensionContext): Promise<boolean> => {
     const cwd = ctx.cwd;
     const epoch = sessionEpoch;
+    const dynamicState = readDynamicState(ctx);
+    const gitSnapshot = await getGitSnapshot(pi, cwd);
+    if (epoch !== sessionEpoch) {
+      return false;
+    }
 
-    refreshDynamicState(ctx);
-    await refreshGitState(cwd, epoch);
+    state = {
+      ...state,
+      ...dynamicState,
+      gitSnapshot,
+    };
+    return true;
   };
 
   const registerStatuslineTool = () => {
@@ -191,6 +204,7 @@ export default function statuslineExtension(pi: ExtensionAPI) {
 
     state = createInitialState();
     footerCwd = cwd;
+    footerRegistered = false;
     footerRenderScheduler.clear();
 
     if (!hasUI) {
@@ -366,16 +380,18 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     createUiOnlyHandler(async (_event, ctx) => {
       clearLiveUsage();
       updateActivity("idle", null, 0);
-      await refreshState(ctx);
-      rerenderFooter(true);
+      if (await refreshState(ctx)) {
+        rerenderFooter(true);
+      }
     }),
   );
 
   pi.on(
     "model_select",
     createUiOnlyHandler(async (_event, ctx) => {
-      await refreshState(ctx);
-      rerenderFooter(true);
+      if (await refreshState(ctx)) {
+        rerenderFooter(true);
+      }
     }),
   );
 }

--- a/packages/pi-statusline/extensions/index.ts
+++ b/packages/pi-statusline/extensions/index.ts
@@ -185,8 +185,27 @@ export default function statuslineExtension(pi: ExtensionAPI) {
         "Show the current status line with model, thinking effort, context, git info, token counts, and live activity",
       parameters: Type.Object({}),
       async execute(_toolCallId, _params, _signal, _onUpdate, ctx: ExtensionContext) {
+        const unavailable = () => ({
+          content: [{ type: "text" as const, text: "Statusline is unavailable in non-UI sessions." }],
+          details: {},
+        });
+
+        try {
+          if (!ctx.hasUI) {
+            return unavailable();
+          }
+        } catch (error) {
+          if (!isStaleExtensionContextError(error)) {
+            throw error;
+          }
+          return unavailable();
+        }
+
         const cwd = ctx.cwd;
-        await refreshState(ctx);
+        if (!(await refreshState(ctx))) {
+          return unavailable();
+        }
+
         const text = buildLines(cwd, state, state.gitSnapshot.branch, undefined, currentPalette).join("\n");
         return {
           content: [{ type: "text", text }],
@@ -259,23 +278,23 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     footerCwd = "";
   });
 
-  pi.on("input", async (event, ctx) => {
-    if (!ctx.hasUI) {
-      return { action: "continue" };
-    }
-
+  const handleUiInput = createUiOnlyHandler(async (event: { text: string }, ctx: DynamicCtx) => {
     clearLiveUsage();
     updateActivity("queued", null, 0);
     refreshDynamicFooter(ctx, true);
 
     const skillName = extractSkillName(event.text, pi.getCommands() as CommandLike[]);
     if (!skillName) {
-      return { action: "continue" };
+      return { action: "continue" as const };
     }
 
     setSkill(skillName);
     rerenderFooter(true);
-    return { action: "continue" };
+    return { action: "continue" as const };
+  });
+
+  pi.on("input", async (event, ctx) => {
+    return (await handleUiInput(event, ctx)) ?? { action: "continue" as const };
   });
 
   pi.on(

--- a/packages/pi-statusline/extensions/index.ts
+++ b/packages/pi-statusline/extensions/index.ts
@@ -1,41 +1,20 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { loadStatuslinePalette } from "./config.js";
-import { buildStatusLines } from "./format.js";
 import { getGitSnapshot } from "./git.js";
+import { buildLines } from "./lines.js";
 import { defaultPalette } from "./palette.js";
-import {
-  getContextLabel,
-  getCwdLabel,
-  getModelLabel,
-  getRepoFallbackLabel,
-  getThinkingLabel,
-  getTokenLabel,
-} from "./session.js";
-import type {
-  ActivityPhase,
-  AssistantUsageLike,
-  CommandLike,
-  GitSnapshot,
-  StatuslinePalette,
-  StatuslineState,
-} from "./types.js";
+import { createRenderScheduler } from "./render-scheduler.js";
+import { getContextLabel, getModelLabel, getThinkingLabel, getTokenLabel } from "./session.js";
+import { createInitialState, getActivityLabel } from "./state.js";
+import type { ActivityPhase, AssistantUsageLike, CommandLike, GitSnapshot } from "./types.js";
+import { createUiOnlyHandler } from "./ui-mode.js";
+
+export { buildLines, getBranchLabel, getDirtyLabel, getWorktreeLabel } from "./lines.js";
+export { createInitialGitSnapshot, createInitialState, getActivityLabel } from "./state.js";
 
 const FOOTER_RENDER_THROTTLE_MS = 100;
-
-type StatuslineInput = {
-  modelLabel: string;
-  thinkingLabel: string;
-  contextLabel: string;
-  branchLabel: string;
-  dirtyLabel: string;
-  tokenLabel: string;
-  repoLabel: string;
-  cwdLabel: string;
-  worktreeLabel: string;
-  skillLabel: string;
-  activityLabel: string;
-};
+const STALE_EXTENSION_CONTEXT_MESSAGE = "This extension ctx is stale after session replacement or reload";
 
 type DynamicCtx = Pick<ExtensionContext, "model" | "sessionManager" | "getContextUsage" | "hasUI">;
 type GitCtx = Pick<ExtensionContext, "cwd" | "hasUI">;
@@ -43,39 +22,8 @@ type SkillToolEvent = { args?: { skill?: string }; tool_input?: { skill?: string
 type AssistantMessageEventLike = { type?: string };
 type AssistantMessageLike = { role?: string; usage?: AssistantUsageLike };
 
-export function createInitialGitSnapshot(): GitSnapshot {
-  return {
-    repoName: null,
-    branch: null,
-    dirtyCount: 0,
-    worktreeLabel: "no git",
-  };
-}
-
-export function getActivityLabel(phase: ActivityPhase, activeToolName?: string | null, activeToolCount = 0): string {
-  if (phase === "tool") {
-    const toolName = activeToolName || "tool";
-    const countSuffix = activeToolCount > 1 ? ` x${activeToolCount}` : "";
-    return `Act: ${toolName}${countSuffix}`;
-  }
-
-  return `Act: ${phase}`;
-}
-
-export function createInitialState(): StatuslineState {
-  return {
-    modelLabel: "Model: none",
-    thinkingLabel: "Thinking: off",
-    contextLabel: "Ctx: n/a",
-    tokenLabel: "↑0/↓0",
-    gitSnapshot: createInitialGitSnapshot(),
-    lastSkill: null,
-    activityLabel: getActivityLabel("idle"),
-    activityPhase: "idle",
-    activeToolCount: 0,
-    activeToolName: null,
-    liveAssistantUsage: null,
-  };
+function isStaleExtensionContextError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(STALE_EXTENSION_CONTEXT_MESSAGE);
 }
 
 export function extractSkillName(text: string, commands: ReadonlyArray<CommandLike>): string | null {
@@ -102,57 +50,14 @@ export function extractSkillName(text: string, commands: ReadonlyArray<CommandLi
   return matchingSkill.name.replace(/^skill:/, "");
 }
 
-export function getBranchLabel(branch: string | null | undefined): string {
-  return `⎇ ${branch || "no git"}`;
-}
-
-export function getWorktreeLabel(worktreeLabel: string): string {
-  return `𖠰 ${worktreeLabel || "no git"}`;
-}
-
-export function getDirtyLabel(dirtyCount: number): string {
-  return `dirty: +${dirtyCount}`;
-}
-
-export function buildLines(
-  cwd: string,
-  state: StatuslineState,
-  branchLabel: string | null,
-  width?: number,
-  palette: StatuslinePalette = defaultPalette,
-): string[] {
-  const input: StatuslineInput = {
-    modelLabel: state.modelLabel,
-    thinkingLabel: state.thinkingLabel,
-    contextLabel: state.contextLabel,
-    branchLabel: getBranchLabel(branchLabel),
-    dirtyLabel: getDirtyLabel(state.gitSnapshot.dirtyCount),
-    tokenLabel: state.tokenLabel,
-    repoLabel: state.gitSnapshot.repoName || getRepoFallbackLabel(cwd),
-    cwdLabel: getCwdLabel(cwd),
-    worktreeLabel: getWorktreeLabel(state.gitSnapshot.worktreeLabel),
-    skillLabel: `Skill: ${state.lastSkill || "none"}`,
-    activityLabel: state.activityLabel,
-  };
-
-  return buildStatusLines(input, width, palette);
-}
-
 export default function statuslineExtension(pi: ExtensionAPI) {
   let state = createInitialState();
   let footerRegistered = false;
-  let requestFooterRender: (() => void) | null = null;
-  let footerRenderTimeout: ReturnType<typeof setTimeout> | null = null;
-  let lastFooterRenderAt = 0;
+  const footerRenderScheduler = createRenderScheduler(FOOTER_RENDER_THROTTLE_MS, isStaleExtensionContextError);
   let currentPalette = defaultPalette;
   let footerCwd = "";
-
-  const clearFooterRenderTimeout = () => {
-    if (footerRenderTimeout) {
-      clearTimeout(footerRenderTimeout);
-      footerRenderTimeout = null;
-    }
-  };
+  let sessionEpoch = 0;
+  let statuslineToolRegistered = false;
 
   const updateActivity = (
     phase: ActivityPhase,
@@ -199,11 +104,21 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     };
   };
 
-  const refreshGitState = async (cwd: string) => {
+  const applyGitSnapshot = (gitSnapshot: GitSnapshot) => {
     state = {
       ...state,
-      gitSnapshot: await getGitSnapshot(pi, cwd),
+      gitSnapshot,
     };
+  };
+
+  const refreshGitState = async (cwd: string, epoch = sessionEpoch): Promise<boolean> => {
+    const gitSnapshot = await getGitSnapshot(pi, cwd);
+    if (epoch !== sessionEpoch) {
+      return false;
+    }
+
+    applyGitSnapshot(gitSnapshot);
+    return true;
   };
 
   const setSkill = (skillName: string | null | undefined) => {
@@ -216,32 +131,7 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     };
   };
 
-  const rerenderFooter = (immediate = false) => {
-    if (!requestFooterRender) {
-      return;
-    }
-
-    const now = Date.now();
-    if (immediate || lastFooterRenderAt === 0 || now - lastFooterRenderAt >= FOOTER_RENDER_THROTTLE_MS) {
-      clearFooterRenderTimeout();
-      lastFooterRenderAt = now;
-      requestFooterRender();
-      return;
-    }
-
-    if (footerRenderTimeout) {
-      return;
-    }
-
-    footerRenderTimeout = setTimeout(
-      () => {
-        footerRenderTimeout = null;
-        lastFooterRenderAt = Date.now();
-        requestFooterRender?.();
-      },
-      FOOTER_RENDER_THROTTLE_MS - (now - lastFooterRenderAt),
-    );
-  };
+  const rerenderFooter = (immediate = false) => footerRenderScheduler.rerender(immediate);
 
   const refreshDynamicFooter = (ctx: DynamicCtx, immediate = false) => {
     refreshDynamicState(ctx);
@@ -251,53 +141,93 @@ export default function statuslineExtension(pi: ExtensionAPI) {
   };
 
   const refreshGitFooter = async (ctx: GitCtx, immediate = false) => {
-    await refreshGitState(ctx.cwd);
-    if (ctx.hasUI) {
+    const cwd = ctx.cwd;
+    const hasUI = ctx.hasUI;
+    const epoch = sessionEpoch;
+
+    const updated = await refreshGitState(cwd, epoch);
+    if (hasUI && updated) {
       rerenderFooter(immediate);
     }
   };
 
-  const emitStatusLines = (ctx: Pick<ExtensionContext, "cwd">) => {
-    const lines = buildLines(ctx.cwd, state, state.gitSnapshot.branch, undefined, currentPalette);
-    for (const line of lines) {
-      console.log(line);
-    }
+  const refreshState = async (ctx: ExtensionContext) => {
+    const cwd = ctx.cwd;
+    const epoch = sessionEpoch;
+
+    refreshDynamicState(ctx);
+    await refreshGitState(cwd, epoch);
   };
 
-  const updateAndLog = async (ctx: ExtensionContext, emit = true) => {
-    refreshDynamicState(ctx);
-    await refreshGitState(ctx.cwd);
-    if (!ctx.hasUI && emit) {
-      emitStatusLines(ctx);
+  const registerStatuslineTool = () => {
+    if (statuslineToolRegistered) {
+      return;
     }
+
+    statuslineToolRegistered = true;
+    pi.registerTool({
+      name: "statusline",
+      label: "Statusline",
+      description:
+        "Show the current status line with model, thinking effort, context, git info, token counts, and live activity",
+      parameters: Type.Object({}),
+      async execute(_toolCallId, _params, _signal, _onUpdate, ctx: ExtensionContext) {
+        const cwd = ctx.cwd;
+        await refreshState(ctx);
+        const text = buildLines(cwd, state, state.gitSnapshot.branch, undefined, currentPalette).join("\n");
+        return {
+          content: [{ type: "text", text }],
+          details: {},
+        };
+      },
+    });
   };
 
   pi.on("session_start", async (_event, ctx) => {
-    state = createInitialState();
-    currentPalette = await loadStatuslinePalette(ctx.cwd);
-    footerCwd = ctx.cwd;
-    requestFooterRender = null;
-    clearFooterRenderTimeout();
-    lastFooterRenderAt = 0;
-    await updateAndLog(ctx);
+    const epoch = ++sessionEpoch;
+    const cwd = ctx.cwd;
+    const hasUI = ctx.hasUI;
+    const ui = ctx.ui;
 
-    if (!ctx.hasUI || footerRegistered) {
+    state = createInitialState();
+    footerCwd = cwd;
+    footerRenderScheduler.clear();
+
+    if (!hasUI) {
+      return;
+    }
+
+    refreshDynamicState(ctx);
+    registerStatuslineTool();
+
+    const [palette, gitSnapshot] = await Promise.all([loadStatuslinePalette(cwd), getGitSnapshot(pi, cwd)]);
+    if (epoch !== sessionEpoch) {
+      return;
+    }
+
+    currentPalette = palette;
+    applyGitSnapshot(gitSnapshot);
+
+    if (footerRegistered) {
       return;
     }
 
     footerRegistered = true;
-    ctx.ui.setFooter((tui, _theme, footerData) => {
-      requestFooterRender = () => tui.requestRender();
-      lastFooterRenderAt = 0;
+    ui.setFooter((tui, _theme, footerData) => {
+      footerRenderScheduler.setRenderCallback(() => tui.requestRender());
       const disposeBranchChange = footerData.onBranchChange(() => {
-        void refreshGitState(footerCwd).then(() => rerenderFooter(true));
+        const branchChangeEpoch = sessionEpoch;
+        const branchChangeCwd = footerCwd;
+        void refreshGitState(branchChangeCwd, branchChangeEpoch).then((updated) => {
+          if (updated) {
+            rerenderFooter(true);
+          }
+        });
       });
 
       return {
         dispose() {
-          clearFooterRenderTimeout();
-          requestFooterRender = null;
-          lastFooterRenderAt = 0;
+          footerRenderScheduler.clear();
           disposeBranchChange();
         },
         invalidate() {},
@@ -309,13 +239,17 @@ export default function statuslineExtension(pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
-    clearFooterRenderTimeout();
-    requestFooterRender = null;
-    lastFooterRenderAt = 0;
+    sessionEpoch += 1;
+    footerRegistered = false;
+    footerRenderScheduler.clear();
     footerCwd = "";
   });
 
   pi.on("input", async (event, ctx) => {
+    if (!ctx.hasUI) {
+      return { action: "continue" };
+    }
+
     clearLiveUsage();
     updateActivity("queued", null, 0);
     refreshDynamicFooter(ctx, true);
@@ -326,112 +260,122 @@ export default function statuslineExtension(pi: ExtensionAPI) {
     }
 
     setSkill(skillName);
-    if (ctx.hasUI) {
-      rerenderFooter(true);
-    }
+    rerenderFooter(true);
     return { action: "continue" };
   });
 
-  pi.on("agent_start", async (_event, ctx) => {
-    clearLiveUsage();
-    updateActivity("running", null, 0);
-    refreshDynamicFooter(ctx, true);
-  });
+  pi.on(
+    "agent_start",
+    createUiOnlyHandler(async (_event, ctx) => {
+      clearLiveUsage();
+      updateActivity("running", null, 0);
+      refreshDynamicFooter(ctx, true);
+    }),
+  );
 
-  pi.on("turn_start", async (_event, ctx) => {
-    updateActivity("thinking", null, state.activeToolCount);
-    refreshDynamicFooter(ctx, true);
-  });
-
-  pi.on("message_start", async (event, ctx) => {
-    updateLiveUsage((event as { message?: AssistantMessageLike }).message);
-
-    const message = (event as { message?: AssistantMessageLike }).message;
-    if (message?.role === "assistant") {
-      updateActivity("responding", null, state.activeToolCount);
-    }
-
-    refreshDynamicFooter(ctx, true);
-  });
-
-  pi.on("message_update", async (event, ctx) => {
-    updateLiveUsage((event as { message?: AssistantMessageLike }).message);
-
-    const assistantMessageEvent = (event as { assistantMessageEvent?: AssistantMessageEventLike })
-      .assistantMessageEvent;
-    if (assistantMessageEvent?.type?.startsWith("thinking")) {
+  pi.on(
+    "turn_start",
+    createUiOnlyHandler(async (_event, ctx) => {
       updateActivity("thinking", null, state.activeToolCount);
-    } else {
-      updateActivity("responding", null, state.activeToolCount);
-    }
+      refreshDynamicFooter(ctx, true);
+    }),
+  );
 
-    refreshDynamicFooter(ctx);
-  });
+  pi.on(
+    "message_start",
+    createUiOnlyHandler(async (event, ctx) => {
+      updateLiveUsage((event as { message?: AssistantMessageLike }).message);
 
-  pi.on("message_end", async (event, ctx) => {
-    updateLiveUsage((event as { message?: AssistantMessageLike }).message);
-    updateActivity(state.activeToolCount > 0 ? "tool" : "running", state.activeToolName, state.activeToolCount);
-    refreshDynamicFooter(ctx, true);
-  });
+      const message = (event as { message?: AssistantMessageLike }).message;
+      if (message?.role === "assistant") {
+        updateActivity("responding", null, state.activeToolCount);
+      }
 
-  pi.on("tool_execution_start", async (event, ctx) => {
-    updateActivity("tool", event.toolName, state.activeToolCount + 1);
-    refreshDynamicFooter(ctx, true);
+      refreshDynamicFooter(ctx, true);
+    }),
+  );
 
-    if (event.toolName !== "Skill" && event.toolName !== "skill") {
-      return;
-    }
+  pi.on(
+    "message_update",
+    createUiOnlyHandler(async (event, ctx) => {
+      updateLiveUsage((event as { message?: AssistantMessageLike }).message);
 
-    const args = (event as SkillToolEvent).args;
-    const toolInput = args ?? (event as SkillToolEvent).tool_input;
-    if (typeof toolInput?.skill === "string" && toolInput.skill.length > 0) {
-      setSkill(toolInput.skill);
-      if (ctx.hasUI) {
+      const assistantMessageEvent = (event as { assistantMessageEvent?: AssistantMessageEventLike })
+        .assistantMessageEvent;
+      if (assistantMessageEvent?.type?.startsWith("thinking")) {
+        updateActivity("thinking", null, state.activeToolCount);
+      } else {
+        updateActivity("responding", null, state.activeToolCount);
+      }
+
+      refreshDynamicFooter(ctx);
+    }),
+  );
+
+  pi.on(
+    "message_end",
+    createUiOnlyHandler(async (event, ctx) => {
+      updateLiveUsage((event as { message?: AssistantMessageLike }).message);
+      updateActivity(state.activeToolCount > 0 ? "tool" : "running", state.activeToolName, state.activeToolCount);
+      refreshDynamicFooter(ctx, true);
+    }),
+  );
+
+  pi.on(
+    "tool_execution_start",
+    createUiOnlyHandler(async (event, ctx) => {
+      updateActivity("tool", event.toolName, state.activeToolCount + 1);
+      refreshDynamicFooter(ctx, true);
+
+      if (event.toolName !== "Skill" && event.toolName !== "skill") {
+        return;
+      }
+
+      const args = (event as SkillToolEvent).args;
+      const toolInput = args ?? (event as SkillToolEvent).tool_input;
+      if (typeof toolInput?.skill === "string" && toolInput.skill.length > 0) {
+        setSkill(toolInput.skill);
         rerenderFooter(true);
       }
-    }
-  });
+    }),
+  );
 
-  pi.on("tool_execution_update", async (event, ctx) => {
-    const activeToolCount = state.activeToolCount > 0 ? state.activeToolCount : 1;
-    updateActivity("tool", event.toolName, activeToolCount);
-    refreshDynamicFooter(ctx);
-  });
+  pi.on(
+    "tool_execution_update",
+    createUiOnlyHandler(async (event, ctx) => {
+      const activeToolCount = state.activeToolCount > 0 ? state.activeToolCount : 1;
+      updateActivity("tool", event.toolName, activeToolCount);
+      refreshDynamicFooter(ctx);
+    }),
+  );
 
-  pi.on("tool_execution_end", async (event, ctx) => {
-    const activeToolCount = Math.max(0, state.activeToolCount - 1);
-    const nextPhase: ActivityPhase = activeToolCount > 0 ? "tool" : "running";
-    const nextToolName = activeToolCount > 0 ? event.toolName : null;
-    updateActivity(nextPhase, nextToolName, activeToolCount);
-    refreshDynamicFooter(ctx, true);
-    await refreshGitFooter(ctx);
-  });
+  pi.on(
+    "tool_execution_end",
+    createUiOnlyHandler(async (event, ctx) => {
+      const activeToolCount = Math.max(0, state.activeToolCount - 1);
+      const nextPhase = activeToolCount > 0 ? "tool" : "running";
+      const nextToolName = activeToolCount > 0 ? event.toolName : null;
+      updateActivity(nextPhase, nextToolName, activeToolCount);
+      refreshDynamicFooter(ctx, true);
+      await refreshGitFooter(ctx);
+    }),
+  );
 
-  pi.on("agent_end", async (_event, ctx) => {
-    clearLiveUsage();
-    updateActivity("idle", null, 0);
-    await updateAndLog(ctx);
-    rerenderFooter(true);
-  });
+  pi.on(
+    "agent_end",
+    createUiOnlyHandler(async (_event, ctx) => {
+      clearLiveUsage();
+      updateActivity("idle", null, 0);
+      await refreshState(ctx);
+      rerenderFooter(true);
+    }),
+  );
 
-  pi.on("model_select", async (_event, ctx) => {
-    await updateAndLog(ctx);
-    rerenderFooter(true);
-  });
-
-  pi.registerTool({
-    name: "statusline",
-    label: "Statusline",
-    description:
-      "Show the current status line with model, thinking effort, context, git info, token counts, and live activity",
-    parameters: Type.Object({}),
-    async execute(_toolCallId, _params, _signal, _onUpdate, ctx: ExtensionContext) {
-      await updateAndLog(ctx, false);
-      const text = buildLines(ctx.cwd, state, state.gitSnapshot.branch, undefined, currentPalette).join("\n");
-      return {
-        content: [{ type: "text", text }],
-        details: {},
-      };
-    },
-  });
+  pi.on(
+    "model_select",
+    createUiOnlyHandler(async (_event, ctx) => {
+      await refreshState(ctx);
+      rerenderFooter(true);
+    }),
+  );
 }

--- a/packages/pi-statusline/extensions/lines.ts
+++ b/packages/pi-statusline/extensions/lines.ts
@@ -1,0 +1,54 @@
+import { buildStatusLines } from "./format.js";
+import { defaultPalette } from "./palette.js";
+import { getCwdLabel, getRepoFallbackLabel } from "./session.js";
+import type { StatuslinePalette, StatuslineState } from "./types.js";
+
+type StatuslineInput = {
+  modelLabel: string;
+  thinkingLabel: string;
+  contextLabel: string;
+  branchLabel: string;
+  dirtyLabel: string;
+  tokenLabel: string;
+  repoLabel: string;
+  cwdLabel: string;
+  worktreeLabel: string;
+  skillLabel: string;
+  activityLabel: string;
+};
+
+export function getBranchLabel(branch: string | null | undefined): string {
+  return `⎇ ${branch || "no git"}`;
+}
+
+export function getWorktreeLabel(worktreeLabel: string): string {
+  return `𖠰 ${worktreeLabel || "no git"}`;
+}
+
+export function getDirtyLabel(dirtyCount: number): string {
+  return `dirty: +${dirtyCount}`;
+}
+
+export function buildLines(
+  cwd: string,
+  state: StatuslineState,
+  branchLabel: string | null,
+  width?: number,
+  palette: StatuslinePalette = defaultPalette,
+): string[] {
+  const input: StatuslineInput = {
+    modelLabel: state.modelLabel,
+    thinkingLabel: state.thinkingLabel,
+    contextLabel: state.contextLabel,
+    branchLabel: getBranchLabel(branchLabel),
+    dirtyLabel: getDirtyLabel(state.gitSnapshot.dirtyCount),
+    tokenLabel: state.tokenLabel,
+    repoLabel: state.gitSnapshot.repoName || getRepoFallbackLabel(cwd),
+    cwdLabel: getCwdLabel(cwd),
+    worktreeLabel: getWorktreeLabel(state.gitSnapshot.worktreeLabel),
+    skillLabel: `Skill: ${state.lastSkill || "none"}`,
+    activityLabel: state.activityLabel,
+  };
+
+  return buildStatusLines(input, width, palette);
+}

--- a/packages/pi-statusline/extensions/render-scheduler.ts
+++ b/packages/pi-statusline/extensions/render-scheduler.ts
@@ -1,0 +1,79 @@
+export type RenderCallback = () => void;
+
+export type RenderScheduler = {
+  clear(): void;
+  rerender(immediate?: boolean): void;
+  setRenderCallback(callback: RenderCallback | null): void;
+};
+
+export function createRenderScheduler(
+  throttleMs: number,
+  isRecoverableRenderError: (error: unknown) => boolean,
+): RenderScheduler {
+  let renderCallback: RenderCallback | null = null;
+  let renderTimeout: ReturnType<typeof setTimeout> | null = null;
+  let lastRenderAt = 0;
+
+  const clearTimeoutIfNeeded = () => {
+    if (renderTimeout) {
+      clearTimeout(renderTimeout);
+      renderTimeout = null;
+    }
+  };
+
+  const requestRender = () => {
+    try {
+      renderCallback?.();
+    } catch (error) {
+      if (!isRecoverableRenderError(error)) {
+        throw error;
+      }
+      clearTimeoutIfNeeded();
+      renderCallback = null;
+      lastRenderAt = 0;
+    }
+  };
+
+  return {
+    clear() {
+      clearTimeoutIfNeeded();
+      renderCallback = null;
+      lastRenderAt = 0;
+    },
+
+    rerender(immediate = false) {
+      if (!renderCallback) {
+        return;
+      }
+
+      const now = Date.now();
+      if (immediate || lastRenderAt === 0 || now - lastRenderAt >= throttleMs) {
+        clearTimeoutIfNeeded();
+        lastRenderAt = now;
+        requestRender();
+        return;
+      }
+
+      if (renderTimeout) {
+        return;
+      }
+
+      renderTimeout = setTimeout(
+        () => {
+          renderTimeout = null;
+          lastRenderAt = Date.now();
+          requestRender();
+        },
+        throttleMs - (now - lastRenderAt),
+      );
+    },
+
+    setRenderCallback(callback: RenderCallback | null) {
+      renderCallback = callback;
+      lastRenderAt = 0;
+      if (!callback) {
+        clearTimeoutIfNeeded();
+      }
+    },
+  };
+}

--- a/packages/pi-statusline/extensions/state.ts
+++ b/packages/pi-statusline/extensions/state.ts
@@ -1,0 +1,36 @@
+import type { ActivityPhase, GitSnapshot, StatuslineState } from "./types.js";
+
+export function createInitialGitSnapshot(): GitSnapshot {
+  return {
+    repoName: null,
+    branch: null,
+    dirtyCount: 0,
+    worktreeLabel: "no git",
+  };
+}
+
+export function getActivityLabel(phase: ActivityPhase, activeToolName?: string | null, activeToolCount = 0): string {
+  if (phase === "tool") {
+    const toolName = activeToolName || "tool";
+    const countSuffix = activeToolCount > 1 ? ` x${activeToolCount}` : "";
+    return `Act: ${toolName}${countSuffix}`;
+  }
+
+  return `Act: ${phase}`;
+}
+
+export function createInitialState(): StatuslineState {
+  return {
+    modelLabel: "Model: none",
+    thinkingLabel: "Thinking: off",
+    contextLabel: "Ctx: n/a",
+    tokenLabel: "↑0/↓0",
+    gitSnapshot: createInitialGitSnapshot(),
+    lastSkill: null,
+    activityLabel: getActivityLabel("idle"),
+    activityPhase: "idle",
+    activeToolCount: 0,
+    activeToolName: null,
+    liveAssistantUsage: null,
+  };
+}

--- a/packages/pi-statusline/extensions/ui-mode.ts
+++ b/packages/pi-statusline/extensions/ui-mode.ts
@@ -1,0 +1,13 @@
+export type UiAvailability = { hasUI: boolean };
+
+export function createUiOnlyHandler<Event, Ctx extends UiAvailability, Result>(
+  handler: (event: Event, ctx: Ctx) => Result | Promise<Result>,
+): (event: Event, ctx: Ctx) => Result | Promise<Result> | undefined {
+  return (event, ctx) => {
+    if (!ctx.hasUI) {
+      return undefined;
+    }
+
+    return handler(event, ctx);
+  };
+}

--- a/packages/pi-statusline/extensions/ui-mode.ts
+++ b/packages/pi-statusline/extensions/ui-mode.ts
@@ -8,19 +8,19 @@ function isStaleExtensionContextError(error: unknown): boolean {
 
 export function createUiOnlyHandler<Event, Ctx extends UiAvailability, Result>(
   handler: (event: Event, ctx: Ctx) => Result | Promise<Result>,
-): (event: Event, ctx: Ctx) => Result | Promise<Result> | undefined {
-  return (event, ctx) => {
+): (event: Event, ctx: Ctx) => Promise<Result | undefined> {
+  return async (event, ctx) => {
     try {
       if (!ctx.hasUI) {
         return undefined;
       }
+
+      return await handler(event, ctx);
     } catch (error) {
       if (!isStaleExtensionContextError(error)) {
         throw error;
       }
       return undefined;
     }
-
-    return handler(event, ctx);
   };
 }

--- a/packages/pi-statusline/extensions/ui-mode.ts
+++ b/packages/pi-statusline/extensions/ui-mode.ts
@@ -1,10 +1,23 @@
 export type UiAvailability = { hasUI: boolean };
 
+const STALE_EXTENSION_CONTEXT_MESSAGE = "This extension ctx is stale after session replacement or reload";
+
+function isStaleExtensionContextError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(STALE_EXTENSION_CONTEXT_MESSAGE);
+}
+
 export function createUiOnlyHandler<Event, Ctx extends UiAvailability, Result>(
   handler: (event: Event, ctx: Ctx) => Result | Promise<Result>,
 ): (event: Event, ctx: Ctx) => Result | Promise<Result> | undefined {
   return (event, ctx) => {
-    if (!ctx.hasUI) {
+    try {
+      if (!ctx.hasUI) {
+        return undefined;
+      }
+    } catch (error) {
+      if (!isStaleExtensionContextError(error)) {
+        throw error;
+      }
       return undefined;
     }
 


### PR DESCRIPTION
## Summary
- Make pi-statusline inert in non-UI modes such as `pi -p`, avoiding footer/tool work where no TUI is available.
- Guard async status refreshes against stale session contexts and stale session-start races.
- Refactor statusline helper logic into focused modules with direct unit coverage.

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [x] Refactor

## Test plan
- `npx vitest run packages/pi-statusline/__tests__`
- `npx tsc --noEmit --project packages/pi-statusline/tsconfig.json`
- `npx biome ci packages/pi-statusline`