### PR TITLE
feat(pi-sequential-thinking): add session state foundation

### DIFF
--- a/docs/architecture/plan-pi-sequential-thinking-state-foundation.md
+++ b/docs/architecture/plan-pi-sequential-thinking-state-foundation.md
@@ -3,7 +3,7 @@ title: "pi-sequential-thinking State Foundation"
 prd: "PRD-009-pi-sequential-thinking-state-foundation"
 date: 2026-05-16
 author: "pi"
-status: Draft
+status: Implemented
 ---
 
 # Plan: pi-sequential-thinking State Foundation

--- a/docs/architecture/plan-pi-sequential-thinking-state-foundation.md
+++ b/docs/architecture/plan-pi-sequential-thinking-state-foundation.md
@@ -1,0 +1,311 @@
+---
+title: "pi-sequential-thinking State Foundation"
+prd: "PRD-009-pi-sequential-thinking-state-foundation"
+date: 2026-05-16
+author: "pi"
+status: Draft
+---
+
+# Plan: pi-sequential-thinking State Foundation
+
+## Source
+
+* **PRD**: `docs/prd/PRD-009-pi-sequential-thinking-state-foundation.md`
+* **Date**: 2026-05-16
+* **Author**: pi
+
+## Architecture Overview
+
+Implement the state foundation as a boundary-normalization and storage refactor of `packages/pi-sequential-thinking`, not as a new package or MCP transport. The current extension already has the right broad shape: `extensions/index.ts` owns tool registration/config/output truncation, `extensions/types.ts` owns thought data and serialization helpers, `extensions/storage.ts` owns JSON persistence, and `extensions/analyzer.ts` summarizes already-loaded thoughts. The plan keeps that shape and adds named sessions, read-only history/status tools, and mutation receipts around it.
+
+The user-facing premise from PRD-009 is that repeated structured reasoning currently fails at the tool boundary and state boundary: MCP-style examples need translation, dynamic reasoning depth can be rejected, unrelated reasoning shares one implicit session, and users cannot inspect state safely without file reads. This implementation bundle is the direct path because normalization reduces call failures, named sessions isolate workflows, history/status tools make state inspectable, and receipts prove whether mutations changed the selected session.
+
+The first architectural move is to create one normalization/validation boundary before any tool handler builds `ThoughtData`. Tool calls may arrive as snake\_case or selected MCP-style camelCase, but the rest of the package should continue using the existing snake\_case internal model. This keeps churn small while satisfying PRD-009 FR-1 through FR-3. Dynamic total adjustment is applied only to the incoming thought record; prior records are not rewritten.
+
+The second move is to make `ThoughtStorage` session-aware while preserving `current_session.json` as the default-session file. Named sessions live under `sessions/<session_id>.json`. This per-session file layout is simple, backward-compatible, and inspectable, but V1 explicitly targets one active pi process per storage directory and does not claim cross-process locking. Phase 2 must treat that as a tested/documented runtime invariant rather than an implicit hope: if expected deployments require multiple writers sharing one storage directory, pause and add a locking/read-modify-write design before session-aware writes land. Status may scan session files up to the PRD-defined threshold of 100 named sessions; above that it reports partial completeness rather than inventing an index.
+
+## Components
+
+### 1. Input Normalization and Validation
+
+**Purpose**: Convert all supported tool inputs into one validated internal shape before storage or analysis.
+
+**Key Details**:
+
+* Add constants and helpers in `packages/pi-sequential-thinking/extensions/types.ts`:
+  * `DEFAULT_SESSION_LABEL = "default"`
+  * `SCHEMA_VERSION = 1`
+  * `MAX_IMPORT_BYTES = 10 * 1024 * 1024`
+  * `STATUS_ENUMERATION_SESSION_THRESHOLD = 100`
+  * `normalizeSessionId(value)` with trim, path-safe validation, and reserved `default` rejection.
+  * `normalizeThoughtInput(args)` with alias conflict detection.
+  * validation helpers for required strings, booleans, positive integers, optional string arrays, and stage values.
+  * TypeBox parameter-schema helpers for aliasable inputs. Do not keep snake\_case alias fields TypeBox-required while expecting camelCase-only calls to work; either optionalize alias pairs and enforce requiredness in shared validation, or use a schema union/anyOf that accepts snake\_case, camelCase, and mixed matching aliases.
+* Alias comparison happens after normalization. Arrays use exact-order deep equality.
+* Dynamic total adjustment happens after positive-integer validation and returns metadata such as `totalThoughtsAdjusted` for receipts.
+* Keep `thoughtFromDict` / `thoughtToDict` compatible with existing persisted camelCase exports while routing new import normalization through shared helpers.
+* Runtime errors should preserve field-level validation details in tool `details` where practical, while keeping text output readable.
+
+**ADR Reference**: None — this is boundary implementation for requirements already settled by PRD-009.
+
+### 2. Session-Aware Storage
+
+**Purpose**: Isolate default and named session histories while preserving default-session compatibility.
+
+**Key Details**:
+
+* Refactor `packages/pi-sequential-thinking/extensions/storage.ts` around session accessors instead of one in-memory `thoughts` array:
+  * default session file remains `current_session.json`.
+  * named session files live at `sessions/<session_id>.json`.
+  * public methods accept optional normalized session IDs: `addThought`, `getThoughts`, `clearHistory`, `exportSession`, `importSession`, `getHistory`, `getSessionMetadata`, `getStatus`.
+* Keep legacy compatibility:
+  * array exports import successfully.
+  * `{ thoughts: [...] }` exports import successfully.
+  * `current_session.json` loads without migration.
+* Imported thought records accept both snake\_case and camelCase serialization names. In particular, legacy snake\_case `thought_number`, `total_thoughts`, and `next_thought_needed` values must be preserved rather than silently defaulted.
+* Create the storage directory and session files with restrictive permissions where supported by the platform, such as owner-only directories and files on POSIX systems. Document residual plaintext-at-rest risk because permissions reduce casual local exposure but do not encrypt content or control backups/sync tools.
+* New-format exports use PRD-009 schema fields: `schemaVersion`, `sessionId`, `sessionLabel`, `thoughts`, `lastUpdated`, `exportedAt`, and `metadata`.
+* Imports normalize missing legacy IDs/timestamps and report warnings to the caller.
+* Export may overwrite an existing file only on explicit `export_session`; the receipt reports `overwroteExistingFile`.
+* Import/export path policy is explicit: `file_path` may be absolute or repo-relative, repo-relative paths resolve from the current working directory, parent directories are created only for export, directory targets are rejected, export rejects a symlink as the final path component to avoid overwriting an unexpected target, and receipts/errors use the same home-redacted path policy as status.
+* Import validates file size before parsing, rejects malformed top-level records, and treats thought text as untrusted inert content.
+
+**ADR Reference**: ADR candidate — per-session JSON storage is durable and shapes future branch/revision work.
+
+### 3. History and Session-Scoped Tool Surface
+
+**Purpose**: Make state inspectable and session-scoped at the tool layer.
+
+**Key Details**:
+
+* Update TypeBox schemas in `packages/pi-sequential-thinking/extensions/index.ts`:
+  * add optional `session_id` / `sessionId` to stateful tools.
+  * accept camelCase aliases at the schema boundary for thought capture fields while retaining snake\_case examples.
+  * avoid parameter schemas that reject camelCase-only calls before shared normalization/validation can run.
+  * add `get_thinking_history` parameters: `session_id` / `sessionId`, `limit`, `offset`, `include_full_thoughts` / `includeFullThoughts`, `piMaxBytes`, `piMaxLines`.
+* `process_thought` flow:
+  1. split pi output-limit params;
+  2. normalize/validate thought input;
+  3. capture pre-count;
+  4. store thought in selected session;
+  5. analyze only that session's thoughts;
+  6. return analysis plus receipt.
+* `get_thinking_history` returns persisted insertion order from oldest to newest, with offset/limit applied after ordering.
+* `get_thinking_history` enforces PRD defaults and bounds: `limit` defaults to 20, `1 <= limit <= 100`, `offset` defaults to 0, and `include_full_thoughts` defaults to true.
+* Trust boundary for content-bearing tools is explicit: V1 assumes callers with access to the local pi tool set are trusted to read local thought content. `get_thinking_history`, `generate_summary`, and export/import docs must label themselves content-bearing; no additional auth layer is added in this slice.
+* `generate_summary` passes only the selected session's thoughts to `ThoughtAnalyzer`. `ThoughtAnalyzer` should not need broad changes unless the implementation chooses to add session metadata to summary wrappers.
+* `clear_history`, `export_session`, and `import_session` default to the default session when no session target or embedded import session exists.
+* `sequential_think` remains a compatibility shim: it accepts optional `session_id` / `sessionId`, writes generated stage prompts to the selected session, summarizes only that session, and returns a receipt.
+
+**ADR Reference**: None — follows PRD-009 tool-scope decisions.
+
+### 4. Receipts, Fingerprints, and Status Diagnostics
+
+**Purpose**: Make mutations and storage state auditable without exposing thought content.
+
+**Key Details**:
+
+* Introduce the final shared receipt/fingerprint builder before the first receipt-bearing tool is wired, likely in `storage.ts` or a new package-local helper if it keeps `index.ts` simpler.
+* Receipt fields match PRD-009: `operation`, `sessionId`, `sessionLabel`, `preCount`, `postCount`, `changed`, timestamp, optional warnings, and `stateFingerprint`.
+* Fingerprints are derived only from non-content metadata: schema/storage version, normalized session ID, thought count, thought IDs, thought timestamps, and session `lastUpdated`.
+* Fingerprints are receipt-correlation and non-content state-change indicators, not tamper-proof integrity proofs. They must not be documented or tested as detecting edits to thought text, tags, axioms, or assumptions when IDs/timestamps/counts are preserved.
+* Add `resolveEffectiveConfig()` or equivalent so runtime code and `get_thinking_status` share one source of truth for `storageDir`, `maxBytes`, `maxLines`, and each value's source label (`flag`, `env`, `project_settings`, `global_settings`, `config_file`, or `default`).
+* Add `get_thinking_status` in `index.ts` backed by storage diagnostics:
+  * home-redacted `storageDir`, `defaultSessionFile`, and every path-bearing `effectiveConfig` field;
+  * `pathDisclosure`;
+  * `namedSessionCount`;
+  * `totalThoughts` when complete;
+  * per-session metadata without thought text/tags/axioms/assumptions;
+  * config source labels;
+  * `writable`;
+  * relative `backupFiles`;
+  * `statusCompleteness`.
+* `get_thinking_status` accepts `piMaxBytes` and `piMaxLines` and routes output through the same truncation path as the existing tools.
+* V1 status scans `current_session.json` and up to 100 named session files. If more named files exist, return partial status with `statusCompleteness.complete: false`.
+* Do not include raw absolute paths by default; any future absolute-path diagnostic option is outside this plan.
+
+**ADR Reference**: None — operational diagnostics are implementation detail under PRD-009.
+
+### 5. Tests and Documentation
+
+**Purpose**: Lock the new behavior while preserving non-obsoleted compatibility.
+
+**Key Details**:
+
+* Update tests before implementation for each phase:
+  * `__tests__/types.test.ts`: alias normalization, conflict detection, dynamic totals, session ID validation, import normalization helpers.
+  * `__tests__/storage.test.ts`: default-session compatibility, named-session isolation, new export schema, legacy imports, malformed/oversized import errors, status metadata, backup file reporting, receipt inputs.
+  * `__tests__/runtime.test.ts`: registered tool behavior for aliases, sessions, history, status, receipts, and `sequential_think` session behavior.
+  * `__tests__/index.test.ts`: new tool registrations.
+  * `__tests__/helpers.test.ts`: any exported helpers for redaction, fingerprints, or config-source status.
+* Update superseded tests intentionally:
+  * strict `total_thoughts < thought_number` rejection becomes dynamic adjustment.
+  * empty-object imports should become malformed top-level import errors for explicit import calls, while missing active storage still loads as empty.
+* Update `packages/pi-sequential-thinking/README.md` with named-session examples, alias support, dynamic totals, history/status tools, local plaintext storage posture, content-bearing vs diagnostic tools, import/export path behavior, and exclusions.
+
+**ADR Reference**: None — verification and documentation work.
+
+## Implementation Order
+
+| Phase | Component                                                                  | Dependencies                                                | Estimated Scope |
+| ----- | -------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------- |
+| 1     | Input Normalization and Validation                                         | None                                                        | M               |
+| 2     | Session-Aware Storage Foundation                                           | Phase 1 constants/session validation + storage ADR decision | L               |
+| 3     | Minimum Validating Tool Slice (`process_thought` + `get_thinking_history`) | Phase 1, Phase 2                                            | M               |
+| 4     | Session-Aware Existing Tools and Import/Export Boundaries                  | Phase 2, Phase 3                                            | L               |
+| 5     | Receipts, Fingerprints, and Status Diagnostics                             | Phase 2, Phase 3, Phase 4                                   | M               |
+| 6     | README and Final Regression Coverage                                       | Phases 1-5                                                  | S               |
+
+### Phase 1: Input Normalization and Validation
+
+Outcome: tool inputs can be normalized and validated independently of storage/tool handlers.
+
+Steps:
+
+1. Add normalization result types to `extensions/types.ts`, including normalized thought input and receipt adjustment metadata.
+2. Add alias-resolution helper that accepts exactly the PRD-defined aliases and fails on conflicting post-normalization values.
+3. Add TypeBox parameter schemas for aliasable fields so camelCase-only calls can reach shared validation instead of being rejected by required snake\_case schema fields.
+4. Add `normalizeSessionId` and reserve case-insensitive `default`.
+5. Update `validateThoughtData` semantics so `total_thoughts < thought_number` no longer fails after normalization; instead, dynamic adjustment records the change.
+6. Add tests for snake\_case, camelCase-only, mixed matching aliases, conflicting aliases, invalid booleans/integers, invalid stages, invalid arrays, and session IDs.
+
+Phase gate:
+
+* `npx vitest run packages/pi-sequential-thinking/__tests__/types.test.ts`
+
+### Phase 2: Session-Aware Storage Foundation
+
+Outcome: default and named sessions persist separately without changing default-session file compatibility.
+
+Steps:
+
+1. Resolve the storage-layout ADR gate before changing storage code: either create/approve the standalone per-session JSON ADR or explicitly record that the ADR index in this plan is the accepted decision record for V1.
+2. Introduce internal session file resolution methods:
+   * `resolveSessionFile(undefined) -> current_session.json`
+   * `resolveSessionFile(sessionId) -> sessions/<sessionId>.json`
+3. Replace the single eager `thoughts` array with session-scoped load/save methods. Keep copying arrays on read.
+4. Preserve atomic write pattern and corrupted-file backup for active storage files.
+5. Add new session-aware public APIs while keeping old method signatures as default-session shims if tests/imports rely on them.
+6. Add storage metadata helpers for counts, lastUpdated, named session listing, backup file listing, writability checks, and one-active-process diagnostic assumptions.
+7. Add tests for default-session load, named isolation, persistence across new `ThoughtStorage` instances, invalid session IDs, restrictive permissions where platform-testable, and no-migration default behavior.
+
+Phase gate:
+
+* `npx vitest run packages/pi-sequential-thinking/__tests__/storage.test.ts`
+
+### Phase 3: Minimum Validating Tool Slice
+
+Outcome: the smallest user-visible foundation works end-to-end: normalized capture, named-session writes, and read-only history.
+
+Steps:
+
+1. Update `processThought` in `extensions/index.ts` to call normalization helpers instead of casting raw args.
+2. Add session-aware `storage.addThought` and `storage.getThoughts` calls.
+3. Return analysis for only the selected session.
+4. Introduce the shared mutation receipt/fingerprint helper and attach the first `process_thought` receipt with pre/post counts and dynamic total adjustment metadata.
+5. Register `get_thinking_history` with bounded `limit` / `offset` / snippet behavior, including default `limit` 20, maximum `limit` 100, default `offset` 0, and default `include_full_thoughts` true.
+6. Add runtime and schema-boundary tests covering snake\_case compatibility, camelCase-only aliases, mixed aliases, named-session isolation, dynamic totals, and history pagination/snippet behavior.
+
+Phase gate:
+
+* `npx vitest run packages/pi-sequential-thinking/__tests__/types.test.ts packages/pi-sequential-thinking/__tests__/storage.test.ts packages/pi-sequential-thinking/__tests__/runtime.test.ts`
+
+### Phase 4: Session-Aware Existing Tools and Import/Export Boundaries
+
+Outcome: existing stateful tools operate on selected sessions and import/export is safe enough for V1.
+
+Steps:
+
+1. Add optional `session_id` / `sessionId` schemas to `generate_summary`, `clear_history`, `export_session`, `import_session`, and `sequential_think`.
+2. Make `generate_summary` read only selected-session thoughts.
+3. Make `clear_history` clear only the selected session and return a receipt.
+4. Implement new export schema with session metadata and overwrite receipt behavior.
+5. Implement import precedence: explicit target wins; otherwise embedded `sessionId`; otherwise default.
+6. Enforce 10 MiB import max before parsing.
+7. Reject malformed top-level explicit imports with structured errors.
+8. Normalize imported legacy thoughts, generating missing IDs/timestamps and returning warnings.
+9. Ensure imported thought records preserve both snake\_case and camelCase numeric/boolean fields before generating defaults.
+10. Update `sequential_think` as a session-aware compatibility shim without redesigning its canned-prompt behavior.
+
+Phase gate:
+
+* `npx vitest run packages/pi-sequential-thinking/__tests__/storage.test.ts packages/pi-sequential-thinking/__tests__/runtime.test.ts`
+
+### Phase 5: Receipts, Fingerprints, and Status Diagnostics
+
+Outcome: stateful behavior is auditable without exposing thought content or raw home paths.
+
+Steps:
+
+1. Reuse and extend the shared receipt/fingerprint helper introduced in Phase 3 for all mutating tools.
+2. Add home-path redaction helper and tests.
+3. Refactor runtime config resolution into `resolveEffectiveConfig()` or equivalent, returning values plus source labels for `storageDir`, `maxBytes`, and `maxLines`.
+4. Implement storage diagnostics for default session, named sessions, backup files, writability, and completeness.
+5. Register `get_thinking_status` with `piMaxBytes` / `piMaxLines` support and route output through the existing truncation helper.
+6. Include effective config values plus source labels in status using the shared effective-config resolver.
+7. Apply the same path-redaction policy to top-level status fields and nested `effectiveConfig.storageDir`.
+8. Enforce status threshold of 100 named sessions; above that, report partial completeness.
+9. Add tests that known thought text, tags, axioms, assumptions, raw home paths, and content-derived hashes are absent from status/receipts; also test config source-label precedence.
+
+Phase gate:
+
+* `npx vitest run packages/pi-sequential-thinking/__tests__`
+
+### Phase 6: README and Final Regression Coverage
+
+Outcome: docs match behavior and all package-level checks pass.
+
+Steps:
+
+1. Update README feature list and tool reference for `get_thinking_history`, `get_thinking_status`, session IDs, aliases, dynamic totals, and receipts.
+2. Document local plaintext storage posture and identify content-bearing vs diagnostic tools.
+3. Document import/export path behavior, symlink/directory handling, overwrite behavior, 10 MiB import limit, content-bearing trust boundary, plaintext file permissions posture, and default session compatibility.
+4. Document out-of-scope branch/revision metadata and dual MCP server architecture.
+5. Run final targeted checks.
+
+Phase gate:
+
+* `npx vitest run packages/pi-sequential-thinking/__tests__`
+* `npx tsc --noEmit --project packages/pi-sequential-thinking/tsconfig.json`
+* `npx biome ci packages/pi-sequential-thinking`
+
+## Risks and Mitigations
+
+| Risk                                                       | Likelihood | Impact | Mitigation                                                                                                                                                      |
+| ---------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Default-session compatibility regresses                    | Medium     | High   | Keep `current_session.json` path unchanged; add fixture-style tests for existing `{ thoughts: [...] }` and legacy array files before refactoring storage.       |
+| Session-aware refactor becomes too large to debug          | Medium     | Medium | Land in validating increments: normalization, storage foundation, then `process_thought` + history before import/export/status.                                 |
+| Alias schemas or normalization accept/reject wrong data    | Medium     | High   | Fail on post-normalization alias conflicts; centralize alias resolution; test mixed snake/camel calls and camelCase-only calls at the registered-tool boundary. |
+| Dynamic total semantics drift into backfilling             | Low        | Medium | Keep adjustment in normalization result for only the incoming thought; add tests that prior records are not rewritten.                                          |
+| Import of untrusted files corrupts active state            | Medium     | High   | Validate file size and shape before replacing session state; reject malformed top-level records; preserve corrupted active-file backup behavior.                |
+| Receipts leak content or paths                             | Low        | High   | Build fingerprints only from IDs/timestamps/counts; add negative tests for thought text and raw home paths in status/receipt output.                            |
+| Status scan is slow with many session files                | Low        | Medium | Use PRD threshold of 100 named sessions; report `statusCompleteness.complete: false` above threshold instead of scanning everything.                            |
+| `sequential_think` continues to imply real model reasoning | Medium     | Low    | Keep only compatibility changes in code, but document it as a legacy helper and defer redesign/deprecation to later backlog.                                    |
+| TypeBox schemas become hard to read with aliases           | Medium     | Low    | Keep schemas permissive with documented optional aliases; move real normalization/validation to TypeScript helpers with tests.                                  |
+
+## Open Questions
+
+* No open implementation questions remain for this plan.
+
+Before Phase 2 begins, the per-session JSON storage decision must be explicitly accepted either through a standalone ADR or by treating this plan's ADR index as the accepted V1 decision record. The PRD-resolved V1 defaults are not open implementation questions for this plan: imports reject files over 10 MiB, status may become partial after 100 named session files, and raw absolute path disclosure remains out of scope unless a future PRD or ADR changes it.
+
+## ADR Index
+
+Decisions made during this plan:
+
+| ADR                                                             | Title                                                                | Status             |
+| --------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------ |
+| ADR-TBD                                                         | Persist named sequential-thinking sessions as per-session JSON files | Proposed           |
+| `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md`     | Stateful Exa Research Planning Tools                                 | Existing precedent |
+| `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md` | In-Memory Exa Research Planning Sessions                             | Existing contrast  |
+
+### ADR candidate assessment
+
+`Persist named sequential-thinking sessions as per-session JSON files` passes the 4-point test:
+
+1. **Multiple approaches** — per-session files, one combined sessions file, and per-thought `session_id` in the current file are all viable.
+2. **Lasting consequences** — storage layout affects future branch/revision metadata, import/export, status enumeration, and migration behavior.
+3. **Disagreement potential** — reasonable engineers could prefer a single indexed file for status performance or per-session files for inspectability.
+4. **Future constraints** — the choice shapes how later safety, archival, and branch/revision features work.
+
+No ADR is recommended for alias normalization or dynamic totals; those are compatibility semantics already established by PRD-009 and do not independently constrain future architecture enough to warrant standalone records.

--- a/docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md
+++ b/docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md
@@ -1,0 +1,235 @@
+---
+date: 2026-05-16
+topic: pi-sequential-thinking-improvements
+focus: improvements to packages/pi-sequential-thinking after external sequential-thinking research
+mode: repo-grounded
+---
+
+# Ideation: pi-sequential-thinking Improvements
+
+## Grounding Context
+
+### Codebase Context
+
+* This repo is an npm workspace of independent TypeScript pi extension packages under `packages/*`, with Biome, Vitest, and package-local `extensions/index.ts` plus `__tests__` conventions.
+
+* `packages/pi-sequential-thinking` currently exposes staged thinking tools: `process_thought`, `generate_summary`, `clear_history`, `export_session`, `import_session`, plus an undocumented `sequential_think` helper.
+
+* Current strengths: five cognitive stages, tags/axioms/assumptions metadata, related-thought analysis, summaries, persistent JSON import/export, and output truncation controls.
+
+* Current gaps: no named sessions, no history inspection tool, no branch/revision metadata, no dynamic total auto-adjustment, no bounded history, no redaction/security warnings, partial duplicated validation, and `sequential_think` stores canned prompts rather than real model reasoning.
+
+* Adjacent pattern: `packages/pi-code-reasoning` already provides branch/revision field semantics, cross-field validation, status/reset tools, max thought count/length, and checklist-oriented tool descriptions.
+
+### Past Learnings
+
+* `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md`: prompt-only multi-step workflows are unreliable; externalize process state into explicit tools. Planning/reasoning tools may recommend next actions but should not hide expensive or side-effectful calls.
+
+* `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`: persistence adds path/config/privacy complexity; start lighter when intra-session state is enough. For `pi-sequential-thinking`, persistence already exists, so preserve backward-compatible JSON behavior.
+
+* `packages/pi-sequential-thinking/extensions/storage.ts`: current persistence already handles import/export, legacy array loading, corrupted-file backup, and atomic temp-file rename. Preserve those safety properties when adding fields/sessions.
+
+* `packages/pi-code-reasoning/extensions/types.ts`: branch/revision metadata needs cross-field validation: revisions require `revises_thought` and forbid branch fields; branches require both `branch_from_thought` and `branch_id`; references should be valid.
+
+### External Context
+
+* Official MCP sequentialthinking establishes canonical branch/revision/dynamic-depth fields and auto-raises `totalThoughts` when `thoughtNumber` exceeds it.
+
+* `spences10/mcp-sequentialthinking-tools` adds `session_id`, `get_thinking_history`, session-aware clear, per-session max history, prompt-injection-like redaction, and optional `available_tools` / `recommended_tools` validation without executing tools.
+
+* `mettamatt/code-reasoning` adds stricter guardrails: strict/loose validation, max thought cap, branch/revision exclusivity, branch reference validation, and guidance-rich errors.
+
+* MAXential Thinking shows a larger future surface: branch/switch/merge/close, get history, tag/search/export/visualize, session save/load/list/summary. Useful as future inspiration, but too large to copy wholesale now.
+
+* `gotza02/mcp-thinking` adds Tree-of-Thought typed steps and summarization/archiving, but bundles unrelated web/shell/project graph tools that do not fit this package.
+
+* `thedotmack/sequential-thinking-skill` reinforces the value of append-only state, full state inspection, and compact status output outside MCP infrastructure.
+
+## Topic Axes
+
+1. Thought capture ergonomics and schema compatibility
+2. Session/history/persistence lifecycle
+3. Branch/revision/navigation workflows
+4. Safety, limits, and tool-planning metadata
+5. Higher-level synthesis, organization, and tool-surface focus
+
+## Ranked Ideas
+
+### 1. Session-scoped history foundation
+
+**Description:** Add `session_id`, a read-only `get_thinking_history` tool, session-aware clear/import/export/summary behavior, and bounded `limit` output. Preserve default behavior as the existing unnamed/default session and keep old exports importable.
+
+**Deeper notes:** This should be the first foundation because it turns the package from one global scratchpad into reusable reasoning memory. The smallest useful slice is: `session_id` on capture/read/clear, default session backward compatibility, branch-ready history records, and a bounded read API. Nice-to-have lifecycle concepts like named titles, archived status, or merge semantics should wait until actual session usage proves they are needed.
+
+**Axis:** Session/history/persistence lifecycle
+
+**Basis:** `direct:` current package has persistent JSON state but no named sessions or live history inspection; `external:` spences10 adds `session_id`, `get_thinking_history`, session-aware clear, and max history.
+
+**Rationale:** This is the foundation that makes later branch/revision/synthesis features usable rather than invisible state. It also gives agents a safe way to inspect state before continuing or clearing it.
+
+**Downsides:** Touches storage, schemas, runtime tests, and README; needs careful backward-compatible JSON migration.
+
+**Confidence:** 94%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 2. Branch/revision metadata with lightweight navigation
+
+**Description:** Add append-only branch/revision metadata to thoughts, validate references, expose branch/revision labels in history and summary, and avoid the full MAXential branch-management surface at first.
+
+**Deeper notes:** This means metadata and views, not a full branch engine. A revision is a new thought that points at the earlier thought it corrects; a branch is a new line of reasoning that names its source and branch ID. The first version should let users record, filter, and summarize those relationships; switch/merge/close can remain explicitly out of scope.
+
+**Axis:** Branch/revision/navigation workflows
+
+**Basis:** `direct:` `pi-sequential-thinking` lacks branch/revision fields while `pi-code-reasoning` has cross-field validation; `external:` official MCP sequentialthinking defines these semantics.
+
+**Rationale:** Real reasoning is not linear; this gives correction and alternatives without jumping straight to branch switching/merge/close tools. Lightweight navigation keeps the surface small while still making alternative paths inspectable.
+
+**Downsides:** Requires reference validation and summary/history UI choices; branch semantics can sprawl if not scoped tightly.
+
+**Confidence:** 91%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 3. MCP-compatible capture normalization and dynamic depth
+
+**Description:** Normalize snake\_case and MCP-style aliases into one internal model, auto-adjust `total_thoughts`, centralize validation, and return guidance-rich errors. Include a low-cost continuation-card response polish if it fits the same work.
+
+**What this gains:** It reduces failed calls when agents use examples from the wider MCP ecosystem, removes needless friction when a thought sequence needs more steps than expected, and creates one validation path that future branch/session/safety features can build on. The gain is not just compatibility; it is fewer interrupted reasoning loops and less schema translation in prompts.
+
+**Axis:** Thought capture ergonomics and schema compatibility
+
+**Basis:** `direct:` validation is partial/duplicated and rejects `total_thoughts < thought_number`; `external:` official MCP auto-raises totals and common implementations use canonical branch/revision/dynamic-depth fields.
+
+**Rationale:** This lowers tool-call friction and lets examples/prompts from the wider sequential-thinking ecosystem transfer into pi. It also prevents later features from duplicating input-normalization decisions.
+
+**Downsides:** Alias support increases schema complexity; conflict resolution between duplicate aliases must be deterministic.
+
+**Confidence:** 90%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 4. State observability: effective config + mutation receipts
+
+**Description:** Add a status/diagnostic view that reports effective config, storage path, writeability, current counts, and backup/corruption files. Mutating calls can return compact receipts: pre/post counts, schema version, mtime, and a short state fingerprint.
+
+**Axis:** Session/history/persistence lifecycle; Safety, limits, and tool-planning metadata
+
+**Basis:** `direct:` README documents multiple config sources and storage paths, but tools do not expose resolved runtime state; `reasoned:` hashes/count receipts detect accidental clears, stale state, failed writes, or wrong storage location.
+
+**Rationale:** Statefulness creates trust problems; observability makes storage behavior auditable without dumping full history.
+
+**Downsides:** Fingerprints/checksums must avoid leaking content while remaining useful; status output can become noisy if overbuilt.
+
+**Confidence:** 87%
+
+**Complexity:** Low-Medium
+
+**Status:** Unexplored
+
+### 5. Focused synthesis with outcome contracts and resume prompts
+
+**Description:** Add summary modes for decisions, open questions, assumptions, branches, tags, and next-stage guidance. Support optional `desired_outcome` / `done_when` and produce a compact resume prompt for future model turns. Clarify, deprecate, or make stateless the misleading `sequential_think` helper.
+
+**Axis:** Higher-level synthesis, organization, and tool-surface focus
+
+**Basis:** `direct:` package tracks stages/tags/axioms/assumptions but summary is generic; fresh-angle analysis identified no explicit success target; `direct:` `sequential_think` is undocumented and stores canned prompts rather than real model reasoning.
+
+**Rationale:** This turns recorded state into usable handoff/resumption artifacts while making the tool surface more honest.
+
+**Downsides:** Must keep synthesis deterministic enough to test; too many summary modes could clutter the schema.
+
+**Confidence:** 85%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 6. Persistence safety layer: bounds, redaction, export warnings
+
+**Description:** Add configurable max history / thought length / response limits for reasoning state, plus optional redaction or warning behavior before storage/export.
+
+**Autotuning ergonomics angle:** Instead of only exposing static knobs, make the tool suggest safe defaults and report pressure signals: current session size, largest thoughts, whether output was truncated, recommended `maxHistorySize`, and whether a summary/archive step would help. Redaction can default to warning-first, with opt-in masking, so safety improves without surprising users.
+
+**Axis:** Safety, limits, and tool-planning metadata
+
+**Basis:** `direct:` package persists and exports thoughts but lacks bounded history and redaction warnings; `external:` spences10 uses prompt-injection-like redaction and per-session history caps; code-reasoning has thought length/count caps.
+
+**Rationale:** Once reasoning is persisted, oversized or sensitive content becomes a product risk rather than just an output-format detail. Autotuning-style status makes safety feel helpful instead of punitive.
+
+**Downsides:** Redaction can produce false positives; default policy must avoid surprising users or silently destroying important context.
+
+**Confidence:** 84%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 7. Evidence and artifact reference anchors
+
+**Description:** Let thoughts optionally attach short evidence snippets, URLs, or repo-relative artifact references such as ADRs, docs, package names, or files. Store and summarize these inert anchors without reading or executing them.
+
+**Axis:** Thought capture ergonomics and schema compatibility; Higher-level synthesis, organization, and tool-surface focus
+
+**Basis:** `direct:` current metadata captures cognitive context but not evidence/source/artifact references; `reasoned:` short evidence and repo-relative anchors add traceability without turning this package into a file reader or citation manager.
+
+**Rationale:** This makes Research/Analysis thoughts more auditable and gives summaries stronger provenance.
+
+**Downsides:** Needs strict portability guidance for repo-relative paths and bounded evidence length; can overlap with research-planning tools if expanded too far.
+
+**Confidence:** 78%
+
+**Complexity:** Low-Medium
+
+**Status:** Unexplored
+
+## Implementation Sequence
+
+This sequence is different from the idea ranking above. The ranked list captures value and confidence; this sequence orders work by dependency, risk reduction, and what should become the first requirements slice.
+
+### Recommended first requirements slice
+
+The strongest first slice is the foundation made from ideas 3, 1, and 4:
+
+1. **MCP-compatible capture normalization and dynamic depth** — stabilize the internal input model first: aliases, dynamic `total_thoughts`, centralized validation, and guidance-rich errors.
+2. **Session-scoped history foundation** — add `session_id`, `get_thinking_history`, session-aware clear/export/import, default-session backward compatibility, and bounded history reads.
+3. **State observability: effective config + mutation receipts** — expose effective runtime state and make mutations auditable through compact pre/post receipts.
+
+**Why this slice:** It creates a clean record model, gives agents a way to inspect stored state, and makes stateful behavior trustworthy before adding advanced reasoning affordances.
+
+**Explicitly out of this first slice:** branch/revision metadata, safety/redaction policy, synthesis/resume prompts, evidence anchors, and the dual pi+MCP adapter architecture. Deferred ideas are preserved in `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md`. The dual-adapter idea is tracked separately in <https://github.com/feniix/pi-extensions/issues/99>.
+
+### Full implementation order
+
+1. **Capture normalization and dynamic depth** — shared validation and record normalization foundation.
+2. **Session-scoped history foundation** — named/default sessions plus read-only inspection.
+3. **State observability and mutation receipts** — storage/config visibility and auditable writes.
+4. **Persistence safety layer** — bounded history, thought limits, warning-first redaction, and autotuning pressure signals.
+5. **Branch/revision metadata with lightweight navigation** — append-only alternatives and corrections once history exists.
+6. **Focused synthesis with outcome contracts and resume prompts** — stronger summaries once sessions and branch metadata provide enough structure.
+7. **Evidence and artifact reference anchors** — provenance metadata after the core record shape stabilizes.
+
+## Rejection Summary
+
+| #  | Idea                                     | Reason Rejected                                                                                                                                      |
+| :- | :--------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1  | Non-executing tool-plan metadata         | Still useful, but less central to `pi-sequential-thinking` than evidence/artifact anchors and state observability; keep as a later optional variant. |
+| 2  | Full branch checkout/merge/close toolset | Too expensive and MAXential-sized for the next improvement; keep lightweight metadata/navigation first.                                              |
+| 3  | Issue-tracker-style session statuses     | Interesting, but over-models sessions before basic named sessions/history exist.                                                                     |
+| 4  | Notebook table-of-contents history       | Duplicate of the stronger session-scoped history foundation.                                                                                         |
+| 5  | Strict workflow mode                     | Useful later, but premature until central validation and branch/revision basics are in place.                                                        |
+| 6  | Archival summary mode                    | Better as a later variant of focused synthesis; not needed in the first survivor set.                                                                |
+| 7  | Import/export preview with diff/checksum | Strong trust idea, but covered enough by state observability + receipts for the ranked set.                                                          |
+| 8  | Consistency check and repair-plan mode   | Valuable later for migrations; too much scope before sessions/history exist.                                                                         |
+| 9  | Mutation backup and restore receipt      | Good variant of receipt/safety work, but not distinct enough for the top set.                                                                        |
+| 10 | Confidence and uncertainty chips         | Useful metadata, but outcome/evidence anchors have stronger immediate grounding.                                                                     |
+| 11 | Stage-fit warnings                       | Risks noisy pseudo-linting; revisit after capture model stabilizes.                                                                                  |
+| 12 | Reasoning boundary manifest              | Too meta for users; better handled in README/tool descriptions unless tool-choice confusion becomes severe.                                          |
+
+No topic axis ended with zero survivors.

--- a/docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md
+++ b/docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md
@@ -1,0 +1,123 @@
+---
+date: 2026-05-16
+topic: pi-sequential-thinking-later-backlog
+source: docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md
+focus: deferred improvements after the first requirements slice
+mode: repo-grounded
+---
+
+# Later Backlog: pi-sequential-thinking Improvements
+
+This file preserves improvements that should remain visible after the first requirements slice for `packages/pi-sequential-thinking`.
+
+The selected first slice is tracked in `docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md`:
+
+1. MCP-compatible capture normalization and dynamic depth
+2. Session-scoped history foundation
+3. State observability: effective config + mutation receipts
+
+Everything below is intentionally deferred, not rejected.
+
+## Deferred Ranked Ideas
+
+### 1. Branch/revision metadata with lightweight navigation
+
+**Why later:** This depends on clean records and inspectable session history. It should come after the first slice so branch-aware reads and summaries have a stable state model to query.
+
+**Keep:**
+
+- Append-only branch/revision metadata.
+- Validation for branch and revision references.
+- Branch/revision labels in history and summary output.
+- Lightweight filtering/navigation.
+
+**Avoid initially:**
+
+- Full branch switching.
+- Branch merge/close workflows.
+- MAXential-style large branch-management surface.
+
+### 2. Persistence safety layer: bounds, redaction, export warnings
+
+**Why later:** Safety belongs soon after the state foundation lands, but it should not block the initial session/history/observability slice.
+
+**Keep:**
+
+- Configurable max history size.
+- Thought length limits.
+- Response/output limits.
+- Export warnings.
+- Warning-first sensitive-content detection.
+- Autotuning-style pressure signals: current session size, largest thoughts, truncation status, and recommended `maxHistorySize`.
+
+**Avoid initially:**
+
+- Silent redaction by default.
+- Heavy security scanning.
+- Surprising destructive trimming without visible receipts.
+
+### 3. Focused synthesis with outcome contracts and resume prompts
+
+**Why later:** Synthesis becomes more valuable once sessions, history, and branch/revision metadata exist.
+
+**Keep:**
+
+- Summary modes for decisions, open questions, assumptions, branches, tags, and next-stage guidance.
+- Optional `desired_outcome` / `done_when` metadata.
+- Compact resume prompts for future model turns.
+- A decision on `sequential_think`: clarify, deprecate, make stateless, or replace with a more honest helper.
+
+**Avoid initially:**
+
+- Too many summary modes before usage patterns are clear.
+- Non-deterministic synthesis that is hard to test.
+- Persisting canned model prompts as if they were generated reasoning.
+
+### 4. Evidence and artifact reference anchors
+
+**Why later:** Useful provenance metadata, but best added after the core thought record shape stabilizes.
+
+**Keep:**
+
+- Optional short evidence snippets.
+- URLs.
+- Repo-relative artifact references such as ADRs, docs, package names, and file paths.
+- Inert storage and summary of anchors without reading or executing referenced content.
+
+**Avoid initially:**
+
+- Turning the package into a file reader, citation manager, or research planner.
+- Absolute local paths in exported records.
+- Unbounded evidence blobs.
+
+## Lower-Priority Follow-Up Candidates
+
+These were rejected from the first ranked set but may be revisited after the deferred ranked ideas above.
+
+| Idea | Later use case |
+| --- | --- |
+| Non-executing tool-plan metadata | Optional metadata for `available_tools` / `recommended_tools` once core state and safety behavior are stable. |
+| Strict workflow mode | Could enforce stage progression or required fields after validation and branch semantics settle. |
+| Archival summary mode | Could compact old sessions after safety bounds and focused synthesis exist. |
+| Import/export preview with diff/checksum | Useful for trust and migration workflows if import/export becomes more complex. |
+| Consistency check and repair-plan mode | Useful if session migration or branch references introduce integrity issues. |
+| Mutation backup and restore receipt | Could strengthen observability/safety if users need undo-style workflows. |
+| Confidence and uncertainty chips | Possible metadata extension if outcome contracts are not enough. |
+| Stage-fit warnings | Possible lint-like guidance, but only if it proves helpful rather than noisy. |
+| Reasoning boundary manifest | Better as documentation unless users keep confusing this package with research/tool-execution workflows. |
+
+## Separate Issue
+
+The dual pi extension + MCP server architecture idea is intentionally excluded from this ideation backlog and tracked separately:
+
+- <https://github.com/feniix/pi-extensions/issues/99>
+
+## Suggested Later Sequence
+
+After the selected first slice lands:
+
+1. Add the persistence safety layer.
+2. Add branch/revision metadata with lightweight navigation.
+3. Add focused synthesis and resume prompts.
+4. Add evidence/artifact anchors.
+5. Revisit lower-priority follow-up candidates based on actual usage.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/analogy-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/analogy-ideas.md
@@ -1,0 +1,97 @@
+# Cross-Domain Analogy Ideas for `packages/pi-sequential-thinking`
+
+## 1. Version-Control Commit Metadata for Thought Capture
+
+**summary:** Treat each thought like a lightweight commit: a stable sequence number, optional revision marker, optional branch origin, and a concise intent line. Add compatibility aliases for canonical MCP-style fields such as `isRevision`, `revisesThought`, `branchFromThought`, `branchId`, and `needsMoreThoughts`, while preserving the package’s existing staged schema. Like Git accepting structured commit metadata without changing the repository model, this improves interoperability without replacing the current tool surface.
+
+**axis:** Thought capture ergonomics and schema compatibility
+
+**basis:** external — The grounding summary notes that official MCP sequentialthinking uses canonical branch/revision/dynamic-depth fields and auto-raises `totalThoughts`; direct — the package currently has five cognitive stages plus metadata but lacks branch/revision metadata.
+
+**why_it_matters:** Users and agents can move between sequential-thinking implementations with less schema friction, and branch/revision data becomes first-class instead of being buried in free text.
+
+**meeting_test:** A thought submitted with MCP-style fields is accepted, normalized into the package’s internal format, included in summaries, and exported without breaking legacy JSON imports.
+
+## 2. Notebook Index and Table-of-Contents History Tool
+
+**summary:** Borrow from notebook systems by adding a read-only history/index tool that returns a compact table of contents for the current thinking session: thought numbers, stages, tags, branch IDs, revision links, and short previews. This is not a full replacement for `generate_summary`; it is closer to a notebook sidebar that helps users navigate raw entries before synthesizing them.
+
+**axis:** Session/history/persistence lifecycle
+
+**basis:** direct — The grounding summary identifies no history inspection tool as a current gap; external — `spences10/mcp-sequentialthinking-tools` includes `get_thinking_history`, and notebook systems commonly expose navigable cell outlines.
+
+**why_it_matters:** Stateful reasoning is hard to trust when users cannot inspect what has been recorded. A compact history view makes the append-only state visible without forcing a full export/import cycle.
+
+**meeting_test:** After several `process_thought` calls, a user can call a history tool and see ordered entries with stage, tags, preview text, and branch/revision references, with output truncation controls respected.
+
+## 3. Issue-Tracker Session Labels and Statuses
+
+**summary:** Model sessions like issue tracker tickets: each named session can have a title, status such as `open`, `paused`, or `archived`, and labels derived from tags or stages. Keep the default unnamed in-memory session for backward compatibility, but allow explicit `session_id` to separate parallel investigations. This mirrors issue trackers where multiple threads can remain organized without changing the underlying comment timeline.
+
+**axis:** Session/history/persistence lifecycle
+
+**basis:** external — The grounding summary cites `session_id`, session-aware clear, and max history in `spences10/mcp-sequentialthinking-tools`; direct — the current package has import/export and clear history but no named sessions.
+
+**why_it_matters:** Agents often juggle multiple reasoning threads. Named sessions reduce accidental cross-contamination between tasks and make persistence more useful while preserving legacy behavior.
+
+**meeting_test:** A user can process thoughts into two different `session_id`s, inspect or clear one without affecting the other, and export/import the data with old array-style imports still supported.
+
+## 4. Lab Notebook Revision Pages
+
+**summary:** Use the research lab notebook analogy: original observations are preserved, corrections are appended as dated revision pages, and the corrected entry explicitly points back to the original. Add clear revision validation and display so revised thoughts are linked, not overwritten. This keeps the current append-only spirit while allowing mistaken assumptions or changed conclusions to be corrected transparently.
+
+**axis:** Branch/revision/navigation workflows
+
+**basis:** direct — The grounding summary says there is no branch/revision metadata and that storage already preserves JSON safely; external — `packages/pi-code-reasoning` and `mettamatt/code-reasoning` provide branch/revision exclusivity and reference validation patterns.
+
+**why_it_matters:** Reasoning evolves. Explicit revision links let users audit how a conclusion changed without losing the original chain of thought.
+
+**meeting_test:** Submitting a revision requires a valid `revises_thought`, rejects simultaneous branch fields, and causes summaries/history to show the revision relationship.
+
+## 5. Git Branch Checkout and Merge-Lane Navigation
+
+**summary:** Add navigation affordances inspired by version-control branches: list branches, show the active branch/lane, and optionally summarize only one lane or compare two lanes. The package does not need a huge MAXential-style surface immediately; a focused branch-aware history and summary mode would give most of the navigational benefit.
+
+**axis:** Branch/revision/navigation workflows
+
+**basis:** external — MAXential Thinking includes branch, switch, merge, close, history, tag/search/export/visualize tools as a larger future menu; direct — current `pi-sequential-thinking` lacks branch metadata and navigation.
+
+**why_it_matters:** Branching is useful only if users can see and follow branches. Lightweight lane navigation prevents alternative reasoning paths from becoming an unreadable flat list.
+
+**meeting_test:** Given thoughts on `main` and `option-a`, a user can list branches and request a summary/history scoped to `option-a` without losing access to the full session.
+
+## 6. Safety Log Caps, Redaction, and Incident Notes
+
+**summary:** Treat the thinking history like a safety log: bound its size, flag suspicious or sensitive-looking content, and record warnings without silently deleting evidence. Add configurable max thought count and thought length, plus redaction/security warnings for prompt-injection-like content or secrets before export. This follows safety-log practice where entries remain auditable but risky material is clearly marked or minimized.
+
+**axis:** Safety, limits, and tool-planning metadata
+
+**basis:** direct — The grounding summary lists no bounded history and no redaction/security warnings as current gaps; external — `spences10/mcp-sequentialthinking-tools` has per-session max history and prompt-injection-like redaction, while `mettamatt/code-reasoning` has max thought caps and guidance-rich validation errors.
+
+**why_it_matters:** Long-running agent sessions can accumulate excessive or sensitive state. Limits and warnings make the extension safer to use in persistent workflows.
+
+**meeting_test:** Oversized thoughts and over-cap histories produce clear validation errors or configured truncation behavior, and exports can include redaction warnings while preserving atomic write/corrupt-file backup guarantees.
+
+## 7. Tool-Planning Kanban Metadata
+
+**summary:** Borrow from kanban boards by allowing each thought to declare optional `available_tools`, `recommended_tools`, and `next_action` metadata, while explicitly not executing those tools. The summary or history view can show a small planning column: proposed next tool, reason, and status. This aligns with the ADR lesson that planning tools may recommend next actions but should not hide expensive or side-effectful calls.
+
+**axis:** Safety, limits, and tool-planning metadata
+
+**basis:** direct — ADR-0016 says externalize process state into explicit tools and do not hide expensive or side-effectful calls; external — `spences10/mcp-sequentialthinking-tools` validates optional `available_tools` and `recommended_tools` without executing tools.
+
+**why_it_matters:** Sequential thinking often produces operational next steps. Capturing tool recommendations as metadata makes plans reviewable and safer than embedding action instructions in prose.
+
+**meeting_test:** A thought can include recommended tool metadata, invalid recommendations are caught against `available_tools` when provided, and no external tool calls are made by `process_thought`.
+
+## 8. Research Notebook Synthesis Cards
+
+**summary:** Add higher-level synthesis cards that organize thoughts by stage, tag, assumption, axiom, branch, and unresolved question. This is analogous to research notebooks where raw observations are periodically distilled into literature notes, findings, and open questions. Keep `generate_summary`, but make it more focused: produce compact sections for conclusions, contradictions, open assumptions, and suggested next thinking stage.
+
+**axis:** Higher-level synthesis, organization, and tool-surface focus
+
+**basis:** direct — The package already has stages, tags, axioms, assumptions, related-thought analysis, and `generate_summary`; external — Tree-of-Thought style systems add typed steps and summarization/archiving, but the grounding summary warns against bundling unrelated tools.
+
+**why_it_matters:** The value of sequential thinking is not only capturing steps but extracting usable structure from them. Better synthesis helps users act on the recorded reasoning without expanding the package into unrelated web/shell/project tooling.
+
+**meeting_test:** `generate_summary` can produce grouped sections for tags/stages/branches, list unresolved assumptions or contradictions, and remain focused on reasoning state rather than invoking external tools.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/codebase-scan.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/codebase-scan.md
@@ -1,0 +1,39 @@
+# Code Context
+
+## Files Retrieved
+1. `AGENTS.md` (lines 1-83) - repo conventions: npm workspace, TS, Biome 2-space/120 cols, Vitest, package layout.
+2. `package.json` (lines 1-45) - root scripts/workspaces and registered pi extensions.
+3. `packages/pi-sequential-thinking/README.md` (lines 1-126) - documented tools/config/stages.
+4. `packages/pi-sequential-thinking/extensions/index.ts` (lines 317-386, 393-778) - schemas, flags, tools, runtime flow incl undocumented `sequential_think`.
+5. `packages/pi-sequential-thinking/extensions/types.ts` (lines 1-143) - stage enum, `ThoughtData`, validation/serialization/UUID.
+6. `packages/pi-sequential-thinking/extensions/analyzer.ts` (lines 1-186) - related-thought analysis and summary generation.
+7. `packages/pi-sequential-thinking/extensions/storage.ts` (lines 1-147) - persistent session store/import/export.
+8. `packages/pi-code-reasoning/README.md` (lines 1-122) - adjacent package feature model: branching/revision/status/reset/checklist.
+9. `packages/pi-code-reasoning/extensions/types.ts` (lines 1-153), `extensions/index.ts` (lines 309-699) - stricter validation, tracker, ergonomic errors.
+
+## Key Code
+- Root shape: npm workspace `packages/*`; each package has `extensions/index.ts`, `__tests__`, README/package metadata; root scripts: `lint`, `typecheck`, `test`, `check`.
+- `pi-sequential-thinking` registers flags at `index.ts` 393-414 and tools at 594-778: `process_thought`, `generate_summary`, `clear_history`, `export_session`, `import_session`, plus `sequential_think` not documented in README/tests.
+- `process_thought` (`index.ts` 511-557) casts raw params, parses 5 fixed stages, validates only non-empty thought, thought_number >=1, total >= current, stores then analyzes.
+- Schemas (`index.ts` 317-386) include `additionalProperties: true`, `piMaxBytes/piMaxLines`; no branch/revision fields.
+- `ThoughtAnalyzer` finds related thoughts by same stage/shared tags and summarizes stage counts/timeline/top tags/completion (`analyzer.ts` 47-186).
+- `ThoughtStorage` persists to `~/.mcp_sequential_thinking/current_session.json` by default and supports JSON import/export with corrupted-file backup (`storage.ts` 13-147).
+
+## Architecture
+- Extension entrypoint owns config/flags/output truncation; creates singleton `ThoughtStorage` + `ThoughtAnalyzer`.
+- Tool calls deserialize params -> build `ThoughtData` -> persist in storage -> analyzer returns JSON-ish result -> `formatToolOutput` truncates and attaches details.
+- Session state is durable for sequential-thinking, unlike `pi-code-reasoning` which uses an in-memory tracker for branches/revisions/status.
+
+## Current capabilities/gaps
+- Capabilities: staged thinking, tagging/axioms/assumptions metadata, related-thought lookup, summaries, persistent import/export, output limits.
+- Gaps likely vs external sequential-thinking implementations: no branching, revision, dynamic total adjustment semantics beyond caller-supplied fields, thought reference validation/order limits, status tool, or rich guidance/error examples.
+- Validation gap: `types.ts` has reusable `validateThoughtData` but `index.ts` duplicates partial checks and does not enforce integer types/required booleans/array element types/max length.
+- UX/doc gap: `sequential_think` exists but is not in README feature/tool list or registration test expectations; it stores prompt templates as thoughts rather than model-generated reasoning.
+
+## Likely leverage points
+- Borrow from `pi-code-reasoning`: `ValidatedThoughtData`, max thought length/count constants, cross-field validation, tracker/status/reset tools, guidance-rich `buildError`, checklist-oriented descriptions.
+- Add branch/revision fields to `ThoughtData` + schemas/storage/analyzer if aligning with external sequential-thinking MCP behavior; migration safe because storage serialization already tolerates missing fields if extended carefully.
+- Consider extracting duplicated config/output helpers later, but keep package-scoped changes and tests first per repo guidance.
+
+## Start Here
+Open `packages/pi-sequential-thinking/extensions/index.ts` first: it defines public schemas/tools and is where external sequential-thinking behavior would be surfaced.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/constraint-flip-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/constraint-flip-ideas.md
@@ -1,0 +1,97 @@
+# Constraint-Flip Improvement Ideas for `packages/pi-sequential-thinking`
+
+## 1. Flip “tiny tool surface” into a focused history-inspection tool
+
+**summary:** Keep `process_thought` as the main capture tool, but add a focused `get_thinking_history` tool for inspecting the current state without mutating it. It could support filters such as stage, tag, branch/session, compact vs full output, and pagination/truncation controls so users do not need to export JSON just to inspect progress.
+
+**axis:** Session/history/persistence lifecycle; Higher-level synthesis, organization, and tool-surface focus
+
+**basis:** direct — the grounding summary says the package currently exposes `process_thought`, `generate_summary`, `clear_history`, `export_session`, and `import_session`, but has “no history inspection tool”; external — `spences10/mcp-sequentialthinking-tools` adds `get_thinking_history`, and `thedotmack/sequential-thinking-skill` reinforces full state inspection and compact status output.
+
+**why_it_matters:** A read-only inspection tool makes the stateful workflow more transparent and reduces accidental dependence on import/export files for simple navigation.
+
+**meeting_test:** A user can ask for “show only analysis-stage thoughts tagged auth in compact form” and get relevant stored thoughts without changing history or touching the filesystem.
+
+## 2. Flip “persistence is explicit and private” into named, optionally persistent sessions
+
+**summary:** Add named `session_id` support while keeping the current unnamed/default history behavior backward compatible. Persistence could remain explicit by default, but import/export and clear operations could become session-aware, allowing users to save, load, list, and clear specific thinking threads instead of treating all history as one global timeline.
+
+**axis:** Session/history/persistence lifecycle
+
+**basis:** direct — the grounding summary identifies “no named sessions” as a current gap and notes existing JSON import/export, legacy array loading, corrupted-file backup, and atomic temp-file rename that should be preserved; external — `spences10/mcp-sequentialthinking-tools` includes `session_id`, session-aware clear, and per-session history controls.
+
+**why_it_matters:** Named sessions let users work on multiple problems in parallel without losing the simplicity and privacy posture of explicit persistence.
+
+**meeting_test:** Existing legacy exported JSON still imports successfully, while new calls can isolate thoughts under `session_id: "refactor-plan"` and clear only that session.
+
+## 3. Flip “linear staged thinking” into branch/revision-aware navigation
+
+**summary:** Add canonical branch and revision fields to `process_thought`, such as `isRevision`, `revisesThought`, `branchFromThought`, `branchId`, and `needsMoreThoughts`, with validation that branches and revisions are mutually exclusive. The tool can remain append-only while representing corrections, alternatives, and explorations as explicit metadata rather than overwriting prior thoughts.
+
+**axis:** Branch/revision/navigation workflows; Thought capture ergonomics and schema compatibility
+
+**basis:** direct — the grounding summary lists “no branch/revision metadata” as a gap and notes that `packages/pi-code-reasoning` already has branch/revision semantics, cross-field validation, and reference checks; external — official MCP sequentialthinking uses `isRevision`, `revisesThought`, `branchFromThought`, `branchId`, and `needsMoreThoughts`.
+
+**why_it_matters:** Real reasoning rarely stays linear; explicit alternatives and corrections make the history auditable without forcing users to fake branches through tags.
+
+**meeting_test:** Submitting a revision without `revisesThought` produces a guidance-rich validation error, while a valid branch can later be filtered or summarized independently.
+
+## 4. Flip “schema compatibility limits ergonomics” into alias-friendly input normalization
+
+**summary:** Accept both the package’s current snake_case fields and MCP-style camelCase aliases for common parameters, normalizing them internally into one canonical model. Include dynamic total adjustment when `thoughtNumber` exceeds `totalThoughts`, mirroring canonical sequentialthinking behavior while preserving current API compatibility.
+
+**axis:** Thought capture ergonomics and schema compatibility
+
+**basis:** direct — the grounding summary notes “partial duplicated validation” and “no dynamic total auto-adjustment”; external — official MCP sequentialthinking auto-raises `totalThoughts` when `thoughtNumber` exceeds it and uses camelCase branch/revision/depth fields.
+
+**why_it_matters:** Alias compatibility reduces friction for users and agents familiar with MCP sequentialthinking, without breaking existing pi users who already use snake_case.
+
+**meeting_test:** Calls using either `thought_number`/`total_thoughts` or `thoughtNumber`/`totalThoughts` store equivalent thoughts, and a thought numbered 6 of 5 returns an adjusted total of 6 rather than failing unnecessarily.
+
+## 5. Flip “lightweight capture” into bounded, safer capture with redaction warnings
+
+**summary:** Add configurable limits for max thoughts, max thought length, and per-session history size, plus warnings or optional redaction for likely secrets and prompt-injection-like content. Keep the default lightweight, but make safety posture visible in tool responses when content is truncated, rejected, or redacted.
+
+**axis:** Safety, limits, and tool-planning metadata
+
+**basis:** direct — the grounding summary lists “no bounded history” and “no redaction/security warnings” as gaps; external — `packages/pi-code-reasoning` has max thought count/length guardrails, and `spences10/mcp-sequentialthinking-tools` includes per-session max history and prompt-injection-like redaction.
+
+**why_it_matters:** Stateful thinking tools can accidentally accumulate sensitive data or unbounded context; explicit guardrails help keep sessions usable and safer over time.
+
+**meeting_test:** A thought containing a likely API key returns a warning or redacted stored value, and an overlong thought or over-cap session produces a clear, actionable response.
+
+## 6. Flip “tool planning should be out of scope” into non-executing tool-plan metadata
+
+**summary:** Extend thoughts with optional `available_tools` and `recommended_tools` metadata that validates tool names and explains next-step suggestions without executing anything. The summary or history tools could surface unresolved recommendations, making the reasoning workflow more operational while respecting the ADR guidance that planning tools should not hide side effects.
+
+**axis:** Safety, limits, and tool-planning metadata; Higher-level synthesis, organization, and tool-surface focus
+
+**basis:** direct — ADR-0016 says planning/reasoning tools may recommend next actions but should not hide expensive or side-effectful calls; external — `spences10/mcp-sequentialthinking-tools` supports optional `available_tools` / `recommended_tools` validation without executing tools.
+
+**why_it_matters:** Agents often use sequential thinking to decide what to do next; structured, non-executing recommendations make that plan inspectable without turning this package into an orchestration system.
+
+**meeting_test:** A thought can recommend `grep` or `read` from a declared available tool list, while recommending an unavailable tool returns validation feedback and performs no side effects.
+
+## 7. Flip “one generic summary” into staged synthesis and archival outputs
+
+**summary:** Keep `generate_summary`, but add modes such as `timeline`, `open_questions`, `decisions`, `branches`, `risks`, and `archive`. This would make synthesis more useful for handoffs and long sessions without requiring a large MAXential-style surface of many separate visualization and organization tools.
+
+**axis:** Higher-level synthesis, organization, and tool-surface focus
+
+**basis:** direct — current strengths include summaries, stages, tags, axioms, assumptions, and related-thought analysis; external — `gotza02/mcp-thinking` includes summarization/archiving, and MAXential Thinking suggests broader future capabilities like session summary, tag/search/export/visualize.
+
+**why_it_matters:** As histories grow, users need more than counts and top tags; targeted synthesis turns captured thoughts into decisions, risks, and next actions.
+
+**meeting_test:** Running `generate_summary` with `mode: "decisions"` returns a concise list of decisions and supporting thought references, while `mode: "archive"` creates a compact handoff summary.
+
+## 8. Flip “compatibility with loose workflows” into an optional strict workflow mode
+
+**summary:** Add a strict validation mode that enforces stage order, required metadata by stage, branch/reference validity, maximum counts, and mutually exclusive branch/revision fields. Default behavior can remain permissive, but strict mode gives teams an opinionated workflow when they want repeatable reasoning traces.
+
+**axis:** Thought capture ergonomics and schema compatibility; Branch/revision/navigation workflows; Safety, limits, and tool-planning metadata
+
+**basis:** direct — the grounding summary contrasts compatibility with stronger opinionated workflow and notes current gaps in branch/revision metadata, bounded history, and duplicated validation; external — `mettamatt/code-reasoning` provides strict/loose validation, max thought cap, branch/revision exclusivity, branch reference validation, and guidance-rich errors.
+
+**why_it_matters:** Different users need different levels of structure; strict mode improves reliability for formal planning while preserving the current low-friction capture path.
+
+**meeting_test:** With strict mode enabled, an Evaluation thought before any Analysis thought or a branch pointing to a nonexistent thought fails with a specific corrective error; with strict mode disabled, legacy behavior remains accepted.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/fresh-ecosystem-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/fresh-ecosystem-ideas.md
@@ -1,0 +1,43 @@
+# Fresh ecosystem/package consolidation ideas — pi-sequential-thinking
+
+## 1. Reasoning boundary manifest
+**Summary:** Add a lightweight `get_reasoning_manifest` tool that reports this package’s scope, supported thought fields, stage model, persistence behavior, and explicit non-goals relative to `pi-code-reasoning` and future reasoning extensions.
+**Axis:** Ecosystem/package consolidation
+**Basis:** direct: the repo has multiple reasoning-oriented packages with overlapping concepts; reasoned: an explicit manifest helps agents choose the right tool without merging package responsibilities.
+**why_it_matters:** Clear package boundaries reduce duplicate feature growth and make it easier for prompts, docs, and future extensions to route generic deliberation to `pi-sequential-thinking` and code-specific reasoning to `pi-code-reasoning`.
+**meeting_test:** A user or agent can call one tool and answer “should I use sequential thinking, code reasoning, or another reasoning tool for this step?” without reading package source.
+
+## 2. Handoff snapshot for downstream reasoning tools
+**Summary:** Add an exportable handoff snapshot that distills current sequential-thinking state into decisions, constraints, unresolved questions, and recommended next reasoning domain, without invoking or depending on the downstream package.
+**Axis:** Cross-tool interoperability
+**Basis:** direct: the package already summarizes stored thoughts; reasoned: handoff artifacts define boundaries between general thinking and specialized future tools while keeping this package non-orchestrating.
+**why_it_matters:** Sequential deliberation often precedes code reasoning, research planning, or design review. A stable handoff format lets those tools consume context without `pi-sequential-thinking` becoming a universal workflow engine.
+**meeting_test:** After a planning session, the user can export a compact handoff that is immediately useful as input context for `pi-code-reasoning` or a future reasoning extension.
+
+## 3. Shared reasoning vocabulary map
+**Summary:** Publish a deterministic vocabulary map from this package’s stages/tags/axioms/assumptions to broader reasoning concepts such as problem, evidence, hypothesis, decision, risk, and follow-up.
+**Axis:** Taxonomy and semantic boundaries
+**Basis:** direct: current thoughts include stages, tags, axioms, and assumptions; external: adjacent reasoning tools use different step taxonomies; reasoned: mapping concepts avoids forcing every package to adopt one schema.
+**why_it_matters:** Future reasoning tools can interoperate semantically while keeping their own specialized language. `pi-sequential-thinking` remains stage-based, but its output becomes easier to compare, search, and reuse across the ecosystem.
+**meeting_test:** A summary can include stable concept buckets that preserve current stage behavior while making the same session understandable to another reasoning package.
+
+## 4. External artifact reference anchors
+**Summary:** Let thoughts optionally attach typed references to files, docs, tickets, ADRs, or package names as inert anchors, with no code analysis or file reading performed by this package.
+**Axis:** Boundary-safe context linking
+**Basis:** direct: current metadata captures cognitive context but not where evidence or decisions came from; reasoned: references connect sequential thinking to code/research tools without duplicating their responsibilities.
+**why_it_matters:** Reasoning state becomes traceable across packages while preserving separation of concerns: `pi-sequential-thinking` records why something mattered, while `pi-code-reasoning` or future tools can interpret the referenced artifact if needed.
+**meeting_test:** A thought can point to `packages/pi-code-reasoning/extensions/types.ts` or an ADR as supporting context, and the package stores and summarizes that link without inspecting or modifying the artifact.
+
+## 5. Package-local interop contract tests
+**Summary:** Add fixtures and tests that assert stable import/export and summary shapes intended for other reasoning packages to consume, without introducing a shared dependency yet.
+**Axis:** Compatibility and consolidation guardrails
+**Basis:** direct: the workspace uses package-local Vitest tests and existing JSON import/export; reasoned: contract fixtures provide consolidation benefits before extracting shared libraries.
+**why_it_matters:** As reasoning packages evolve, accidental schema drift can break handoffs. Contract tests make interoperability intentional while keeping package ownership independent.
+**meeting_test:** A fixture produced by `pi-sequential-thinking` can be validated in CI as a stable ecosystem artifact, and changes to it require an explicit test update.
+
+## 6. Reasoning context size budget report
+**Summary:** Add a report that estimates stored reasoning context size by stage, tag, and metadata category so users can decide what to summarize or hand off to specialized tools.
+**Axis:** Operational interoperability
+**Basis:** direct: outputs already support truncation controls and summaries; reasoned: cross-tool handoffs need predictable context budgets, especially when multiple reasoning extensions may be chained manually.
+**why_it_matters:** This keeps `pi-sequential-thinking` useful as a source of context without overloading downstream tools or prompts. It also clarifies when the sequential record should be summarized before being passed elsewhere.
+**meeting_test:** Before copying context into `pi-code-reasoning`, the user can see a compact budget report and choose a stage/tag slice that fits their next tool call.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/fresh-minimal-moves.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/fresh-minimal-moves.md
@@ -1,0 +1,51 @@
+# Fresh minimal moves — pi-sequential-thinking
+
+Additional improvement ideas that avoid the current survivor set and favor small product moves with outsized usefulness.
+
+## 1. Copy-paste continuation card
+
+- **summary:** Have every `process_thought` response end with a compact continuation card: next `thought_number`, likely next `stage`, remaining count, and a ready-to-copy mini JSON argument skeleton. No new tool required.
+- **axis:** Thought capture ergonomics and schema compatibility
+- **basis:** direct: current tool already computes progress and next-thought state; reasoned: agents frequently lose exact field names or counters across turns.
+- **why_it_matters:** The package would feel immediately more helpful because it reduces the most common friction: “what exact call do I make next?” without changing storage or semantics.
+- **meeting_test:** After recording thought 2 of 5, the response includes a tiny “Continue with…” block that a user or agent can paste and fill in for thought 3.
+
+## 2. Optional outcome contract on the first thought
+
+- **summary:** Let users optionally attach `desired_outcome` and `done_when` strings to any thought, especially thought 1; summaries then echo whether the session appears to have satisfied that contract.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** direct: the current framework has stages but no explicit success target; reasoned: structured thinking is more useful when it remembers what “finished” means.
+- **why_it_matters:** This turns a sequence from generic journaling into a lightweight problem-solving loop with a visible finish line, while adding only two optional fields.
+- **meeting_test:** A session started with `done_when: "choose one release blocker to fix first"` ends with a summary section saying whether a blocker was actually chosen.
+
+## 3. Confidence and uncertainty chips
+
+- **summary:** Add optional `confidence` and `uncertainties` fields to thoughts, then surface average/lowest confidence and unresolved uncertainties in `generate_summary`.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct: the package already stores assumptions challenged and axioms used; reasoned: users need to distinguish settled reasoning from shaky reasoning without a new workflow.
+- **why_it_matters:** A tiny metadata addition makes summaries much more decision-ready: not just what was thought, but how reliable the thinker believed it was.
+- **meeting_test:** A five-thought session with two low-confidence research notes produces a summary calling out “lowest confidence: Research thought 2” and listing open uncertainties.
+
+## 4. Evidence snippets for research claims
+
+- **summary:** Add an optional `evidence` array of short strings or URLs to `process_thought`; summaries can show which conclusions are backed by evidence-heavy thoughts versus unsupported notes.
+- **axis:** Thought capture ergonomics and schema compatibility
+- **basis:** direct: the current Research stage has no first-class way to attach source material; external: many reasoning and research workflows benefit from lightweight citation trails; reasoned: short evidence slots avoid building a full citation manager.
+- **why_it_matters:** This makes the Research and Analysis stages feel substantially more practical for real work while keeping the tool surface unchanged.
+- **meeting_test:** A research thought can include two URLs or quoted facts, and `generate_summary` includes an “Evidence captured” count with the referenced thought numbers.
+
+## 5. Stage-fit warnings, not enforcement
+
+- **summary:** Return gentle warnings when metadata appears mismatched with the selected stage, such as `evidence` on Conclusion but no evidence in Research, or many assumptions in Conclusion with no Analysis thought. Never reject the call.
+- **axis:** Thought capture ergonomics and schema compatibility
+- **basis:** direct: current stages are explicit but mostly descriptive; reasoned: soft coaching improves reasoning quality without creating strict workflow mode or extra tools.
+- **why_it_matters:** The extension would feel like a helpful thinking partner rather than a passive log, while preserving append-only flexibility.
+- **meeting_test:** If a user jumps from Problem Definition directly to Conclusion, the response records the thought but adds a short warning suggesting a Research or Analysis pass.
+
+## 6. Resume prompt in summaries
+
+- **summary:** Add a compact “resume prompt” string to `generate_summary` that compresses the current state, key tags, open uncertainties, and next recommended stage into text suitable for a future model turn.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** direct: current summaries already compute timeline, tags, and completion status; reasoned: users often need to carry reasoning state across context windows or between agents.
+- **why_it_matters:** This makes existing summaries operational, not just descriptive, and helps users continue work without adding named sessions, history browsing, or new persistence behavior.
+- **meeting_test:** Running `generate_summary` after an incomplete session returns a 5-8 line block beginning “Resume this reasoning by…” with the next stage and unresolved questions.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/fresh-trust-debug-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/fresh-trust-debug-ideas.md
@@ -1,0 +1,55 @@
+# Fresh trust/debuggability ideas — pi-sequential-thinking
+
+## 1. Effective configuration and storage status report
+
+- **title:** Effective configuration and storage status report
+- **summary:** Add a `get_status`/`diagnose_storage` style tool that reports the resolved storage directory, config source for each setting, active output limits, whether the directory is readable/writable, current persisted state file path, thought count, last modified time, and any detected backup/corruption-recovery files.
+- **axis:** Session/history/persistence lifecycle
+- **basis:** direct: README documents multiple config sources and default storage, while current tools do not expose the resolved runtime state; reasoned: operators trust long-running stateful tools more when they can confirm where state is being written and which limits are active.
+- **why_it_matters:** During long agent runs, users need a quick way to answer “which state am I using?” before clearing, exporting, importing, or debugging missing thoughts.
+- **meeting_test:** After starting pi with a custom config file and storage dir, calling the status tool returns the effective values, the source of each value, storage health checks, current thought count, and clear warnings for any unwritable or missing paths.
+
+## 2. State fingerprint receipts on mutating calls
+
+- **title:** State fingerprint receipts on mutating calls
+- **summary:** Return a compact state receipt from `process_thought`, `clear_history`, `import_session`, and `export_session`: pre/post thought counts, latest thought number, storage file mtime, schema version, and a short deterministic hash/fingerprint of the persisted state.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct: the package is stateful and persists JSON, but normal outputs focus on analysis rather than confirming persistence; reasoned: small deterministic receipts help users and agents detect stale state, accidental clears, failed writes, or concurrent-looking surprises without dumping full history.
+- **why_it_matters:** Long runs often fail through ambiguity rather than hard errors; a receipt makes each write auditable and gives users something concrete to compare across turns.
+- **meeting_test:** Recording a thought returns a receipt whose count increments by one and whose fingerprint changes; exporting without mutation preserves the fingerprint; clearing history returns the prior count and a new empty-state fingerprint.
+
+## 3. Import/export preview with diff and checksum
+
+- **title:** Import/export preview with diff and checksum
+- **summary:** Add dry-run options for import/export that validate the target file, report schema version, thought counts, stage/tag deltas, duplicate or out-of-order thought numbers, destination path, and a checksum before changing active state or writing a file.
+- **axis:** Session/history/persistence lifecycle
+- **basis:** direct: import/export already exist and storage preserves backward-compatible JSON behavior; reasoned: previews reduce fear around destructive or confusing state transitions.
+- **why_it_matters:** Users are more willing to rely on persisted reasoning if they can inspect what an import will replace and verify what an export contains before committing it.
+- **meeting_test:** Running import in preview mode against a valid file reports exactly what would change and leaves active history unchanged; running it against malformed JSON reports validation details without modifying storage.
+
+## 4. Summary provenance and coverage markers
+
+- **title:** Summary provenance and coverage markers
+- **summary:** Make `generate_summary` include provenance metadata: generated timestamp, number of thoughts considered, first/latest thought numbers, included stage counts, top tags source counts, truncation status, and optional per-section thought references for timeline, assumptions, and conclusions.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** direct: summaries already produce stage counts, timeline, top tags, and completion status; reasoned: trust in summaries improves when users can see what evidence was included and whether anything was omitted or truncated.
+- **why_it_matters:** In long runs, a summary can otherwise look authoritative while silently covering only part of the state or hiding truncation effects.
+- **meeting_test:** Given a history with multiple stages and tags, summary output states the exact thought count covered, references source thought numbers for key sections, and flags when output limits caused truncation.
+
+## 5. Consistency check and repair-plan mode
+
+- **title:** Consistency check and repair-plan mode
+- **summary:** Add a read-only consistency checker that scans in-memory and persisted state for gaps, duplicate thought numbers, invalid stages, malformed timestamps, missing required metadata, non-array legacy shapes, and storage/file mismatch, then returns a repair plan without applying changes.
+- **axis:** Thought capture ergonomics and schema compatibility
+- **basis:** direct: current storage handles legacy arrays and corrupted-file backup, and grounding notes partial duplicated validation; external: code-reasoning emphasizes cross-field validation and strict/loose guardrails; reasoned: a separate checker gives operators confidence before and after migrations.
+- **why_it_matters:** When state survives many agent turns or package upgrades, users need a non-destructive way to verify that the ledger is internally coherent.
+- **meeting_test:** A crafted session containing duplicate numbers and an invalid stage produces a structured report with severity, affected thought indices, and recommended fixes, while leaving the session unchanged.
+
+## 6. Mutation backup and restore receipt
+
+- **title:** Mutation backup and restore receipt
+- **summary:** Before destructive mutations such as `clear_history` or state-replacing `import_session`, automatically create or expose a timestamped backup path and return a restore command/tool hint plus pre/post counts and fingerprint.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct: storage already backs up corrupted files and import/clear can materially change persistent state; reasoned: explicit restore receipts make destructive operations feel reversible and auditable.
+- **why_it_matters:** Users trust long-running reasoning tools more when they can recover from an accidental clear or wrong import without manually hunting through storage internals.
+- **meeting_test:** Clearing a non-empty history returns a backup file path that exists on disk; importing that backup restores the original count and state fingerprint.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/inversion-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/inversion-ideas.md
@@ -1,0 +1,57 @@
+# Inversion, Removal, and Automation Ideas for `packages/pi-sequential-thinking`
+
+## 1. Invert Total-Thought Planning into Dynamic Depth
+- **summary:** Let `process_thought` accept MCP-compatible dynamic-depth fields such as `needsMoreThoughts`, and automatically raise `total_thoughts` when `thought_number` exceeds the prior estimate. This removes the need for users to predict exact depth before thinking has unfolded while preserving the existing staged flow.
+- **axis:** Thought capture ergonomics and schema compatibility
+- **basis:** direct — the grounding summary says the package currently has “no dynamic total auto-adjustment”; external — official MCP sequentialthinking uses `needsMoreThoughts` and auto-raises `totalThoughts` when `thoughtNumber` exceeds it.
+- **why_it_matters:** Sequential thinking is often exploratory, so rigid totals create friction and schema incompatibility with adjacent tooling.
+- **meeting_test:** A user can submit thought 6 of an original 5-thought sequence with `needsMoreThoughts: true`, and the stored session plus summary reflect the expanded total without validation failure.
+
+## 2. Remove the Canned `sequential_think` Surface or Make It Explicitly Stateless
+- **summary:** Deprecate or rename the undocumented `sequential_think` helper so the package does not imply it performs model reasoning when it only stores canned prompts. If retained, position it as a prompt-template utility that does not mutate core thought history unless explicitly requested.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** direct — the grounding summary notes `sequential_think` is undocumented and “stores canned prompts rather than real model reasoning”; reasoned — reducing misleading tool surface keeps the package focused on externalized stateful reasoning support.
+- **why_it_matters:** Users and agents need clear tool semantics to avoid mistaking template capture for actual sequential reasoning progress.
+- **meeting_test:** Tool descriptions and README make it impossible to confuse `sequential_think` with `process_thought`, and tests assert whether it is deprecated, hidden, or stateless.
+
+## 3. Automate Session Names and Add Lightweight Session Lifecycle Tools
+- **summary:** Add optional `session_id` support with default automatic session creation, plus focused tools to list, inspect, clear, export, and import a named session. Keep the current JSON import/export format backward compatible, including legacy array loading and corrupted-file backup behavior.
+- **axis:** Session/history/persistence lifecycle
+- **basis:** direct — current gaps include “no named sessions” and “no history inspection tool”; direct — storage already supports legacy arrays, corrupted-file backup, and atomic temp-file rename; external — `spences10/mcp-sequentialthinking-tools` provides `session_id`, `get_thinking_history`, and session-aware clear.
+- **why_it_matters:** Named sessions let users separate unrelated reasoning threads without losing the package’s existing persistence safety.
+- **meeting_test:** Two named sessions can be created, independently inspected and cleared, and old exported JSON arrays still import successfully.
+
+## 4. Invert Linear History into Branch and Revision Navigation
+- **summary:** Add branch/revision metadata compatible with canonical sequential-thinking fields: `isRevision`, `revisesThought`, `branchFromThought`, and `branchId`. Include validation that revisions and branches are mutually exclusive and references point to existing thoughts.
+- **axis:** Branch/revision/navigation workflows
+- **basis:** direct — current gaps include “no branch/revision metadata”; direct — `packages/pi-code-reasoning` already has branch/revision semantics and cross-field validation; external — official MCP sequentialthinking defines canonical branch/revision fields.
+- **why_it_matters:** Real reasoning often backtracks, forks, and corrects itself; explicit navigation prevents revisions from being hidden as ordinary appended thoughts.
+- **meeting_test:** A revision cannot include branch fields, a branch must include both source thought and branch ID, and history output groups or labels branches and revisions clearly.
+
+## 5. Automate Guardrails for History Size, Thought Length, and Validation Mode
+- **summary:** Introduce configurable maximum thought count, maximum thought length, and strict/loose validation modes. When limits are reached, return guidance-rich errors or truncation recommendations rather than silently accepting unbounded history.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct — current gaps include “no bounded history” and “partial duplicated validation”; external — `packages/pi-code-reasoning` and `mettamatt/code-reasoning` include max thought caps, validation modes, and helpful validation errors.
+- **why_it_matters:** Stateful reasoning tools can accumulate large or malformed state; explicit limits improve reliability, cost control, and predictable downstream summaries.
+- **meeting_test:** Configuration can cap thought count and length, invalid branch/revision metadata fails consistently, and tests cover both strict and loose validation behavior.
+
+## 6. Remove Sensitive Content by Default with Redaction Hooks
+- **summary:** Add optional redaction of prompt-injection-like instructions, secrets, and configured patterns before thoughts are persisted or exported. Include warnings in tool responses when redaction occurs, while allowing users to disable or customize patterns when needed.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct — current gaps include “no redaction/security warnings”; external — `spences10/mcp-sequentialthinking-tools` includes prompt-injection-like redaction; reasoned — persistence and export make sensitive content retention more consequential.
+- **why_it_matters:** The package stores reasoning state over time, so accidental retention of secrets or adversarial instructions can propagate into summaries and exported files.
+- **meeting_test:** A thought containing a configured secret-like pattern is stored/exported in redacted form and the response reports that redaction happened.
+
+## 7. Automate Tool-Planning Metadata Without Executing Tools
+- **summary:** Let thoughts optionally declare `available_tools` and `recommended_tools`, then validate recommendations against the available set and surface them in summaries. Keep the tool strictly advisory: it should never invoke external tools or hide side effects behind reasoning capture.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct — ADR-0016 says planning tools may recommend next actions but should not hide expensive or side-effectful calls; external — `spences10/mcp-sequentialthinking-tools` validates optional `available_tools` and `recommended_tools` without executing tools.
+- **why_it_matters:** Agents benefit from explicit next-tool planning, but users need assurance that recording a thought will not unexpectedly perform actions.
+- **meeting_test:** A thought can recommend tools, invalid recommendations are flagged, and no code path executes recommended tools.
+
+## 8. Invert Summary Generation into Searchable, Structured Synthesis
+- **summary:** Expand `generate_summary` into focused synthesis outputs such as stage timeline, top tags, open assumptions, revised thoughts, branches, and action candidates. Add a lightweight history/search view by tag, stage, branch, or assumption rather than forcing users to inspect raw JSON exports.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** direct — current strengths include stages, tags, axioms, assumptions, related-thought analysis, and summaries; direct — current gaps include no history inspection tool; external — MAXential Thinking includes tag/search/export/visualize and session summary concepts, while the grounding summary cautions that copying its whole surface would be too large.
+- **why_it_matters:** The existing metadata becomes more valuable when users can retrieve and synthesize it without expanding the package into an unrelated mega-tool.
+- **meeting_test:** Users can request a compact synthesis filtered by tag or stage and receive organized open questions, assumptions, revisions, and next-action candidates.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/leverage-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/leverage-ideas.md
@@ -1,0 +1,65 @@
+# Leverage and Compounding Ideas for `packages/pi-sequential-thinking`
+
+## 1. Canonical MCP-Compatible Thought Capture Fields
+
+- **summary:** Add optional aliases/fields that mirror the canonical MCP sequentialthinking schema, including `isRevision`, `revisesThought`, `branchFromThought`, `branchId`, and `needsMoreThoughts`, while preserving the current snake_case API. Normalize both naming styles internally so existing users keep working and external examples become easier to port. Also auto-raise `total_thoughts`/`totalThoughts` when a thought number exceeds the declared total.
+- **axis:** Thought capture ergonomics and schema compatibility
+- **basis:** direct — The grounding summary states the package currently has `process_thought` with staged thinking metadata, while external MCP sequentialthinking uses canonical branch/revision/dynamic-depth fields and auto-raises `totalThoughts` when needed.
+- **why_it_matters:** Compatibility compounds leverage because prompts, examples, and workflows from the broader sequential-thinking ecosystem can be reused without translation. Auto-adjusting totals reduces friction during live reasoning when the user discovers the task needs more steps.
+- **meeting_test:** A thought submitted with camelCase MCP fields is stored identically to one submitted with existing snake_case fields, existing tests still pass, and submitting `thought_number: 6` with `total_thoughts: 5` records a total of 6 or higher.
+
+## 2. Named Sessions with Backward-Compatible Import/Export
+
+- **summary:** Introduce optional `session_id` support for `process_thought`, `generate_summary`, `clear_history`, `export_session`, and `import_session`. Keep the current default unnamed session behavior and preserve legacy JSON array import/export so existing saved files remain usable. Store sessions in a simple top-level map only when session IDs are used.
+- **axis:** Session/history/persistence lifecycle
+- **basis:** direct — The grounding summary identifies no named sessions as a current gap, notes existing JSON persistence with legacy array loading and atomic temp-file rename in `extensions/storage.ts`, and cites external tools that add `session_id` and session-aware clear.
+- **why_it_matters:** Sessions let users compound multiple reasoning threads without overwriting one another. Backward compatibility protects the existing persistence contract while adding a higher-leverage organization layer.
+- **meeting_test:** Users can create two sessions, summarize each independently, clear one without affecting the other, and import an old array-format export with no data loss.
+
+## 3. History Inspection Tool with Filtering and Compact Output
+
+- **summary:** Add `get_thinking_history` to inspect stored thoughts without generating a synthesis. Support filters such as `session_id`, `stage`, `tag`, `branch_id`, thought-number range, and a compact mode that returns only key metadata plus truncated thought text. Include pagination or a `limit` parameter to keep responses bounded.
+- **axis:** Session/history/persistence lifecycle
+- **basis:** direct — The grounding summary lists no history inspection tool as a current gap, while `spences10/mcp-sequentialthinking-tools` and `thedotmack/sequential-thinking-skill` both emphasize history/state inspection.
+- **why_it_matters:** Inspectable history turns the tool from an append-only black box into reusable working memory. Filtering compounds prior thoughts by making old reasoning searchable and referenceable in later steps.
+- **meeting_test:** After recording thoughts across stages and tags, a user can retrieve only matching entries with deterministic ordering, bounded output, and no mutation of stored history.
+
+## 4. Branch and Revision Workflow Semantics
+
+- **summary:** Add first-class branch/revision metadata and validation to `process_thought`, reusing semantics from `pi-code-reasoning`: revisions require a revised thought reference and cannot also branch, while branches require both source thought and branch ID. Expose branch metadata in summaries and history so users can follow alternate lines of reasoning. Keep this as metadata and navigation support rather than adding heavyweight tree-management tools immediately.
+- **axis:** Branch/revision/navigation workflows
+- **basis:** direct — The grounding summary says the package has no branch/revision metadata, notes `packages/pi-code-reasoning` already provides branch/revision field semantics and cross-field validation, and cites external MCP sequentialthinking branch/revision fields.
+- **why_it_matters:** Branching lets users explore alternatives without losing the main thread, and revisions let them correct reasoning while preserving provenance. Borrowing existing in-repo semantics compounds proven validation patterns instead of inventing new ones.
+- **meeting_test:** Invalid combinations such as a revision with branch fields fail with guidance-rich errors, valid branch thoughts appear grouped or linked in history/summary output, and references to nonexistent thoughts are rejected or clearly warned based on validation mode.
+
+## 5. Safety Limits and Redaction-Aware Persistence
+
+- **summary:** Add configurable maximums for thought count, thought length, and returned history size, plus optional redaction warnings for secrets or prompt-injection-like content before export/import. Keep redaction advisory or opt-in so normal reasoning remains smooth, but ensure exports clearly warn when sensitive-looking data is present. Preserve atomic write and corrupted-file backup behavior.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct — The grounding summary lists no bounded history and no redaction/security warnings as gaps, notes storage already has corrupted-file backup and atomic temp-file rename, and cites external tools with max history, max thought caps, and redaction features.
+- **why_it_matters:** Sequential-thinking state can accumulate sensitive data quickly. Limits and warnings make the tool safer for long-running sessions while preventing runaway context and file growth.
+- **meeting_test:** Configured caps reject or truncate oversized inputs with clear errors, exported sessions include warnings or redacted fields when enabled, and existing atomic persistence tests continue to pass.
+
+## 6. Tool-Planning Metadata Without Tool Execution
+
+- **summary:** Add optional fields such as `available_tools`, `recommended_tools`, and `next_action` to capture planning intent alongside a thought. Validate recommendations against the declared available tools but never call those tools from sequential-thinking itself. Surface recommended next steps in `process_thought` responses and summaries.
+- **axis:** Safety, limits, and tool-planning metadata
+- **basis:** direct — The grounding summary cites ADR-0016: planning/reasoning tools may recommend next actions but should not hide expensive or side-effectful calls, and external tools validate `available_tools` / `recommended_tools` without executing tools.
+- **why_it_matters:** The tool becomes a safer planning hub that can coordinate human or agent action without taking side effects. Capturing recommendations compounds reasoning into actionable workflow state.
+- **meeting_test:** A thought can list available tools and recommended tools, invalid recommendations produce validation feedback, and no external tool execution occurs as a side effect of calling `process_thought`.
+
+## 7. Focused Synthesis Views Beyond One Generic Summary
+
+- **summary:** Extend `generate_summary` with focused modes such as `timeline`, `open_questions`, `decisions`, `assumptions`, `tags`, and `branches`. These can be lightweight deterministic aggregations from existing metadata rather than model-generated prose. Include per-session and filtered summaries so users can synthesize only the relevant slice of history.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** reasoned — The package already has `generate_summary`, tags, axioms, assumptions, related-thought analysis, and stages; the grounding summary also notes MAXential Thinking’s broader menu of summary/list/search/visualize tools but warns it is too large to copy wholesale now.
+- **why_it_matters:** Focused summaries turn accumulated thoughts into reusable artifacts: decisions, assumptions, and unresolved questions. This compounds value from the metadata users already enter without expanding the package into an unrelated tool suite.
+- **meeting_test:** Calling `generate_summary` with a focus option returns a deterministic, filtered view using stored thought metadata, and unsupported modes fail with a clear schema error.
+
+## 8. Replace or Reframe `sequential_think` as a Prompt Template Helper
+
+- **summary:** Rework the undocumented `sequential_think` helper so it does not imply that it performs hidden model reasoning. Either document it as a prompt-template generator that does not store thoughts, or fold its useful guidance into tool descriptions and examples for `process_thought`. Keep the main tool surface centered on explicit state capture.
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **basis:** direct — The grounding summary says `sequential_think` is undocumented and stores canned prompts rather than real model reasoning, while ADR-0016 says prompt-only multi-step workflows are unreliable and process state should be externalized into explicit tools.
+- **why_it_matters:** Clarifying this helper prevents user confusion and keeps leverage concentrated in the stateful tools that actually compound reasoning history. Better descriptions and examples can improve adoption without adding more surface area.
+- **meeting_test:** Documentation and tool descriptions clearly state what `sequential_think` does or it is deprecated in favor of `process_thought`, and tests verify it does not create misleading stored reasoning entries unless explicitly intended.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/pain-friction-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/pain-friction-ideas.md
@@ -1,0 +1,65 @@
+# Pain and Friction Ideas for `packages/pi-sequential-thinking`
+
+## 1. MCP-Compatible Capture Aliases and Dynamic Depth
+
+- **axis:** Thought capture ergonomics and schema compatibility
+- **summary:** Add input aliases compatible with the canonical MCP sequentialthinking schema, such as `needsMoreThoughts`, `isRevision`, `revisesThought`, `branchFromThought`, and `branchId`, while preserving the current snake_case fields. Also auto-adjust `total_thoughts` upward when `thought_number` exceeds the submitted total, instead of forcing callers to predict depth perfectly. This reduces friction for users and agents moving between sequential-thinking implementations.
+- **basis:** direct — The grounding summary says the package currently has staged `process_thought` fields but lacks dynamic total auto-adjustment; external — official MCP sequentialthinking uses branch/revision/dynamic-depth fields and auto-raises `totalThoughts` when `thoughtNumber` exceeds it.
+- **why_it_matters:** Agents often discover that a reasoning chain needs more steps only after starting. Schema compatibility and forgiving depth handling make the tool easier to call correctly and reduce invalid or prematurely compressed reasoning.
+- **meeting_test:** A caller can submit either snake_case or MCP-style camelCase fields, and a thought with `thought_number: 6` and `total_thoughts: 5` is accepted with the stored total raised to 6.
+
+## 2. Guided Validation Errors for Thought Capture
+
+- **axis:** Thought capture ergonomics and schema compatibility
+- **summary:** Replace scattered or duplicated validation with centralized, guidance-rich validation for stage names, thought numbering, metadata arrays, and mutually dependent fields. Error messages should explain what failed, show the expected shape, and suggest the smallest correction. This targets the friction of trial-and-error tool calls when schemas are strict.
+- **basis:** direct — The grounding summary identifies partial duplicated validation as a current gap; external — `mettamatt/code-reasoning` is noted for strict/loose validation, cross-field checks, and guidance-rich errors.
+- **why_it_matters:** Sequential-thinking tools are often invoked mid-task, where a failed call interrupts reasoning flow. Better validation reduces repeated failed calls and makes the tool safer to integrate with multiple agent backends.
+- **meeting_test:** Invalid inputs produce a structured error containing the field, reason, expected format, and a concrete corrected example, with no duplicate validation logic paths.
+
+## 3. Named Sessions with Backward-Compatible Import/Export
+
+- **axis:** Session/history/persistence lifecycle
+- **summary:** Introduce optional `session_id` support for `process_thought`, `generate_summary`, `clear_history`, `export_session`, and `import_session`, while keeping the current single-history behavior as the default session. Persist sessions in a backward-compatible JSON shape and continue supporting legacy array imports. This removes the friction of unrelated tasks sharing one global reasoning history.
+- **basis:** direct — The package has import/export persistence but no named sessions; direct — storage already supports legacy array loading, corrupted-file backup, and atomic temp-file rename; external — `spences10/mcp-sequentialthinking-tools` includes `session_id`, session-aware clear, and session history.
+- **why_it_matters:** Users and agents may work on multiple tasks in the same pi process. Named sessions prevent cross-contamination of summaries, related-thought analysis, and clears while preserving existing workflows.
+- **meeting_test:** Two different `session_id` values maintain separate histories; omitting `session_id` behaves exactly like today; old exported JSON arrays still import successfully.
+
+## 4. History Inspection, Status, and Bounded Retention
+
+- **axis:** Session/history/persistence lifecycle
+- **summary:** Add a `get_thinking_history` or `status` tool that can list recent thoughts, counts by stage/tag, session IDs, and truncation state without requiring export. Pair it with configurable max thought count or max history per session, plus clear feedback when older entries are pruned or archived. This addresses the pain of invisible in-memory state growing without direct inspection.
+- **basis:** direct — The grounding summary says there is no history inspection tool and no bounded history; external — `spences10/mcp-sequentialthinking-tools` has `get_thinking_history` and per-session max history; external — `thedotmack/sequential-thinking-skill` reinforces append-only state plus full state inspection and compact status output.
+- **why_it_matters:** Stateful reasoning is only useful if users can see and manage the state. Bounded retention also protects long-running sessions from excessive memory growth and overly large tool responses.
+- **meeting_test:** A user can call one tool to inspect the current session without exporting a file, and setting a max history limit results in predictable pruning or archiving with an explicit notice.
+
+## 5. Branch and Revision Metadata with Navigation Views
+
+- **axis:** Branch/revision/navigation workflows
+- **summary:** Add first-class branch and revision fields to thoughts, including validation that revisions reference an existing thought and branches specify both a source thought and branch ID. Provide summary/history views that group thoughts by branch and show revision chains. This reduces friction when reasoning needs to backtrack, compare alternatives, or correct earlier assumptions.
+- **basis:** direct — The package has no branch/revision metadata; direct — `packages/pi-code-reasoning` already has branch/revision semantics and cross-field validation; external — official MCP sequentialthinking defines `isRevision`, `revisesThought`, `branchFromThought`, and `branchId`.
+- **why_it_matters:** Real problem solving is rarely linear. Branches and revisions let agents preserve exploratory reasoning without overwriting or muddling the main chain.
+- **meeting_test:** A branch thought cannot be stored without both `branch_from_thought` and `branch_id`; a revision cannot also declare branch fields; summaries display branch IDs and revision targets.
+
+## 6. Safe Tool-Planning Metadata Without Execution
+
+- **axis:** Safety, limits, and tool-planning metadata
+- **summary:** Add optional `available_tools`, `recommended_tools`, or `next_actions` metadata to `process_thought` so the tool can record planning suggestions without invoking tools. Validate recommended tools against available tools when both are supplied, and clearly state that recommendations are advisory only. This supports planning while avoiding hidden side effects.
+- **basis:** direct — Current strengths include metadata such as tags, axioms, and assumptions, but tool-planning metadata is only an axis/gap area; direct — ADR-0016 says planning tools may recommend next actions but should not hide expensive or side-effectful calls; external — `spences10/mcp-sequentialthinking-tools` supports optional `available_tools` / `recommended_tools` validation without executing tools.
+- **why_it_matters:** Agents often need to decide which tool to use after a reasoning step. Capturing those recommendations in state improves continuity while keeping execution explicit and controllable.
+- **meeting_test:** A thought can include recommended tool names, invalid recommendations are flagged when an available-tool list is present, and no tool execution occurs as part of the sequential-thinking call.
+
+## 7. Redaction Warnings and Sensitive-Content Guardrails
+
+- **axis:** Safety, limits, and tool-planning metadata
+- **summary:** Add configurable redaction or warning behavior for likely secrets, prompt-injection snippets, and sensitive personal data in thoughts and exports. The feature could default to warning-only for backward compatibility, with opt-in masking before persistence or export. This addresses the pain of a persistence-enabled reasoning tool accidentally storing unsafe content.
+- **basis:** direct — The grounding summary notes no redaction/security warnings as a current gap; direct — persistence already exists through JSON import/export, making stored sensitive content a real concern; external — `spences10/mcp-sequentialthinking-tools` includes prompt-injection-like redaction.
+- **why_it_matters:** Reasoning traces can contain copied logs, prompts, credentials, or user data. Guardrails lower the chance that exports or saved sessions leak sensitive information.
+- **meeting_test:** Submitting text containing a token-like secret triggers a warning or redaction according to configuration, and exported sessions reflect the configured safety mode.
+
+## 8. Focused Synthesis Views and Surface Cleanup
+
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **summary:** Improve `generate_summary` with focused modes such as open questions, assumptions challenged, decisions, tag clusters, branch summaries, and next recommended reasoning stage. At the same time, clarify or remove the undocumented `sequential_think` helper if it stores canned prompts rather than real model reasoning. This keeps the tool surface centered on useful stateful reasoning instead of confusing helper behavior.
+- **basis:** direct — The package has `generate_summary`, tags/axioms/assumptions metadata, and related-thought analysis; direct — the grounding summary says `sequential_think` is undocumented and stores canned prompts rather than real model reasoning; external — MAXential Thinking suggests richer session summary, tag/search/export/visualize surfaces, but the grounding summary cautions that the full surface is too large to copy wholesale.
+- **why_it_matters:** Long reasoning histories become hard to use unless summaries organize them around decisions, risks, and next steps. Removing or documenting confusing tool surfaces reduces user surprise and keeps the package focused.
+- **meeting_test:** `generate_summary` supports at least two focused summary modes using existing metadata, and `sequential_think` is either documented with clear limitations or removed/deprecated with tests updated.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/progress.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/progress.md
@@ -1,0 +1,16 @@
+# Progress
+
+## Status
+Complete
+
+## Tasks
+- Read repo guidance and scanned top-level layout.
+- Inspected `packages/pi-sequential-thinking` README, entrypoint, types, analyzer, storage, tests at a shallow level.
+- Quickly compared adjacent `packages/pi-code-reasoning` README/types/entrypoint for reusable patterns.
+
+## Files Changed
+- `codebase-scan.md`
+- `progress.md`
+
+## Notes
+- Findings written to `codebase-scan.md` under the requested 40-line budget.

--- a/docs/ideation/pi-sequential-thinking-state-foundation/raw/reframe-ideas.md
+++ b/docs/ideation/pi-sequential-thinking-state-foundation/raw/reframe-ideas.md
@@ -1,0 +1,65 @@
+# Reframe Ideas for `packages/pi-sequential-thinking`
+
+## 1. Treat `total_thoughts` as a Living Estimate, Not a Contract
+
+- **axis:** Thought capture ergonomics and schema compatibility
+- **summary:** Reframe the thought count from a fixed upfront plan into a mutable estimate that can expand when reasoning discovers more work. Add MCP-compatible `needsMoreThoughts` / `needs_more_thoughts` handling and auto-raise `total_thoughts` when `thought_number` exceeds the current total, while preserving existing snake_case fields.
+- **basis:** external — The grounding summary notes official MCP sequentialthinking supports `needsMoreThoughts` and auto-raises `totalThoughts` when `thoughtNumber` exceeds it; direct — current package has staged thought capture but lacks dynamic total auto-adjustment.
+- **why_it_matters:** Users often discover complexity mid-sequence, and rigid totals make them choose between inaccurate metadata or restarting. Dynamic estimates improve flow while staying compatible with the broader sequential-thinking ecosystem.
+- **meeting_test:** A user can submit thought 6 of an originally planned 5-thought session with `needs_more_thoughts: true`, and the stored session/report reflects an updated total without validation failure.
+
+## 2. Make History Inspection a First-Class Tool Instead of an Export Side Effect
+
+- **axis:** Session/history/persistence lifecycle
+- **summary:** Add a `get_thinking_history` or `get_session_status` tool that returns recent thoughts, filters by stage/tag/session, and exposes compact counters without requiring JSON export/import. This reframes history as live working memory rather than only a persistence artifact.
+- **basis:** direct — The package currently has `generate_summary`, `clear_history`, `export_session`, and `import_session`, but the grounding summary identifies no history inspection tool; external — spences10/mcp-sequentialthinking-tools and sequential-thinking-skill emphasize full state inspection.
+- **why_it_matters:** Agents need to inspect prior reasoning before continuing, revising, or summarizing. A read-only history/status surface reduces accidental destructive operations and avoids forcing users to parse exported files.
+- **meeting_test:** After processing several thoughts, calling the new tool returns ordered stored thoughts with metadata and supports at least one narrowing option such as `limit`, `stage`, or `tag`.
+
+## 3. Assume One Linear Chain Is the Exception: Add Branch and Revision Metadata
+
+- **axis:** Branch/revision/navigation workflows
+- **summary:** Extend thought input with branch/revision fields such as `is_revision`, `revises_thought`, `branch_from_thought`, and `branch_id`, with aliases for canonical MCP camelCase. Keep storage append-only, but make relationships explicit so users can explore alternatives or correct earlier reasoning without overwriting history.
+- **basis:** external — Official MCP sequentialthinking defines branch/revision fields; direct — the grounding summary says this package has no branch/revision metadata, while `pi-code-reasoning` already has branch/revision semantics and validation patterns.
+- **why_it_matters:** Real reasoning often forks, backtracks, and revises. Capturing those moves explicitly makes summaries more accurate and prevents “correction” thoughts from being indistinguishable from ordinary continuation.
+- **meeting_test:** A revision must reference an existing thought, a branch must include both branch source and branch id, and invalid combinations produce guidance-rich validation errors.
+
+## 4. Reframe Persistence Around Named Sessions, Not a Single Global Memory
+
+- **axis:** Session/history/persistence lifecycle
+- **summary:** Introduce optional `session_id` support across process, summary, clear, import, and export operations while keeping legacy single-session JSON valid. Session-aware clear and export would let users reset or move one reasoning thread without disturbing others.
+- **basis:** external — spences10/mcp-sequentialthinking-tools includes `session_id`, session-aware clear, and per-session history; direct — current persistence already supports JSON import/export, legacy array loading, corrupted-file backup, and atomic temp-file rename, but the grounding summary notes no named sessions.
+- **why_it_matters:** Multiple tasks may be active in the same pi run or persisted file. Named sessions reduce cross-contamination and make the tool safer for long-lived agent workflows.
+- **meeting_test:** Existing exported arrays still import, while new exports can contain multiple sessions and operations scoped to `session_id` affect only that session.
+
+## 5. Add Guardrails That Assume Reasoning Logs Can Become Too Large or Too Sensitive
+
+- **axis:** Safety, limits, and tool-planning metadata
+- **summary:** Add configurable max thought count, max thought length, optional bounded history per session, and redaction warnings for secrets or prompt-injection-like content. This reframes the tool from an unlimited scratchpad into a managed reasoning log with predictable size and privacy behavior.
+- **basis:** external — spences10/mcp-sequentialthinking-tools has per-session max history and redaction; mettamatt/code-reasoning adds max thought cap and strict/loose validation; direct — current gaps include no bounded history and no redaction/security warnings.
+- **why_it_matters:** Stateful tools can silently accumulate sensitive or oversized content. Limits and warnings make the extension safer in persistent environments and more reliable under model/context constraints.
+- **meeting_test:** Overlong thoughts or sessions beyond configured limits produce clear errors or truncation/archive behavior, and obvious secret-like strings trigger a warning without breaking normal use.
+
+## 6. Separate Tool Planning Metadata From Tool Execution
+
+- **axis:** Safety, limits, and tool-planning metadata
+- **summary:** Let `process_thought` optionally record `available_tools`, `recommended_tools`, or `next_action` metadata, validating names against a provided list but never executing anything. This reframes sequential thinking as a planning ledger that can recommend safe next steps without hiding side effects.
+- **basis:** external — ADR-0016 says planning/reasoning tools may recommend next actions but should not hide expensive or side-effectful calls; spences10/mcp-sequentialthinking-tools supports optional available/recommended tool validation without executing tools.
+- **why_it_matters:** Agents often reason about which tool to use next, and recording that plan improves traceability. Keeping execution separate preserves user control and avoids surprising side effects.
+- **meeting_test:** A thought can include recommended tool names, invalid names are flagged when an allowlist is supplied, and no external tool invocation occurs as part of processing the thought.
+
+## 7. Turn Summary Into Structured Synthesis, Not Just Counts
+
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **summary:** Enhance `generate_summary` with optional synthesis modes such as decisions, open questions, assumptions challenged, branches, risks, and next steps. This reframes summary output from a progress report into a compact reasoning artifact that can guide follow-up work.
+- **basis:** direct — The package already tracks stages, tags, axioms, assumptions, related thoughts, and summaries; external — Tree-of-Thought and MAXential-style systems show value in organization, search, and higher-level summarization, while the grounding summary cautions against copying an oversized surface wholesale.
+- **why_it_matters:** Users need actionable synthesis after a reasoning session, not only metadata totals. Structured sections make the tool more useful while reusing fields it already captures.
+- **meeting_test:** Calling `generate_summary` with a mode or options object returns sections for at least decisions/open questions/assumptions or equivalent structured outputs derived from stored thoughts.
+
+## 8. Deprecate or Reframe `sequential_think` as Prompt Scaffolding, Not Hidden Reasoning
+
+- **axis:** Higher-level synthesis, organization, and tool-surface focus
+- **summary:** Clarify, rename, or deprecate the undocumented `sequential_think` helper so it does not imply that the tool performs model reasoning when it stores canned prompts. If retained, position it as a prompt-template/scaffolding generator that helps users start staged thinking, separate from `process_thought` state capture.
+- **basis:** direct — The grounding summary states `sequential_think` is undocumented and stores canned prompts rather than real model reasoning; reasoned — misleading tool names can create incorrect expectations about what state is captured or analyzed.
+- **why_it_matters:** Tool-surface focus improves trust and reduces confusion for agents choosing between tools. Clear naming also prevents accidental reliance on synthetic reasoning that was never actually produced by the model.
+- **meeting_test:** README/tool descriptions accurately distinguish prompt scaffolding from recorded reasoning, and tests verify the helper either emits scaffold content without mutating history or is marked deprecated with a migration path.

--- a/docs/prd/PRD-009-pi-sequential-thinking-state-foundation.md
+++ b/docs/prd/PRD-009-pi-sequential-thinking-state-foundation.md
@@ -14,13 +14,15 @@ version: "1.0"
 
 ## 1. Problem & Context
 
-`packages/pi-sequential-thinking` gives pi users a native structured-thinking extension with staged thoughts, tags, axioms, assumptions, summaries, import/export, and persistent JSON storage. It is useful today, but its state model is still too global and too strict for repeated agent use:
+`packages/pi-sequential-thinking` gives pi users a native structured-thinking extension with staged thoughts, tags, axioms, assumptions, summaries, import/export, and persistent JSON storage. It is useful today, but its state model is still too global and too strict for repeated use by one active pi process:
 
 * `process_thought` only reads snake\_case inputs even though the wider MCP sequential-thinking ecosystem uses camelCase fields such as `thoughtNumber`, `totalThoughts`, and `nextThoughtNeeded`.
 * `total_thoughts < thought_number` is rejected, while the canonical MCP sequential-thinking behavior treats the total as an estimate and expands it dynamically.
 * validation is split between `extensions/types.ts` and inline checks in `extensions/index.ts`, making future field additions riskier.
 * all thoughts live in one implicit `current_session.json`; there is no `session_id`, no read-only history inspection tool, and no way to summarize, clear, export, or import one named session.
 * stateful behavior is not observable enough: users cannot ask which storage directory/config is active, whether the store is writable, how many sessions/thoughts exist, or whether a mutating call actually changed persisted state.
+
+These gaps have already appeared in the work that produced this PRD: external MCP examples need manual field-name translation before they can be reused, the current `total_thoughts >= thought_number` rule conflicts with canonical sequential-thinking examples that expand the estimate midstream, and reviewing/clearing the persisted `current_session.json` requires either summary generation or manual file inspection rather than a safe read-only history/status tool. The first implementation is assumption-backed foundation work for one active pi process per storage directory; concurrent multi-process coordination is deliberately not claimed by this slice.
 
 This PRD turns the selected first ideation slice into implementation requirements. It is original work, not a PRD for an existing tracker issue. Related ideation is captured in `docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md`; deferred work is preserved in `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md`.
 
@@ -34,7 +36,7 @@ This PRD turns the selected first ideation slice into implementation requirement
 | **Dynamic depth**              | Calls with `thought_number > total_thoughts` are accepted and normalized             | Stored `total_thoughts` becomes at least `thought_number`; receipt reports the adjustment                                                                                   |
 | **Centralized validation**     | Thought validation logic has one implementation path                                 | Inline validation duplication in `processThought` is removed or delegates to shared helpers                                                                                 |
 | **Session-scoped history**     | Named sessions can be written, read, summarized, cleared, exported, and imported     | `session_id` works across `process_thought`, `get_thinking_history`, `generate_summary`, `clear_history`, `export_session`, `import_session`, and legacy `sequential_think` |
-| **Backward compatibility**     | Existing default-session behavior and legacy exports remain usable                   | Current tests pass; legacy array and `{ thoughts: [...] }` imports still load                                                                                               |
+| **Backward compatibility**     | Existing default-session behavior and legacy exports remain usable                   | Existing non-obsoleted behavior remains covered; tests superseded by this PRD are updated; legacy array and `{ thoughts: [...] }` imports still load                        |
 | **State observability**        | Users can inspect effective state without reading files directly                     | New status tool reports effective config, storage path, session counts, writability, and backup/corruption file hints                                                       |
 | **Auditable mutations**        | Mutating tools return compact receipts                                               | `process_thought`, `clear_history`, `import_session`, `export_session`, and `sequential_think` include pre/post counts and session metadata                                 |
 
@@ -85,15 +87,23 @@ This PRD turns the selected first ideation slice into implementation requirement
 
 ### Out of scope / later
 
-| What                                                         | Why                                                                                                              | Tracked in                                                         |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Branch/revision metadata                                     | Depends on stable sessions/history and should not expand the first slice                                         | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
-| Persistence safety layer: bounds, redaction, export warnings | Important follow-up, but should use the state/status foundation from this PRD                                    | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
-| Focused synthesis, outcome contracts, and resume prompts     | More valuable after sessions and branch metadata exist                                                           | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
-| Redesign, replacement, or deprecation of `sequential_think`  | This PRD only makes the existing helper session-aware; broader behavior changes are part of later synthesis work | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
-| Evidence/artifact reference anchors                          | Add after the core thought record shape stabilizes                                                               | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
-| Dual pi extension + MCP server architecture                  | Separate architectural exploration; not part of this product slice                                               | #99                                                                |
-| Full branch switch/merge/close workflows                     | Too large for the selected foundation slice                                                                      | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| What                                                                            | Why                                                                                                                                                             | Tracked in                                                         |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Branch/revision metadata                                                        | Depends on stable sessions/history and should not expand the first slice                                                                                        | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Persistence safety layer: automatic bounds, redaction, and rich export warnings | Important follow-up, but should use the state/status foundation from this PRD; V1 still states a content privacy posture and validates import/export boundaries | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Focused synthesis, outcome contracts, and resume prompts                        | More valuable after sessions and branch metadata exist                                                                                                          | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Redesign, replacement, or deprecation of `sequential_think`                     | This PRD only makes the existing helper session-aware; broader behavior changes are part of later synthesis work                                                | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Evidence/artifact reference anchors                                             | Add after the core thought record shape stabilizes                                                                                                              | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Dual pi extension + MCP server architecture                                     | Separate architectural exploration; not part of this product slice                                                                                              | #99                                                                |
+| Full branch switch/merge/close workflows                                        | Too large for the selected foundation slice                                                                                                                     | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+
+### Content privacy posture for this slice
+
+Stored thoughts, tags, axioms, and assumptions are potentially sensitive user-authored content. V1 keeps the existing local plaintext JSON storage model and does not add automatic redaction or encryption, but it must make that posture explicit in README documentation and tool descriptions. Content-bearing tools (`get_thinking_history`, `generate_summary`, `export_session`, and `import_session`) may return or move thought content by design; diagnostic surfaces (`get_thinking_status` and mutation receipts) must remain content-free. Export/import operations must be explicit user/model calls and must not be triggered by status or summary tools.
+
+### Implementation slicing within this PRD
+
+The implementation plan should treat this PRD as a sequence of validating increments rather than one irreversible batch. The minimum validating increment is normalization/dynamic totals plus default/named session writes and `get_thinking_history`. Status diagnostics, import/export expansion, and receipts should build on that increment after the storage layout is proven by tests. This preserves the selected foundation scope while reducing reversal cost if the per-session file layout needs adjustment.
 
 ### Design for future (build with awareness)
 
@@ -149,7 +159,7 @@ And the error identifies the conflicting aliases for thought_number
 
 `total_thoughts` must be treated as an estimate. If a call provides `thought_number` greater than `total_thoughts`, the tool must accept the thought and store `total_thoughts` equal to `thought_number`. The response must include a receipt field that reports the adjustment.
 
-Existing calls where `total_thoughts >= thought_number` must preserve the provided total.
+Existing calls where `total_thoughts >= thought_number` must preserve the provided total. Dynamic adjustment normalizes only the incoming thought record; it must not backfill or rewrite earlier thoughts in the same session. Summaries should continue to derive completion from the session's recorded thoughts, using the maximum recorded `total_thoughts` where needed.
 
 **Acceptance criteria:**
 
@@ -317,6 +327,13 @@ New-format exports must use this top-level schema:
 
 For named sessions, `sessionId` is the normalized session ID and `sessionLabel` matches it. The default session uses `sessionId: null` and `sessionLabel: "default"`. If a caller provides `session_id` during import and it conflicts with the file's embedded `sessionId`, the provided target wins and the receipt includes a warning.
 
+Import/export file boundary policy:
+
+* `file_path` may be absolute or repo-relative, matching existing tool behavior, but parent directories are created only for export.
+* Export must not overwrite a directory; if the target file already exists, overwrite is allowed only for explicit `export_session` calls and the receipt reports `overwroteExistingFile`.
+* Import must validate JSON shape, enforce a default maximum import file size of 10 MiB before parsing, reject malformed top-level records with a structured error, and preserve the existing corrupted-current-session backup behavior for active storage files.
+* Import treats files as untrusted content: it must normalize IDs/timestamps/session IDs through the same validation path as tool input and must never execute or dereference paths, URLs, or text inside thought records.
+
 **Acceptance criteria:**
 
 ```gherkin
@@ -371,17 +388,21 @@ The extension must register a read-only status tool, named `get_thinking_status`
 
 The response must include at least:
 
-* `storageDir` as the resolved active storage directory;
-* `defaultSessionFile` as the default session file path or relative file name;
+* `storageDir` as the resolved active storage directory, redacted to `~` for the current user's home directory by default;
+* `defaultSessionFile` as the default session file path or relative file name, also home-redacted by default;
+* `pathDisclosure` describing whether paths are `home_redacted`, `relative`, or `absolute_diagnostic`;
 * `namedSessionCount`;
 * `totalThoughts` across known sessions;
 * `sessions` metadata with `sessionId`, `label`, `thoughtCount`, `lastUpdated`, and `isDefault`;
-* `effectiveConfig` with `storageDir`, `maxBytes`, and `maxLines`, plus source labels such as `flag`, `env`, `project_settings`, `global_settings`, `config_file`, or `default`;
+* `effectiveConfig` with `storageDir`, `maxBytes`, and `maxLines`, plus source labels such as `flag`, `env`, `project_settings`, `global_settings`, `config_file`, or `default`; all path-bearing fields inside `effectiveConfig`, including `effectiveConfig.storageDir`, use the same redaction policy as top-level status paths;
 * `writable` for whether the storage directory appears writable;
 * `backupFiles` as relative filenames under the storage directory, not absolute paths;
+* `statusCompleteness`, with `complete: true` when all known session files were inspected and `complete: false` plus a reason when a documented threshold prevents full enumeration;
 * `schemaVersion` or `storageVersion` when available.
 
-The tool must not include full thought text, thought snippets, tags, axioms, assumptions, or content-derived hashes.
+V1 may compute status by scanning the default session file and `sessions/*.json` files rather than maintaining a metadata index. Default enumeration threshold is 100 named session files; above that threshold, status may return partial counts with `statusCompleteness.complete: false` instead of loading every session file.
+
+The tool must not include full thought text, thought snippets, tags, axioms, assumptions, or content-derived hashes. Absolute path disclosure, if added later for diagnostics, must be an explicit option and must not be the default.
 
 **Acceptance criteria:**
 
@@ -389,7 +410,8 @@ The tool must not include full thought text, thought snippets, tags, axioms, ass
 Given default session has 1 thought
 And named session "research" has 2 thoughts
 When the model calls get_thinking_status
-Then the response includes storageDir
+Then the response includes storageDir with the current user's home directory redacted to ~
+And it reports pathDisclosure "home_redacted"
 And it reports namedSessionCount 1
 And it reports totalThoughts 3
 And it includes session metadata where the default session has sessionId null and label "default"
@@ -420,6 +442,13 @@ Receipt fields should include:
 * `savedAt` or `exportedAt` / `importedAt`;
 * `stateFingerprint` derived only from non-content inputs: schema/storage version, normalized session ID, thought count, thought IDs, thought timestamps, and session `lastUpdated`;
 * optional operation-specific data such as `totalThoughtsAdjusted` or import warnings.
+
+V1 identity rules:
+
+* New thoughts continue to receive an `id` and `timestamp` before storage.
+* Imported legacy thoughts without an `id` receive a generated ID during normalization.
+* Imported legacy thoughts without a `timestamp` receive an import-time timestamp and the receipt includes a normalization warning.
+* Fingerprints are allowed to change after an import that normalizes missing IDs or timestamps; this is expected and must be visible through import warnings.
 
 `stateFingerprint` must not hash or encode thought text, tags, axioms, assumptions, or local absolute paths.
 
@@ -463,7 +492,9 @@ Required README updates:
 * dynamic total behavior;
 * accepted alias naming;
 * default-session backward compatibility;
-* explicit note that branch/revision metadata and dual MCP server architecture are not included in this release.
+* explicit note that branch/revision metadata and dual MCP server architecture are not included in this release;
+* local plaintext storage posture, including which tools are content-bearing and which diagnostics stay content-free;
+* import/export path, overwrite, and maximum import-size behavior.
 
 **Acceptance criteria:**
 
@@ -484,17 +515,17 @@ And how to check storage/status diagnostics
 
 ## 6. Non-Functional Requirements
 
-| Category                   | Requirement                                                                                                                                                  |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Backward compatibility** | Existing persisted default-session files and legacy exports must continue to load without a manual migration step.                                           |
-| **No new transport scope** | The implementation must remain a native pi extension and must not add an MCP server entrypoint.                                                              |
-| **Dependency discipline**  | Prefer no new runtime dependencies; if a dependency is necessary, justify it in the implementation plan before adding it.                                    |
-| **Path safety**            | Named session IDs must not allow path traversal, directory separators, or the reserved case-insensitive ID `default`.                                        |
-| **Determinism**            | Validation and alias conflict behavior must be deterministic and covered by tests.                                                                           |
-| **Privacy**                | `get_thinking_status` and receipts must not include full thought content.                                                                                    |
-| **Concurrency**            | V1 may assume one active pi process per storage directory; if concurrent writers exist, behavior is last-writer-wins and must not be presented as lock-safe. |
-| **Performance**            | Status and history reads should be bounded and avoid loading more content than needed for requested session output where practical.                          |
-| **Testability**            | All new tools and storage paths must be covered by fast Vitest tests under `packages/pi-sequential-thinking/__tests__/`.                                     |
+| Category                   | Requirement                                                                                                                                                                                                                                    |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Backward compatibility** | Existing persisted default-session files and legacy exports must continue to load without a manual migration step.                                                                                                                             |
+| **No new transport scope** | The implementation must remain a native pi extension and must not add an MCP server entrypoint.                                                                                                                                                |
+| **Dependency discipline**  | Prefer no new runtime dependencies; if a dependency is necessary, justify it in the implementation plan before adding it.                                                                                                                      |
+| **Path safety**            | Named session IDs must not allow path traversal, directory separators, or the reserved case-insensitive ID `default`.                                                                                                                          |
+| **Determinism**            | Validation and alias conflict behavior must be deterministic and covered by tests.                                                                                                                                                             |
+| **Privacy**                | Stored thoughts are potentially sensitive plaintext local content; status and receipts must remain content-free, all status path fields must be home-redacted by default, and README/tool docs must state the local plaintext storage posture. |
+| **Concurrency**            | V1 targets one active pi process per storage directory; if concurrent writers exist, behavior is last-writer-wins and must not be presented as lock-safe.                                                                                      |
+| **Performance**            | Status and history reads should be bounded and avoid loading more content than needed for requested session output where practical.                                                                                                            |
+| **Testability**            | All new tools and storage paths must be covered by fast Vitest tests under `packages/pi-sequential-thinking/__tests__/`.                                                                                                                       |
 
 ---
 
@@ -502,15 +533,16 @@ And how to check storage/status diagnostics
 
 ### Risks
 
-| Risk                                                        | Severity | Likelihood | Mitigation                                                                                                                                           |
-| ----------------------------------------------------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Session storage migration breaks existing users             | High     | Medium     | Keep default session at `current_session.json`; add tests using existing export/current-session shapes.                                              |
-| Alias support creates ambiguous inputs                      | Medium   | Medium     | Fail on conflicting aliases rather than choosing precedence; document accepted aliases.                                                              |
-| Status output leaks thought content                         | Medium   | Low        | Build status from metadata only and add a test that known thought text is absent.                                                                    |
-| Receipts become noisy and destabilize tests                 | Medium   | Medium     | Keep receipt schema compact; assert field presence and stable counts rather than exact timestamps.                                                   |
-| Import/export semantics become confusing with sessions      | Medium   | Medium     | Require explicit `session_id` for named imports/exports and clearly document default-session behavior.                                               |
-| This first slice drifts into branch/revision or safety work | Medium   | Medium     | Keep out-of-scope table explicit and defer those to the later backlog.                                                                               |
-| Concurrent pi processes overwrite session files             | Medium   | Low        | Document V1 single-process assumptions; preserve atomic rename writes; do not claim cross-process locking until a later locking/index design exists. |
+| Risk                                                         | Severity | Likelihood | Mitigation                                                                                                                                                                                        |
+| ------------------------------------------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session storage migration breaks existing users              | High     | Medium     | Keep default session at `current_session.json`; add tests using existing export/current-session shapes.                                                                                           |
+| Alias support creates ambiguous inputs                       | Medium   | Medium     | Fail on conflicting aliases rather than choosing precedence; document accepted aliases.                                                                                                           |
+| Status output leaks thought content or sensitive paths       | Medium   | Low        | Build status from metadata only, redact home paths by default, use relative backup filenames, and add tests that known thought text and raw home paths are absent.                                |
+| Receipts become noisy and destabilize tests                  | Medium   | Medium     | Keep receipt schema compact; assert field presence and stable counts rather than exact timestamps.                                                                                                |
+| Test expectations conflict with intentional behavior changes | Medium   | Low        | Update tests that encode superseded behavior, including strict `total_thoughts >= thought_number` rejection and empty-object import handling, while preserving non-obsoleted compatibility tests. |
+| Import/export semantics become confusing with sessions       | Medium   | Medium     | Document import destination precedence clearly: explicit `session_id` wins; otherwise embedded `sessionId` is used; otherwise import into the default session.                                    |
+| This first slice drifts into branch/revision or safety work  | Medium   | Medium     | Keep out-of-scope table explicit and defer those to the later backlog.                                                                                                                            |
+| Concurrent pi processes overwrite session files              | Medium   | Low        | Narrow V1 language to one active pi process per storage directory; preserve atomic rename writes; do not claim cross-process locking until a later locking/index design exists.                   |
 
 ### Assumptions
 
@@ -519,7 +551,10 @@ And how to check storage/status diagnostics
 * Named session IDs do not need human-readable titles or archive status in this first slice.
 * Per-session files are acceptable for V1 and easier to inspect/recover than one monolithic sessions file.
 * V1 can assume a single active pi process per storage directory; cross-process locking is not part of this PRD.
+* Local plaintext storage is acceptable for V1 when documented; automatic redaction/encryption is deferred.
 * Existing output truncation is sufficient for V1 bounded responses when combined with `get_thinking_history` limits.
+* Default import file size limit is 10 MiB.
+* Default status enumeration threshold is 100 named session files.
 
 ---
 
@@ -624,24 +659,28 @@ And how to check storage/status diagnostics
 
 1. Add shared normalization and validation helpers with tests, including dynamic total adjustment.
 2. Update `process_thought` to use the shared helpers and emit mutation receipts.
-3. Extend `ThoughtStorage` for default/named sessions while preserving `current_session.json` behavior.
-4. Add `get_thinking_history` and session-aware summary/clear/export/import behavior.
-5. Add `get_thinking_status` and storage diagnostics.
-6. Update README examples and tool documentation.
-7. Run targeted package tests, typecheck, and Biome checks.
+3. Extend `ThoughtStorage` for default/named session writes while preserving `current_session.json` behavior.
+4. Add `get_thinking_history` and prove default/named session isolation as the minimum validating increment.
+5. Add session-aware summary/clear/export/import behavior, including the file boundary policy and import normalization warnings.
+6. Add `get_thinking_status` and storage diagnostics, including home-redacted paths and the V1 enumeration threshold.
+7. Update README examples, tool documentation, and plaintext local-storage privacy posture.
+8. Run targeted package tests, typecheck, and Biome checks.
 
 ---
 
 ## 12. Open Questions
 
-| #  | Question                                                                        | Owner             | Due        | Status                                                                                                                                                                      |
-| -- | ------------------------------------------------------------------------------- | ----------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Q1 | Should branch/revision metadata be included in this first slice?                | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. It is deferred to the later backlog.                                                                                                                      |
-| Q2 | Should dual pi extension + MCP server architecture be part of this PRD?         | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. It is tracked separately in #99.                                                                                                                          |
-| Q3 | Should named session IDs allow slashes or nested paths?                         | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. V1 session IDs are path-safe labels only.                                                                                                                 |
-| Q4 | Should `get_thinking_history` default to returning full thought bodies?         | Sebastian Otaegui | 2026-05-16 | **Resolved:** Yes, bounded by `limit` and existing output truncation; snippets are available through `include_full_thoughts: false`.                                        |
-| Q5 | Should `sequential_think` participate in sessions?                              | Sebastian Otaegui | 2026-05-16 | **Resolved:** Yes, as a compatibility shim only. It accepts optional `session_id`, writes to the selected session, and returns receipts; broader redesign remains deferred. |
-| Q6 | What wins when an import file embeds one session but the caller passes another? | Sebastian Otaegui | 2026-05-16 | **Resolved:** The caller-provided session wins and the receipt reports a warning.                                                                                           |
+| #  | Question                                                                          | Owner             | Due        | Status                                                                                                                                                                      |
+| -- | --------------------------------------------------------------------------------- | ----------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1 | Should branch/revision metadata be included in this first slice?                  | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. It is deferred to the later backlog.                                                                                                                      |
+| Q2 | Should dual pi extension + MCP server architecture be part of this PRD?           | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. It is tracked separately in #99.                                                                                                                          |
+| Q3 | Should named session IDs allow slashes or nested paths?                           | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. V1 session IDs are path-safe labels only.                                                                                                                 |
+| Q4 | Should `get_thinking_history` default to returning full thought bodies?           | Sebastian Otaegui | 2026-05-16 | **Resolved:** Yes, bounded by `limit` and existing output truncation; snippets are available through `include_full_thoughts: false`.                                        |
+| Q5 | Should `sequential_think` participate in sessions?                                | Sebastian Otaegui | 2026-05-16 | **Resolved:** Yes, as a compatibility shim only. It accepts optional `session_id`, writes to the selected session, and returns receipts; broader redesign remains deferred. |
+| Q6 | What wins when an import file embeds one session but the caller passes another?   | Sebastian Otaegui | 2026-05-16 | **Resolved:** The caller-provided session wins and the receipt reports a warning.                                                                                           |
+| Q7 | Does V1 protect persisted thought content with encryption or automatic redaction? | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. V1 keeps local plaintext JSON storage, documents that posture, and keeps diagnostics content-free; richer safety/redaction is deferred.                   |
+| Q8 | Does V1 support concurrent writers to the same storage directory?                 | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. V1 targets one active pi process per storage directory and documents last-writer-wins if users violate that assumption.                                   |
+| Q9 | What are V1's default import and status thresholds?                               | Sebastian Otaegui | 2026-05-16 | **Resolved:** Imports reject files over 10 MiB by default; status may return partial counts after 100 named session files.                                                  |
 
 ---
 
@@ -660,9 +699,11 @@ And how to check storage/status diagnostics
 
 ## 14. Changelog
 
-| Date       | Change        | Author            |
-| ---------- | ------------- | ----------------- |
-| 2026-05-16 | Initial draft | Sebastian Otaegui |
+| Date       | Change                             | Author            |
+| ---------- | ---------------------------------- | ----------------- |
+| 2026-05-16 | Addressed second refine findings   | Sebastian Otaegui |
+| 2026-05-16 | Addressed document review findings | Sebastian Otaegui |
+| 2026-05-16 | Initial draft                      | Sebastian Otaegui |
 
 ---
 
@@ -677,6 +718,8 @@ Post-implementation checklist:
 5. Manually exercise `process_thought` with camelCase aliases and verify stored history is normalized.
 6. Record thoughts in default session and a named session, then confirm `get_thinking_history` returns isolated results.
 7. Call `sequential_think` with a named `session_id` and confirm generated prompts are written only to that session with a receipt.
-8. Call `get_thinking_status` and confirm it reports storage/session metadata, config source labels, and relative backup filenames without thought content.
+8. Call `get_thinking_status` and confirm it reports storage/session metadata, config source labels, home-redacted paths, status completeness, and relative backup filenames without thought content.
 9. Export and import a legacy `{ thoughts: [...] }` session into a named session and confirm the default session remains unchanged.
 10. Import a new-format export with an embedded `sessionId` into a different explicit `session_id` and confirm the explicit target wins with a warning.
+11. Import legacy thoughts missing IDs or timestamps and confirm generated identity fields plus receipt warnings.
+12. Attempt import/export with malformed files, directories, and oversized files and confirm structured errors without unintended state changes.

--- a/docs/prd/PRD-009-pi-sequential-thinking-state-foundation.md
+++ b/docs/prd/PRD-009-pi-sequential-thinking-state-foundation.md
@@ -1,0 +1,682 @@
+---
+title: "pi-sequential-thinking State Foundation"
+prd: PRD-009
+status: Draft
+owner: "Sebastian Otaegui"
+issue: "N/A"
+date: 2026-05-16
+version: "1.0"
+---
+
+# PRD: pi-sequential-thinking State Foundation
+
+---
+
+## 1. Problem & Context
+
+`packages/pi-sequential-thinking` gives pi users a native structured-thinking extension with staged thoughts, tags, axioms, assumptions, summaries, import/export, and persistent JSON storage. It is useful today, but its state model is still too global and too strict for repeated agent use:
+
+* `process_thought` only reads snake\_case inputs even though the wider MCP sequential-thinking ecosystem uses camelCase fields such as `thoughtNumber`, `totalThoughts`, and `nextThoughtNeeded`.
+* `total_thoughts < thought_number` is rejected, while the canonical MCP sequential-thinking behavior treats the total as an estimate and expands it dynamically.
+* validation is split between `extensions/types.ts` and inline checks in `extensions/index.ts`, making future field additions riskier.
+* all thoughts live in one implicit `current_session.json`; there is no `session_id`, no read-only history inspection tool, and no way to summarize, clear, export, or import one named session.
+* stateful behavior is not observable enough: users cannot ask which storage directory/config is active, whether the store is writable, how many sessions/thoughts exist, or whether a mutating call actually changed persisted state.
+
+This PRD turns the selected first ideation slice into implementation requirements. It is original work, not a PRD for an existing tracker issue. Related ideation is captured in `docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md`; deferred work is preserved in `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md`.
+
+---
+
+## 2. Goals & Success Metrics
+
+| Goal                           | Metric                                                                               | Target                                                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Compatible thought capture** | `process_thought` accepts current snake\_case fields and MCP-style camelCase aliases | Existing snake\_case tests pass; new camelCase alias tests pass                                                                                                             |
+| **Dynamic depth**              | Calls with `thought_number > total_thoughts` are accepted and normalized             | Stored `total_thoughts` becomes at least `thought_number`; receipt reports the adjustment                                                                                   |
+| **Centralized validation**     | Thought validation logic has one implementation path                                 | Inline validation duplication in `processThought` is removed or delegates to shared helpers                                                                                 |
+| **Session-scoped history**     | Named sessions can be written, read, summarized, cleared, exported, and imported     | `session_id` works across `process_thought`, `get_thinking_history`, `generate_summary`, `clear_history`, `export_session`, `import_session`, and legacy `sequential_think` |
+| **Backward compatibility**     | Existing default-session behavior and legacy exports remain usable                   | Current tests pass; legacy array and `{ thoughts: [...] }` imports still load                                                                                               |
+| **State observability**        | Users can inspect effective state without reading files directly                     | New status tool reports effective config, storage path, session counts, writability, and backup/corruption file hints                                                       |
+| **Auditable mutations**        | Mutating tools return compact receipts                                               | `process_thought`, `clear_history`, `import_session`, `export_session`, and `sequential_think` include pre/post counts and session metadata                                 |
+
+**Guardrails (must not regress):**
+
+* Existing tools remain registered: `process_thought`, `generate_summary`, `clear_history`, `export_session`, `import_session`, and `sequential_think`.
+* Existing snake\_case tool calls continue to work unchanged.
+* Existing config resolution continues to work: settings files, `MCP_STORAGE_DIR`, `SEQ_THINK_*` environment variables, and current CLI flags.
+* Existing output truncation behavior using `piMaxBytes` and `piMaxLines` continues to apply to new and modified tool outputs.
+* Existing default storage at `~/.mcp_sequential_thinking/current_session.json` remains the default-session source of truth.
+* No MCP server, network transport, or dual-adapter architecture is introduced by this PRD.
+
+---
+
+## 3. Users & Use Cases
+
+### Primary: pi user doing repeated structured reasoning
+
+> As a pi user, I want to keep separate named thinking sessions so that unrelated reasoning workflows do not overwrite or pollute one another.
+
+**Preconditions:** `@feniix/pi-sequential-thinking` is installed and the user calls the extension tools in pi.
+
+### Secondary: LLM agent using sequential-thinking tools
+
+> As the model executing a multi-step task, I want flexible field aliases, dynamic totals, and history inspection so that I can continue reasoning without failed calls or hidden state assumptions.
+
+**Preconditions:** The model has access to the registered pi tools and can call them with JSON parameters.
+
+### Future: Follow-on feature implementer
+
+> As a developer adding branch/revision metadata later, I want a normalized record model and session-aware storage so that branches can be attached to stable thought histories instead of one global list.
+
+---
+
+## 4. Scope
+
+### In scope
+
+1. **Input normalization** — accept snake\_case and selected MCP-style camelCase aliases for thought capture and serialization boundaries.
+2. **Dynamic total adjustment** — treat `total_thoughts` / `totalThoughts` as an estimate and automatically raise it to `thought_number` when needed.
+3. **Shared validation helpers** — centralize required field, type, conflict, and normalization validation in `extensions/types.ts` or a new helper module.
+4. **Session ID support** — add optional `session_id` / `sessionId` to stateful tools with a path-safe session ID policy.
+5. **Read-only history tool** — add `get_thinking_history` with bounded output and session metadata.
+6. **Session-aware existing tools** — make summary, clear, export, import, and the legacy `sequential_think` helper operate on the requested session, defaulting to the current default session.
+7. **State status tool** — add a tool for effective config, storage path, session counts, backup/corruption hints, and writability.
+8. **Mutation receipts** — return compact pre/post state receipts from mutating tools.
+9. **Tests and docs** — update unit/runtime tests and `packages/pi-sequential-thinking/README.md`.
+
+### Out of scope / later
+
+| What                                                         | Why                                                                                                              | Tracked in                                                         |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Branch/revision metadata                                     | Depends on stable sessions/history and should not expand the first slice                                         | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Persistence safety layer: bounds, redaction, export warnings | Important follow-up, but should use the state/status foundation from this PRD                                    | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Focused synthesis, outcome contracts, and resume prompts     | More valuable after sessions and branch metadata exist                                                           | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Redesign, replacement, or deprecation of `sequential_think`  | This PRD only makes the existing helper session-aware; broader behavior changes are part of later synthesis work | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Evidence/artifact reference anchors                          | Add after the core thought record shape stabilizes                                                               | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+| Dual pi extension + MCP server architecture                  | Separate architectural exploration; not part of this product slice                                               | #99                                                                |
+| Full branch switch/merge/close workflows                     | Too large for the selected foundation slice                                                                      | `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md` |
+
+### Design for future (build with awareness)
+
+The implementation should normalize inputs into one internal `ThoughtData` shape before storage and analysis. That normalized shape should leave room for later optional metadata such as branch/revision fields, safety warnings, and evidence anchors without forcing those fields into this PRD.
+
+Storage should keep default-session compatibility while making named-session access explicit enough for later features to query one session, list session metadata, or validate references within a session.
+
+---
+
+## 5. Functional Requirements
+
+### FR-1: Normalize thought capture aliases into one internal model
+
+`process_thought` must accept the current snake\_case fields and MCP-style camelCase aliases for the same required thought fields. The implementation must normalize both styles into the existing internal snake\_case `ThoughtData` model before validation, persistence, or analysis.
+
+Minimum aliases:
+
+| Internal field           | Accepted aliases                                  |
+| ------------------------ | ------------------------------------------------- |
+| `thought_number`         | `thought_number`, `thoughtNumber`                 |
+| `total_thoughts`         | `total_thoughts`, `totalThoughts`                 |
+| `next_thought_needed`    | `next_thought_needed`, `nextThoughtNeeded`        |
+| `axioms_used`            | `axioms_used`, `axiomsUsed`                       |
+| `assumptions_challenged` | `assumptions_challenged`, `assumptionsChallenged` |
+| `session_id`             | `session_id`, `sessionId`                         |
+
+If both aliases for a field are present with the same value, the call succeeds. If both aliases are present with conflicting values, the call fails with a field-specific validation error. Alias comparison happens after normalization: strings are trimmed, omitted optional arrays normalize to `[]`, and arrays use exact-order deep equality rather than set equality.
+
+**Acceptance criteria:**
+
+```gherkin
+Given an empty default thinking session
+When the model calls process_thought with thoughtNumber 1, totalThoughts 3, nextThoughtNeeded true, stage "Analysis", and thought "Use aliases"
+Then the tool records the thought
+And the stored thought has thought_number 1, total_thoughts 3, and next_thought_needed true
+```
+
+```gherkin
+Given an empty default thinking session
+When the model calls process_thought with thought_number 1 and thoughtNumber 2
+Then the tool returns an error
+And the error identifies the conflicting aliases for thought_number
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/types.ts` — define normalized input types, alias normalization, and conflict validation.
+* `packages/pi-sequential-thinking/extensions/index.ts` — use normalized inputs in tool handlers and schemas.
+* `packages/pi-sequential-thinking/__tests__/types.test.ts` — cover alias normalization and conflicts.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover alias calls through the registered tool.
+
+### FR-2: Support dynamic total\_thoughts adjustment
+
+`total_thoughts` must be treated as an estimate. If a call provides `thought_number` greater than `total_thoughts`, the tool must accept the thought and store `total_thoughts` equal to `thought_number`. The response must include a receipt field that reports the adjustment.
+
+Existing calls where `total_thoughts >= thought_number` must preserve the provided total.
+
+**Acceptance criteria:**
+
+```gherkin
+Given an empty default thinking session
+When the model calls process_thought with thought_number 5, total_thoughts 3, next_thought_needed true, stage "Analysis", and thought "Need more steps"
+Then the tool records the thought
+And the stored thought has total_thoughts 5
+And the tool response includes a receipt showing totalThoughtsAdjusted from 3 to 5
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/types.ts` — normalize dynamic totals after required integer validation.
+* `packages/pi-sequential-thinking/extensions/index.ts` — include adjustment data in the mutation receipt.
+* `packages/pi-sequential-thinking/__tests__/types.test.ts` — replace strict failure expectation with dynamic adjustment expectations.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover dynamic totals through `process_thought`.
+
+### FR-3: Centralize validation and guidance-rich errors
+
+Validation for thought capture must live in shared helpers rather than being duplicated inline. Invalid tool calls must produce actionable errors with field names and messages. The external tool output may remain a text error, but `details.error` or equivalent structured details should preserve the validation information where feasible.
+
+Validation must cover at least:
+
+* non-empty `thought`;
+* positive integer `thought_number`;
+* positive integer `total_thoughts` before dynamic adjustment;
+* boolean `next_thought_needed`;
+* valid `stage`;
+* array-of-string optional metadata fields;
+* alias conflicts;
+* session ID format when provided.
+
+**Acceptance criteria:**
+
+```gherkin
+Given an empty default thinking session
+When the model calls process_thought with thought "   ", thought_number 1, total_thoughts 1, next_thought_needed false, and stage "Analysis"
+Then the call fails
+And the error includes field "thought" and message "Thought content cannot be empty"
+```
+
+```gherkin
+Given an empty default thinking session
+When the model calls process_thought with session_id "bad/session", thought "x", thought_number 1, total_thoughts 1, next_thought_needed false, and stage "Analysis"
+Then the call fails
+And the error identifies session_id as invalid
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/types.ts` — own validation helpers and exported validation result types.
+* `packages/pi-sequential-thinking/extensions/index.ts` — remove or delegate inline checks.
+* `packages/pi-sequential-thinking/__tests__/types.test.ts` — cover all validation branches.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover user-visible tool errors.
+
+### FR-4: Add session-scoped storage while preserving the default session
+
+The storage layer must support one default session plus named sessions. Omitting `session_id` must behave like today and use `current_session.json`. Providing a `session_id` must isolate thoughts for that session.
+
+Session IDs must be path-safe. V1 session IDs should allow only letters, numbers, dot, underscore, and hyphen, with a maximum length of 80 characters. Leading/trailing whitespace is trimmed. Empty or invalid IDs fail validation. The case-insensitive ID `default` is reserved for the default session label and must not be accepted as a named session ID.
+
+Named sessions should be persisted under the configured storage directory without changing the default-session file path. A recommended layout is:
+
+* default session: `current_session.json`
+* named sessions: `sessions/<session_id>.json`
+
+**Acceptance criteria:**
+
+```gherkin
+Given a storage directory with no thoughts
+When the model records thought "Default" without session_id
+And records thought "Named" with session_id "architecture-review"
+Then get_thinking_history without session_id returns only "Default"
+And get_thinking_history with session_id "architecture-review" returns only "Named"
+```
+
+```gherkin
+Given an existing storage directory containing current_session.json from version 3.0.1
+When a new ThoughtStorage instance starts
+Then default-session history loads from current_session.json
+And no migration step is required for default-session reads
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/storage.ts` — add session-aware read/write/clear/export/import APIs.
+* `packages/pi-sequential-thinking/extensions/types.ts` — add `session_id` input normalization and validation.
+* `packages/pi-sequential-thinking/extensions/index.ts` — pass session IDs from tools to storage.
+* `packages/pi-sequential-thinking/__tests__/storage.test.ts` — cover default compatibility, named-session isolation, invalid session IDs, and persistence.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover end-to-end session isolation.
+
+### FR-5: Add get\_thinking\_history for bounded read-only inspection
+
+The extension must register a new `get_thinking_history` tool. It returns recorded thoughts for one session without mutating state.
+
+Parameters:
+
+| Parameter                                       | Type    | Required | Default          | Description                                      |
+| ----------------------------------------------- | ------- | -------- | ---------------- | ------------------------------------------------ |
+| `session_id` / `sessionId`                      | string  | no       | default session  | Session to inspect                               |
+| `limit`                                         | integer | no       | 20               | Maximum thoughts to return                       |
+| `offset`                                        | integer | no       | 0                | Number of thoughts to skip from the start        |
+| `include_full_thoughts` / `includeFullThoughts` | boolean | no       | true             | Whether to include full thought text or snippets |
+| `piMaxBytes`                                    | integer | no       | configured limit | Existing output truncation override              |
+| `piMaxLines`                                    | integer | no       | configured limit | Existing output truncation override              |
+
+`limit` must be bounded to prevent accidental full dumps. V1 should enforce `1 <= limit <= 100`. History is returned in persisted insertion order from oldest to newest; `offset` and `limit` are applied after that ordering. This order is intentionally different from summaries that may present a stage/timeline view.
+
+**Acceptance criteria:**
+
+```gherkin
+Given session "plan" contains 3 thoughts numbered 1, 2, and 3
+When the model calls get_thinking_history with session_id "plan" and limit 2
+Then the response includes session_id "plan"
+And it returns 2 thoughts
+And it reports totalThoughts 3 and hasMore true
+```
+
+```gherkin
+Given session "plan" contains a long thought
+When the model calls get_thinking_history with include_full_thoughts false
+Then the response includes a snippet for that thought
+And it does not include the full thought body
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/index.ts` — define schema and register `get_thinking_history`.
+* `packages/pi-sequential-thinking/extensions/storage.ts` — provide bounded session history retrieval.
+* `packages/pi-sequential-thinking/extensions/types.ts` — define history request validation helpers if shared.
+* `packages/pi-sequential-thinking/__tests__/index.test.ts` — assert tool registration.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover history calls, limits, offsets, and snippets.
+* `packages/pi-sequential-thinking/README.md` — document the new tool.
+
+### FR-6: Make summary, clear, export, and import session-aware
+
+Existing stateful tools must accept optional `session_id` / `sessionId` and default to the default session when omitted.
+
+Required behavior:
+
+* `generate_summary` summarizes only the selected session.
+* `clear_history` clears only the selected session.
+* `export_session` exports only the selected session and includes session metadata.
+* `import_session` imports into the selected session; when omitted, it imports into the embedded `sessionId` from a new-format export; when no target or embedded session exists, it imports into the default session.
+* `sequential_think` remains the existing legacy helper, but accepts optional `session_id` / `sessionId`, writes its generated staged prompts to the selected session, summarizes only that session, and returns a mutation receipt. Broader redesign, replacement, or deprecation is out of scope.
+* Existing import formats remain accepted: legacy array exports and `{ thoughts: [...] }` objects.
+
+New-format exports must use this top-level schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "sessionId": null,
+  "sessionLabel": "default",
+  "thoughts": [],
+  "lastUpdated": "2026-05-16T00:00:00.000Z",
+  "exportedAt": "2026-05-16T00:00:00.000Z",
+  "metadata": {
+    "totalThoughts": 0,
+    "stages": {}
+  }
+}
+```
+
+For named sessions, `sessionId` is the normalized session ID and `sessionLabel` matches it. The default session uses `sessionId: null` and `sessionLabel: "default"`. If a caller provides `session_id` during import and it conflicts with the file's embedded `sessionId`, the provided target wins and the receipt includes a warning.
+
+**Acceptance criteria:**
+
+```gherkin
+Given default session contains one thought
+And session "research" contains two thoughts
+When the model calls generate_summary with session_id "research"
+Then the summary reports totalThoughts 2
+And it does not include the default-session thought
+```
+
+```gherkin
+Given session "research" contains two thoughts
+When the model calls clear_history with session_id "research"
+Then session "research" is empty
+And the default session is unchanged
+And the response includes preCount 2 and postCount 0
+```
+
+```gherkin
+Given an export file in legacy array format
+When the model calls import_session with file_path "legacy.json" and session_id "legacy-import"
+Then get_thinking_history with session_id "legacy-import" returns the imported thoughts
+And the default session is unchanged
+```
+
+```gherkin
+Given session "scratch" is empty
+When the model calls sequential_think with topic "Database migration strategy", num_thoughts 5, and session_id "scratch"
+Then the generated staged prompts are stored in session "scratch"
+And the default session is unchanged
+And the response includes a receipt with operation "sequential_think"
+```
+
+```gherkin
+Given a new-format export embeds sessionId "research"
+When the model calls import_session with file_path "research.json" and session_id "review"
+Then the imported thoughts are written to session "review"
+And the response receipt includes a session mismatch warning
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/index.ts` — add optional session params and receipts to existing tools.
+* `packages/pi-sequential-thinking/extensions/storage.ts` — implement session-aware clear/export/import/summary access.
+* `packages/pi-sequential-thinking/__tests__/storage.test.ts` — cover import/export and clear per session.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover session-aware tools through registered runtime.
+* `packages/pi-sequential-thinking/README.md` — update tool docs and examples.
+
+### FR-7: Add state observability status tool
+
+The extension must register a read-only status tool, named `get_thinking_status`, that reports effective runtime state without dumping thought content.
+
+The response must include at least:
+
+* `storageDir` as the resolved active storage directory;
+* `defaultSessionFile` as the default session file path or relative file name;
+* `namedSessionCount`;
+* `totalThoughts` across known sessions;
+* `sessions` metadata with `sessionId`, `label`, `thoughtCount`, `lastUpdated`, and `isDefault`;
+* `effectiveConfig` with `storageDir`, `maxBytes`, and `maxLines`, plus source labels such as `flag`, `env`, `project_settings`, `global_settings`, `config_file`, or `default`;
+* `writable` for whether the storage directory appears writable;
+* `backupFiles` as relative filenames under the storage directory, not absolute paths;
+* `schemaVersion` or `storageVersion` when available.
+
+The tool must not include full thought text, thought snippets, tags, axioms, assumptions, or content-derived hashes.
+
+**Acceptance criteria:**
+
+```gherkin
+Given default session has 1 thought
+And named session "research" has 2 thoughts
+When the model calls get_thinking_status
+Then the response includes storageDir
+And it reports namedSessionCount 1
+And it reports totalThoughts 3
+And it includes session metadata where the default session has sessionId null and label "default"
+And it includes session metadata for "research"
+And it does not include the full text of any thought
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/index.ts` — define schema and register `get_thinking_status`.
+* `packages/pi-sequential-thinking/extensions/storage.ts` — expose storage diagnostics and session metadata.
+* `packages/pi-sequential-thinking/__tests__/index.test.ts` — assert tool registration.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover status output.
+* `packages/pi-sequential-thinking/README.md` — document the status tool.
+
+### FR-8: Return mutation receipts from state-changing tools
+
+Mutating tools must include compact receipts that make state changes auditable. For this PRD, mutating tools are `process_thought`, `clear_history`, `export_session`, `import_session`, and `sequential_think`. Receipts must avoid full thought content and should be stable enough for tests.
+
+Receipt fields should include:
+
+* `operation`;
+* `sessionId` with `null` for the default session;
+* `sessionLabel` with `"default"` for the default session;
+* `preCount`;
+* `postCount`;
+* `changed`;
+* `savedAt` or `exportedAt` / `importedAt`;
+* `stateFingerprint` derived only from non-content inputs: schema/storage version, normalized session ID, thought count, thought IDs, thought timestamps, and session `lastUpdated`;
+* optional operation-specific data such as `totalThoughtsAdjusted` or import warnings.
+
+`stateFingerprint` must not hash or encode thought text, tags, axioms, assumptions, or local absolute paths.
+
+**Acceptance criteria:**
+
+```gherkin
+Given session "research" contains 1 thought
+When the model calls process_thought with session_id "research" and a second valid thought
+Then the response includes a receipt with operation "process_thought"
+And preCount is 1
+And postCount is 2
+And changed is true
+And stateFingerprint is present
+```
+
+```gherkin
+Given session "research" is empty
+When the model calls clear_history with session_id "research"
+Then the response includes changed false
+And preCount is 0
+And postCount is 0
+And stateFingerprint is present
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/extensions/index.ts` — attach receipts to mutating tool responses.
+* `packages/pi-sequential-thinking/extensions/storage.ts` — provide counts, save metadata, and fingerprint inputs.
+* `packages/pi-sequential-thinking/__tests__/runtime.test.ts` — cover user-visible receipts.
+* `packages/pi-sequential-thinking/__tests__/storage.test.ts` — cover receipt-supporting metadata.
+
+### FR-9: Update documentation and preserve package ergonomics
+
+Documentation must reflect the new first-slice behavior without implying that later backlog work is already implemented.
+
+Required README updates:
+
+* new `session_id` usage examples;
+* `get_thinking_history` documentation;
+* `get_thinking_status` documentation;
+* dynamic total behavior;
+* accepted alias naming;
+* default-session backward compatibility;
+* explicit note that branch/revision metadata and dual MCP server architecture are not included in this release.
+
+**Acceptance criteria:**
+
+```gherkin
+Given a developer opens packages/pi-sequential-thinking/README.md
+When they read the Tools section
+Then they can see how to record a thought in a named session
+And how to inspect that session history
+And how to check storage/status diagnostics
+```
+
+**Files:**
+
+* `packages/pi-sequential-thinking/README.md` — update feature list, tool docs, examples, and limitations.
+* `packages/pi-sequential-thinking/__tests__/index.test.ts` — ensure registered tool list expectations include new tools.
+
+---
+
+## 6. Non-Functional Requirements
+
+| Category                   | Requirement                                                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Backward compatibility** | Existing persisted default-session files and legacy exports must continue to load without a manual migration step.                                           |
+| **No new transport scope** | The implementation must remain a native pi extension and must not add an MCP server entrypoint.                                                              |
+| **Dependency discipline**  | Prefer no new runtime dependencies; if a dependency is necessary, justify it in the implementation plan before adding it.                                    |
+| **Path safety**            | Named session IDs must not allow path traversal, directory separators, or the reserved case-insensitive ID `default`.                                        |
+| **Determinism**            | Validation and alias conflict behavior must be deterministic and covered by tests.                                                                           |
+| **Privacy**                | `get_thinking_status` and receipts must not include full thought content.                                                                                    |
+| **Concurrency**            | V1 may assume one active pi process per storage directory; if concurrent writers exist, behavior is last-writer-wins and must not be presented as lock-safe. |
+| **Performance**            | Status and history reads should be bounded and avoid loading more content than needed for requested session output where practical.                          |
+| **Testability**            | All new tools and storage paths must be covered by fast Vitest tests under `packages/pi-sequential-thinking/__tests__/`.                                     |
+
+---
+
+## 7. Risks & Assumptions
+
+### Risks
+
+| Risk                                                        | Severity | Likelihood | Mitigation                                                                                                                                           |
+| ----------------------------------------------------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session storage migration breaks existing users             | High     | Medium     | Keep default session at `current_session.json`; add tests using existing export/current-session shapes.                                              |
+| Alias support creates ambiguous inputs                      | Medium   | Medium     | Fail on conflicting aliases rather than choosing precedence; document accepted aliases.                                                              |
+| Status output leaks thought content                         | Medium   | Low        | Build status from metadata only and add a test that known thought text is absent.                                                                    |
+| Receipts become noisy and destabilize tests                 | Medium   | Medium     | Keep receipt schema compact; assert field presence and stable counts rather than exact timestamps.                                                   |
+| Import/export semantics become confusing with sessions      | Medium   | Medium     | Require explicit `session_id` for named imports/exports and clearly document default-session behavior.                                               |
+| This first slice drifts into branch/revision or safety work | Medium   | Medium     | Keep out-of-scope table explicit and defer those to the later backlog.                                                                               |
+| Concurrent pi processes overwrite session files             | Medium   | Low        | Document V1 single-process assumptions; preserve atomic rename writes; do not claim cross-process locking until a later locking/index design exists. |
+
+### Assumptions
+
+* The PRD is for original repository work, not for a source GitHub or Linear issue.
+* `session_id` can be optional and omitted calls should continue to mean the default session.
+* Named session IDs do not need human-readable titles or archive status in this first slice.
+* Per-session files are acceptable for V1 and easier to inspect/recover than one monolithic sessions file.
+* V1 can assume a single active pi process per storage directory; cross-process locking is not part of this PRD.
+* Existing output truncation is sufficient for V1 bounded responses when combined with `get_thinking_history` limits.
+
+---
+
+## 8. Design Decisions
+
+### D1: Normalize to the existing snake\_case internal model
+
+**Options considered:**
+
+1. Keep snake\_case only — simplest implementation, but preserves compatibility friction with MCP-style examples.
+2. Convert the internal model to camelCase — aligns with MCP serialization, but creates unnecessary churn across current code/tests.
+3. Accept aliases at boundaries and normalize internally to snake\_case — supports both users while preserving existing internals.
+
+**Decision:** Accept aliases at tool/input boundaries and normalize into the existing snake\_case internal `ThoughtData` shape.
+
+**Rationale:** This maximizes compatibility while minimizing implementation churn and preserving current tests/docs patterns.
+
+**Future path:** Later branch/revision aliases can follow the same boundary-normalization pattern.
+
+### D2: Fail on conflicting aliases
+
+**Options considered:**
+
+1. Prefer snake\_case when both aliases are present — predictable for existing users but can hide model mistakes.
+2. Prefer camelCase when both aliases are present — aligns with MCP, but can surprise pi-native callers.
+3. Fail when aliases conflict — more strict, but safest and easiest to debug.
+
+**Decision:** If both aliases are present with different values, return a validation error.
+
+**Rationale:** Silent precedence would make tool calls harder to audit and could store the wrong thought metadata.
+
+### D3: Preserve `current_session.json` for the default session
+
+**Options considered:**
+
+1. Migrate all sessions into a new combined file — easier global status, but risky for existing users.
+2. Keep default session at `current_session.json` and store named sessions separately — preserves compatibility and allows incremental adoption.
+3. Keep one global list and add `session_id` fields inside each thought — simpler storage file, but makes session clear/export/import less isolated.
+
+**Decision:** Preserve `current_session.json` for the default session and store named sessions under a `sessions/` directory.
+
+**Rationale:** This avoids a mandatory migration and keeps session files inspectable and recoverable.
+
+**Future path:** A future storage version can add an index file if session listing becomes too expensive or needs richer metadata.
+
+### D4: Add read-only status rather than expanding summaries
+
+**Options considered:**
+
+1. Put config/storage diagnostics in `generate_summary` — fewer tools, but mixes content summary with runtime diagnostics.
+2. Add `get_thinking_status` — clearer separation between state diagnostics and reasoning summaries.
+3. Only document where files live — requires users to inspect local storage manually.
+
+**Decision:** Add `get_thinking_status` as a separate read-only tool.
+
+**Rationale:** State observability is operational, not cognitive summary. A separate tool can avoid thought content and stay safe to call.
+
+### D5: Import destination precedence
+
+**Options considered:**
+
+1. Always import into the embedded `sessionId` from the export file — convenient for restores, but surprising when a caller explicitly targets a session.
+2. Always ignore embedded `sessionId` — predictable for explicit calls, but loses useful restore metadata when no target is supplied.
+3. Use explicit `session_id` when provided; otherwise use embedded `sessionId`; otherwise use the default session — preserves metadata while respecting caller intent.
+
+**Decision:** Explicit `session_id` / `sessionId` wins over embedded export metadata. A mismatch emits an import warning in the receipt.
+
+**Rationale:** Tool arguments should be authoritative, but export metadata should still make no-argument restores useful.
+
+---
+
+## 9. File Breakdown
+
+| File                                                        | Change type | FR                                             | Description                                                                                                                                   |
+| ----------------------------------------------------------- | ----------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/pi-sequential-thinking/extensions/types.ts`       | Modify      | FR-1, FR-2, FR-3, FR-4, FR-5                   | Add normalized input/session types, alias handling, dynamic total adjustment, and shared validation helpers.                                  |
+| `packages/pi-sequential-thinking/extensions/storage.ts`     | Modify      | FR-4, FR-5, FR-6, FR-7, FR-8                   | Add session-aware storage APIs, bounded history reads, diagnostics, counts, and receipt-supporting metadata.                                  |
+| `packages/pi-sequential-thinking/extensions/index.ts`       | Modify      | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7, FR-8 | Update schemas, tool handlers, `sequential_think` session behavior, new `get_thinking_history` and `get_thinking_status` tools, and receipts. |
+| `packages/pi-sequential-thinking/README.md`                 | Modify      | FR-9                                           | Document session IDs, aliases, dynamic totals, history/status tools, examples, and exclusions.                                                |
+| `packages/pi-sequential-thinking/__tests__/types.test.ts`   | Modify      | FR-1, FR-2, FR-3, FR-4, FR-5                   | Cover normalization, validation, alias conflicts, dynamic totals, and session ID validation.                                                  |
+| `packages/pi-sequential-thinking/__tests__/storage.test.ts` | Modify      | FR-4, FR-5, FR-6, FR-7, FR-8                   | Cover named/default session persistence, bounded reads, import/export, diagnostics, and metadata.                                             |
+| `packages/pi-sequential-thinking/__tests__/index.test.ts`   | Modify      | FR-5, FR-7, FR-9                               | Assert new tool registrations and preserve existing registration expectations.                                                                |
+| `packages/pi-sequential-thinking/__tests__/runtime.test.ts` | Modify      | FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7, FR-8 | Cover end-to-end registered tool behavior for aliases, sessions, history, status, and receipts.                                               |
+| `packages/pi-sequential-thinking/__tests__/helpers.test.ts` | Modify      | FR-7, FR-8                                     | Extend helper coverage if status/receipt helpers are exported for testing.                                                                    |
+
+---
+
+## 10. Dependencies & Constraints
+
+* The package is a TypeScript pi extension with entrypoint `packages/pi-sequential-thinking/extensions/index.ts`.
+* The package uses TypeBox schemas for tool parameters.
+* Existing peer dependencies in `packages/pi-sequential-thinking/package.json` should remain sufficient for this PRD unless the implementation plan proves otherwise.
+* Tests should run with `npx vitest run packages/pi-sequential-thinking/__tests__`.
+* Type checking should run with `npx tsc --noEmit --project packages/pi-sequential-thinking/tsconfig.json`.
+* Formatting/linting should run with `npx biome ci packages/pi-sequential-thinking`.
+* Default storage remains `~/.mcp_sequential_thinking` when no storage directory is configured.
+* Repository paths in documentation and tests must remain repo-relative.
+
+---
+
+## 11. Rollout Plan
+
+1. Add shared normalization and validation helpers with tests, including dynamic total adjustment.
+2. Update `process_thought` to use the shared helpers and emit mutation receipts.
+3. Extend `ThoughtStorage` for default/named sessions while preserving `current_session.json` behavior.
+4. Add `get_thinking_history` and session-aware summary/clear/export/import behavior.
+5. Add `get_thinking_status` and storage diagnostics.
+6. Update README examples and tool documentation.
+7. Run targeted package tests, typecheck, and Biome checks.
+
+---
+
+## 12. Open Questions
+
+| #  | Question                                                                        | Owner             | Due        | Status                                                                                                                                                                      |
+| -- | ------------------------------------------------------------------------------- | ----------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Q1 | Should branch/revision metadata be included in this first slice?                | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. It is deferred to the later backlog.                                                                                                                      |
+| Q2 | Should dual pi extension + MCP server architecture be part of this PRD?         | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. It is tracked separately in #99.                                                                                                                          |
+| Q3 | Should named session IDs allow slashes or nested paths?                         | Sebastian Otaegui | 2026-05-16 | **Resolved:** No. V1 session IDs are path-safe labels only.                                                                                                                 |
+| Q4 | Should `get_thinking_history` default to returning full thought bodies?         | Sebastian Otaegui | 2026-05-16 | **Resolved:** Yes, bounded by `limit` and existing output truncation; snippets are available through `include_full_thoughts: false`.                                        |
+| Q5 | Should `sequential_think` participate in sessions?                              | Sebastian Otaegui | 2026-05-16 | **Resolved:** Yes, as a compatibility shim only. It accepts optional `session_id`, writes to the selected session, and returns receipts; broader redesign remains deferred. |
+| Q6 | What wins when an import file embeds one session but the caller passes another? | Sebastian Otaegui | 2026-05-16 | **Resolved:** The caller-provided session wins and the receipt reports a warning.                                                                                           |
+
+---
+
+## 13. Related
+
+| Issue                                                                                  | Relationship                                                              |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `docs/ideation/2026-05-16-pi-sequential-thinking-improvements-ideation.md`             | Source ideation for selected first slice                                  |
+| `docs/ideation/2026-05-16-pi-sequential-thinking-later-backlog.md`                     | Deferred related ideas after this PRD                                     |
+| #99 — Explore dual pi extension and MCP server architecture for pi-sequential-thinking | Related but explicitly out of scope                                       |
+| `packages/pi-code-reasoning/extensions/types.ts`                                       | Local reference for validation discipline and branch/revision future work |
+| `docs/adr/ADR-0016-stateful-exa-research-planning-tools.md`                            | Related precedent for stateful tools over prompt-only workflows           |
+| `docs/adr/ADR-0017-in-memory-exa-research-planning-sessions.md`                        | Related precedent for scoping session persistence tradeoffs               |
+
+---
+
+## 14. Changelog
+
+| Date       | Change        | Author            |
+| ---------- | ------------- | ----------------- |
+| 2026-05-16 | Initial draft | Sebastian Otaegui |
+
+---
+
+## 15. Verification (Appendix)
+
+Post-implementation checklist:
+
+1. Run `npx vitest run packages/pi-sequential-thinking/__tests__`.
+2. Run `npx tsc --noEmit --project packages/pi-sequential-thinking/tsconfig.json`.
+3. Run `npx biome ci packages/pi-sequential-thinking`.
+4. Manually exercise `process_thought` with snake\_case fields and verify existing behavior still works.
+5. Manually exercise `process_thought` with camelCase aliases and verify stored history is normalized.
+6. Record thoughts in default session and a named session, then confirm `get_thinking_history` returns isolated results.
+7. Call `sequential_think` with a named `session_id` and confirm generated prompts are written only to that session with a receipt.
+8. Call `get_thinking_status` and confirm it reports storage/session metadata, config source labels, and relative backup filenames without thought content.
+9. Export and import a legacy `{ thoughts: [...] }` session into a named session and confirm the default session remains unchanged.
+10. Import a new-format export with an embedded `sessionId` into a different explicit `session_id` and confirm the explicit target wins with a warning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8009,7 +8009,7 @@
     },
     "packages/pi-sequential-thinking": {
       "name": "@feniix/pi-sequential-thinking",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -136,7 +136,7 @@ Example named-session call:
 
 ### `get_thinking_history`
 
-Read recorded thoughts for one session with bounded pagination.
+Read recorded thoughts for one session with bounded pagination. With the V1 JSON-per-session storage layout, history reads reject persisted session files over 10 MiB instead of parsing unbounded local state.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -157,7 +157,7 @@ Example:
 
 ### `get_thinking_status`
 
-Return content-free diagnostics: session counts, storage writability, backup file names, effective config source labels, and current state fingerprints. Home-directory paths are redacted with `~` where possible.
+Return content-free diagnostics: session counts, storage writability, backup file names, effective config source labels, and current state fingerprints. Home-directory paths are redacted with `~` where possible. Status output may be partial after the named-session threshold, skips invalid session filenames, and reports corrupt session files without moving them to backups.
 
 Example:
 

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -121,6 +121,19 @@ Record and analyze a sequential thought with metadata.
 
 Successful mutation responses include a content-free `receipt` with the session label, pre/post counts, save time, and a state fingerprint.
 
+Example named-session call:
+
+```json
+{
+  "thought": "Compare storage options before choosing one.",
+  "thoughtNumber": 1,
+  "totalThoughts": 3,
+  "nextThoughtNeeded": true,
+  "stage": "Analysis",
+  "session_id": "architecture-review"
+}
+```
+
 ### `get_thinking_history`
 
 Read recorded thoughts for one session with bounded pagination.
@@ -132,9 +145,25 @@ Read recorded thoughts for one session with bounded pagination.
 | `offset` | integer | `0` | Number of thoughts to skip from the start |
 | `include_full_thoughts` / `includeFullThoughts` | boolean | `true` | Set `false` to return metadata plus a short snippet instead of full thought text |
 
+Example:
+
+```json
+{
+  "session_id": "architecture-review",
+  "limit": 20,
+  "include_full_thoughts": false
+}
+```
+
 ### `get_thinking_status`
 
 Return content-free diagnostics: session counts, storage writability, backup file names, effective config source labels, and current state fingerprints. Home-directory paths are redacted with `~` where possible.
+
+Example:
+
+```json
+{}
+```
 
 ### `generate_summary`
 
@@ -146,7 +175,7 @@ Clear one session. Accepts optional `session_id` / `sessionId` and returns a mut
 
 ### `export_session`
 
-Export one session to a JSON file.
+Export one session to a JSON file. `file_path` may be absolute or repo-relative; parent directories are created automatically. Export rejects directory targets and final-path symlinks. Existing files may be overwritten by this explicit tool call, and the receipt reports `overwroteExistingFile`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -155,7 +184,7 @@ Export one session to a JSON file.
 
 ### `import_session`
 
-Import a JSON session file. Imports are limited to 10 MiB, validated as untrusted content, and assigned fresh IDs/timestamps when needed.
+Import a JSON session file. `file_path` may be absolute or repo-relative. Parent directories are not created for import. Imports reject directories, final-path symlinks, malformed top-level records, and files over 10 MiB. Thought text is treated as inert untrusted content; missing IDs/timestamps are normalized when needed.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -198,6 +227,8 @@ The Sequential Thinking framework organizes thoughts through five cognitive stag
 - `process_thought`, `get_thinking_history`, `generate_summary`, `export_session`, `import_session`, and `sequential_think` are content-bearing tools.
 - `get_thinking_status` and mutation receipts are designed to avoid thought text, tags, axioms, and assumptions.
 - V1 assumes one active pi process per storage directory. Add locking before using a shared directory with multiple writers.
+- Branch/revision metadata is not included in this release.
+- A dual pi extension + MCP server architecture is not included in this release; this remains a native pi extension only.
 
 ## Requirements
 

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -4,14 +4,17 @@
 
 ## Features
 
-- **Process Thought** (`process_thought`): Record and analyze sequential thoughts with stage metadata
-- **Generate Summary** (`generate_summary`): Summarize the entire thinking process
-- **Clear History** (`clear_history`): Reset the thinking session
-- **Export Session** (`export_session`): Save thinking sessions to JSON files
-- **Import Session** (`import_session`): Load previously exported sessions
-- **Configurable Output Limits**: Client-side byte and line truncation
-- **Flexible Configuration**: settings.json, custom JSON config files, environment variables, and CLI flags
-- **Native TypeScript**: No external dependencies or child processes
+- **Process Thought** (`process_thought`): Record and analyze sequential thoughts with stage metadata.
+- **Session-Scoped History**: Use the default session or named `session_id` values for independent thinking threads.
+- **Get History** (`get_thinking_history`): Read bounded, paginated session history.
+- **Get Status** (`get_thinking_status`): Inspect content-free storage/config diagnostics and state fingerprints.
+- **Generate Summary** (`generate_summary`): Summarize one thinking session.
+- **Clear History** (`clear_history`): Reset one thinking session.
+- **Export/Import Session** (`export_session`, `import_session`): Move session JSON files with validation and receipts.
+- **MCP-Compatible Aliases**: Accept snake_case fields and camelCase aliases such as `thoughtNumber` and `totalThoughts`.
+- **Dynamic Depth**: If `thought_number` exceeds `total_thoughts`, the incoming thought is normalized to the larger total.
+- **Configurable Output Limits**: Client-side byte and line truncation.
+- **Native TypeScript**: No MCP server transport or child process dependencies.
 
 ## Install
 
@@ -27,11 +30,23 @@ pi -e npm:@feniix/pi-sequential-thinking
 
 ## Configuration
 
-### Option 1: Default Configuration
+### Default Configuration
 
-Works out of the box. Sessions are stored in `~/.mcp_sequential_thinking/`.
+Works out of the box. The default session is stored at:
 
-### Option 2: Environment Variables
+```text
+~/.mcp_sequential_thinking/current_session.json
+```
+
+Named sessions are stored under:
+
+```text
+~/.mcp_sequential_thinking/sessions/<session_id>.json
+```
+
+`default` is reserved as the default-session label and cannot be used as a named `session_id`.
+
+### Environment Variables
 
 ```bash
 export MCP_STORAGE_DIR="~/.my-thinking-sessions"
@@ -39,7 +54,7 @@ export SEQ_THINK_MAX_BYTES=102400
 export SEQ_THINK_MAX_LINES=5000
 ```
 
-### Option 3: Settings File
+### Settings File
 
 Use pi's standard settings locations:
 
@@ -62,20 +77,29 @@ Under the `pi-sequential-thinking` key:
 > If you want a separate private override file, use `--seq-think-config-file` or `SEQ_THINK_CONFIG_FILE` to point to a custom JSON config file.
 > Legacy aliases `--seq-think-config` and `SEQ_THINK_CONFIG` are still accepted but deprecated.
 
-### Option 4: CLI Flags
+### CLI Flags
 
 ```bash
 pi --seq-think-storage-dir=/tmp/thoughts --seq-think-max-bytes=102400
 ```
 
-### Config Resolution Order
+### Effective Configuration Precedence
 
-1. `--seq-think-config-file` flag path
-2. `SEQ_THINK_CONFIG_FILE` environment variable
-3. legacy `--seq-think-config` flag path (deprecated)
-4. legacy `SEQ_THINK_CONFIG` environment variable (deprecated)
-3. `.pi/settings.json` under `pi-sequential-thinking` (project-level)
-4. `~/.pi/agent/settings.json` under `pi-sequential-thinking` (global)
+Per-field precedence is:
+
+1. CLI flags
+2. Environment variables
+3. Project settings (`.pi/settings.json`)
+4. Global settings (`~/.pi/agent/settings.json`)
+5. Built-in defaults
+
+Custom config file discovery uses:
+
+1. `--seq-think-config-file`
+2. deprecated `--seq-think-config`
+3. `SEQ_THINK_CONFIG_FILE`
+4. deprecated `SEQ_THINK_CONFIG`
+5. settings files listed above
 
 ## Tools
 
@@ -86,44 +110,74 @@ Record and analyze a sequential thought with metadata.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `thought` | string | yes | The content of your thought |
-| `thought_number` | integer | yes | Position in sequence (starting at 1) |
-| `total_thoughts` | integer | yes | Expected total thoughts |
-| `next_thought_needed` | boolean | yes | Whether more thoughts follow |
-| `stage` | string | yes | One of: "Problem Definition", "Research", "Analysis", "Synthesis", "Conclusion" |
+| `thought_number` / `thoughtNumber` | integer | yes | Position in sequence, starting at 1 |
+| `total_thoughts` / `totalThoughts` | integer | yes | Estimated total thoughts; normalized upward for dynamic depth |
+| `next_thought_needed` / `nextThoughtNeeded` | boolean | yes | Whether more thoughts follow |
+| `stage` | string | yes | One of: `Problem Definition`, `Research`, `Analysis`, `Synthesis`, `Conclusion` |
+| `session_id` / `sessionId` | string | no | Named session to write; omit for the default session |
 | `tags` | string[] | no | Keywords or categories |
-| `axioms_used` | string[] | no | Principles applied |
-| `assumptions_challenged` | string[] | no | Assumptions questioned |
+| `axioms_used` / `axiomsUsed` | string[] | no | Principles applied |
+| `assumptions_challenged` / `assumptionsChallenged` | string[] | no | Assumptions questioned |
+
+Successful mutation responses include a content-free `receipt` with the session label, pre/post counts, save time, and a state fingerprint.
+
+### `get_thinking_history`
+
+Read recorded thoughts for one session with bounded pagination.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `session_id` / `sessionId` | string | default session | Session to read |
+| `limit` | integer | `20` | Maximum thoughts to return, capped at `100` |
+| `offset` | integer | `0` | Number of thoughts to skip from the start |
+| `include_full_thoughts` / `includeFullThoughts` | boolean | `true` | Set `false` to return metadata plus a short snippet instead of full thought text |
+
+### `get_thinking_status`
+
+Return content-free diagnostics: session counts, storage writability, backup file names, effective config source labels, and current state fingerprints. Home-directory paths are redacted with `~` where possible.
 
 ### `generate_summary`
 
-Generate a summary of the entire thinking process. Returns stage counts, timeline, top tags, and completion status.
+Generate a summary for one session. Accepts optional `session_id` / `sessionId`.
 
 ### `clear_history`
 
-Reset the thinking process by clearing all recorded thoughts.
+Clear one session. Accepts optional `session_id` / `sessionId` and returns a mutation receipt.
 
 ### `export_session`
 
-Export the current thinking session to a JSON file.
+Export one session to a JSON file.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `file_path` | string | yes | Path to save the exported JSON file |
+| `session_id` / `sessionId` | string | no | Session to export; omit for the default session |
 
 ### `import_session`
 
-Import a previously exported thinking session from a JSON file.
+Import a JSON session file. Imports are limited to 10 MiB, validated as untrusted content, and assigned fresh IDs/timestamps when needed.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `file_path` | string | yes | Path to the JSON file to import |
+| `session_id` / `sessionId` | string | no | Target session; explicit target wins over embedded session metadata |
+
+### `sequential_think`
+
+Compatibility helper that generates a staged sequence for a topic and writes it to the selected session.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `topic` | string | yes | Topic or question to think through |
+| `num_thoughts` | integer | no | Number of generated stages, 3–10; default `5` |
+| `session_id` / `sessionId` | string | no | Session to write |
 
 ## CLI Flags
 
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
-| `--seq-think-storage-dir` | `MCP_STORAGE_DIR` | — | Storage directory for sessions |
-| `--seq-think-config-file` | `SEQ_THINK_CONFIG_FILE` | — | Custom JSON config file path (overrides settings.json lookup) |
+| `--seq-think-storage-dir` | `MCP_STORAGE_DIR` | `~/.mcp_sequential_thinking` | Storage directory for sessions |
+| `--seq-think-config-file` | `SEQ_THINK_CONFIG_FILE` | — | Custom JSON config file path |
 | `--seq-think-config` | `SEQ_THINK_CONFIG` | — | Deprecated alias for the config file path |
 | `--seq-think-max-bytes` | `SEQ_THINK_MAX_BYTES` | `51200` | Max output bytes |
 | `--seq-think-max-lines` | `SEQ_THINK_MAX_LINES` | `2000` | Max output lines |
@@ -137,6 +191,13 @@ The Sequential Thinking framework organizes thoughts through five cognitive stag
 3. **Analysis** — Examine and evaluate the evidence
 4. **Synthesis** — Combine insights into a coherent view
 5. **Conclusion** — Draw final conclusions and recommendations
+
+## Privacy and Storage Notes
+
+- V1 storage is local plaintext JSON.
+- `process_thought`, `get_thinking_history`, `generate_summary`, `export_session`, `import_session`, and `sequential_think` are content-bearing tools.
+- `get_thinking_status` and mutation receipts are designed to avoid thought text, tags, axioms, and assumptions.
+- V1 assumes one active pi process per storage directory. Add locking before using a shared directory with multiple writers.
 
 ## Requirements
 

--- a/packages/pi-sequential-thinking/README.md
+++ b/packages/pi-sequential-thinking/README.md
@@ -227,8 +227,6 @@ The Sequential Thinking framework organizes thoughts through five cognitive stag
 - `process_thought`, `get_thinking_history`, `generate_summary`, `export_session`, `import_session`, and `sequential_think` are content-bearing tools.
 - `get_thinking_status` and mutation receipts are designed to avoid thought text, tags, axioms, and assumptions.
 - V1 assumes one active pi process per storage directory. Add locking before using a shared directory with multiple writers.
-- Branch/revision metadata is not included in this release.
-- A dual pi extension + MCP server architecture is not included in this release; this remains a native pi extension only.
 
 ## Requirements
 

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -343,6 +343,8 @@ describe("pi-sequential-thinking writeTempFile", () => {
 
   it("writes temp file and returns path", () => {
     const path = writeTempFile("test_tool", "content here");
+    expect(path).toBeDefined();
+    if (!path) throw new Error("expected path");
     tempFiles.push(path);
     expect(path).toContain("pi-seq-think-test_tool");
     expect(path).toContain(".txt");
@@ -351,6 +353,8 @@ describe("pi-sequential-thinking writeTempFile", () => {
 
   it("sanitizes tool name", () => {
     const path = writeTempFile("my-tool!@#", "content");
+    expect(path).toBeDefined();
+    if (!path) throw new Error("expected path");
     tempFiles.push(path);
     expect(path).toContain("my-tool__");
   });

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeString,
   parseConfig,
   resolveConfigPath,
+  resolveEffectiveConfig,
   resolveEffectiveLimits,
   splitParams,
   toJsonString,
@@ -18,6 +19,39 @@ import {
 } from "../extensions/index.js";
 
 describe("pi-sequential-thinking helpers", () => {
+  it("resolves effective config values with source labels", () => {
+    const effective = resolveEffectiveConfig({
+      flags: { storageDir: "/flag/storage", maxBytes: "1000" },
+      env: { MCP_STORAGE_DIR: "/env/storage", SEQ_THINK_MAX_BYTES: "2000", SEQ_THINK_MAX_LINES: "3000" },
+      config: {
+        config: { storageDir: "/config/storage", maxBytes: 111, maxLines: 222 },
+        sources: { storageDir: "project_settings", maxBytes: "global_settings", maxLines: "config_file" },
+      },
+    });
+
+    expect(effective).toEqual({
+      storageDir: "/flag/storage",
+      maxBytes: 1000,
+      maxLines: 3000,
+      sources: { storageDir: "flag", maxBytes: "flag", maxLines: "env" },
+    });
+  });
+
+  it("falls back to config and defaults in effective config", () => {
+    const effective = resolveEffectiveConfig({
+      flags: {},
+      env: {},
+      config: { config: { storageDir: "/project/storage" }, sources: { storageDir: "project_settings" } },
+    });
+
+    expect(effective).toEqual({
+      storageDir: "/project/storage",
+      maxBytes: 51200,
+      maxLines: 2000,
+      sources: { storageDir: "project_settings", maxBytes: "default", maxLines: "default" },
+    });
+  });
+
   it("splits params and clamps limits", () => {
     const { toolArgs, requestedLimits } = splitParams({
       piMaxBytes: "100",

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -3,10 +3,9 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  DEFAULT_CONFIG_FILE,
   formatToolOutput,
   isRecord,
-  loadConfig,
+  loadConfigWithSources,
   normalizeNumber,
   normalizeString,
   parseConfig,
@@ -89,14 +88,6 @@ describe("pi-sequential-thinking helpers", () => {
     expect(normalizeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
   });
 
-  it("keeps DEFAULT_CONFIG_FILE available for reference", () => {
-    expect(DEFAULT_CONFIG_FILE).toMatchObject({
-      storageDir: null,
-      maxBytes: 51200,
-      maxLines: 2000,
-    });
-  });
-
   it("loads config from standard pi settings files", async () => {
     const originalHome = process.env.HOME;
     const originalCwd = process.cwd();
@@ -126,7 +117,7 @@ describe("pi-sequential-thinking helpers", () => {
 
     try {
       const mod = await import("../extensions/index.js");
-      expect(mod.loadConfig(undefined)).toEqual({
+      expect(mod.loadConfigWithSources(undefined)?.config).toEqual({
         storageDir: "/tmp/thoughts",
         maxBytes: 111,
         maxLines: 22,
@@ -158,7 +149,7 @@ describe("pi-sequential-thinking helpers", () => {
 
     try {
       const mod = await import("../extensions/index.js");
-      expect(mod.loadConfig(undefined)).toBeNull();
+      expect(mod.loadConfigWithSources(undefined)).toBeNull();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Ignoring legacy config file"));
     } finally {
       warnSpy.mockRestore();
@@ -257,11 +248,11 @@ describe("pi-sequential-thinking resolveConfigPath", () => {
   });
 });
 
-describe("pi-sequential-thinking loadConfig", () => {
+describe("pi-sequential-thinking loadConfigWithSources", () => {
   it("returns null when no config exists", () => {
     const base = mkdtempSync(join(tmpdir(), "pi-seq-think-load-"));
     const configPath = join(base, "nonexistent.json");
-    expect(loadConfig(configPath)).toBeNull();
+    expect(loadConfigWithSources(configPath)).toBeNull();
   });
 
   it("loads valid config file", () => {
@@ -269,7 +260,11 @@ describe("pi-sequential-thinking loadConfig", () => {
     const configPath = join(base, "seq-think.json");
     writeFileSync(configPath, JSON.stringify({ storageDir: "/custom", maxBytes: 123 }), "utf-8");
 
-    expect(loadConfig(configPath)).toEqual({ storageDir: "/custom", maxBytes: 123, maxLines: undefined });
+    expect(loadConfigWithSources(configPath)?.config).toEqual({
+      storageDir: "/custom",
+      maxBytes: 123,
+      maxLines: undefined,
+    });
   });
 
   it("returns null on invalid JSON", () => {
@@ -277,7 +272,7 @@ describe("pi-sequential-thinking loadConfig", () => {
     const configPath = join(base, "invalid.json");
     writeFileSync(configPath, "not valid json", "utf-8");
 
-    expect(loadConfig(configPath)).toBeNull();
+    expect(loadConfigWithSources(configPath)).toBeNull();
   });
 });
 

--- a/packages/pi-sequential-thinking/__tests__/helpers.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/helpers.test.ts
@@ -237,6 +237,20 @@ describe("pi-sequential-thinking resolveConfigPath", () => {
     expect(resolveConfigPath(absolute)).toBe(absolute);
   });
 
+  it("resolves effective home-relative storage directories", () => {
+    expect(resolveEffectiveConfig({ flags: { storageDir: "~/.seq-think-flag" } }).storageDir).toBe(
+      join(homedir(), ".seq-think-flag"),
+    );
+    expect(resolveEffectiveConfig({ env: { MCP_STORAGE_DIR: "~/.seq-think-env" } }).storageDir).toBe(
+      join(homedir(), ".seq-think-env"),
+    );
+    expect(
+      resolveEffectiveConfig({
+        config: { config: { storageDir: "~/.seq-think-config" }, sources: { storageDir: "project_settings" } },
+      }).storageDir,
+    ).toBe(join(homedir(), ".seq-think-config"));
+  });
+
   it("resolves relative paths from cwd", () => {
     const result = resolveConfigPath("relative/path.json");
     expect(result).toBe(resolve(process.cwd(), "relative/path.json"));

--- a/packages/pi-sequential-thinking/__tests__/index.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/index.test.ts
@@ -23,8 +23,27 @@ describe("pi-sequential-thinking", () => {
         "clear_history",
         "export_session",
         "import_session",
+        "get_thinking_history",
+        "get_thinking_status",
+        "sequential_think",
       ]),
     );
+  });
+
+  it("registers process_thought schema without requiring snake_case aliases only", () => {
+    const mockPi = createMockPi();
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
+
+    const processTool = mockPi.registerTool.mock.calls
+      .map(([tool]) => tool)
+      .find((tool) => tool.name === "process_thought");
+    const required = (processTool?.parameters as { required?: string[] }).required ?? [];
+
+    expect(required).toContain("thought");
+    expect(required).toContain("stage");
+    expect(required).not.toContain("thought_number");
+    expect(required).not.toContain("total_thoughts");
+    expect(required).not.toContain("next_thought_needed");
   });
 
   it("registers flags", () => {

--- a/packages/pi-sequential-thinking/__tests__/runtime.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/runtime.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -15,33 +15,35 @@ const createMockPi = (flags: Record<string, string | boolean | undefined> = {}) 
 
 const getRegisteredTool = (mockPi: ReturnType<typeof createMockPi>, name: string) => {
   const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-  return tools.find((tool) => tool.name === name);
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Missing registered tool ${name}`);
+  }
+  return tool;
 };
 
+const parseToolJson = (result: { content: Array<{ text: string }> }) => JSON.parse(result.content[0].text);
+
 describe("pi-sequential-thinking runtime", () => {
-  it("processes thoughts, summarizes, clears, exports, imports, and runs sequential_think", async () => {
+  it("normalizes camelCase, adjusts dynamic totals, records receipts, and reads named history", async () => {
     const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-"));
-    const exportPath = join(storageDir, "nested", "session.json");
     const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
     sequentialThinking(mockPi as unknown as ExtensionAPI);
 
     const processTool = getRegisteredTool(mockPi, "process_thought");
-    const summaryTool = getRegisteredTool(mockPi, "generate_summary");
-    const clearTool = getRegisteredTool(mockPi, "clear_history");
-    const exportTool = getRegisteredTool(mockPi, "export_session");
-    const importTool = getRegisteredTool(mockPi, "import_session");
-    const sequentialTool = getRegisteredTool(mockPi, "sequential_think");
-
+    const historyTool = getRegisteredTool(mockPi, "get_thinking_history");
     const onUpdate = vi.fn();
-    const processResult = await processTool?.execute(
+
+    const processResult = await processTool.execute(
       "call-1",
       {
-        thought: "We should use a feature flag for rollout",
-        thought_number: 1,
-        total_thoughts: 3,
-        next_thought_needed: true,
+        thought: "Use aliases and grow depth",
+        thoughtNumber: 5,
+        totalThoughts: 3,
+        nextThoughtNeeded: true,
         stage: "Analysis",
-        tags: ["rollout"],
+        tags: ["runtime"],
+        sessionId: "research",
       },
       undefined,
       onUpdate,
@@ -53,46 +55,219 @@ describe("pi-sequential-thinking runtime", () => {
       details: { status: "pending" },
     });
     expect(processResult.isError).toBe(false);
-    expect(processResult.content[0].text).toContain("thoughtAnalysis");
+    const processed = parseToolJson(processResult);
+    expect(processed.thoughtAnalysis.currentThought.totalThoughts).toBe(5);
+    expect(processed.receipt).toMatchObject({
+      operation: "process_thought",
+      sessionId: "research",
+      sessionLabel: "research",
+      preCount: 0,
+      postCount: 1,
+      changed: true,
+      totalThoughtsAdjusted: { from: 3, to: 5 },
+    });
+    expect(processed.receipt.stateFingerprint).toBeDefined();
 
-    const summaryResult = await summaryTool?.execute("call-2", {}, undefined, undefined, undefined);
-    expect(summaryResult.isError).toBe(false);
-    expect(summaryResult.content[0].text).toContain("summary");
+    const historyResult = await historyTool.execute(
+      "call-2",
+      { session_id: "research", limit: 20, include_full_thoughts: false },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(historyResult.isError).toBe(false);
+    const history = parseToolJson(historyResult);
+    expect(history.sessionId).toBe("research");
+    expect(history.totalThoughts).toBe(1);
+    expect(history.thoughts[0].thoughtNumber).toBe(5);
+    expect(history.thoughts[0].snippet).toContain("Use aliases");
+    expect(history.thoughts[0].thought).toBeUndefined();
+  });
 
-    const exportResult = await exportTool?.execute(
+  it("summarizes, clears, exports, imports, and runs sequential_think per session", async () => {
+    const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-tools-"));
+    const exportPath = join(storageDir, "nested", "session.json");
+    const legacyPath = join(storageDir, "legacy.json");
+    const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
+
+    const processTool = getRegisteredTool(mockPi, "process_thought");
+    const summaryTool = getRegisteredTool(mockPi, "generate_summary");
+    const clearTool = getRegisteredTool(mockPi, "clear_history");
+    const exportTool = getRegisteredTool(mockPi, "export_session");
+    const importTool = getRegisteredTool(mockPi, "import_session");
+    const historyTool = getRegisteredTool(mockPi, "get_thinking_history");
+    const sequentialTool = getRegisteredTool(mockPi, "sequential_think");
+
+    await processTool.execute(
       "call-3",
-      { file_path: exportPath },
+      {
+        thought: "Default thought",
+        thought_number: 1,
+        total_thoughts: 2,
+        next_thought_needed: true,
+        stage: "Analysis",
+      },
       undefined,
       undefined,
       undefined,
     );
-    expect(exportResult.content[0].text).toContain("Session exported");
-    expect(existsSync(exportPath)).toBe(true);
+    await processTool.execute(
+      "call-4",
+      {
+        thought: "Research thought",
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+        stage: "Conclusion",
+        session_id: "research",
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
 
-    const clearResult = await clearTool?.execute("call-4", {}, undefined, undefined, undefined);
-    expect(clearResult.content[0].text).toContain("Thought history cleared");
-
-    const importResult = await importTool?.execute(
+    const summaryResult = await summaryTool.execute(
       "call-5",
-      { file_path: exportPath },
+      { session_id: "research" },
       undefined,
       undefined,
       undefined,
     );
-    expect(importResult.content[0].text).toContain("Session imported");
+    expect(parseToolJson(summaryResult).summary.totalThoughts).toBe(1);
+    expect(summaryResult.content[0].text).not.toContain("Default thought");
 
-    const sequentialResult = await sequentialTool?.execute(
+    const exportResult = await exportTool.execute(
       "call-6",
-      { topic: "Database migration strategy", num_thoughts: 5 },
+      { file_path: exportPath, session_id: "research" },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(exportResult.isError).toBe(false);
+    expect(existsSync(exportPath)).toBe(true);
+    expect(parseToolJson(exportResult).receipt.operation).toBe("export_session");
+    expect(JSON.parse(readFileSync(exportPath, "utf-8")).sessionId).toBe("research");
+
+    const clearResult = await clearTool.execute("call-7", { session_id: "research" }, undefined, undefined, undefined);
+    expect(parseToolJson(clearResult).receipt).toMatchObject({
+      operation: "clear_history",
+      sessionId: "research",
+      preCount: 1,
+      postCount: 0,
+      changed: true,
+    });
+
+    writeFileSync(
+      legacyPath,
+      JSON.stringify([
+        {
+          id: "legacy-id",
+          thought: "Legacy thought",
+          thought_number: 4,
+          total_thoughts: 4,
+          next_thought_needed: false,
+          stage: "Conclusion",
+          timestamp: "2026-05-16T00:00:00.000Z",
+        },
+      ]),
+      "utf-8",
+    );
+
+    const importResult = await importTool.execute(
+      "call-8",
+      { file_path: legacyPath, session_id: "legacy-import" },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(parseToolJson(importResult).receipt).toMatchObject({
+      operation: "import_session",
+      sessionId: "legacy-import",
+      preCount: 0,
+      postCount: 1,
+      changed: true,
+    });
+
+    const importedHistory = parseToolJson(
+      await historyTool.execute("call-9", { session_id: "legacy-import" }, undefined, undefined, undefined),
+    );
+    expect(importedHistory.thoughts[0].thoughtNumber).toBe(4);
+
+    const sequentialResult = await sequentialTool.execute(
+      "call-10",
+      { topic: "Database migration strategy", num_thoughts: 5, session_id: "scratch" },
       undefined,
       undefined,
       undefined,
     );
     expect(sequentialResult.isError).toBe(false);
-    expect(sequentialResult.content[0].text).toContain('"database"');
+    const sequential = parseToolJson(sequentialResult);
+    expect(sequential.receipt).toMatchObject({
+      operation: "sequential_think",
+      sessionId: "scratch",
+      preCount: 0,
+      postCount: 5,
+    });
+
+    const scratchHistory = parseToolJson(
+      await historyTool.execute("call-11", { session_id: "scratch" }, undefined, undefined, undefined),
+    );
+    expect(scratchHistory.totalThoughts).toBe(5);
+
+    const defaultHistory = parseToolJson(await historyTool.execute("call-12", {}, undefined, undefined, undefined));
+    expect(defaultHistory.totalThoughts).toBe(1);
+    expect(defaultHistory.thoughts[0].thought).toBe("Default thought");
   });
 
-  it("returns validation errors for invalid runtime inputs", async () => {
+  it("returns content-free status with effective config source labels", async () => {
+    const originalHome = process.env.HOME;
+    const tempHome = mkdtempSync(join(tmpdir(), "pi-seq-runtime-status-home-"));
+    process.env.HOME = tempHome;
+    try {
+      const storageDir = join(tempHome, ".mcp_sequential_thinking");
+      const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir, "--seq-think-max-bytes": "1000" });
+      sequentialThinking(mockPi as unknown as ExtensionAPI);
+
+      const processTool = getRegisteredTool(mockPi, "process_thought");
+      const statusTool = getRegisteredTool(mockPi, "get_thinking_status");
+
+      await processTool.execute(
+        "call-status-1",
+        {
+          thought: "Sensitive status thought",
+          thought_number: 1,
+          total_thoughts: 1,
+          next_thought_needed: false,
+          stage: "Analysis",
+          tags: ["private"],
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      const statusResult = await statusTool.execute("call-status-2", {}, undefined, undefined, undefined);
+      expect(statusResult.isError).toBe(false);
+      const status = parseToolJson(statusResult);
+      const statusText = JSON.stringify(status);
+
+      expect(status.storageDir).toContain("~");
+      expect(status.pathDisclosure).toBe("home_redacted");
+      expect(status.totalThoughts).toBe(1);
+      expect(status.effectiveConfig.sources.storageDir).toBe("flag");
+      expect(status.effectiveConfig.sources.maxBytes).toBe("flag");
+      expect(status.effectiveConfig.sources.maxLines).toBe("project_settings");
+      expect(statusText).not.toContain("Sensitive status thought");
+      expect(statusText).not.toContain("private");
+      expect(statusText).not.toContain(storageDir);
+    } finally {
+      if (originalHome) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+    }
+  });
+
+  it("returns structured validation errors for invalid runtime inputs", async () => {
     const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-errors-"));
     const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
     sequentialThinking(mockPi as unknown as ExtensionAPI);
@@ -100,8 +275,8 @@ describe("pi-sequential-thinking runtime", () => {
     const processTool = getRegisteredTool(mockPi, "process_thought");
     const importTool = getRegisteredTool(mockPi, "import_session");
 
-    const invalidThought = await processTool?.execute(
-      "call-7",
+    const invalidThought = await processTool.execute(
+      "call-13",
       {
         thought: "   ",
         thought_number: 1,
@@ -115,9 +290,13 @@ describe("pi-sequential-thinking runtime", () => {
     );
     expect(invalidThought.isError).toBe(true);
     expect(invalidThought.content[0].text).toContain("Thought content cannot be empty");
+    expect(invalidThought.details.validationErrors).toContainEqual({
+      field: "thought",
+      message: "Thought content cannot be empty",
+    });
 
-    const missingImport = await importTool?.execute(
-      "call-8",
+    const missingImport = await importTool.execute(
+      "call-14",
       { file_path: join(storageDir, "missing.json") },
       undefined,
       undefined,

--- a/packages/pi-sequential-thinking/__tests__/runtime.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/runtime.test.ts
@@ -84,6 +84,43 @@ describe("pi-sequential-thinking runtime", () => {
     expect(history.thoughts[0].thought).toBeUndefined();
   });
 
+  it("rejects conflicting history include_full_thoughts aliases", async () => {
+    const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-history-aliases-"));
+    const mockPi = createMockPi({ "--seq-think-storage-dir": storageDir });
+    sequentialThinking(mockPi as unknown as ExtensionAPI);
+
+    const processTool = getRegisteredTool(mockPi, "process_thought");
+    const historyTool = getRegisteredTool(mockPi, "get_thinking_history");
+
+    await processTool.execute(
+      "call-history-aliases-1",
+      {
+        thought: "Alias conflict should not expose this full text",
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+        stage: "Analysis",
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    const historyResult = await historyTool.execute(
+      "call-history-aliases-2",
+      { include_full_thoughts: true, includeFullThoughts: false },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(historyResult.isError).toBe(true);
+    expect(historyResult.details.validationErrors).toContainEqual({
+      field: "include_full_thoughts",
+      message: "Conflicting aliases for include_full_thoughts",
+    });
+  });
+
   it("summarizes, clears, exports, imports, and runs sequential_think per session", async () => {
     const storageDir = mkdtempSync(join(tmpdir(), "pi-seq-runtime-tools-"));
     const exportPath = join(storageDir, "nested", "session.json");
@@ -129,7 +166,7 @@ describe("pi-sequential-thinking runtime", () => {
 
     const summaryResult = await summaryTool.execute(
       "call-5",
-      { session_id: "research" },
+      { sessionId: "research" },
       undefined,
       undefined,
       undefined,
@@ -139,7 +176,7 @@ describe("pi-sequential-thinking runtime", () => {
 
     const exportResult = await exportTool.execute(
       "call-6",
-      { file_path: exportPath, session_id: "research" },
+      { file_path: exportPath, sessionId: "research" },
       undefined,
       undefined,
       undefined,
@@ -149,7 +186,7 @@ describe("pi-sequential-thinking runtime", () => {
     expect(parseToolJson(exportResult).receipt.operation).toBe("export_session");
     expect(JSON.parse(readFileSync(exportPath, "utf-8")).sessionId).toBe("research");
 
-    const clearResult = await clearTool.execute("call-7", { session_id: "research" }, undefined, undefined, undefined);
+    const clearResult = await clearTool.execute("call-7", { sessionId: "research" }, undefined, undefined, undefined);
     expect(parseToolJson(clearResult).receipt).toMatchObject({
       operation: "clear_history",
       sessionId: "research",
@@ -176,7 +213,7 @@ describe("pi-sequential-thinking runtime", () => {
 
     const importResult = await importTool.execute(
       "call-8",
-      { file_path: legacyPath, session_id: "legacy-import" },
+      { file_path: legacyPath, sessionId: "legacy-import" },
       undefined,
       undefined,
       undefined,
@@ -190,13 +227,13 @@ describe("pi-sequential-thinking runtime", () => {
     });
 
     const importedHistory = parseToolJson(
-      await historyTool.execute("call-9", { session_id: "legacy-import" }, undefined, undefined, undefined),
+      await historyTool.execute("call-9", { sessionId: "legacy-import" }, undefined, undefined, undefined),
     );
     expect(importedHistory.thoughts[0].thoughtNumber).toBe(4);
 
     const sequentialResult = await sequentialTool.execute(
       "call-10",
-      { topic: "Database migration strategy", num_thoughts: 5, session_id: "scratch" },
+      { topic: "Database migration strategy", num_thoughts: 5, sessionId: "scratch" },
       undefined,
       undefined,
       undefined,
@@ -211,7 +248,7 @@ describe("pi-sequential-thinking runtime", () => {
     });
 
     const scratchHistory = parseToolJson(
-      await historyTool.execute("call-11", { session_id: "scratch" }, undefined, undefined, undefined),
+      await historyTool.execute("call-11", { sessionId: "scratch" }, undefined, undefined, undefined),
     );
     expect(scratchHistory.totalThoughts).toBe(5);
 
@@ -273,6 +310,7 @@ describe("pi-sequential-thinking runtime", () => {
     sequentialThinking(mockPi as unknown as ExtensionAPI);
 
     const processTool = getRegisteredTool(mockPi, "process_thought");
+    const summaryTool = getRegisteredTool(mockPi, "generate_summary");
     const importTool = getRegisteredTool(mockPi, "import_session");
 
     const invalidThought = await processTool.execute(
@@ -304,5 +342,18 @@ describe("pi-sequential-thinking runtime", () => {
     );
     expect(missingImport.isError).toBe(true);
     expect(missingImport.content[0].text).toContain("File not found");
+
+    const conflictingSession = await summaryTool.execute(
+      "call-15",
+      { session_id: "one", sessionId: "two" },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(conflictingSession.isError).toBe(true);
+    expect(conflictingSession.details.validationErrors).toContainEqual({
+      field: "session_id",
+      message: "Conflicting aliases for session_id",
+    });
   });
 });

--- a/packages/pi-sequential-thinking/__tests__/storage.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/storage.test.ts
@@ -1,10 +1,24 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ThoughtStorage } from "../extensions/index.js";
 import type { ThoughtData } from "../extensions/types.js";
-import { ThoughtStage } from "../extensions/types.js";
+import {
+  MAX_IMPORT_BYTES,
+  SCHEMA_VERSION,
+  STATUS_ENUMERATION_SESSION_THRESHOLD,
+  ThoughtStage,
+} from "../extensions/types.js";
 
 const createThought = (overrides: Partial<ThoughtData> = {}): ThoughtData => ({
   id: "test-id-1",
@@ -13,7 +27,7 @@ const createThought = (overrides: Partial<ThoughtData> = {}): ThoughtData => ({
   total_thoughts: 3,
   next_thought_needed: true,
   stage: ThoughtStage.ANALYSIS,
-  timestamp: new Date().toISOString(),
+  timestamp: "2026-05-16T00:00:00.000Z",
   tags: [],
   axioms_used: [],
   assumptions_challenged: [],
@@ -24,16 +38,11 @@ describe("ThoughtStorage", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = join(tmpdir(), `pi-storage-test-${Date.now()}`);
-    mkdirSync(tempDir, { recursive: true });
+    tempDir = mkdtempSync(join(tmpdir(), "pi-storage-test-"));
   });
 
   afterEach(() => {
-    try {
-      rmSync(tempDir, { recursive: true, force: true });
-    } catch {
-      // ignore cleanup errors
-    }
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
   describe("constructor", () => {
@@ -44,234 +53,329 @@ describe("ThoughtStorage", () => {
 
     it("creates default directory when none specified", () => {
       const storage = new ThoughtStorage();
-      // Should not throw and should create directory
       expect(storage).toBeDefined();
+    });
+
+    it("uses restrictive directory permissions where supported", () => {
+      const storageDir = join(tempDir, "restricted");
+      new ThoughtStorage(storageDir);
+
+      if (process.platform !== "win32") {
+        expect(statSync(storageDir).mode & 0o077).toBe(0);
+      }
     });
   });
 
-  describe("addThought", () => {
-    it("adds a thought to storage", () => {
+  describe("default and named sessions", () => {
+    it("adds thoughts to the default session", () => {
       const storage = new ThoughtStorage(tempDir);
-      const thought = createThought();
-
-      storage.addThought(thought);
+      storage.addThought(createThought());
 
       const thoughts = storage.getAllThoughts();
       expect(thoughts).toHaveLength(1);
       expect(thoughts[0].thought).toBe("Test thought content");
+      expect(existsSync(join(tempDir, "current_session.json"))).toBe(true);
     });
 
-    it("persists thought to disk", () => {
+    it("isolates named sessions from the default session", () => {
       const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought());
+      storage.addThought(createThought({ thought: "Default" }));
+      storage.addThought(createThought({ id: "named-id", thought: "Named" }), "architecture-review");
 
-      // Create new instance to verify persistence
+      expect(storage.getAllThoughts().map((t) => t.thought)).toEqual(["Default"]);
+      expect(storage.getAllThoughts("architecture-review").map((t) => t.thought)).toEqual(["Named"]);
+      expect(existsSync(join(tempDir, "sessions", "architecture-review.json"))).toBe(true);
+    });
+
+    it("persists named sessions across instances", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought: "Persisted" }), "named");
+
       const storage2 = new ThoughtStorage(tempDir);
-      const thoughts = storage2.getAllThoughts();
-
-      expect(thoughts).toHaveLength(1);
+      expect(storage2.getAllThoughts("named")).toHaveLength(1);
+      expect(storage2.getAllThoughts("named")[0].thought).toBe("Persisted");
     });
 
-    it("adds multiple thoughts", () => {
+    it("loads existing current_session.json without migration", () => {
+      writeFileSync(
+        join(tempDir, "current_session.json"),
+        JSON.stringify({
+          thoughts: [
+            {
+              id: "existing-id",
+              thought: "Existing default",
+              thoughtNumber: 1,
+              totalThoughts: 1,
+              nextThoughtNeeded: false,
+              stage: "Conclusion",
+              timestamp: "2026-05-16T00:00:00.000Z",
+            },
+          ],
+          lastUpdated: "2026-05-16T00:00:00.000Z",
+        }),
+        "utf-8",
+      );
+
       const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought({ thought_number: 1 }));
-      storage.addThought(createThought({ thought_number: 2 }));
-      storage.addThought(createThought({ thought_number: 3 }));
-
-      const thoughts = storage.getAllThoughts();
-      expect(thoughts).toHaveLength(3);
-    });
-  });
-
-  describe("getAllThoughts", () => {
-    it("returns empty array when no thoughts", () => {
-      const storage = new ThoughtStorage(tempDir);
-      expect(storage.getAllThoughts()).toEqual([]);
-    });
-
-    it("returns copy of thoughts array", () => {
-      const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought());
-
-      const thoughts1 = storage.getAllThoughts();
-      const thoughts2 = storage.getAllThoughts();
-
-      expect(thoughts1).not.toBe(thoughts2);
-      expect(thoughts1).toEqual(thoughts2);
-    });
-
-    it("modifying returned array does not affect storage", () => {
-      const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought());
-
-      const thoughts = storage.getAllThoughts();
-      thoughts.push(createThought({ id: "modified" }));
-
       expect(storage.getAllThoughts()).toHaveLength(1);
+      expect(storage.getAllThoughts()[0].thought).toBe("Existing default");
+    });
+
+    it("rejects invalid named session ids", () => {
+      const storage = new ThoughtStorage(tempDir);
+      expect(() => storage.addThought(createThought(), "bad/session")).toThrow(/session_id/i);
+      expect(() => storage.getAllThoughts("default")).toThrow(/reserved/i);
     });
   });
 
   describe("clearHistory", () => {
-    it("clears all thoughts", () => {
+    it("clears only the selected session and returns receipt metadata", () => {
       const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought());
-      storage.addThought(createThought());
+      storage.addThought(createThought({ thought: "Default" }));
+      storage.addThought(createThought({ id: "named-id", thought: "Named" }), "named");
 
-      storage.clearHistory();
+      const result = storage.clearHistory("named");
 
-      expect(storage.getAllThoughts()).toEqual([]);
+      expect(result.preCount).toBe(1);
+      expect(result.postCount).toBe(0);
+      expect(result.changed).toBe(true);
+      expect(storage.getAllThoughts()).toHaveLength(1);
+      expect(storage.getAllThoughts("named")).toHaveLength(0);
+    });
+  });
+
+  describe("history", () => {
+    it("returns bounded history in insertion order with pagination", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ id: "one", thought: "First", thought_number: 1 }), "plan");
+      storage.addThought(createThought({ id: "two", thought: "Second", thought_number: 2 }), "plan");
+      storage.addThought(createThought({ id: "three", thought: "Third", thought_number: 3 }), "plan");
+
+      const history = storage.getHistory({ sessionId: "plan", limit: 2, offset: 1, includeFullThoughts: true });
+
+      expect(history.totalThoughts).toBe(3);
+      expect(history.hasMore).toBe(false);
+      expect(history.thoughts.map((t) => t.thoughtNumber)).toEqual([2, 3]);
+      expect(history.thoughts.map((t) => t.thought)).toEqual(["Second", "Third"]);
     });
 
-    it("persists cleared state", () => {
+    it("returns snippets without full thought bodies when requested", () => {
       const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought());
-      storage.clearHistory();
+      const longThought = "x".repeat(180);
+      storage.addThought(createThought({ thought: longThought }), "plan");
 
-      const storage2 = new ThoughtStorage(tempDir);
-      expect(storage2.getAllThoughts()).toEqual([]);
+      const history = storage.getHistory({ sessionId: "plan", includeFullThoughts: false });
+      expect(history.thoughts[0].snippet).toBeDefined();
+      expect(history.thoughts[0].thought).toBeUndefined();
+      expect(history.thoughts[0].snippet).not.toBe(longThought);
+    });
+
+    it("enforces history bounds", () => {
+      const storage = new ThoughtStorage(tempDir);
+      expect(() => storage.getHistory({ limit: 0 })).toThrow(/limit/i);
+      expect(() => storage.getHistory({ limit: 101 })).toThrow(/limit/i);
+      expect(() => storage.getHistory({ offset: -1 })).toThrow(/offset/i);
     });
   });
 
   describe("exportSession", () => {
-    it("exports thoughts to file", () => {
+    it("exports the selected session with the new schema", () => {
       const storage = new ThoughtStorage(tempDir);
-      storage.addThought(createThought({ thought: "First thought" }));
-      storage.addThought(createThought({ thought: "Second thought", thought_number: 2 }));
+      storage.addThought(createThought({ thought: "Default" }));
+      storage.addThought(createThought({ id: "named-id", thought: "Named" }), "research");
 
       const exportPath = join(tempDir, "export.json");
-      storage.exportSession(exportPath);
+      const result = storage.exportSession(exportPath, "research");
 
-      expect(existsSync(exportPath)).toBe(true);
-
+      expect(result.preCount).toBe(1);
+      expect(result.postCount).toBe(1);
+      expect(result.overwroteExistingFile).toBe(false);
       const exported = JSON.parse(readFileSync(exportPath, "utf-8"));
-      expect(exported.thoughts).toHaveLength(2);
-      expect(exported.metadata.totalThoughts).toBe(2);
-      expect(exported.metadata.stages).toBeDefined();
+      expect(exported.schemaVersion).toBe(SCHEMA_VERSION);
+      expect(exported.sessionId).toBe("research");
+      expect(exported.sessionLabel).toBe("research");
+      expect(exported.thoughts).toHaveLength(1);
+      expect(exported.thoughts[0].thought).toBe("Named");
+      expect(exported.metadata.totalThoughts).toBe(1);
     });
 
-    it("includes export timestamp", () => {
+    it("reports overwrite and rejects directories and final symlinks", () => {
       const storage = new ThoughtStorage(tempDir);
       storage.addThought(createThought());
 
-      const exportPath = join(tempDir, "export2.json");
-      storage.exportSession(exportPath);
+      const exportPath = join(tempDir, "export.json");
+      writeFileSync(exportPath, "{}", "utf-8");
+      expect(storage.exportSession(exportPath).overwroteExistingFile).toBe(true);
+      expect(() => storage.exportSession(tempDir)).toThrow(/directory/i);
 
-      const exported = JSON.parse(readFileSync(exportPath, "utf-8"));
-      expect(exported.exportedAt).toBeDefined();
+      if (process.platform !== "win32") {
+        const symlinkPath = join(tempDir, "export-link.json");
+        const targetPath = join(tempDir, "target.json");
+        writeFileSync(targetPath, "{}", "utf-8");
+        try {
+          symlinkSync(targetPath, symlinkPath);
+        } catch {
+          // ignore unsupported symlink creation
+        }
+        if (existsSync(symlinkPath) && lstatSync(symlinkPath).isSymbolicLink()) {
+          expect(() => storage.exportSession(symlinkPath)).toThrow(/symlink/i);
+        }
+      }
     });
   });
 
   describe("importSession", () => {
-    it("imports thoughts from file", () => {
-      // First, create an export file manually
-      const exportPath = join(tempDir, "import.json");
-      const exportData = {
-        thoughts: [
+    it("imports legacy arrays into a named session without touching default", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought: "Default" }));
+      const legacyPath = join(tempDir, "legacy.json");
+      writeFileSync(
+        legacyPath,
+        JSON.stringify([
           {
-            id: "imported-1",
-            thought: "Imported thought 1",
-            thought_number: 1,
-            total_thoughts: 2,
+            id: "legacy-id",
+            thought: "Legacy thought",
+            thought_number: 4,
+            total_thoughts: 6,
             next_thought_needed: true,
             stage: "Analysis",
-            timestamp: new Date().toISOString(),
-            tags: [],
-            axioms_used: [],
-            assumptions_challenged: [],
+            timestamp: "2026-05-16T00:00:00.000Z",
           },
-          {
-            id: "imported-2",
-            thought: "Imported thought 2",
-            thought_number: 2,
-            total_thoughts: 2,
-            next_thought_needed: false,
-            stage: "Conclusion",
-            timestamp: new Date().toISOString(),
-            tags: [],
-            axioms_used: [],
-            assumptions_challenged: [],
-          },
-        ],
-        lastUpdated: new Date().toISOString(),
-      };
-      writeFileSync(exportPath, JSON.stringify(exportData), "utf-8");
+        ]),
+        "utf-8",
+      );
 
-      // Import into new storage
-      const storage = new ThoughtStorage(tempDir);
-      storage.importSession(exportPath);
+      const result = storage.importSession(legacyPath, "legacy-import");
 
-      const thoughts = storage.getAllThoughts();
-      expect(thoughts).toHaveLength(2);
-      expect(thoughts[0].thought).toBe("Imported thought 1");
-      expect(thoughts[1].thought).toBe("Imported thought 2");
+      expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining("legacy")]));
+      expect(storage.getAllThoughts()).toHaveLength(1);
+      const imported = storage.getAllThoughts("legacy-import");
+      expect(imported).toHaveLength(1);
+      expect(imported[0]).toMatchObject({
+        thought_number: 4,
+        total_thoughts: 6,
+        next_thought_needed: true,
+      });
     });
 
-    it("handles legacy format (array directly)", () => {
-      const legacyPath = join(tempDir, "legacy.json");
-      const legacyData = [
-        {
-          id: "legacy-1",
-          thought: "Legacy thought",
-          thought_number: 1,
-          total_thoughts: 1,
-          next_thought_needed: false,
-          stage: "Conclusion",
-          timestamp: new Date().toISOString(),
-          tags: [],
-          axioms_used: [],
-          assumptions_challenged: [],
+    it("uses embedded sessionId when no explicit target is provided", () => {
+      const storage = new ThoughtStorage(tempDir);
+      const importPath = join(tempDir, "research.json");
+      writeFileSync(
+        importPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          sessionId: "research",
+          sessionLabel: "research",
+          thoughts: [createThought({ thought: "Embedded" })],
+        }),
+        "utf-8",
+      );
+
+      storage.importSession(importPath);
+      expect(storage.getAllThoughts("research")[0].thought).toBe("Embedded");
+      expect(storage.getAllThoughts()).toEqual([]);
+    });
+
+    it("lets explicit target win over embedded sessionId and returns a warning", () => {
+      const storage = new ThoughtStorage(tempDir);
+      const importPath = join(tempDir, "research.json");
+      writeFileSync(
+        importPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          sessionId: "research",
+          sessionLabel: "research",
+          thoughts: [createThought({ thought: "Moved" })],
+        }),
+        "utf-8",
+      );
+
+      const result = storage.importSession(importPath, "review");
+      expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining("sessionId")]));
+      expect(storage.getAllThoughts("review")[0].thought).toBe("Moved");
+      expect(storage.getAllThoughts("research")).toEqual([]);
+    });
+
+    it("rejects missing, malformed, directory, and oversized explicit imports", () => {
+      const storage = new ThoughtStorage(tempDir);
+      expect(() => storage.importSession(join(tempDir, "missing.json"))).toThrow(/File not found/i);
+
+      const malformedPath = join(tempDir, "malformed.json");
+      writeFileSync(malformedPath, JSON.stringify({}), "utf-8");
+      expect(() => storage.importSession(malformedPath)).toThrow(/thoughts/i);
+
+      expect(() => storage.importSession(tempDir)).toThrow(/directory/i);
+
+      const oversizedPath = join(tempDir, "oversized.json");
+      writeFileSync(oversizedPath, " ".repeat(MAX_IMPORT_BYTES + 1), "utf-8");
+      expect(() => storage.importSession(oversizedPath)).toThrow(/10 MiB/i);
+    });
+  });
+
+  describe("status", () => {
+    it("reports content-free status with redacted paths and backup files", () => {
+      const homeStorageDir = join(tempDir, "home", ".mcp_sequential_thinking");
+      const storage = new ThoughtStorage(homeStorageDir, { homeDir: join(tempDir, "home") });
+      storage.addThought(createThought({ thought: "Sensitive default", tags: ["secret"] }));
+      storage.addThought(createThought({ id: "named-id", thought: "Sensitive named" }), "research");
+      writeFileSync(join(homeStorageDir, "current_session.json.bak.test"), "{}", "utf-8");
+
+      const status = storage.getStatus({
+        effectiveConfig: {
+          storageDir: homeStorageDir,
+          maxBytes: 51200,
+          maxLines: 2000,
+          sources: { storageDir: "flag", maxBytes: "default", maxLines: "default" },
         },
-      ];
-      writeFileSync(legacyPath, JSON.stringify(legacyData), "utf-8");
+      });
 
-      const storage = new ThoughtStorage(tempDir);
-      storage.importSession(legacyPath);
-
-      const thoughts = storage.getAllThoughts();
-      expect(thoughts).toHaveLength(1);
-      expect(thoughts[0].thought).toBe("Legacy thought");
+      const serialized = JSON.stringify(status);
+      expect(status.storageDir).toContain("~");
+      expect(status.pathDisclosure).toBe("home_redacted");
+      expect(status.namedSessionCount).toBe(1);
+      expect(status.totalThoughts).toBe(2);
+      expect(status.sessions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId: null, label: "default", thoughtCount: 1, isDefault: true }),
+          expect.objectContaining({ sessionId: "research", label: "research", thoughtCount: 1, isDefault: false }),
+        ]),
+      );
+      expect(status.backupFiles).toEqual(["current_session.json.bak.test"]);
+      expect(status.effectiveConfig?.sources.storageDir).toBe("flag");
+      expect(serialized).not.toContain("Sensitive");
+      expect(serialized).not.toContain("secret");
+      expect(serialized).not.toContain(homeStorageDir);
     });
 
-    it("handles empty/invalid file", () => {
-      const emptyPath = join(tempDir, "empty.json");
-      writeFileSync(emptyPath, JSON.stringify({}), "utf-8");
-
+    it("reports partial status after the named-session enumeration threshold", () => {
       const storage = new ThoughtStorage(tempDir);
-      storage.importSession(emptyPath);
+      for (let index = 0; index < STATUS_ENUMERATION_SESSION_THRESHOLD + 1; index++) {
+        storage.addThought(createThought({ id: `thought-${index}` }), `session-${index}`);
+      }
 
-      expect(storage.getAllThoughts()).toEqual([]);
-    });
+      const status = storage.getStatus();
 
-    it("handles non-existent file", () => {
-      const storage = new ThoughtStorage(tempDir);
-      storage.importSession(join(tempDir, "nonexistent.json"));
-
-      expect(storage.getAllThoughts()).toEqual([]);
+      expect(status.namedSessionCount).toBe(STATUS_ENUMERATION_SESSION_THRESHOLD + 1);
+      expect(status.totalThoughts).toBeUndefined();
+      expect(status.statusCompleteness).toMatchObject({
+        complete: false,
+        inspectedNamedSessions: STATUS_ENUMERATION_SESSION_THRESHOLD,
+        namedSessionThreshold: STATUS_ENUMERATION_SESSION_THRESHOLD,
+      });
+      expect(status.sessions).toHaveLength(STATUS_ENUMERATION_SESSION_THRESHOLD + 1); // default + inspected named sessions
     });
   });
 
   describe("error handling", () => {
-    it("handles corrupted JSON file gracefully", () => {
-      const corruptedPath = join(tempDir, "corrupted.json");
-      writeFileSync(corruptedPath, "not valid json {{{", "utf-8");
-
-      // Should not throw
-      const storage = new ThoughtStorage(tempDir);
-      expect(storage.getAllThoughts()).toEqual([]);
-    });
-
-    it("handles invalid current_session.json", () => {
-      // Create a storage with the session file
+    it("backs up corrupted active session files and recovers empty", () => {
       const sessionFile = join(tempDir, "current_session.json");
       writeFileSync(sessionFile, "not valid json {{{{json", "utf-8");
 
-      // Create storage - should handle corrupted session gracefully
       const storage = new ThoughtStorage(tempDir);
 
-      // Should load empty and overwrite with valid data
       expect(storage.getAllThoughts()).toEqual([]);
-
-      // Save should work
+      expect(storage.getStatus().backupFiles.some((file) => file.startsWith("current_session.json.bak."))).toBe(true);
       storage.addThought(createThought());
       expect(storage.getAllThoughts()).toHaveLength(1);
     });

--- a/packages/pi-sequential-thinking/__tests__/storage.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/storage.test.ts
@@ -406,7 +406,9 @@ describe("ThoughtStorage", () => {
 
       const status = storage.getStatus();
 
-      expect(status.namedSessionCount).toBe(STATUS_ENUMERATION_SESSION_THRESHOLD + 1);
+      // namedSessionCount is capped at the enumeration threshold so the value
+      // is interpretable; the partial-completion flag signals overflow.
+      expect(status.namedSessionCount).toBe(STATUS_ENUMERATION_SESSION_THRESHOLD);
       expect(status.totalThoughts).toBeUndefined();
       expect(status.statusCompleteness).toMatchObject({
         complete: false,
@@ -458,6 +460,147 @@ describe("ThoughtStorage", () => {
       expect(storage.getStatus().backupFiles.some((file) => file.startsWith("current_session.json.bak."))).toBe(true);
       storage.addThought(createThought());
       expect(storage.getAllThoughts()).toHaveLength(1);
+    });
+
+    it("backs up default session file that parses to an object missing the thoughts array", () => {
+      const sessionFile = join(tempDir, "current_session.json");
+      writeFileSync(sessionFile, JSON.stringify({ lastUpdated: "2026-05-16T00:00:00.000Z" }), "utf-8");
+
+      const storage = new ThoughtStorage(tempDir);
+
+      expect(storage.getAllThoughts()).toEqual([]);
+      expect(storage.getStatus().backupFiles.some((file) => file.startsWith("current_session.json.bak."))).toBe(true);
+    });
+
+    it("does not back up a named session that has a valid thoughts array but an invalid embedded sessionId", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      const sessionFile = join(sessionsDir, "review.json");
+      writeFileSync(
+        sessionFile,
+        JSON.stringify({
+          schemaVersion: 1,
+          sessionId: "default",
+          thoughts: [createThought({ thought: "Still valid" })],
+        }),
+        "utf-8",
+      );
+
+      const storage = new ThoughtStorage(tempDir);
+      expect(storage.getAllThoughts("review")[0].thought).toBe("Still valid");
+      expect(storage.getStatus().backupFiles.some((file) => file.includes("review.json.bak."))).toBe(false);
+    });
+  });
+
+  describe("reads do not materialize session directories", () => {
+    it("does not create the sessions/ directory when calling getAllThoughts on the default session", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.getAllThoughts();
+      expect(existsSync(join(tempDir, "sessions"))).toBe(false);
+    });
+
+    it("does not create the sessions/ directory when reading history for the default session", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.getHistory();
+      expect(existsSync(join(tempDir, "sessions"))).toBe(false);
+    });
+
+    it("does not create the sessions/ directory when calling getStatus with no named sessions", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.getStatus();
+      expect(existsSync(join(tempDir, "sessions"))).toBe(false);
+    });
+  });
+
+  describe("importSession overwrite reporting", () => {
+    it("reports preCount and overwroteExistingThoughts when importing into a populated session", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought: "Existing" }), "target");
+
+      const importPath = join(tempDir, "import.json");
+      writeFileSync(
+        importPath,
+        JSON.stringify({ schemaVersion: 1, sessionId: "target", thoughts: [createThought({ thought: "Replaced" })] }),
+        "utf-8",
+      );
+
+      const result = storage.importSession(importPath, "target");
+
+      expect(result.preCount).toBe(1);
+      expect(result.postCount).toBe(1);
+      expect(result.overwroteExistingThoughts).toBe(true);
+    });
+
+    it("reports overwroteExistingThoughts false when target session was empty", () => {
+      const storage = new ThoughtStorage(tempDir);
+
+      const importPath = join(tempDir, "import.json");
+      writeFileSync(
+        importPath,
+        JSON.stringify({ schemaVersion: 1, sessionId: "empty", thoughts: [createThought({ thought: "New" })] }),
+        "utf-8",
+      );
+
+      const result = storage.importSession(importPath, "empty");
+      expect(result.preCount).toBe(0);
+      expect(result.overwroteExistingThoughts).toBe(false);
+    });
+
+    it("reports changed=false when imported content is identical to existing", () => {
+      const storage = new ThoughtStorage(tempDir);
+      const existing = createThought({ id: "fixed-id", thought: "Same", timestamp: "2026-05-16T00:00:00.000Z" });
+      storage.addThought(existing, "stable");
+
+      const importPath = join(tempDir, "identical.json");
+      writeFileSync(
+        importPath,
+        JSON.stringify({ schemaVersion: 1, sessionId: "stable", thoughts: [existing] }),
+        "utf-8",
+      );
+
+      const result = storage.importSession(importPath, "stable");
+      expect(result.changed).toBe(false);
+    });
+  });
+
+  describe("getStatus completeness with corrupt sessions", () => {
+    it("flags totalThoughts undefined and complete=false when any session is corrupt", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "broken.json"), "not valid json", "utf-8");
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought: "Default" }));
+
+      const status = storage.getStatus();
+
+      expect(status.statusCompleteness.complete).toBe(false);
+      expect(status.statusCompleteness.reason).toMatch(/corrupt/i);
+      expect(status.totalThoughts).toBeUndefined();
+    });
+  });
+
+  describe("namedSessionCount accuracy", () => {
+    it("caps reported namedSessionCount at the enumeration threshold so the value is not misleading", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      const storage = new ThoughtStorage(tempDir);
+      for (let index = 0; index < STATUS_ENUMERATION_SESSION_THRESHOLD + 5; index++) {
+        writeFileSync(join(sessionsDir, `session-${index}.json`), JSON.stringify({ thoughts: [] }), "utf-8");
+      }
+
+      const status = storage.getStatus();
+      expect(status.namedSessionCount).toBeLessThanOrEqual(STATUS_ENUMERATION_SESSION_THRESHOLD);
+      expect(status.statusCompleteness.complete).toBe(false);
+    });
+  });
+
+  describe("non-explicit load size guard", () => {
+    it("rejects oversized named session file when loading via getAllThoughts (non-explicit load)", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      writeFileSync(join(sessionsDir, "huge.json"), " ".repeat(MAX_IMPORT_BYTES + 1), "utf-8");
+      const storage = new ThoughtStorage(tempDir);
+      expect(() => storage.getAllThoughts("huge")).toThrow(/10 MiB/i);
     });
   });
 });

--- a/packages/pi-sequential-thinking/__tests__/storage.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/storage.test.ts
@@ -1,6 +1,7 @@
 import {
   existsSync,
   lstatSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -176,6 +177,16 @@ describe("ThoughtStorage", () => {
       expect(() => storage.getHistory({ limit: 101 })).toThrow(/limit/i);
       expect(() => storage.getHistory({ offset: -1 })).toThrow(/offset/i);
     });
+
+    it("rejects oversized persisted history files before parsing", () => {
+      const storage = new ThoughtStorage(tempDir);
+      const sessionFile = join(tempDir, "current_session.json");
+      writeFileSync(sessionFile, "{".repeat(MAX_IMPORT_BYTES + 1), "utf-8");
+
+      expect(() => storage.getHistory()).toThrow(/10 MiB/i);
+      expect(existsSync(sessionFile)).toBe(true);
+      expect(storage.getStatus().backupFiles.some((file) => file.startsWith("current_session.json.bak."))).toBe(false);
+    });
   });
 
   describe("exportSession", () => {
@@ -256,6 +267,43 @@ describe("ThoughtStorage", () => {
         total_thoughts: 6,
         next_thought_needed: true,
       });
+    });
+
+    it("imports legacy objects without session metadata into the default session", () => {
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ thought: "Replaced default" }));
+      const legacyPath = join(tempDir, "legacy-object.json");
+      writeFileSync(
+        legacyPath,
+        JSON.stringify({
+          thoughts: [
+            {
+              id: "legacy-object-id",
+              thought: "Legacy object thought",
+              thoughtNumber: 2,
+              totalThoughts: 3,
+              nextThoughtNeeded: true,
+              stage: "Research",
+              timestamp: "2026-05-16T00:00:00.000Z",
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const result = storage.importSession(legacyPath);
+
+      expect(result).toMatchObject({ sessionId: null, preCount: 1, postCount: 1, changed: true });
+      expect(storage.getAllThoughts()).toEqual([
+        expect.objectContaining({
+          id: "legacy-object-id",
+          thought: "Legacy object thought",
+          thought_number: 2,
+          total_thoughts: 3,
+          next_thought_needed: true,
+          stage: ThoughtStage.RESEARCH,
+        }),
+      ]);
     });
 
     it("uses embedded sessionId when no explicit target is provided", () => {
@@ -349,9 +397,11 @@ describe("ThoughtStorage", () => {
     });
 
     it("reports partial status after the named-session enumeration threshold", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
       const storage = new ThoughtStorage(tempDir);
-      for (let index = 0; index < STATUS_ENUMERATION_SESSION_THRESHOLD + 1; index++) {
-        storage.addThought(createThought({ id: `thought-${index}` }), `session-${index}`);
+      for (let index = 0; index < STATUS_ENUMERATION_SESSION_THRESHOLD + 5; index++) {
+        writeFileSync(join(sessionsDir, `session-${index}.json`), JSON.stringify({ thoughts: [] }), "utf-8");
       }
 
       const status = storage.getStatus();
@@ -364,6 +414,36 @@ describe("ThoughtStorage", () => {
         namedSessionThreshold: STATUS_ENUMERATION_SESSION_THRESHOLD,
       });
       expect(status.sessions).toHaveLength(STATUS_ENUMERATION_SESSION_THRESHOLD + 1); // default + inspected named sessions
+    });
+
+    it("skips invalid named session files while reporting status", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      const storage = new ThoughtStorage(tempDir);
+      storage.addThought(createThought({ id: "valid-id" }), "valid");
+      writeFileSync(join(sessionsDir, "default.json"), "{}", "utf-8");
+
+      const status = storage.getStatus();
+
+      expect(status.sessions).toEqual(expect.arrayContaining([expect.objectContaining({ sessionId: "valid" })]));
+      expect(status.sessions).not.toEqual(expect.arrayContaining([expect.objectContaining({ sessionId: "default" })]));
+      expect(status.statusCompleteness.skippedInvalidNamedSessions).toBe(1);
+    });
+
+    it("reports corrupt named sessions without moving the file to a backup", () => {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      const corruptSessionFile = join(sessionsDir, "corrupt.json");
+      writeFileSync(corruptSessionFile, "not valid json {{{{json", "utf-8");
+      const storage = new ThoughtStorage(tempDir);
+
+      const status = storage.getStatus();
+
+      expect(existsSync(corruptSessionFile)).toBe(true);
+      expect(status.backupFiles.some((file) => file.includes("corrupt.json.bak."))).toBe(false);
+      expect(status.sessions).toEqual(
+        expect.arrayContaining([expect.objectContaining({ sessionId: "corrupt", thoughtCount: 0, corrupt: true })]),
+      );
     });
   });
 

--- a/packages/pi-sequential-thinking/__tests__/types.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/types.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_SESSION_LABEL,
   generateUuid,
   isValidThoughtData,
+  normalizeSessionId,
+  normalizeThoughtInput,
   parseThoughtStage,
   ThoughtStage,
+  ThoughtValidationError,
   thoughtFromDict,
   thoughtToDict,
   validateThoughtData,
@@ -25,74 +29,197 @@ describe("ThoughtStage", () => {
   });
 });
 
-describe("validateThoughtData", () => {
-  it("returns no errors for valid data", () => {
-    const data = {
-      thought: "My thought",
+describe("normalizeSessionId", () => {
+  it("normalizes omitted sessions to the default label", () => {
+    expect(normalizeSessionId(undefined)).toEqual({ sessionId: null, sessionLabel: DEFAULT_SESSION_LABEL });
+  });
+
+  it("trims and accepts path-safe named sessions", () => {
+    expect(normalizeSessionId("  architecture.review-1  ")).toEqual({
+      sessionId: "architecture.review-1",
+      sessionLabel: "architecture.review-1",
+    });
+  });
+
+  it("rejects empty, traversal, separator, long, and reserved default session ids", () => {
+    for (const sessionId of ["", "   ", "bad/session", "bad\\session", "../bad", ".", "..", "default", "DEFAULT"]) {
+      expect(() => normalizeSessionId(sessionId)).toThrow(ThoughtValidationError);
+    }
+
+    expect(() => normalizeSessionId("a".repeat(81))).toThrow(ThoughtValidationError);
+  });
+});
+
+describe("normalizeThoughtInput", () => {
+  it("normalizes snake_case thought input", () => {
+    const result = normalizeThoughtInput({
+      thought: "Use snake case",
       thought_number: 1,
       total_thoughts: 3,
-    };
-    expect(validateThoughtData(data)).toEqual([]);
+      next_thought_needed: true,
+      stage: "Analysis",
+      tags: ["compat"],
+      axioms_used: ["Preserve old calls"],
+      assumptions_challenged: ["Only camelCase matters"],
+    });
+
+    expect(result.thought).toMatchObject({
+      thought: "Use snake case",
+      thought_number: 1,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: ThoughtStage.ANALYSIS,
+      tags: ["compat"],
+      axioms_used: ["Preserve old calls"],
+      assumptions_challenged: ["Only camelCase matters"],
+    });
+    expect(result.session).toEqual({ sessionId: null, sessionLabel: DEFAULT_SESSION_LABEL });
+    expect(result.adjustments).toEqual({});
+  });
+
+  it("normalizes camelCase aliases and named sessions", () => {
+    const result = normalizeThoughtInput({
+      thought: "Use aliases",
+      thoughtNumber: 2,
+      totalThoughts: 4,
+      nextThoughtNeeded: false,
+      stage: "Synthesis",
+      axiomsUsed: ["Boundary compatibility"],
+      assumptionsChallenged: ["Schemas must stay snake-only"],
+      sessionId: "review",
+    });
+
+    expect(result.thought.thought_number).toBe(2);
+    expect(result.thought.total_thoughts).toBe(4);
+    expect(result.thought.next_thought_needed).toBe(false);
+    expect(result.thought.stage).toBe(ThoughtStage.SYNTHESIS);
+    expect(result.thought.axioms_used).toEqual(["Boundary compatibility"]);
+    expect(result.thought.assumptions_challenged).toEqual(["Schemas must stay snake-only"]);
+    expect(result.session).toEqual({ sessionId: "review", sessionLabel: "review" });
+  });
+
+  it("allows matching snake_case and camelCase aliases after normalization", () => {
+    const result = normalizeThoughtInput({
+      thought: "Both aliases agree",
+      thought_number: 1,
+      thoughtNumber: 1,
+      total_thoughts: 2,
+      totalThoughts: 2,
+      next_thought_needed: true,
+      nextThoughtNeeded: true,
+      stage: "Research",
+      axioms_used: ["a", "b"],
+      axiomsUsed: ["a", "b"],
+      session_id: "  aliases  ",
+      sessionId: "aliases",
+    });
+
+    expect(result.thought.thought_number).toBe(1);
+    expect(result.thought.axioms_used).toEqual(["a", "b"]);
+    expect(result.session.sessionId).toBe("aliases");
+  });
+
+  it("fails on conflicting aliases", () => {
+    expect(() =>
+      normalizeThoughtInput({
+        thought: "Conflict",
+        thought_number: 1,
+        thoughtNumber: 2,
+        total_thoughts: 2,
+        next_thought_needed: false,
+        stage: "Analysis",
+      }),
+    ).toThrow(/conflicting aliases.*thought_number/i);
+
+    expect(() =>
+      normalizeThoughtInput({
+        thought: "Array conflict",
+        thought_number: 1,
+        total_thoughts: 2,
+        next_thought_needed: false,
+        stage: "Analysis",
+        axioms_used: ["a", "b"],
+        axiomsUsed: ["b", "a"],
+      }),
+    ).toThrow(/conflicting aliases.*axioms_used/i);
+  });
+
+  it("dynamically raises total_thoughts for the incoming thought only", () => {
+    const result = normalizeThoughtInput({
+      thought: "Need more steps",
+      thought_number: 5,
+      total_thoughts: 3,
+      next_thought_needed: true,
+      stage: "Analysis",
+    });
+
+    expect(result.thought.total_thoughts).toBe(5);
+    expect(result.adjustments.totalThoughtsAdjusted).toEqual({ from: 3, to: 5 });
+  });
+
+  it("returns field-specific validation errors", () => {
+    try {
+      normalizeThoughtInput({
+        thought: "   ",
+        thought_number: 0,
+        total_thoughts: 0,
+        next_thought_needed: "nope",
+        stage: "Unknown",
+        tags: ["ok", 123],
+      });
+      throw new Error("Expected validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ThoughtValidationError);
+      const validationError = error as ThoughtValidationError;
+      expect(validationError.errors.map((e) => e.field)).toEqual(
+        expect.arrayContaining(["thought", "thought_number", "total_thoughts", "next_thought_needed", "stage", "tags"]),
+      );
+    }
+  });
+});
+
+describe("validateThoughtData", () => {
+  it("returns no errors for valid data", () => {
+    expect(
+      validateThoughtData({
+        thought: "My thought",
+        thought_number: 1,
+        total_thoughts: 3,
+        next_thought_needed: true,
+        stage: ThoughtStage.ANALYSIS,
+        tags: [],
+        axioms_used: [],
+        assumptions_challenged: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not reject total_thoughts below thought_number because normalization adjusts it", () => {
+    expect(
+      validateThoughtData({
+        thought: "My thought",
+        thought_number: 5,
+        total_thoughts: 3,
+        next_thought_needed: true,
+        stage: ThoughtStage.ANALYSIS,
+        tags: [],
+        axioms_used: [],
+        assumptions_challenged: [],
+      }),
+    ).toEqual([]);
   });
 
   it("returns error for empty thought", () => {
-    const data = {
-      thought: "",
-      thought_number: 1,
-      total_thoughts: 3,
-    };
-    expect(validateThoughtData(data)).toContainEqual({
+    expect(validateThoughtData({ thought: "", thought_number: 1, total_thoughts: 3 })).toContainEqual({
       field: "thought",
       message: "Thought content cannot be empty",
-    });
-  });
-
-  it("returns error for whitespace-only thought", () => {
-    const data = {
-      thought: "   ",
-      thought_number: 1,
-      total_thoughts: 3,
-    };
-    expect(validateThoughtData(data)).toContainEqual({
-      field: "thought",
-      message: "Thought content cannot be empty",
-    });
-  });
-
-  it("returns error for non-positive thought_number", () => {
-    const data = {
-      thought: "My thought",
-      thought_number: 0,
-      total_thoughts: 3,
-    };
-    expect(validateThoughtData(data)).toContainEqual({
-      field: "thought_number",
-      message: "Thought number must be a positive integer",
-    });
-  });
-
-  it("returns error when total_thoughts < thought_number", () => {
-    const data = {
-      thought: "My thought",
-      thought_number: 5,
-      total_thoughts: 3,
-    };
-    expect(validateThoughtData(data)).toContainEqual({
-      field: "total_thoughts",
-      message: "Total thoughts must be greater or equal to current thought number",
     });
   });
 });
 
 describe("isValidThoughtData", () => {
   it("returns true for valid data", () => {
-    expect(
-      isValidThoughtData({
-        thought: "My thought",
-        thought_number: 1,
-        total_thoughts: 3,
-      }),
-    ).toBe(true);
+    expect(isValidThoughtData({ thought: "My thought", thought_number: 1, total_thoughts: 3 })).toBe(true);
   });
 
   it("returns false for invalid data", () => {
@@ -140,14 +267,13 @@ describe("thoughtToDict", () => {
       timestamp: "2024-01-01T00:00:00.000Z",
       id: "test-id",
     };
-    const dict = thoughtToDict(thought, true);
-    expect(dict.id).toBe("test-id");
+    expect(thoughtToDict(thought, true).id).toBe("test-id");
   });
 });
 
 describe("thoughtFromDict", () => {
   it("parses dict with camelCase keys", () => {
-    const dict = {
+    const thought = thoughtFromDict({
       thought: "Test thought",
       thoughtNumber: 2,
       totalThoughts: 5,
@@ -158,23 +284,20 @@ describe("thoughtFromDict", () => {
       assumptionsChallenged: [],
       timestamp: "2024-01-01T00:00:00.000Z",
       id: "parsed-id",
-    };
-    const thought = thoughtFromDict(dict);
-    expect(thought.thought).toBe("Test thought");
+    });
     expect(thought.thought_number).toBe(2);
     expect(thought.total_thoughts).toBe(5);
     expect(thought.next_thought_needed).toBe(false);
     expect(thought.stage).toBe(ThoughtStage.SYNTHESIS);
-    expect(thought.tags).toEqual(["tag1", "tag2"]);
     expect(thought.axioms_used).toEqual(["axiom1"]);
     expect(thought.id).toBe("parsed-id");
   });
 
-  it("parses dict with snake_case keys", () => {
-    const dict = {
+  it("parses dict with snake_case keys without defaulting numeric and boolean fields", () => {
+    const thought = thoughtFromDict({
       thought: "Test thought",
-      thought_number: 1,
-      total_thoughts: 3,
+      thought_number: 4,
+      total_thoughts: 6,
       next_thought_needed: true,
       stage: "Conclusion",
       tags: [],
@@ -182,30 +305,30 @@ describe("thoughtFromDict", () => {
       assumptions_challenged: [],
       timestamp: "2024-01-01T00:00:00.000Z",
       id: "snake-id",
-    };
-    const thought = thoughtFromDict(dict);
-    expect(thought.thought_number).toBe(1);
+    });
+    expect(thought.thought_number).toBe(4);
+    expect(thought.total_thoughts).toBe(6);
+    expect(thought.next_thought_needed).toBe(true);
     expect(thought.stage).toBe(ThoughtStage.CONCLUSION);
   });
 
-  it("generates id when not provided", () => {
-    const dict = {
+  it("generates id and timestamp when not provided", () => {
+    const thought = thoughtFromDict({
       thought: "Test thought",
       thoughtNumber: 1,
       totalThoughts: 1,
       nextThoughtNeeded: false,
       stage: "Analysis",
-    };
-    const thought = thoughtFromDict(dict);
+    });
     expect(thought.id).toBeDefined();
     expect(thought.id).toMatch(/^[0-9a-f-]+$/);
+    expect(Date.parse(thought.timestamp)).not.toBeNaN();
   });
 });
 
 describe("generateUuid", () => {
   it("generates valid UUID format", () => {
-    const uuid = generateUuid();
-    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(generateUuid()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 
   it("generates unique IDs", () => {

--- a/packages/pi-sequential-thinking/__tests__/types.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/types.test.ts
@@ -143,6 +143,28 @@ describe("normalizeThoughtInput", () => {
     ).toThrow(/conflicting aliases.*axioms_used/i);
   });
 
+  it("rejects thought_number and total_thoughts beyond the upper bound", () => {
+    expect(() =>
+      normalizeThoughtInput({
+        thought: "Way too big",
+        thought_number: Number.MAX_SAFE_INTEGER,
+        total_thoughts: 3,
+        next_thought_needed: false,
+        stage: "Analysis",
+      }),
+    ).toThrow(/thought_number/);
+
+    expect(() =>
+      normalizeThoughtInput({
+        thought: "Way too big total",
+        thought_number: 1,
+        total_thoughts: 1_000_001,
+        next_thought_needed: false,
+        stage: "Analysis",
+      }),
+    ).toThrow(/total_thoughts/);
+  });
+
   it("dynamically raises total_thoughts for the incoming thought only", () => {
     const result = normalizeThoughtInput({
       thought: "Need more steps",

--- a/packages/pi-sequential-thinking/__tests__/types.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/types.test.ts
@@ -324,6 +324,21 @@ describe("thoughtFromDict", () => {
     expect(thought.id).toMatch(/^[0-9a-f-]+$/);
     expect(Date.parse(thought.timestamp)).not.toBeNaN();
   });
+
+  it("preserves legacy defaults for partial records", () => {
+    const thought = thoughtFromDict({});
+
+    expect(thought).toMatchObject({
+      thought: "",
+      thought_number: 1,
+      total_thoughts: 1,
+      next_thought_needed: false,
+      stage: ThoughtStage.ANALYSIS,
+      tags: [],
+      axioms_used: [],
+      assumptions_challenged: [],
+    });
+  });
 });
 
 describe("generateUuid", () => {

--- a/packages/pi-sequential-thinking/__tests__/types.test.ts
+++ b/packages/pi-sequential-thinking/__tests__/types.test.ts
@@ -8,7 +8,6 @@ import {
   parseThoughtStage,
   ThoughtStage,
   ThoughtValidationError,
-  thoughtFromDict,
   thoughtToDict,
   validateThoughtData,
 } from "../extensions/types.js";
@@ -268,76 +267,6 @@ describe("thoughtToDict", () => {
       id: "test-id",
     };
     expect(thoughtToDict(thought, true).id).toBe("test-id");
-  });
-});
-
-describe("thoughtFromDict", () => {
-  it("parses dict with camelCase keys", () => {
-    const thought = thoughtFromDict({
-      thought: "Test thought",
-      thoughtNumber: 2,
-      totalThoughts: 5,
-      nextThoughtNeeded: false,
-      stage: "Synthesis",
-      tags: ["tag1", "tag2"],
-      axiomsUsed: ["axiom1"],
-      assumptionsChallenged: [],
-      timestamp: "2024-01-01T00:00:00.000Z",
-      id: "parsed-id",
-    });
-    expect(thought.thought_number).toBe(2);
-    expect(thought.total_thoughts).toBe(5);
-    expect(thought.next_thought_needed).toBe(false);
-    expect(thought.stage).toBe(ThoughtStage.SYNTHESIS);
-    expect(thought.axioms_used).toEqual(["axiom1"]);
-    expect(thought.id).toBe("parsed-id");
-  });
-
-  it("parses dict with snake_case keys without defaulting numeric and boolean fields", () => {
-    const thought = thoughtFromDict({
-      thought: "Test thought",
-      thought_number: 4,
-      total_thoughts: 6,
-      next_thought_needed: true,
-      stage: "Conclusion",
-      tags: [],
-      axioms_used: [],
-      assumptions_challenged: [],
-      timestamp: "2024-01-01T00:00:00.000Z",
-      id: "snake-id",
-    });
-    expect(thought.thought_number).toBe(4);
-    expect(thought.total_thoughts).toBe(6);
-    expect(thought.next_thought_needed).toBe(true);
-    expect(thought.stage).toBe(ThoughtStage.CONCLUSION);
-  });
-
-  it("generates id and timestamp when not provided", () => {
-    const thought = thoughtFromDict({
-      thought: "Test thought",
-      thoughtNumber: 1,
-      totalThoughts: 1,
-      nextThoughtNeeded: false,
-      stage: "Analysis",
-    });
-    expect(thought.id).toBeDefined();
-    expect(thought.id).toMatch(/^[0-9a-f-]+$/);
-    expect(Date.parse(thought.timestamp)).not.toBeNaN();
-  });
-
-  it("preserves legacy defaults for partial records", () => {
-    const thought = thoughtFromDict({});
-
-    expect(thought).toMatchObject({
-      thought: "",
-      thought_number: 1,
-      total_thoughts: 1,
-      next_thought_needed: false,
-      stage: ThoughtStage.ANALYSIS,
-      tags: [],
-      axioms_used: [],
-      assumptions_challenged: [],
-    });
   });
 });
 

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -22,6 +22,7 @@ import {
 import {
   DEFAULT_HISTORY_LIMIT,
   generateUuid,
+  isRecord,
   MAX_HISTORY_LIMIT,
   normalizeSessionId,
   normalizeThoughtInput,
@@ -34,12 +35,6 @@ import {
 // =============================================================================
 // Constants
 // =============================================================================
-
-const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
-  storageDir: null,
-  maxBytes: DEFAULT_MAX_BYTES,
-  maxLines: DEFAULT_MAX_LINES,
-};
 
 type ConfigSource = "flag" | "env" | "project_settings" | "global_settings" | "config_file" | "default";
 
@@ -61,8 +56,6 @@ interface SeqThinkConfigWithSources {
   config: SeqThinkConfig;
   sources: Partial<Record<keyof SeqThinkConfig, ConfigSource>>;
 }
-
-interface EffectiveSeqThinkConfig extends EffectiveConfigStatus {}
 
 interface ResolveEffectiveConfigInput {
   flags?: {
@@ -94,10 +87,6 @@ interface McpToolDetails {
 // =============================================================================
 // Utility Functions
 // =============================================================================
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function toJsonString(value: unknown): string {
   if (typeof value === "string") {
@@ -285,10 +274,6 @@ function warnIgnoredLegacyConfigFiles(): void {
   }
 }
 
-function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
-  return loadConfigWithSources(configPath)?.config ?? null;
-}
-
 function loadConfigWithSources(configPath: string | undefined): SeqThinkConfigWithSources | null {
   const envConfigFile = process.env.SEQ_THINK_CONFIG_FILE;
   const legacyEnvConfig = process.env.SEQ_THINK_CONFIG;
@@ -353,7 +338,7 @@ function mergeConfigWithSources(
   };
 }
 
-function resolveEffectiveConfig(input: ResolveEffectiveConfigInput = {}): EffectiveSeqThinkConfig {
+function resolveEffectiveConfig(input: ResolveEffectiveConfigInput = {}): EffectiveConfigStatus {
   const flags = input.flags ?? {};
   const env = input.env ?? process.env;
   const config = input.config;
@@ -613,7 +598,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
         : undefined;
   };
 
-  const getEffectiveConfig = (): EffectiveSeqThinkConfig => {
+  const getEffectiveConfig = (): EffectiveConfigStatus => {
     const config = loadConfigWithSources(getConfiguredFile());
     return resolveEffectiveConfig({
       flags: {
@@ -635,7 +620,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     return { maxBytes: config.maxBytes, maxLines: config.maxLines };
   };
 
-  const effectiveConfigForStatus = (): EffectiveSeqThinkConfig => {
+  const effectiveConfigForStatus = (): EffectiveConfigStatus => {
     const config = getEffectiveConfig();
     return {
       ...config,
@@ -980,10 +965,8 @@ export default function sequentialThinking(pi: ExtensionAPI) {
 
 // Export utilities for testing
 export {
-  DEFAULT_CONFIG_FILE,
   formatToolOutput,
   isRecord,
-  loadConfig,
   loadConfigWithSources,
   normalizeNumber,
   normalizeString,

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -370,8 +370,10 @@ function resolveEffectiveConfig(input: ResolveEffectiveConfigInput = {}): Effect
   const envMaxLines = normalizeNumber(env.SEQ_THINK_MAX_LINES);
   const configMaxLines = config?.config.maxLines;
 
+  const storageDir = flagStorageDir ?? envStorageDir ?? configStorageDir;
+
   return {
-    storageDir: flagStorageDir ?? envStorageDir ?? configStorageDir,
+    storageDir: storageDir ? resolveConfigPath(storageDir) : undefined,
     maxBytes: flagMaxBytes ?? envMaxBytes ?? configMaxBytes ?? DEFAULT_MAX_BYTES,
     maxLines: flagMaxLines ?? envMaxLines ?? configMaxLines ?? DEFAULT_MAX_LINES,
     sources: {
@@ -412,6 +414,31 @@ function sessionIdFromArgs(args: Record<string, unknown>): string | null {
     return snakeSession.sessionId;
   }
   return normalizeSessionId(snake ?? camel).sessionId;
+}
+
+function includeFullThoughtsFromArgs(args: Record<string, unknown>): boolean {
+  const snake = args.include_full_thoughts;
+  const camel = args.includeFullThoughts;
+  const hasSnake = snake !== undefined;
+  const hasCamel = camel !== undefined;
+
+  if (hasSnake && typeof snake !== "boolean") {
+    throw new ThoughtValidationError([
+      { field: "include_full_thoughts", message: "include_full_thoughts must be a boolean" },
+    ]);
+  }
+  if (hasCamel && typeof camel !== "boolean") {
+    throw new ThoughtValidationError([
+      { field: "include_full_thoughts", message: "include_full_thoughts must be a boolean" },
+    ]);
+  }
+  if (hasSnake && hasCamel && snake !== camel) {
+    throw new ThoughtValidationError([
+      { field: "include_full_thoughts", message: "Conflicting aliases for include_full_thoughts" },
+    ]);
+  }
+
+  return hasSnake ? (snake as boolean) : hasCamel ? (camel as boolean) : true;
 }
 
 function toReceipt(
@@ -719,12 +746,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
 
   function getThinkingHistory(args: Record<string, unknown>) {
     const sessionId = sessionIdFromArgs(args);
-    const includeFullThoughts =
-      typeof args.include_full_thoughts === "boolean"
-        ? args.include_full_thoughts
-        : typeof args.includeFullThoughts === "boolean"
-          ? args.includeFullThoughts
-          : true;
+    const includeFullThoughts = includeFullThoughtsFromArgs(args);
     return storage.getHistory({
       sessionId,
       limit: normalizeNumber(args.limit) ?? DEFAULT_HISTORY_LIMIT,

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -479,16 +479,43 @@ const outputLimitParams = {
 const processThoughtParams = Type.Object(
   {
     thought: Type.String({ description: "The content of your thought." }),
-    thought_number: Type.Optional(Type.Integer({ minimum: 1, description: "Position in your sequence." })),
-    thoughtNumber: Type.Optional(Type.Integer({ minimum: 1, description: "camelCase alias for thought_number." })),
+    thought_number: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description:
+          "Position in your sequence. Required at runtime — supply this field or its camelCase alias thoughtNumber.",
+      }),
+    ),
+    thoughtNumber: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "camelCase alias for thought_number. Required at runtime — supply either form.",
+      }),
+    ),
     total_thoughts: Type.Optional(
-      Type.Integer({ minimum: 1, description: "Expected total thoughts in the sequence." }),
+      Type.Integer({
+        minimum: 1,
+        description:
+          "Expected total thoughts in the sequence. Required at runtime — supply this field or its camelCase alias totalThoughts.",
+      }),
     ),
-    totalThoughts: Type.Optional(Type.Integer({ minimum: 1, description: "camelCase alias for total_thoughts." })),
+    totalThoughts: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "camelCase alias for total_thoughts. Required at runtime — supply either form.",
+      }),
+    ),
     next_thought_needed: Type.Optional(
-      Type.Boolean({ description: "Whether more thoughts are needed after this one." }),
+      Type.Boolean({
+        description:
+          "Whether more thoughts are needed after this one. Required at runtime — supply this field or its camelCase alias nextThoughtNeeded.",
+      }),
     ),
-    nextThoughtNeeded: Type.Optional(Type.Boolean({ description: "camelCase alias for next_thought_needed." })),
+    nextThoughtNeeded: Type.Optional(
+      Type.Boolean({
+        description: "camelCase alias for next_thought_needed. Required at runtime — supply either form.",
+      }),
+    ),
     stage: Type.Union(
       [
         Type.Literal("Problem Definition"),
@@ -545,8 +572,14 @@ const getThinkingHistoryParams = Type.Object(
       Type.Integer({ minimum: 1, maximum: MAX_HISTORY_LIMIT, description: "Maximum thoughts to return." }),
     ),
     offset: Type.Optional(Type.Integer({ minimum: 0, description: "Number of thoughts to skip from the start." })),
-    include_full_thoughts: Type.Optional(Type.Boolean({ description: "Whether to include full thought text." })),
-    includeFullThoughts: Type.Optional(Type.Boolean({ description: "camelCase alias for include_full_thoughts." })),
+    include_full_thoughts: Type.Optional(
+      Type.Boolean({
+        description: "Whether to include full thought text. Default true; pass false to receive 120-char snippets.",
+      }),
+    ),
+    includeFullThoughts: Type.Optional(
+      Type.Boolean({ description: "camelCase alias for include_full_thoughts. Default true." }),
+    ),
     ...outputLimitParams,
   },
   { additionalProperties: true },
@@ -947,7 +980,12 @@ export default function sequentialThinking(pi: ExtensionAPI) {
   pi.registerTool({
     name: "get_thinking_status",
     label: "Get Thinking Status",
-    description: "Read content-free storage and configuration diagnostics for sequential thinking sessions.",
+    description:
+      "Read content-free storage and configuration diagnostics for sequential thinking sessions. " +
+      "Returns storage writability, per-session thought counts and state fingerprints, corrupt-session flags with error strings, " +
+      "backup file names, effectiveConfig.sources labels (flag/env/project_settings/global_settings/config_file/default), " +
+      "and a statusCompleteness block indicating whether the listing was truncated or contained corrupt entries. " +
+      "Use writable=false or sessions[].corrupt=true to diagnose write and parse failures.",
     parameters: getThinkingStatusParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
       return executeTool(
@@ -964,7 +1002,9 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     name: "sequential_think",
     label: "Sequential Thinking",
     description:
-      "Think through a topic systematically using structured cognitive stages. Compatibility helper that writes generated prompts to the selected session.",
+      "Scaffold a complete staged thinking sequence for a topic in one call. " +
+      "Generates one thought per cognitive stage (Problem Definition through Conclusion) and writes them to the selected session. " +
+      "Use process_thought instead when you want to record your own thoughts step-by-step.",
     parameters: sequentialThinkParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
       const { toolArgs } = splitParams(params as Record<string, unknown>);

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -115,10 +115,12 @@ function formatToolOutput(
 
   if (truncation.truncated) {
     tempFile = writeTempFile(toolName, rawText);
+    const tempSuffix = tempFile
+      ? `Full output saved to: ${tempFile}`
+      : "Full output unavailable (could not write overflow file)";
     text +=
       `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
-      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
-      `Full output saved to: ${tempFile}]`;
+      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ${tempSuffix}]`;
   }
 
   if (truncation.firstLineExceedsLimit && rawText.length > 0) {
@@ -146,12 +148,20 @@ function formatToolOutput(
   };
 }
 
-function writeTempFile(toolName: string, content: string): string {
+function writeTempFile(toolName: string, content: string): string | undefined {
   const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
   const filename = `pi-seq-think-${safeName}-${Date.now()}.txt`;
   const filePath = join(tmpdir(), filename);
-  writeFileSync(filePath, content, "utf-8");
-  return filePath;
+  try {
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+  } catch (error) {
+    // If /tmp is full or unwritable, the truncated tool result is still
+    // useful — don't convert a successful tool call into an error.
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[pi-sequential-thinking] Could not write truncation overflow file: ${message}`);
+    return undefined;
+  }
 }
 
 function normalizeString(value: unknown): string | undefined {

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -207,10 +207,10 @@ function resolveEffectiveLimits(
 function resolveConfigPath(configPath: string): string {
   const trimmed = configPath.trim();
   if (trimmed.startsWith("~/")) {
-    return join(homedir(), trimmed.slice(2));
+    return join(getHomeDir(), trimmed.slice(2));
   }
   if (trimmed.startsWith("~")) {
-    return join(homedir(), trimmed.slice(1));
+    return join(getHomeDir(), trimmed.slice(1));
   }
   if (isAbsolute(trimmed)) {
     return trimmed;
@@ -624,7 +624,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     const config = getEffectiveConfig();
     return {
       ...config,
-      storageDir: config.storageDir ?? join(homedir(), ".mcp_sequential_thinking"),
+      storageDir: config.storageDir ?? join(getHomeDir(), ".mcp_sequential_thinking"),
     };
   };
 
@@ -704,7 +704,10 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     message: string;
     receipt: Record<string, unknown>;
   } {
-    const filePath = args.file_path as string;
+    const filePath = normalizeString(args.file_path);
+    if (!filePath) {
+      throw new ThoughtValidationError([{ field: "file_path", message: "file_path is required" }]);
+    }
     const sessionId = sessionIdFromArgs(args);
     const result = storage.exportSession(filePath, sessionId);
     return {
@@ -719,7 +722,10 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     message: string;
     receipt: Record<string, unknown>;
   } {
-    const filePath = args.file_path as string;
+    const filePath = normalizeString(args.file_path);
+    if (!filePath) {
+      throw new ThoughtValidationError([{ field: "file_path", message: "file_path is required" }]);
+    }
     const sessionId = sessionIdFromArgs(args);
     const result = storage.importSession(filePath, sessionId);
     return {
@@ -750,8 +756,8 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     summary: unknown;
     receipt: Record<string, unknown>;
   } {
-    const topic = args.topic as string;
-    if (!topic?.trim()) {
+    const topic = normalizeString(args.topic);
+    if (!topic) {
       throw new ThoughtValidationError([{ field: "topic", message: "topic cannot be empty" }]);
     }
     const requestedThoughts = normalizeNumber(args.num_thoughts) ?? 5;

--- a/packages/pi-sequential-thinking/extensions/index.ts
+++ b/packages/pi-sequential-thinking/extensions/index.ts
@@ -3,30 +3,6 @@
  *
  * Provides structured progressive thinking through defined cognitive stages.
  * This is a native TypeScript implementation with no external dependencies.
- *
- * Setup:
- * 1. Install: pi install npm:@feniix/pi-sequential-thinking
- * 2. Optional config:
- *    - Settings file: ~/.pi/agent/settings.json or .pi/settings.json under the pi-sequential-thinking key
- *      (or set SEQ_THINK_CONFIG_FILE / --seq-think-config-file for a custom path)
- *      Keys: storageDir, maxBytes, maxLines
- *    - MCP_STORAGE_DIR (storage directory for thought sessions)
- *    - SEQ_THINK_MAX_BYTES (default: 51200)
- *    - SEQ_THINK_MAX_LINES (default: 2000)
- * 3. Or pass flags:
- *    --seq-think-storage-dir, --seq-think-config-file, --seq-think-max-bytes, --seq-think-max-lines
- *
- * Usage:
- *   "Think through this architecture decision step by step"
- *   "Process a thought about the database schema design"
- *   "Generate a summary of the thinking process"
- *
- * Tools:
- *   - process_thought: Record and analyze a sequential thought with stage metadata
- *   - generate_summary: Generate a summary of the entire thinking process
- *   - clear_history: Reset the thinking process
- *   - export_session: Export the current thinking session to a JSON file
- *   - import_session: Import a previously exported thinking session
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -36,8 +12,24 @@ import type { AgentToolUpdateCallback, ExtensionAPI } from "@earendil-works/pi-c
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { ThoughtAnalyzer } from "./analyzer.js";
-import { ThoughtStorage } from "./storage.js";
-import { generateUuid, parseThoughtStage, type ThoughtData, ThoughtStage } from "./types.js";
+import {
+  type EffectiveConfigStatus,
+  type ExportSessionResult,
+  type ImportSessionResult,
+  type SessionOperationResult,
+  ThoughtStorage,
+} from "./storage.js";
+import {
+  DEFAULT_HISTORY_LIMIT,
+  generateUuid,
+  MAX_HISTORY_LIMIT,
+  normalizeSessionId,
+  normalizeThoughtInput,
+  type ThoughtData,
+  ThoughtStage,
+  ThoughtValidationError,
+  type ValidationError,
+} from "./types.js";
 
 // =============================================================================
 // Constants
@@ -48,6 +40,8 @@ const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
   maxBytes: DEFAULT_MAX_BYTES,
   maxLines: DEFAULT_MAX_LINES,
 };
+
+type ConfigSource = "flag" | "env" | "project_settings" | "global_settings" | "config_file" | "default";
 
 function getHomeDir(): string {
   return process.env.HOME || homedir();
@@ -61,6 +55,40 @@ interface SeqThinkConfig {
   storageDir?: string;
   maxBytes?: number;
   maxLines?: number;
+}
+
+interface SeqThinkConfigWithSources {
+  config: SeqThinkConfig;
+  sources: Partial<Record<keyof SeqThinkConfig, ConfigSource>>;
+}
+
+interface EffectiveSeqThinkConfig extends EffectiveConfigStatus {}
+
+interface ResolveEffectiveConfigInput {
+  flags?: {
+    storageDir?: unknown;
+    maxBytes?: unknown;
+    maxLines?: unknown;
+  };
+  env?: Record<string, string | undefined>;
+  config?: SeqThinkConfigWithSources | null;
+}
+
+interface McpToolDetails {
+  tool: string;
+  truncated: boolean;
+  truncation?: {
+    truncatedBy: "lines" | "bytes" | null;
+    totalLines: number;
+    totalBytes: number;
+    outputLines: number;
+    outputBytes: number;
+    maxLines: number;
+    maxBytes: number;
+  };
+  tempFile?: string;
+  error?: string;
+  validationErrors?: ValidationError[];
 }
 
 // =============================================================================
@@ -212,7 +240,18 @@ function parseConfig(raw: unknown, pathHint: string): SeqThinkConfig {
   };
 }
 
-function loadSettingsConfig(path: string): SeqThinkConfig | null {
+function sourceForConfig(config: SeqThinkConfig, source: ConfigSource): SeqThinkConfigWithSources {
+  const sources: SeqThinkConfigWithSources["sources"] = {};
+  if (config.storageDir !== undefined) sources.storageDir = source;
+  if (config.maxBytes !== undefined) sources.maxBytes = source;
+  if (config.maxLines !== undefined) sources.maxLines = source;
+  return { config, sources };
+}
+
+function loadSettingsConfig(
+  path: string,
+  source: "project_settings" | "global_settings",
+): SeqThinkConfigWithSources | null {
   if (!existsSync(path)) {
     return null;
   }
@@ -223,7 +262,7 @@ function loadSettingsConfig(path: string): SeqThinkConfig | null {
     if (!isRecord(config)) {
       return null;
     }
-    return parseConfig(config, path);
+    return sourceForConfig(parseConfig(config, path), source);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[pi-sequential-thinking] Failed to parse settings ${path}: ${message}`);
@@ -247,17 +286,21 @@ function warnIgnoredLegacyConfigFiles(): void {
 }
 
 function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
+  return loadConfigWithSources(configPath)?.config ?? null;
+}
+
+function loadConfigWithSources(configPath: string | undefined): SeqThinkConfigWithSources | null {
   const envConfigFile = process.env.SEQ_THINK_CONFIG_FILE;
   const legacyEnvConfig = process.env.SEQ_THINK_CONFIG;
   if (configPath) {
-    return loadConfigFile(resolveConfigPath(configPath));
+    return loadConfigFileWithSources(resolveConfigPath(configPath));
   }
   if (envConfigFile) {
-    return loadConfigFile(resolveConfigPath(envConfigFile));
+    return loadConfigFileWithSources(resolveConfigPath(envConfigFile));
   }
   if (legacyEnvConfig) {
     console.warn("[pi-sequential-thinking] SEQ_THINK_CONFIG is deprecated; use SEQ_THINK_CONFIG_FILE.");
-    return loadConfigFile(resolveConfigPath(legacyEnvConfig));
+    return loadConfigFileWithSources(resolveConfigPath(legacyEnvConfig));
   }
 
   warnIgnoredLegacyConfigFiles();
@@ -265,21 +308,17 @@ function loadConfig(configPath: string | undefined): SeqThinkConfig | null {
   const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
   const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
 
-  const globalConfig = loadSettingsConfig(globalSettingsPath);
-  const projectConfig = loadSettingsConfig(projectSettingsPath);
+  const globalConfig = loadSettingsConfig(globalSettingsPath, "global_settings");
+  const projectConfig = loadSettingsConfig(projectSettingsPath, "project_settings");
 
   if (!globalConfig && !projectConfig) {
     return null;
   }
 
-  return {
-    storageDir: projectConfig?.storageDir ?? globalConfig?.storageDir,
-    maxBytes: projectConfig?.maxBytes ?? globalConfig?.maxBytes,
-    maxLines: projectConfig?.maxLines ?? globalConfig?.maxLines,
-  };
+  return mergeConfigWithSources(globalConfig, projectConfig);
 }
 
-function loadConfigFile(path: string): SeqThinkConfig | null {
+function loadConfigFileWithSources(path: string): SeqThinkConfigWithSources | null {
   if (!existsSync(path)) {
     return null;
   }
@@ -287,7 +326,7 @@ function loadConfigFile(path: string): SeqThinkConfig | null {
   try {
     const raw = readFileSync(path, "utf-8");
     const parsed = JSON.parse(raw);
-    return parseConfig(parsed, path);
+    return sourceForConfig(parseConfig(parsed, path), "config_file");
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[pi-sequential-thinking] Failed to parse config ${path}: ${message}`);
@@ -295,34 +334,139 @@ function loadConfigFile(path: string): SeqThinkConfig | null {
   }
 }
 
-interface McpToolDetails {
-  tool: string;
-  truncated: boolean;
-  truncation?: {
-    truncatedBy: "lines" | "bytes" | null;
-    totalLines: number;
-    totalBytes: number;
-    outputLines: number;
-    outputBytes: number;
-    maxLines: number;
-    maxBytes: number;
+function mergeConfigWithSources(
+  globalConfig: SeqThinkConfigWithSources | null,
+  projectConfig: SeqThinkConfigWithSources | null,
+): SeqThinkConfigWithSources {
+  const config: SeqThinkConfig = {
+    storageDir: projectConfig?.config.storageDir ?? globalConfig?.config.storageDir,
+    maxBytes: projectConfig?.config.maxBytes ?? globalConfig?.config.maxBytes,
+    maxLines: projectConfig?.config.maxLines ?? globalConfig?.config.maxLines,
   };
-  tempFile?: string;
+  return {
+    config,
+    sources: {
+      storageDir: projectConfig?.sources.storageDir ?? globalConfig?.sources.storageDir,
+      maxBytes: projectConfig?.sources.maxBytes ?? globalConfig?.sources.maxBytes,
+      maxLines: projectConfig?.sources.maxLines ?? globalConfig?.sources.maxLines,
+    },
+  };
+}
+
+function resolveEffectiveConfig(input: ResolveEffectiveConfigInput = {}): EffectiveSeqThinkConfig {
+  const flags = input.flags ?? {};
+  const env = input.env ?? process.env;
+  const config = input.config;
+
+  const flagStorageDir = normalizeString(flags.storageDir);
+  const envStorageDir = normalizeString(env.MCP_STORAGE_DIR);
+  const configStorageDir = config?.config.storageDir;
+
+  const flagMaxBytes = normalizeNumber(flags.maxBytes);
+  const envMaxBytes = normalizeNumber(env.SEQ_THINK_MAX_BYTES);
+  const configMaxBytes = config?.config.maxBytes;
+
+  const flagMaxLines = normalizeNumber(flags.maxLines);
+  const envMaxLines = normalizeNumber(env.SEQ_THINK_MAX_LINES);
+  const configMaxLines = config?.config.maxLines;
+
+  return {
+    storageDir: flagStorageDir ?? envStorageDir ?? configStorageDir,
+    maxBytes: flagMaxBytes ?? envMaxBytes ?? configMaxBytes ?? DEFAULT_MAX_BYTES,
+    maxLines: flagMaxLines ?? envMaxLines ?? configMaxLines ?? DEFAULT_MAX_LINES,
+    sources: {
+      storageDir: flagStorageDir
+        ? "flag"
+        : envStorageDir
+          ? "env"
+          : configStorageDir
+            ? (config?.sources.storageDir ?? "config_file")
+            : "default",
+      maxBytes: flagMaxBytes
+        ? "flag"
+        : envMaxBytes
+          ? "env"
+          : configMaxBytes
+            ? (config?.sources.maxBytes ?? "config_file")
+            : "default",
+      maxLines: flagMaxLines
+        ? "flag"
+        : envMaxLines
+          ? "env"
+          : configMaxLines
+            ? (config?.sources.maxLines ?? "config_file")
+            : "default",
+    },
+  };
+}
+
+function sessionIdFromArgs(args: Record<string, unknown>): string | null {
+  const snake = args.session_id;
+  const camel = args.sessionId;
+  if (snake !== undefined && camel !== undefined) {
+    const snakeSession = normalizeSessionId(snake);
+    const camelSession = normalizeSessionId(camel);
+    if (snakeSession.sessionId !== camelSession.sessionId) {
+      throw new ThoughtValidationError([{ field: "session_id", message: "Conflicting aliases for session_id" }]);
+    }
+    return snakeSession.sessionId;
+  }
+  return normalizeSessionId(snake ?? camel).sessionId;
+}
+
+function toReceipt(
+  operation: string,
+  result: SessionOperationResult | ExportSessionResult | ImportSessionResult,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const receipt: Record<string, unknown> = {
+    operation,
+    sessionId: result.sessionId,
+    sessionLabel: result.sessionLabel,
+    preCount: result.preCount,
+    postCount: result.postCount,
+    changed: result.changed,
+    savedAt: result.savedAt,
+    stateFingerprint: result.stateFingerprint,
+    ...extra,
+  };
+
+  if ("exportedAt" in result) receipt.exportedAt = result.exportedAt;
+  if ("importedAt" in result) receipt.importedAt = result.importedAt;
+  if ("overwroteExistingFile" in result) receipt.overwroteExistingFile = result.overwroteExistingFile;
+  if ("filePath" in result) receipt.filePath = result.filePath;
+  if (result.warnings && result.warnings.length > 0) receipt.warnings = result.warnings;
+
+  return receipt;
 }
 
 // =============================================================================
 // Tool Parameters
 // =============================================================================
 
+const sessionParams = {
+  session_id: Type.Optional(Type.String({ description: "Session to use. Omit for the default session." })),
+  sessionId: Type.Optional(Type.String({ description: "camelCase alias for session_id." })),
+};
+
+const outputLimitParams = {
+  piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+  piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+};
+
 const processThoughtParams = Type.Object(
   {
     thought: Type.String({ description: "The content of your thought." }),
-    thought_number: Type.Integer({
-      minimum: 1,
-      description: "Position in your sequence (e.g., 1 for first thought).",
-    }),
-    total_thoughts: Type.Integer({ minimum: 1, description: "Expected total thoughts in the sequence." }),
-    next_thought_needed: Type.Boolean({ description: "Whether more thoughts are needed after this one." }),
+    thought_number: Type.Optional(Type.Integer({ minimum: 1, description: "Position in your sequence." })),
+    thoughtNumber: Type.Optional(Type.Integer({ minimum: 1, description: "camelCase alias for thought_number." })),
+    total_thoughts: Type.Optional(
+      Type.Integer({ minimum: 1, description: "Expected total thoughts in the sequence." }),
+    ),
+    totalThoughts: Type.Optional(Type.Integer({ minimum: 1, description: "camelCase alias for total_thoughts." })),
+    next_thought_needed: Type.Optional(
+      Type.Boolean({ description: "Whether more thoughts are needed after this one." }),
+    ),
+    nextThoughtNeeded: Type.Optional(Type.Boolean({ description: "camelCase alias for next_thought_needed." })),
     stage: Type.Union(
       [
         Type.Literal("Problem Definition"),
@@ -337,30 +481,28 @@ const processThoughtParams = Type.Object(
     axioms_used: Type.Optional(
       Type.Array(Type.String(), { description: "Principles or axioms applied in your thought." }),
     ),
+    axiomsUsed: Type.Optional(Type.Array(Type.String(), { description: "camelCase alias for axioms_used." })),
     assumptions_challenged: Type.Optional(
-      Type.Array(Type.String(), {
-        description: "Assumptions your thought questions or challenges.",
-      }),
+      Type.Array(Type.String(), { description: "Assumptions your thought questions or challenges." }),
     ),
-    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+    assumptionsChallenged: Type.Optional(
+      Type.Array(Type.String(), { description: "camelCase alias for assumptions_challenged." }),
+    ),
+    ...sessionParams,
+    ...outputLimitParams,
   },
   { additionalProperties: true },
 );
 
-const generateSummaryParams = Type.Object(
-  {
-    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-  },
-  { additionalProperties: true },
-);
+const sessionScopedParams = Type.Object({ ...sessionParams, ...outputLimitParams }, { additionalProperties: true });
 
-const clearHistoryParams = Type.Object({}, { additionalProperties: true });
+const clearHistoryParams = sessionScopedParams;
 
 const exportSessionParams = Type.Object(
   {
     file_path: Type.String({ description: "Path to save the exported session JSON file." }),
+    ...sessionParams,
+    ...outputLimitParams,
   },
   { additionalProperties: true },
 );
@@ -368,9 +510,27 @@ const exportSessionParams = Type.Object(
 const importSessionParams = Type.Object(
   {
     file_path: Type.String({ description: "Path to the JSON file to import." }),
+    ...sessionParams,
+    ...outputLimitParams,
   },
   { additionalProperties: true },
 );
+
+const getThinkingHistoryParams = Type.Object(
+  {
+    ...sessionParams,
+    limit: Type.Optional(
+      Type.Integer({ minimum: 1, maximum: MAX_HISTORY_LIMIT, description: "Maximum thoughts to return." }),
+    ),
+    offset: Type.Optional(Type.Integer({ minimum: 0, description: "Number of thoughts to skip from the start." })),
+    include_full_thoughts: Type.Optional(Type.Boolean({ description: "Whether to include full thought text." })),
+    includeFullThoughts: Type.Optional(Type.Boolean({ description: "camelCase alias for include_full_thoughts." })),
+    ...outputLimitParams,
+  },
+  { additionalProperties: true },
+);
+
+const getThinkingStatusParams = Type.Object({ ...outputLimitParams }, { additionalProperties: true });
 
 const sequentialThinkParams = Type.Object(
   {
@@ -378,8 +538,8 @@ const sequentialThinkParams = Type.Object(
     num_thoughts: Type.Optional(
       Type.Integer({ minimum: 3, maximum: 10, description: "Number of thoughts to generate (default: 5)." }),
     ),
-    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+    ...sessionParams,
+    ...outputLimitParams,
   },
   { additionalProperties: true },
 );
@@ -413,66 +573,46 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     type: "string",
   });
 
-  const getStorageDir = (): string | undefined => {
-    const storageDirFlag = pi.getFlag("--seq-think-storage-dir");
-    if (typeof storageDirFlag === "string" && storageDirFlag.trim().length > 0) {
-      return resolveConfigPath(storageDirFlag);
-    }
-
+  const getConfiguredFile = (): string | undefined => {
     const configFileFlag = pi.getFlag("--seq-think-config-file");
     const legacyConfigFlag = pi.getFlag("--seq-think-config");
-    const configFlag =
-      typeof configFileFlag === "string"
-        ? configFileFlag
-        : typeof legacyConfigFlag === "string"
-          ? legacyConfigFlag
-          : undefined;
     if (typeof configFileFlag !== "string" && typeof legacyConfigFlag === "string") {
       console.warn("[pi-sequential-thinking] --seq-think-config is deprecated; use --seq-think-config-file.");
     }
-    const config = loadConfig(configFlag);
-    const envStorageDir = normalizeString(process.env.MCP_STORAGE_DIR);
-    if (envStorageDir) {
-      return resolveConfigPath(envStorageDir);
-    }
-    if (config?.storageDir) {
-      return resolveConfigPath(config.storageDir);
-    }
-    return undefined;
+    return typeof configFileFlag === "string"
+      ? configFileFlag
+      : typeof legacyConfigFlag === "string"
+        ? legacyConfigFlag
+        : undefined;
   };
 
-  // Create singleton storage and analyzer
-  const storage = new ThoughtStorage(getStorageDir());
+  const getEffectiveConfig = (): EffectiveSeqThinkConfig => {
+    const config = loadConfigWithSources(getConfiguredFile());
+    return resolveEffectiveConfig({
+      flags: {
+        storageDir: pi.getFlag("--seq-think-storage-dir"),
+        maxBytes: pi.getFlag("--seq-think-max-bytes"),
+        maxLines: pi.getFlag("--seq-think-max-lines"),
+      },
+      env: process.env,
+      config,
+    });
+  };
+
+  const initialConfig = getEffectiveConfig();
+  const storage = new ThoughtStorage(initialConfig.storageDir);
   const analyzer = new ThoughtAnalyzer();
 
   const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
-    const maxBytesFlag = pi.getFlag("--seq-think-max-bytes");
-    const maxLinesFlag = pi.getFlag("--seq-think-max-lines");
-    const configFileFlag = pi.getFlag("--seq-think-config-file");
-    const legacyConfigFlag = pi.getFlag("--seq-think-config");
-    const configFlag =
-      typeof configFileFlag === "string"
-        ? configFileFlag
-        : typeof legacyConfigFlag === "string"
-          ? legacyConfigFlag
-          : undefined;
-    if (typeof configFileFlag !== "string" && typeof legacyConfigFlag === "string") {
-      console.warn("[pi-sequential-thinking] --seq-think-config is deprecated; use --seq-think-config-file.");
-    }
-    const config = loadConfig(configFlag);
+    const config = getEffectiveConfig();
+    return { maxBytes: config.maxBytes, maxLines: config.maxLines };
+  };
 
-    const maxBytes =
-      typeof maxBytesFlag === "string"
-        ? normalizeNumber(maxBytesFlag)
-        : normalizeNumber(process.env.SEQ_THINK_MAX_BYTES ?? config?.maxBytes);
-    const maxLines =
-      typeof maxLinesFlag === "string"
-        ? normalizeNumber(maxLinesFlag)
-        : normalizeNumber(process.env.SEQ_THINK_MAX_LINES ?? config?.maxLines);
-
+  const effectiveConfigForStatus = (): EffectiveSeqThinkConfig => {
+    const config = getEffectiveConfig();
     return {
-      maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
-      maxLines: maxLines ?? DEFAULT_MAX_LINES,
+      ...config,
+      storageDir: config.storageDir ?? join(homedir(), ".mcp_sequential_thinking"),
     };
   };
 
@@ -498,10 +638,11 @@ export default function sequentialThinking(pi: ExtensionAPI) {
       return { content: [{ type: "text" as const, text }], details, isError: false };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const validationErrors = error instanceof ThoughtValidationError ? error.errors : undefined;
       return {
         content: [{ type: "text" as const, text: `Sequential Thinking error: ${message}` }],
         isError: true,
-        details: { tool: toolName, error: message },
+        details: { tool: toolName, truncated: false, error: message, validationErrors },
       };
     }
   };
@@ -510,81 +651,161 @@ export default function sequentialThinking(pi: ExtensionAPI) {
   // Tool Implementations
   // =============================================================================
 
-  function processThought(args: Record<string, unknown>): { thoughtAnalysis: unknown } {
-    const thought = args.thought as string;
-    const thoughtNumber = args.thought_number as number;
-    const totalThoughts = args.total_thoughts as number;
-    const nextThoughtNeeded = args.next_thought_needed as boolean;
-    const stageStr = args.stage as string;
-    const tags = (args.tags as string[]) ?? [];
-    const axiomsUsed = (args.axioms_used as string[]) ?? [];
-    const assumptionsChallenged = (args.assumptions_challenged as string[]) ?? [];
+  function processThought(args: Record<string, unknown>): {
+    thoughtAnalysis: unknown;
+    receipt: Record<string, unknown>;
+  } {
+    const normalized = normalizeThoughtInput(args);
+    const storageResult = storage.addThought(normalized.thought, normalized.session.sessionId);
+    const allThoughts = storage.getAllThoughts(normalized.session.sessionId);
+    const analysis = analyzer.analyzeThought(normalized.thought, allThoughts);
 
-    // Parse stage
-    const stage: ThoughtStage = parseThoughtStage(stageStr);
+    return {
+      ...analysis,
+      receipt: toReceipt("process_thought", storageResult, { ...normalized.adjustments }),
+    };
+  }
 
-    // Create thought data
-    const thoughtData: ThoughtData = {
-      thought,
-      thought_number: thoughtNumber,
-      total_thoughts: totalThoughts,
-      next_thought_needed: nextThoughtNeeded,
-      stage,
-      tags,
-      axioms_used: axiomsUsed,
-      assumptions_challenged: assumptionsChallenged,
-      timestamp: new Date().toISOString(),
-      id: generateUuid(),
+  function generateSummary(args: Record<string, unknown>): {
+    sessionId: string | null;
+    sessionLabel: string;
+    summary: unknown;
+  } {
+    const sessionId = sessionIdFromArgs(args);
+    const session = normalizeSessionId(sessionId);
+    const thoughts = storage.getAllThoughts(session.sessionId);
+    return { sessionId: session.sessionId, sessionLabel: session.sessionLabel, ...analyzer.generateSummary(thoughts) };
+  }
+
+  function clearHistory(args: Record<string, unknown>): {
+    status: string;
+    message: string;
+    receipt: Record<string, unknown>;
+  } {
+    const sessionId = sessionIdFromArgs(args);
+    const result = storage.clearHistory(sessionId);
+    return { status: "success", message: "Thought history cleared", receipt: toReceipt("clear_history", result) };
+  }
+
+  function exportSession(args: Record<string, unknown>): {
+    status: string;
+    message: string;
+    receipt: Record<string, unknown>;
+  } {
+    const filePath = args.file_path as string;
+    const sessionId = sessionIdFromArgs(args);
+    const result = storage.exportSession(filePath, sessionId);
+    return {
+      status: "success",
+      message: `Session exported to ${result.filePath}`,
+      receipt: toReceipt("export_session", result),
+    };
+  }
+
+  function importSession(args: Record<string, unknown>): {
+    status: string;
+    message: string;
+    receipt: Record<string, unknown>;
+  } {
+    const filePath = args.file_path as string;
+    const sessionId = sessionIdFromArgs(args);
+    const result = storage.importSession(filePath, sessionId);
+    return {
+      status: "success",
+      message: `Session imported from ${filePath}`,
+      receipt: toReceipt("import_session", result),
+    };
+  }
+
+  function getThinkingHistory(args: Record<string, unknown>) {
+    const sessionId = sessionIdFromArgs(args);
+    const includeFullThoughts =
+      typeof args.include_full_thoughts === "boolean"
+        ? args.include_full_thoughts
+        : typeof args.includeFullThoughts === "boolean"
+          ? args.includeFullThoughts
+          : true;
+    return storage.getHistory({
+      sessionId,
+      limit: normalizeNumber(args.limit) ?? DEFAULT_HISTORY_LIMIT,
+      offset: normalizeNumber(args.offset) ?? 0,
+      includeFullThoughts,
+    });
+  }
+
+  function getThinkingStatus() {
+    return storage.getStatus({ effectiveConfig: effectiveConfigForStatus() });
+  }
+
+  function sequentialThink(args: Record<string, unknown>): {
+    sessionId: string | null;
+    sessionLabel: string;
+    summary: unknown;
+    receipt: Record<string, unknown>;
+  } {
+    const topic = args.topic as string;
+    if (!topic?.trim()) {
+      throw new ThoughtValidationError([{ field: "topic", message: "topic cannot be empty" }]);
+    }
+    const requestedThoughts = normalizeNumber(args.num_thoughts) ?? 5;
+    const numThoughts = Math.min(Math.max(requestedThoughts, 3), 10);
+    const sessionId = sessionIdFromArgs(args);
+    const session = normalizeSessionId(sessionId);
+    const preCount = storage.getAllThoughts(session.sessionId).length;
+
+    const stages: ThoughtStage[] = [
+      ThoughtStage.PROBLEM_DEFINITION,
+      ThoughtStage.RESEARCH,
+      ThoughtStage.ANALYSIS,
+      ThoughtStage.SYNTHESIS,
+      ThoughtStage.CONCLUSION,
+    ];
+
+    const stagePrompts: Record<ThoughtStage, string> = {
+      [ThoughtStage.PROBLEM_DEFINITION]: `Define the problem: What exactly needs to be decided or solved regarding "${topic}"? What are the constraints and success criteria?`,
+      [ThoughtStage.RESEARCH]: `Research options for "${topic}": What are the available choices? What are their tradeoffs? What does the evidence say?`,
+      [ThoughtStage.ANALYSIS]: `Analyze "${topic}": Examine each option in detail. What are the pros and cons? What are the risks?`,
+      [ThoughtStage.SYNTHESIS]: `Synthesize insights about "${topic}": How do the pieces fit together? What is the overall assessment?`,
+      [ThoughtStage.CONCLUSION]: `Draw a conclusion about "${topic}": What is the recommendation? What is the final verdict?`,
     };
 
-    // Validate
-    if (!thought.trim()) {
-      throw new Error("Thought content cannot be empty");
-    }
-    if (thoughtNumber < 1) {
-      throw new Error("Thought number must be a positive integer");
-    }
-    if (totalThoughts < thoughtNumber) {
-      throw new Error("Total thoughts must be greater or equal to current thought number");
+    let lastResult: SessionOperationResult | undefined;
+    const thoughtCount = Math.min(numThoughts, stages.length);
+    for (let i = 0; i < thoughtCount; i++) {
+      const stage = stages[i];
+      const thoughtData: ThoughtData = {
+        thought: stagePrompts[stage],
+        thought_number: i + 1,
+        total_thoughts: thoughtCount,
+        next_thought_needed: i < thoughtCount - 1,
+        stage,
+        tags: [topic.toLowerCase().split(/\s+/)[0]],
+        axioms_used: [],
+        assumptions_challenged: [],
+        timestamp: new Date().toISOString(),
+        id: generateUuid(),
+      };
+      lastResult = storage.addThought(thoughtData, session.sessionId);
     }
 
-    // Store and analyze
-    storage.addThought(thoughtData);
-    const allThoughts = storage.getAllThoughts();
-    const analysis = analyzer.analyzeThought(thoughtData, allThoughts);
+    const thoughts = storage.getAllThoughts(session.sessionId);
+    const summary = analyzer.generateSummary(thoughts);
+    const fallbackResult: SessionOperationResult = {
+      sessionId: session.sessionId,
+      sessionLabel: session.sessionLabel,
+      preCount,
+      postCount: thoughts.length,
+      changed: thoughts.length !== preCount,
+      savedAt: new Date().toISOString(),
+      stateFingerprint: lastResult?.stateFingerprint ?? "",
+    };
 
-    return analysis;
-  }
-
-  function generateSummary(): { summary: unknown } {
-    const thoughts = storage.getAllThoughts();
-    return analyzer.generateSummary(thoughts);
-  }
-
-  function clearHistory(): { status: string; message: string } {
-    storage.clearHistory();
-    return { status: "success", message: "Thought history cleared" };
-  }
-
-  function exportSession(args: Record<string, unknown>): { status: string; message: string } {
-    const filePath = args.file_path as string;
-    if (!filePath) {
-      throw new Error("file_path is required");
-    }
-    storage.exportSession(filePath);
-    return { status: "success", message: `Session exported to ${filePath}` };
-  }
-
-  function importSession(args: Record<string, unknown>): { status: string; message: string } {
-    const filePath = args.file_path as string;
-    if (!filePath) {
-      throw new Error("file_path is required");
-    }
-    if (!existsSync(filePath)) {
-      throw new Error(`File not found: ${filePath}`);
-    }
-    storage.importSession(filePath);
-    return { status: "success", message: `Session imported from ${filePath}` };
+    return {
+      sessionId: session.sessionId,
+      sessionLabel: session.sessionLabel,
+      ...summary,
+      receipt: toReceipt("sequential_think", lastResult ? { ...lastResult, preCount } : fallbackResult),
+    };
   }
 
   // =============================================================================
@@ -597,7 +818,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     description:
       "Record and analyze a sequential thought with metadata. Use this to break down complex problems " +
       "into structured steps through stages: Problem Definition, Research, Analysis, Synthesis, Conclusion. " +
-      "Each thought is tracked with its position in the sequence, stage, tags, and related analysis.",
+      "Accepts snake_case fields and MCP-style camelCase aliases. Content-bearing: stores thought text in local plaintext JSON.",
     parameters: processThoughtParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
       const { toolArgs } = splitParams(params as Record<string, unknown>);
@@ -615,14 +836,14 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     name: "generate_summary",
     label: "Generate Thinking Summary",
     description:
-      "Generate a summary of the entire sequential thinking process. Returns stage counts, " +
-      "timeline, top tags, and completion status. Use after processing multiple thoughts.",
-    parameters: generateSummaryParams,
+      "Generate a summary of one thinking session. Content-bearing: summaries derive from stored thought content.",
+    parameters: sessionScopedParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
       return executeTool(
         "generate_summary",
         "Generating summary...",
-        generateSummary,
+        () => generateSummary(toolArgs),
         onUpdate,
         params as Record<string, unknown>,
       );
@@ -632,13 +853,14 @@ export default function sequentialThinking(pi: ExtensionAPI) {
   pi.registerTool({
     name: "clear_history",
     label: "Clear Thought History",
-    description: "Reset the sequential thinking process by clearing all recorded thoughts.",
+    description: "Reset one thinking session by clearing recorded thoughts.",
     parameters: clearHistoryParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
       return executeTool(
         "clear_history",
         "Clearing history...",
-        clearHistory,
+        () => clearHistory(toolArgs),
         onUpdate,
         params as Record<string, unknown>,
       );
@@ -649,8 +871,7 @@ export default function sequentialThinking(pi: ExtensionAPI) {
     name: "export_session",
     label: "Export Thinking Session",
     description:
-      "Export the current thinking session to a JSON file for sharing or backup. " +
-      "Parent directories are created automatically.",
+      "Export one thinking session to a JSON file. Content-bearing: exported files include thought text. Parent directories are created automatically.",
     parameters: exportSessionParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
       const { toolArgs } = splitParams(params as Record<string, unknown>);
@@ -667,7 +888,8 @@ export default function sequentialThinking(pi: ExtensionAPI) {
   pi.registerTool({
     name: "import_session",
     label: "Import Thinking Session",
-    description: "Import a previously exported thinking session from a JSON file.",
+    description:
+      "Import a previously exported thinking session from a JSON file. Treats imported thought text as inert content.",
     parameters: importSessionParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
       const { toolArgs } = splitParams(params as Record<string, unknown>);
@@ -682,81 +904,54 @@ export default function sequentialThinking(pi: ExtensionAPI) {
   });
 
   pi.registerTool({
+    name: "get_thinking_history",
+    label: "Get Thinking History",
+    description:
+      "Read recorded thoughts for one session with bounded pagination. Content-bearing: may return full thought text unless include_full_thoughts=false.",
+    parameters: getThinkingHistoryParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      return executeTool(
+        "get_thinking_history",
+        "Getting thinking history...",
+        () => getThinkingHistory(toolArgs),
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
+
+  pi.registerTool({
+    name: "get_thinking_status",
+    label: "Get Thinking Status",
+    description: "Read content-free storage and configuration diagnostics for sequential thinking sessions.",
+    parameters: getThinkingStatusParams,
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      return executeTool(
+        "get_thinking_status",
+        "Getting thinking status...",
+        getThinkingStatus,
+        onUpdate,
+        params as Record<string, unknown>,
+      );
+    },
+  });
+
+  pi.registerTool({
     name: "sequential_think",
     label: "Sequential Thinking",
     description:
-      "Think through a topic systematically using structured cognitive stages. " +
-      "Call this when user asks to 'think through', 'analyze', or 'decide' something. " +
-      "Processes through Problem Definition → Research → Analysis → Synthesis → Conclusion. " +
-      "Returns a structured summary with recommendations.",
+      "Think through a topic systematically using structured cognitive stages. Compatibility helper that writes generated prompts to the selected session.",
     parameters: sequentialThinkParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-      const { toolArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
-      const maxLimits = getMaxLimits();
-      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-
-      onUpdate?.({
-        content: [{ type: "text" as const, text: "Starting structured thinking process..." }],
-        details: { status: "pending" },
-      });
-
-      try {
-        const topic = toolArgs.topic as string;
-        const numThoughts = (toolArgs.num_thoughts as number) || 5;
-
-        // Generate thoughts for each stage
-        const stages: ThoughtStage[] = [
-          ThoughtStage.PROBLEM_DEFINITION,
-          ThoughtStage.RESEARCH,
-          ThoughtStage.ANALYSIS,
-          ThoughtStage.SYNTHESIS,
-          ThoughtStage.CONCLUSION,
-        ];
-
-        const stagePrompts: Record<ThoughtStage, string> = {
-          [ThoughtStage.PROBLEM_DEFINITION]: `Define the problem: What exactly needs to be decided or solved regarding "${topic}"? What are the constraints and success criteria?`,
-          [ThoughtStage.RESEARCH]: `Research options for "${topic}": What are the available choices? What are their tradeoffs? What does the evidence say?`,
-          [ThoughtStage.ANALYSIS]: `Analyze "${topic}": Examine each option in detail. What are the pros and cons? What are the risks?`,
-          [ThoughtStage.SYNTHESIS]: `Synthesize insights about "${topic}": How do the pieces fit together? What is the overall assessment?`,
-          [ThoughtStage.CONCLUSION]: `Draw a conclusion about "${topic}": What is the recommendation? What is the final verdict?`,
-        };
-
-        // Process thoughts for each stage
-        for (let i = 0; i < Math.min(numThoughts, stages.length); i++) {
-          const stage = stages[i];
-          const thoughtData: ThoughtData = {
-            thought: stagePrompts[stage],
-            thought_number: i + 1,
-            total_thoughts: Math.min(numThoughts, stages.length),
-            next_thought_needed: i < Math.min(numThoughts, stages.length) - 1,
-            stage,
-            tags: [topic.toLowerCase().split(/\s+/)[0]], // First word of topic as tag
-            axioms_used: [],
-            assumptions_challenged: [],
-            timestamp: new Date().toISOString(),
-            id: generateUuid(),
-          };
-
-          storage.addThought(thoughtData);
-        }
-
-        // Generate summary
-        const summary = analyzer.generateSummary(storage.getAllThoughts());
-        const { text, details } = formatToolOutput("sequential_think", summary, effectiveLimits);
-
-        return {
-          content: [{ type: "text" as const, text }],
-          details,
-          isError: false,
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          content: [{ type: "text" as const, text: `Sequential Thinking error: ${message}` }],
-          isError: true,
-          details: { tool: "sequential_think", error: message },
-        };
-      }
+      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      return executeTool(
+        "sequential_think",
+        "Starting structured thinking process...",
+        () => sequentialThink(toolArgs),
+        onUpdate,
+        params as Record<string, unknown>,
+      );
     },
   });
 }
@@ -767,10 +962,12 @@ export {
   formatToolOutput,
   isRecord,
   loadConfig,
+  loadConfigWithSources,
   normalizeNumber,
   normalizeString,
   parseConfig,
   resolveConfigPath,
+  resolveEffectiveConfig,
   resolveEffectiveLimits,
   splitParams,
   toJsonString,

--- a/packages/pi-sequential-thinking/extensions/storage.ts
+++ b/packages/pi-sequential-thinking/extensions/storage.ts
@@ -2,144 +2,677 @@
  * ThoughtStorage - Persistence layer for sequential thinking sessions
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  accessSync,
+  chmodSync,
+  existsSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import { type ThoughtData, thoughtFromDict, thoughtToDict } from "./types.js";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import {
+  DEFAULT_HISTORY_LIMIT,
+  MAX_HISTORY_LIMIT,
+  MAX_IMPORT_BYTES,
+  normalizeSessionId,
+  normalizeThoughtRecord,
+  SCHEMA_VERSION,
+  type SessionInfo,
+  STATUS_ENUMERATION_SESSION_THRESHOLD,
+  type ThoughtData,
+  ThoughtStage,
+  thoughtToDict,
+} from "./types.js";
+
+// =============================================================================
+// Public Types
+// =============================================================================
+
+export interface SessionOperationResult {
+  sessionId: string | null;
+  sessionLabel: string;
+  preCount: number;
+  postCount: number;
+  changed: boolean;
+  savedAt: string;
+  stateFingerprint: string;
+  warnings?: string[];
+}
+
+export interface ExportSessionResult extends SessionOperationResult {
+  exportedAt: string;
+  overwroteExistingFile: boolean;
+  filePath: string;
+}
+
+export interface ImportSessionResult extends SessionOperationResult {
+  importedAt: string;
+  embeddedSessionId?: string | null;
+}
+
+export interface HistoryRequest {
+  sessionId?: string | null;
+  limit?: number;
+  offset?: number;
+  includeFullThoughts?: boolean;
+}
+
+export interface HistoryThoughtItem {
+  id: string;
+  thoughtNumber: number;
+  totalThoughts: number;
+  nextThoughtNeeded: boolean;
+  stage: string;
+  tags: string[];
+  axiomsUsed: string[];
+  assumptionsChallenged: string[];
+  timestamp: string;
+  thought?: string;
+  snippet?: string;
+}
+
+export interface ThinkingHistory {
+  sessionId: string | null;
+  sessionLabel: string;
+  totalThoughts: number;
+  offset: number;
+  limit: number;
+  returnedThoughts: number;
+  hasMore: boolean;
+  thoughts: HistoryThoughtItem[];
+}
+
+export interface EffectiveConfigStatus {
+  storageDir?: string;
+  maxBytes: number;
+  maxLines: number;
+  sources: {
+    storageDir: string;
+    maxBytes: string;
+    maxLines: string;
+  };
+}
+
+export interface SessionStatusMetadata {
+  sessionId: string | null;
+  label: string;
+  thoughtCount: number;
+  lastUpdated: string | null;
+  isDefault: boolean;
+  stateFingerprint: string;
+}
+
+export interface ThinkingStatus {
+  storageDir: string;
+  defaultSessionFile: string;
+  pathDisclosure: "home_redacted" | "relative" | "absolute_diagnostic";
+  namedSessionCount: number;
+  totalThoughts?: number;
+  sessions: SessionStatusMetadata[];
+  effectiveConfig?: EffectiveConfigStatus;
+  writable: boolean;
+  backupFiles: string[];
+  statusCompleteness: {
+    complete: boolean;
+    reason?: string;
+    inspectedNamedSessions: number;
+    namedSessionThreshold: number;
+  };
+  schemaVersion: number;
+  storageVersion: number;
+}
+
+interface StoredSession {
+  thoughts: ThoughtData[];
+  lastUpdated: string | null;
+  warnings: string[];
+  embeddedSessionId?: string | null;
+}
+
+interface ThoughtStorageOptions {
+  homeDir?: string;
+}
 
 // =============================================================================
 // Storage Class
 // =============================================================================
 
 export class ThoughtStorage {
-  private thoughts: ThoughtData[] = [];
   private readonly storageDir: string;
   private readonly currentSessionFile: string;
+  private readonly homeDir: string;
 
-  constructor(storageDir?: string) {
-    if (storageDir) {
-      this.storageDir = storageDir;
-    } else {
-      this.storageDir = join(homedir(), ".mcp_sequential_thinking");
-    }
+  constructor(storageDir?: string, options: ThoughtStorageOptions = {}) {
+    this.storageDir = storageDir ? resolve(storageDir) : join(homedir(), ".mcp_sequential_thinking");
+    this.homeDir = options.homeDir ? resolve(options.homeDir) : homedir();
 
-    // Ensure storage directory exists
-    mkdirSync(this.storageDir, { recursive: true });
-
+    this.ensureDirectory(this.storageDir);
     this.currentSessionFile = join(this.storageDir, "current_session.json");
 
-    // Load existing session
-    this.loadSession();
+    // Load default once at startup for compatibility with corrupted-file backup behavior.
+    this.loadSessionFile(this.currentSessionFile, {
+      missingAsEmpty: true,
+      backupCorrupted: true,
+      explicitImport: false,
+    });
   }
 
   // =============================================================================
   // Public API
   // =============================================================================
 
-  addThought(thought: ThoughtData): void {
-    this.thoughts.push(thought);
-    this.saveSession();
+  addThought(thought: ThoughtData, sessionId?: string | null): SessionOperationResult {
+    const session = this.resolveSession(sessionId);
+    const loaded = this.loadSession(session.sessionId);
+    const preCount = loaded.thoughts.length;
+    const thoughts = [...loaded.thoughts, thought];
+    const savedAt = this.saveSession(session.sessionId, thoughts);
+    return this.createOperationResult(session, preCount, thoughts.length, thoughts, savedAt, true);
   }
 
-  getAllThoughts(): ThoughtData[] {
-    // Return a copy to prevent external modification
-    return [...this.thoughts];
+  getAllThoughts(sessionId?: string | null): ThoughtData[] {
+    return this.getThoughts(sessionId);
   }
 
-  clearHistory(): void {
-    this.thoughts = [];
-    this.saveSession();
+  getThoughts(sessionId?: string | null): ThoughtData[] {
+    const session = this.resolveSession(sessionId);
+    return [...this.loadSession(session.sessionId).thoughts];
   }
 
-  exportSession(filePath: string): void {
-    const exportData = {
-      thoughts: this.thoughts.map((t) => thoughtToDict(t, true)),
-      lastUpdated: new Date().toISOString(),
-      exportedAt: new Date().toISOString(),
-      metadata: {
-        totalThoughts: this.thoughts.length,
-        stages: this.getStageCounts(),
+  clearHistory(sessionId?: string | null): SessionOperationResult {
+    const session = this.resolveSession(sessionId);
+    const loaded = this.loadSession(session.sessionId);
+    const preCount = loaded.thoughts.length;
+    const savedAt = this.saveSession(session.sessionId, []);
+    return this.createOperationResult(session, preCount, 0, [], savedAt, preCount > 0);
+  }
+
+  getHistory(request: HistoryRequest = {}): ThinkingHistory {
+    const session = this.resolveSession(request.sessionId);
+    const limit = request.limit ?? DEFAULT_HISTORY_LIMIT;
+    const offset = request.offset ?? 0;
+    const includeFullThoughts = request.includeFullThoughts ?? true;
+
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_HISTORY_LIMIT) {
+      throw new Error(`limit must be between 1 and ${MAX_HISTORY_LIMIT}`);
+    }
+    if (!Number.isInteger(offset) || offset < 0) {
+      throw new Error("offset must be a non-negative integer");
+    }
+
+    const thoughts = this.loadSession(session.sessionId).thoughts;
+    const selected = thoughts.slice(offset, offset + limit);
+
+    return {
+      sessionId: session.sessionId,
+      sessionLabel: session.sessionLabel,
+      totalThoughts: thoughts.length,
+      offset,
+      limit,
+      returnedThoughts: selected.length,
+      hasMore: offset + limit < thoughts.length,
+      thoughts: selected.map((thought) => this.toHistoryThought(thought, includeFullThoughts)),
+    };
+  }
+
+  exportSession(filePath: string, sessionId?: string | null): ExportSessionResult {
+    if (!filePath?.trim()) {
+      throw new Error("file_path is required");
+    }
+    const session = this.resolveSession(sessionId);
+    const thoughts = this.loadSession(session.sessionId).thoughts;
+    const targetPath = this.resolveExternalPath(filePath);
+    this.ensureExternalWriteTarget(targetPath);
+
+    const exportedAt = new Date().toISOString();
+    const overwroteExistingFile = existsSync(targetPath);
+    const data = this.createSessionEnvelope(session, thoughts, exportedAt);
+    this.saveToFile(targetPath, data);
+
+    return {
+      ...this.createOperationResult(session, thoughts.length, thoughts.length, thoughts, exportedAt, true),
+      exportedAt,
+      overwroteExistingFile,
+      filePath: this.redactPath(targetPath).value,
+    };
+  }
+
+  importSession(filePath: string, sessionId?: string | null): ImportSessionResult {
+    if (!filePath?.trim()) {
+      throw new Error("file_path is required");
+    }
+    const importPath = this.resolveExternalPath(filePath);
+    const loaded = this.loadSessionFile(importPath, {
+      missingAsEmpty: false,
+      backupCorrupted: false,
+      explicitImport: true,
+    });
+
+    const explicitSession = sessionId === undefined || sessionId === null ? undefined : this.resolveSession(sessionId);
+    const embeddedSession =
+      loaded.embeddedSessionId === undefined ? undefined : this.resolveSession(loaded.embeddedSessionId);
+    const targetSession = explicitSession ?? embeddedSession ?? this.resolveSession(undefined);
+    const warnings = [...loaded.warnings];
+    if (explicitSession && embeddedSession && explicitSession.sessionId !== embeddedSession.sessionId) {
+      warnings.push(
+        `Import target session_id '${explicitSession.sessionLabel}' overrides embedded sessionId '${embeddedSession.sessionLabel}'.`,
+      );
+    }
+
+    const previous = this.loadSession(targetSession.sessionId).thoughts;
+    const importedAt = new Date().toISOString();
+    const savedAt = this.saveSession(targetSession.sessionId, loaded.thoughts);
+    const result = this.createOperationResult(
+      targetSession,
+      previous.length,
+      loaded.thoughts.length,
+      loaded.thoughts,
+      savedAt,
+      this.fingerprintFor(targetSession, previous, null) !==
+        this.fingerprintFor(targetSession, loaded.thoughts, savedAt),
+    );
+
+    return {
+      ...result,
+      importedAt,
+      embeddedSessionId: loaded.embeddedSessionId,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  getStatus(options: { effectiveConfig?: EffectiveConfigStatus } = {}): ThinkingStatus {
+    const namedSessionIds = this.listNamedSessionIds();
+    const complete = namedSessionIds.length <= STATUS_ENUMERATION_SESSION_THRESHOLD;
+    const inspectedNamedSessionIds = complete
+      ? namedSessionIds
+      : namedSessionIds.slice(0, STATUS_ENUMERATION_SESSION_THRESHOLD);
+
+    const sessions: SessionStatusMetadata[] = [this.getSessionMetadata(null)];
+    for (const sessionId of inspectedNamedSessionIds) {
+      sessions.push(this.getSessionMetadata(sessionId));
+    }
+
+    const totalThoughts = complete ? sessions.reduce((sum, session) => sum + session.thoughtCount, 0) : undefined;
+    const storageRedaction = this.redactPath(this.storageDir);
+    const defaultFileRedaction = this.redactPath(this.currentSessionFile);
+
+    return {
+      storageDir: storageRedaction.value,
+      defaultSessionFile: defaultFileRedaction.value,
+      pathDisclosure: storageRedaction.disclosure,
+      namedSessionCount: namedSessionIds.length,
+      totalThoughts,
+      sessions,
+      effectiveConfig: options.effectiveConfig ? this.redactEffectiveConfig(options.effectiveConfig) : undefined,
+      writable: this.isWritable(this.storageDir),
+      backupFiles: this.listBackupFiles(),
+      statusCompleteness: {
+        complete,
+        reason: complete
+          ? undefined
+          : `Named session count exceeds threshold ${STATUS_ENUMERATION_SESSION_THRESHOLD}; status is partial.`,
+        inspectedNamedSessions: inspectedNamedSessionIds.length,
+        namedSessionThreshold: STATUS_ENUMERATION_SESSION_THRESHOLD,
       },
+      schemaVersion: SCHEMA_VERSION,
+      storageVersion: SCHEMA_VERSION,
     };
-
-    this.saveToFile(filePath, exportData);
-  }
-
-  importSession(filePath: string): void {
-    const loadedThoughts = this.loadFromFile(filePath);
-    this.thoughts = loadedThoughts;
-    this.saveSession();
   }
 
   // =============================================================================
-  // Private Methods
+  // Session helpers
   // =============================================================================
 
-  private loadSession(): void {
-    this.thoughts = this.loadFromFile(this.currentSessionFile);
+  private resolveSession(sessionId?: string | null): SessionInfo {
+    return normalizeSessionId(sessionId === null ? undefined : sessionId);
   }
 
-  private saveSession(): void {
-    const data = {
-      thoughts: this.thoughts.map((t) => thoughtToDict(t, true)),
-      lastUpdated: new Date().toISOString(),
+  private resolveSessionFile(sessionId: string | null): string {
+    if (sessionId === null) {
+      return this.currentSessionFile;
+    }
+    const sessionsDir = join(this.storageDir, "sessions");
+    this.ensureDirectory(sessionsDir);
+    return join(sessionsDir, `${sessionId}.json`);
+  }
+
+  private loadSession(sessionId: string | null): StoredSession {
+    return this.loadSessionFile(this.resolveSessionFile(sessionId), {
+      missingAsEmpty: true,
+      backupCorrupted: true,
+      explicitImport: false,
+    });
+  }
+
+  private saveSession(sessionId: string | null, thoughts: ThoughtData[]): string {
+    const session = this.resolveSession(sessionId);
+    const lastUpdated = new Date().toISOString();
+    this.saveToFile(
+      this.resolveSessionFile(session.sessionId),
+      this.createSessionEnvelope(session, thoughts, undefined, lastUpdated),
+    );
+    return lastUpdated;
+  }
+
+  private getSessionMetadata(sessionId: string | null): SessionStatusMetadata {
+    const session = this.resolveSession(sessionId);
+    const loaded = this.loadSession(session.sessionId);
+    return {
+      sessionId: session.sessionId,
+      label: session.sessionLabel,
+      thoughtCount: loaded.thoughts.length,
+      lastUpdated: loaded.lastUpdated,
+      isDefault: session.sessionId === null,
+      stateFingerprint: this.fingerprintFor(session, loaded.thoughts, loaded.lastUpdated),
     };
-
-    this.saveToFile(this.currentSessionFile, data);
   }
 
-  private loadFromFile(filePath: string): ThoughtData[] {
+  // =============================================================================
+  // File parsing and serialization
+  // =============================================================================
+
+  private loadSessionFile(
+    filePath: string,
+    options: { missingAsEmpty: boolean; backupCorrupted: boolean; explicitImport: boolean },
+  ): StoredSession {
     if (!existsSync(filePath)) {
-      return [];
+      if (options.missingAsEmpty) {
+        return { thoughts: [], lastUpdated: null, warnings: [] };
+      }
+      throw new Error(`File not found: ${this.redactPath(filePath).value}`);
+    }
+
+    this.ensureReadableFile(filePath, options.explicitImport);
+
+    if (options.explicitImport && statSync(filePath).size > MAX_IMPORT_BYTES) {
+      throw new Error("Import file exceeds maximum size of 10 MiB");
     }
 
     try {
       const content = readFileSync(filePath, "utf-8");
-      const data = JSON.parse(content);
-
-      if (!data || !Array.isArray(data.thoughts)) {
-        // Handle legacy format (array directly)
-        if (Array.isArray(data)) {
-          return data.map((item) => thoughtFromDict(item as Record<string, unknown>));
-        }
-        return [];
-      }
-
-      return data.thoughts.map((item: Record<string, unknown>) => thoughtFromDict(item));
+      const data = JSON.parse(content) as unknown;
+      return this.parseSessionData(data, options.explicitImport);
     } catch (error) {
-      // Handle corrupted file - create backup and return empty
-      console.warn(`[pi-sequential-thinking] Error loading ${filePath}: ${error}`);
-      this.backupCorruptedFile(filePath);
-      return [];
+      if (options.backupCorrupted) {
+        console.warn(`[pi-sequential-thinking] Error loading ${this.redactPath(filePath).value}: ${error}`);
+        this.backupCorruptedFile(filePath);
+        return { thoughts: [], lastUpdated: null, warnings: [] };
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid session file ${this.redactPath(filePath).value}: ${message}`);
     }
+  }
+
+  private parseSessionData(data: unknown, explicitImport: boolean): StoredSession {
+    if (Array.isArray(data)) {
+      const normalized = this.normalizeThoughtRecords(data);
+      return {
+        thoughts: normalized.thoughts,
+        lastUpdated: null,
+        warnings: ["Imported legacy array session format.", ...normalized.warnings],
+      };
+    }
+
+    if (!this.isRecord(data)) {
+      throw new Error("Session file must be an object or legacy thought array");
+    }
+
+    if (!Array.isArray(data.thoughts)) {
+      if (!explicitImport) {
+        return { thoughts: [], lastUpdated: null, warnings: [] };
+      }
+      throw new Error("Session file must contain a thoughts array");
+    }
+
+    const normalized = this.normalizeThoughtRecords(data.thoughts);
+    return {
+      thoughts: normalized.thoughts,
+      lastUpdated: typeof data.lastUpdated === "string" ? data.lastUpdated : null,
+      warnings: normalized.warnings,
+      embeddedSessionId: this.parseEmbeddedSessionId(data.sessionId),
+    };
+  }
+
+  private normalizeThoughtRecords(records: unknown[]): { thoughts: ThoughtData[]; warnings: string[] } {
+    const thoughts: ThoughtData[] = [];
+    const warnings: string[] = [];
+    records.forEach((record, index) => {
+      if (!this.isRecord(record)) {
+        throw new Error(`thoughts[${index}] must be an object`);
+      }
+      const normalized = normalizeThoughtRecord(record);
+      thoughts.push(normalized.thought);
+      warnings.push(...normalized.warnings.map((warning) => `thoughts[${index}]: ${warning}`));
+    });
+    return { thoughts, warnings };
+  }
+
+  private parseEmbeddedSessionId(value: unknown): string | null | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    return normalizeSessionId(value).sessionId;
+  }
+
+  private createSessionEnvelope(
+    session: SessionInfo,
+    thoughts: ThoughtData[],
+    exportedAt?: string,
+    lastUpdated = new Date().toISOString(),
+  ): Record<string, unknown> {
+    const data: Record<string, unknown> = {
+      schemaVersion: SCHEMA_VERSION,
+      sessionId: session.sessionId,
+      sessionLabel: session.sessionLabel,
+      thoughts: thoughts.map((thought) => thoughtToDict(thought, true)),
+      lastUpdated,
+      metadata: {
+        totalThoughts: thoughts.length,
+        stages: this.getStageCounts(thoughts),
+      },
+    };
+    if (exportedAt) {
+      data.exportedAt = exportedAt;
+    }
+    return data;
   }
 
   private saveToFile(filePath: string, data: Record<string, unknown>): void {
-    // Ensure parent directory exists
-    mkdirSync(dirname(filePath), { recursive: true });
+    this.ensureDirectory(dirname(filePath));
+    const tempPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+    writeFileSync(tempPath, JSON.stringify(data, null, 2), { encoding: "utf-8", mode: 0o600 });
+    this.restrictFilePermissions(tempPath);
+    renameSync(tempPath, filePath);
+    this.restrictFilePermissions(filePath);
+  }
 
-    const lockPath = `${filePath}.lock`;
+  // =============================================================================
+  // Diagnostics and receipts
+  // =============================================================================
 
-    // Simple file locking simulation using atomic write
-    // In production, you'd use a proper file locking library
-    this.acquireLock(lockPath);
-    try {
-      const tempPath = `${filePath}.tmp.${Date.now()}`;
-      writeFileSync(tempPath, JSON.stringify(data, null, 2), "utf-8");
-      // Atomic rename
-      renameSync(tempPath, filePath);
-    } finally {
-      this.releaseLock(lockPath);
+  private createOperationResult(
+    session: SessionInfo,
+    preCount: number,
+    postCount: number,
+    thoughts: ThoughtData[],
+    savedAt: string,
+    changed: boolean,
+  ): SessionOperationResult {
+    return {
+      sessionId: session.sessionId,
+      sessionLabel: session.sessionLabel,
+      preCount,
+      postCount,
+      changed,
+      savedAt,
+      stateFingerprint: this.fingerprintFor(session, thoughts, savedAt),
+    };
+  }
+
+  private fingerprintFor(session: SessionInfo, thoughts: ThoughtData[], lastUpdated: string | null): string {
+    const payload = {
+      schemaVersion: SCHEMA_VERSION,
+      sessionId: session.sessionId,
+      thoughtCount: thoughts.length,
+      thoughtIds: thoughts.map((thought) => thought.id),
+      thoughtTimestamps: thoughts.map((thought) => thought.timestamp),
+      lastUpdated,
+    };
+    return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+  }
+
+  private toHistoryThought(thought: ThoughtData, includeFullThoughts: boolean): HistoryThoughtItem {
+    const item: HistoryThoughtItem = {
+      id: thought.id,
+      thoughtNumber: thought.thought_number,
+      totalThoughts: thought.total_thoughts,
+      nextThoughtNeeded: thought.next_thought_needed,
+      stage: thought.stage,
+      tags: thought.tags,
+      axiomsUsed: thought.axioms_used,
+      assumptionsChallenged: thought.assumptions_challenged,
+      timestamp: thought.timestamp,
+    };
+    if (includeFullThoughts) {
+      item.thought = thought.thought;
+    } else {
+      item.snippet = thought.thought.length > 120 ? `${thought.thought.slice(0, 117)}...` : thought.thought;
+    }
+    return item;
+  }
+
+  private getStageCounts(thoughts: ThoughtData[]): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const stage of Object.values(ThoughtStage)) {
+      const count = thoughts.filter((thought) => thought.stage === stage).length;
+      if (count > 0) {
+        counts[stage] = count;
+      }
+    }
+    return counts;
+  }
+
+  private listNamedSessionIds(): string[] {
+    const sessionsDir = join(this.storageDir, "sessions");
+    if (!existsSync(sessionsDir)) {
+      return [];
+    }
+    return readdirSync(sessionsDir)
+      .filter((file) => file.endsWith(".json"))
+      .map((file) => file.slice(0, -".json".length))
+      .sort();
+  }
+
+  private listBackupFiles(): string[] {
+    const files: string[] = [];
+    const collect = (dir: string) => {
+      if (!existsSync(dir)) return;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          collect(fullPath);
+        } else if (entry.name.includes(".bak.")) {
+          files.push(relative(this.storageDir, fullPath));
+        }
+      }
+    };
+    collect(this.storageDir);
+    return files.sort();
+  }
+
+  private redactEffectiveConfig(config: EffectiveConfigStatus): EffectiveConfigStatus {
+    return {
+      ...config,
+      storageDir: config.storageDir ? this.redactPath(resolve(config.storageDir)).value : undefined,
+      sources: { ...config.sources },
+    };
+  }
+
+  private redactPath(filePath: string): { value: string; disclosure: ThinkingStatus["pathDisclosure"] } {
+    const resolvedHome = resolve(this.homeDir);
+    const resolvedPath = resolve(filePath);
+    if (resolvedPath === resolvedHome || resolvedPath.startsWith(`${resolvedHome}/`)) {
+      const suffix = resolvedPath.slice(resolvedHome.length);
+      return { value: suffix ? `~${suffix}` : "~", disclosure: "home_redacted" };
+    }
+    if (!isAbsolute(filePath)) {
+      return { value: filePath, disclosure: "relative" };
+    }
+    return { value: `<absolute:${basename(filePath)}>`, disclosure: "absolute_diagnostic" };
+  }
+
+  // =============================================================================
+  // Filesystem utilities
+  // =============================================================================
+
+  private resolveExternalPath(filePath: string): string {
+    const trimmed = filePath.trim();
+    return isAbsolute(trimmed) ? trimmed : resolve(process.cwd(), trimmed);
+  }
+
+  private ensureExternalWriteTarget(filePath: string): void {
+    if (existsSync(filePath)) {
+      const stats = lstatSync(filePath);
+      if (stats.isDirectory()) {
+        throw new Error(`Cannot export to directory: ${this.redactPath(filePath).value}`);
+      }
+      if (stats.isSymbolicLink()) {
+        throw new Error(`Cannot export to symlink: ${this.redactPath(filePath).value}`);
+      }
     }
   }
 
-  private acquireLock(_lockPath: string): void {
-    // Simplified locking - in production use proper file locking
-    // The atomic rename pattern above provides reasonable safety
+  private ensureReadableFile(filePath: string, explicitImport: boolean): void {
+    const stats = lstatSync(filePath);
+    if (stats.isDirectory()) {
+      throw new Error(`Cannot import directory: ${this.redactPath(filePath).value}`);
+    }
+    if (explicitImport && stats.isSymbolicLink()) {
+      throw new Error(`Cannot import symlink: ${this.redactPath(filePath).value}`);
+    }
   }
 
-  private releaseLock(_lockPath: string): void {
-    // Simplified locking release
+  private ensureDirectory(dir: string): void {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    this.restrictDirectoryPermissions(dir);
+  }
+
+  private restrictDirectoryPermissions(dir: string): void {
+    if (process.platform === "win32") return;
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Best effort only; some filesystems ignore POSIX modes.
+    }
+  }
+
+  private restrictFilePermissions(filePath: string): void {
+    if (process.platform === "win32") return;
+    try {
+      chmodSync(filePath, 0o600);
+    } catch {
+      // Best effort only; some filesystems ignore POSIX modes.
+    }
+  }
+
+  private isWritable(dir: string): boolean {
+    try {
+      accessSync(dir, fsConstants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private backupCorruptedFile(filePath: string): void {
@@ -152,17 +685,13 @@ export class ThoughtStorage {
 
     try {
       renameSync(filePath, backupPath);
-      console.log(`[pi-sequential-thinking] Backed up corrupted file to ${backupPath}`);
+      console.log(`[pi-sequential-thinking] Backed up corrupted file to ${this.redactPath(backupPath).value}`);
     } catch {
-      console.warn(`[pi-sequential-thinking] Could not backup corrupted file ${filePath}`);
+      console.warn(`[pi-sequential-thinking] Could not backup corrupted file ${this.redactPath(filePath).value}`);
     }
   }
 
-  private getStageCounts(): Record<string, number> {
-    const counts: Record<string, number> = {};
-    for (const thought of this.thoughts) {
-      counts[thought.stage] = (counts[thought.stage] || 0) + 1;
-    }
-    return counts;
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
   }
 }

--- a/packages/pi-sequential-thinking/extensions/storage.ts
+++ b/packages/pi-sequential-thinking/extensions/storage.ts
@@ -15,6 +15,7 @@ import {
   readFileSync,
   renameSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -59,6 +60,7 @@ export interface ExportSessionResult extends SessionOperationResult {
 export interface ImportSessionResult extends SessionOperationResult {
   importedAt: string;
   embeddedSessionId?: string | null;
+  overwroteExistingThoughts: boolean;
 }
 
 export interface HistoryRequest {
@@ -163,11 +165,18 @@ export class ThoughtStorage {
     this.currentSessionFile = join(this.storageDir, "current_session.json");
 
     // Load default once at startup for compatibility with corrupted-file backup behavior.
-    this.loadSessionFile(this.currentSessionFile, {
-      missingAsEmpty: true,
-      backupCorrupted: true,
-      explicitImport: false,
-    });
+    // OS-level errors (EACCES, EMFILE, etc.) must not crash the constructor — the
+    // extension should still register so callers can diagnose via get_thinking_status.
+    try {
+      this.loadSessionFile(this.currentSessionFile, {
+        missingAsEmpty: true,
+        backupCorrupted: true,
+        explicitImport: false,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[pi-sequential-thinking] Startup load failed for default session: ${message}`);
+    }
   }
 
   // =============================================================================
@@ -272,34 +281,37 @@ export class ThoughtStorage {
     const previous = this.loadSession(targetSession.sessionId).thoughts;
     const importedAt = new Date().toISOString();
     const savedAt = this.saveSession(targetSession.sessionId, loaded.thoughts);
+    // `changed` should reflect content drift only, not the savedAt timestamp.
+    // Compare content fingerprints (which exclude lastUpdated) so re-importing
+    // identical content reports changed=false.
+    const changed =
+      this.contentFingerprintFor(targetSession, previous) !==
+      this.contentFingerprintFor(targetSession, loaded.thoughts);
     const result = this.createOperationResult(
       targetSession,
       previous.length,
       loaded.thoughts.length,
       loaded.thoughts,
       savedAt,
-      this.fingerprintFor(targetSession, previous, null) !==
-        this.fingerprintFor(targetSession, loaded.thoughts, savedAt),
+      changed,
     );
 
     return {
       ...result,
       importedAt,
       embeddedSessionId: loaded.embeddedSessionId,
+      overwroteExistingThoughts: previous.length > 0,
       warnings: warnings.length > 0 ? warnings : undefined,
     };
   }
 
   getStatus(options: { effectiveConfig?: EffectiveConfigStatus } = {}): ThinkingStatus {
-    const namedSessionIds = this.listNamedSessionIds();
-    const namedSessionsComplete = namedSessionIds.length <= STATUS_ENUMERATION_SESSION_THRESHOLD;
-    const inspectedNamedSessionIds = namedSessionsComplete
-      ? namedSessionIds
-      : namedSessionIds.slice(0, STATUS_ENUMERATION_SESSION_THRESHOLD);
+    const namedSessionListing = this.listNamedSessionIds();
+    const namedSessionsComplete = !namedSessionListing.overflowed && !namedSessionListing.error;
 
     const sessions: SessionStatusMetadata[] = [this.getSessionMetadata(null)];
     let skippedInvalidNamedSessions = 0;
-    for (const sessionId of inspectedNamedSessionIds) {
+    for (const sessionId of namedSessionListing.ids) {
       try {
         normalizeSessionId(sessionId);
         sessions.push(this.getSessionMetadata(sessionId));
@@ -312,17 +324,22 @@ export class ThoughtStorage {
       }
     }
 
+    const corruptSessionCount = sessions.filter((session) => session.corrupt).length;
     const backupListing = this.listBackupFiles();
-    const complete = namedSessionsComplete && backupListing.complete;
+    const complete = namedSessionsComplete && backupListing.complete && corruptSessionCount === 0;
     const completenessReasons = [
-      namedSessionsComplete
-        ? undefined
-        : `Named session count exceeds threshold ${STATUS_ENUMERATION_SESSION_THRESHOLD}; status is partial.`,
+      namedSessionListing.overflowed
+        ? `Named session count exceeds threshold ${STATUS_ENUMERATION_SESSION_THRESHOLD}; status is partial.`
+        : undefined,
+      namedSessionListing.error ? `Named session enumeration failed: ${namedSessionListing.error}` : undefined,
       backupListing.reason,
+      corruptSessionCount > 0
+        ? `${corruptSessionCount} session${corruptSessionCount === 1 ? " is" : "s are"} corrupt; totalThoughts excluded.`
+        : undefined,
     ].filter((reason): reason is string => Boolean(reason));
-    const totalThoughts = namedSessionsComplete
-      ? sessions.reduce((sum, session) => sum + session.thoughtCount, 0)
-      : undefined;
+    // totalThoughts is omitted whenever enumeration is partial OR any session
+    // failed to load: otherwise the sum silently understates content.
+    const totalThoughts = complete ? sessions.reduce((sum, session) => sum + session.thoughtCount, 0) : undefined;
     const storageRedaction = this.redactPath(this.storageDir);
     const defaultFileRedaction = this.redactPath(this.currentSessionFile);
 
@@ -330,7 +347,7 @@ export class ThoughtStorage {
       storageDir: storageRedaction.value,
       defaultSessionFile: defaultFileRedaction.value,
       pathDisclosure: storageRedaction.disclosure,
-      namedSessionCount: namedSessionIds.length,
+      namedSessionCount: namedSessionListing.ids.length,
       totalThoughts,
       sessions,
       effectiveConfig: options.effectiveConfig ? this.redactEffectiveConfig(options.effectiveConfig) : undefined,
@@ -339,7 +356,7 @@ export class ThoughtStorage {
       statusCompleteness: {
         complete,
         reason: completenessReasons.length > 0 ? completenessReasons.join(" ") : undefined,
-        inspectedNamedSessions: inspectedNamedSessionIds.length,
+        inspectedNamedSessions: namedSessionListing.ids.length,
         namedSessionThreshold: STATUS_ENUMERATION_SESSION_THRESHOLD,
         skippedInvalidNamedSessions: skippedInvalidNamedSessions || undefined,
       },
@@ -355,9 +372,7 @@ export class ThoughtStorage {
     if (sessionId === null) {
       return this.currentSessionFile;
     }
-    const sessionsDir = join(this.storageDir, "sessions");
-    this.ensureDirectory(sessionsDir);
-    return join(sessionsDir, `${sessionId}.json`);
+    return join(this.storageDir, "sessions", `${sessionId}.json`);
   }
 
   private loadSession(sessionId: string | null): StoredSession {
@@ -432,8 +447,15 @@ export class ThoughtStorage {
 
     this.ensureReadableFile(filePath, options.explicitImport);
 
-    if (options.explicitImport && statSync(filePath).size > MAX_IMPORT_BYTES) {
-      throw new Error("Import file exceeds maximum size of 10 MiB");
+    // Apply the size cap unconditionally so a planted oversize session file
+    // cannot OOM the process on any read path (status enumeration, history,
+    // addThought, constructor warmup), not just explicit imports.
+    if (statSync(filePath).size > MAX_IMPORT_BYTES) {
+      throw new Error(
+        options.explicitImport
+          ? "Import file exceeds maximum size of 10 MiB"
+          : "Session file exceeds maximum size of 10 MiB",
+      );
     }
 
     try {
@@ -451,7 +473,7 @@ export class ThoughtStorage {
     }
   }
 
-  private parseSessionData(data: unknown, explicitImport: boolean): StoredSession {
+  private parseSessionData(data: unknown, _explicitImport: boolean): StoredSession {
     if (Array.isArray(data)) {
       const normalized = this.normalizeThoughtRecords(data);
       return {
@@ -466,9 +488,9 @@ export class ThoughtStorage {
     }
 
     if (!Array.isArray(data.thoughts)) {
-      if (!explicitImport) {
-        return { thoughts: [], lastUpdated: null, warnings: [] };
-      }
+      // Throw on both paths so loadSessionFile's catch handles the backup
+      // (when backupCorrupted is true) instead of silently returning empty
+      // and letting the next save overwrite a malformed-but-parseable file.
       throw new Error("Session file must contain a thoughts array");
     }
 
@@ -502,7 +524,17 @@ export class ThoughtStorage {
     if (value === null) {
       return null;
     }
-    return normalizeSessionId(value).sessionId;
+    try {
+      return normalizeSessionId(value).sessionId;
+    } catch (error) {
+      if (error instanceof ThoughtValidationError) {
+        // An invalid embedded sessionId should not condemn an otherwise-valid
+        // session file. Treat the embedded id as absent and let the caller
+        // either fall back to the default or use an explicit target.
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   private createSessionEnvelope(
@@ -533,7 +565,19 @@ export class ThoughtStorage {
     const tempPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(16).slice(2)}`;
     writeFileSync(tempPath, JSON.stringify(data, null, 2), { encoding: "utf-8", mode: 0o600 });
     this.restrictFilePermissions(tempPath);
-    renameSync(tempPath, filePath);
+    try {
+      renameSync(tempPath, filePath);
+    } catch (error) {
+      // Avoid leaving a writable temp file behind when the atomic rename fails
+      // (ENOSPC, EACCES, cross-device). The temp file's content is unpublished
+      // so unlinking is the safe cleanup.
+      try {
+        unlinkSync(tempPath);
+      } catch {
+        // best effort; surface the original error below
+      }
+      throw error;
+    }
     this.restrictFilePermissions(filePath);
   }
 
@@ -572,6 +616,13 @@ export class ThoughtStorage {
     return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
   }
 
+  // Content-only fingerprint used to compare two thought sets without regard
+  // to when they were saved. Used to decide whether an operation produced an
+  // actual change in stored content (vs. a timestamp-only rewrite).
+  private contentFingerprintFor(session: SessionInfo, thoughts: ThoughtData[]): string {
+    return this.fingerprintFor(session, thoughts, null);
+  }
+
   private toHistoryThought(thought: ThoughtData, includeFullThoughts: boolean): HistoryThoughtItem {
     const item: HistoryThoughtItem = {
       id: thought.id,
@@ -603,28 +654,38 @@ export class ThoughtStorage {
     return counts;
   }
 
-  private listNamedSessionIds(): string[] {
+  private listNamedSessionIds(): { ids: string[]; overflowed: boolean; error?: string } {
     const sessionsDir = join(this.storageDir, "sessions");
     if (!existsSync(sessionsDir)) {
-      return [];
+      return { ids: [], overflowed: false };
     }
 
     const sessionIds: string[] = [];
-    const dir = opendirSync(sessionsDir);
+    let overflowed = false;
+    let dir: Dir;
+    try {
+      dir = opendirSync(sessionsDir);
+    } catch (error) {
+      // EACCES / EMFILE on the sessions directory must not crash status.
+      // Surface the failure as a partial-enumeration reason.
+      const message = error instanceof Error ? error.message : String(error);
+      return { ids: [], overflowed: true, error: message };
+    }
     try {
       for (let entry = dir.readSync(); entry !== null; entry = dir.readSync()) {
         if (entry.isFile() && entry.name.endsWith(".json")) {
-          sessionIds.push(entry.name.slice(0, -".json".length));
-          if (sessionIds.length > STATUS_ENUMERATION_SESSION_THRESHOLD) {
+          if (sessionIds.length >= STATUS_ENUMERATION_SESSION_THRESHOLD) {
+            overflowed = true;
             break;
           }
+          sessionIds.push(entry.name.slice(0, -".json".length));
         }
       }
     } finally {
       dir.closeSync();
     }
 
-    return sessionIds.sort();
+    return { ids: sessionIds.sort(), overflowed };
   }
 
   private listBackupFiles(): { files: string[]; complete: boolean; reason?: string } {
@@ -661,7 +722,10 @@ export class ThoughtStorage {
           const fullPath = join(dirPath, entry.name);
           if (entry.isDirectory()) {
             dirs.push(fullPath);
-          } else if (entry.isFile() && entry.name.includes(".bak.")) {
+          } else if (entry.isFile() && entry.name.includes(".bak.") && !entry.name.endsWith(".json")) {
+            // Backup names are `<orig>.bak.<timestamp>` (no .json suffix). Excluding
+            // .json files here prevents a session file like `foo.bak.json` from
+            // showing up in both backupFiles and sessions.
             files.push(relative(this.storageDir, fullPath));
           }
 
@@ -792,5 +856,4 @@ export class ThoughtStorage {
       console.warn(`[pi-sequential-thinking] Could not backup corrupted file ${this.redactPath(filePath).value}`);
     }
   }
-
 }

--- a/packages/pi-sequential-thinking/extensions/storage.ts
+++ b/packages/pi-sequential-thinking/extensions/storage.ts
@@ -3,6 +3,7 @@
  */
 
 import { createHash } from "node:crypto";
+import type { Dir } from "node:fs";
 import {
   accessSync,
   chmodSync,
@@ -10,7 +11,7 @@ import {
   constants as fsConstants,
   lstatSync,
   mkdirSync,
-  readdirSync,
+  opendirSync,
   readFileSync,
   renameSync,
   statSync,
@@ -29,6 +30,7 @@ import {
   STATUS_ENUMERATION_SESSION_THRESHOLD,
   type ThoughtData,
   ThoughtStage,
+  ThoughtValidationError,
   thoughtToDict,
 } from "./types.js";
 
@@ -108,6 +110,8 @@ export interface SessionStatusMetadata {
   lastUpdated: string | null;
   isDefault: boolean;
   stateFingerprint: string;
+  corrupt?: boolean;
+  error?: string;
 }
 
 export interface ThinkingStatus {
@@ -125,6 +129,7 @@ export interface ThinkingStatus {
     reason?: string;
     inspectedNamedSessions: number;
     namedSessionThreshold: number;
+    skippedInvalidNamedSessions?: number;
   };
   schemaVersion: number;
   storageVersion: number;
@@ -208,6 +213,7 @@ export class ThoughtStorage {
       throw new Error("offset must be a non-negative integer");
     }
 
+    this.ensureHistoryFileWithinSizeLimit(this.resolveSessionFile(session.sessionId));
     const thoughts = this.loadSession(session.sessionId).thoughts;
     const selected = thoughts.slice(offset, offset + limit);
 
@@ -290,17 +296,37 @@ export class ThoughtStorage {
 
   getStatus(options: { effectiveConfig?: EffectiveConfigStatus } = {}): ThinkingStatus {
     const namedSessionIds = this.listNamedSessionIds();
-    const complete = namedSessionIds.length <= STATUS_ENUMERATION_SESSION_THRESHOLD;
-    const inspectedNamedSessionIds = complete
+    const namedSessionsComplete = namedSessionIds.length <= STATUS_ENUMERATION_SESSION_THRESHOLD;
+    const inspectedNamedSessionIds = namedSessionsComplete
       ? namedSessionIds
       : namedSessionIds.slice(0, STATUS_ENUMERATION_SESSION_THRESHOLD);
 
     const sessions: SessionStatusMetadata[] = [this.getSessionMetadata(null)];
+    let skippedInvalidNamedSessions = 0;
     for (const sessionId of inspectedNamedSessionIds) {
-      sessions.push(this.getSessionMetadata(sessionId));
+      try {
+        normalizeSessionId(sessionId);
+        sessions.push(this.getSessionMetadata(sessionId));
+      } catch (error) {
+        if (error instanceof ThoughtValidationError) {
+          skippedInvalidNamedSessions += 1;
+          continue;
+        }
+        throw error;
+      }
     }
 
-    const totalThoughts = complete ? sessions.reduce((sum, session) => sum + session.thoughtCount, 0) : undefined;
+    const backupListing = this.listBackupFiles();
+    const complete = namedSessionsComplete && backupListing.complete;
+    const completenessReasons = [
+      namedSessionsComplete
+        ? undefined
+        : `Named session count exceeds threshold ${STATUS_ENUMERATION_SESSION_THRESHOLD}; status is partial.`,
+      backupListing.reason,
+    ].filter((reason): reason is string => Boolean(reason));
+    const totalThoughts = namedSessionsComplete
+      ? sessions.reduce((sum, session) => sum + session.thoughtCount, 0)
+      : undefined;
     const storageRedaction = this.redactPath(this.storageDir);
     const defaultFileRedaction = this.redactPath(this.currentSessionFile);
 
@@ -313,14 +339,13 @@ export class ThoughtStorage {
       sessions,
       effectiveConfig: options.effectiveConfig ? this.redactEffectiveConfig(options.effectiveConfig) : undefined,
       writable: this.isWritable(this.storageDir),
-      backupFiles: this.listBackupFiles(),
+      backupFiles: backupListing.files,
       statusCompleteness: {
         complete,
-        reason: complete
-          ? undefined
-          : `Named session count exceeds threshold ${STATUS_ENUMERATION_SESSION_THRESHOLD}; status is partial.`,
+        reason: completenessReasons.length > 0 ? completenessReasons.join(" ") : undefined,
         inspectedNamedSessions: inspectedNamedSessionIds.length,
         namedSessionThreshold: STATUS_ENUMERATION_SESSION_THRESHOLD,
+        skippedInvalidNamedSessions: skippedInvalidNamedSessions || undefined,
       },
       schemaVersion: SCHEMA_VERSION,
       storageVersion: SCHEMA_VERSION,
@@ -352,6 +377,12 @@ export class ThoughtStorage {
     });
   }
 
+  private ensureHistoryFileWithinSizeLimit(filePath: string): void {
+    if (existsSync(filePath) && statSync(filePath).size > MAX_IMPORT_BYTES) {
+      throw new Error("History session file exceeds maximum size of 10 MiB");
+    }
+  }
+
   private saveSession(sessionId: string | null, thoughts: ThoughtData[]): string {
     const session = this.resolveSession(sessionId);
     const lastUpdated = new Date().toISOString();
@@ -364,15 +395,33 @@ export class ThoughtStorage {
 
   private getSessionMetadata(sessionId: string | null): SessionStatusMetadata {
     const session = this.resolveSession(sessionId);
-    const loaded = this.loadSession(session.sessionId);
-    return {
-      sessionId: session.sessionId,
-      label: session.sessionLabel,
-      thoughtCount: loaded.thoughts.length,
-      lastUpdated: loaded.lastUpdated,
-      isDefault: session.sessionId === null,
-      stateFingerprint: this.fingerprintFor(session, loaded.thoughts, loaded.lastUpdated),
-    };
+    try {
+      const loaded = this.loadSessionFile(this.resolveSessionFile(session.sessionId), {
+        missingAsEmpty: true,
+        backupCorrupted: false,
+        explicitImport: false,
+      });
+      return {
+        sessionId: session.sessionId,
+        label: session.sessionLabel,
+        thoughtCount: loaded.thoughts.length,
+        lastUpdated: loaded.lastUpdated,
+        isDefault: session.sessionId === null,
+        stateFingerprint: this.fingerprintFor(session, loaded.thoughts, loaded.lastUpdated),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        sessionId: session.sessionId,
+        label: session.sessionLabel,
+        thoughtCount: 0,
+        lastUpdated: null,
+        isDefault: session.sessionId === null,
+        stateFingerprint: this.fingerprintFor(session, [], null),
+        corrupt: true,
+        error: message,
+      };
+    }
   }
 
   // =============================================================================
@@ -568,27 +617,89 @@ export class ThoughtStorage {
     if (!existsSync(sessionsDir)) {
       return [];
     }
-    return readdirSync(sessionsDir)
-      .filter((file) => file.endsWith(".json"))
-      .map((file) => file.slice(0, -".json".length))
-      .sort();
-  }
 
-  private listBackupFiles(): string[] {
-    const files: string[] = [];
-    const collect = (dir: string) => {
-      if (!existsSync(dir)) return;
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const fullPath = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          collect(fullPath);
-        } else if (entry.name.includes(".bak.")) {
-          files.push(relative(this.storageDir, fullPath));
+    const sessionIds: string[] = [];
+    const dir = opendirSync(sessionsDir);
+    try {
+      for (let entry = dir.readSync(); entry !== null; entry = dir.readSync()) {
+        if (entry.isFile() && entry.name.endsWith(".json")) {
+          sessionIds.push(entry.name.slice(0, -".json".length));
+          if (sessionIds.length > STATUS_ENUMERATION_SESSION_THRESHOLD) {
+            break;
+          }
         }
       }
+    } finally {
+      dir.closeSync();
+    }
+
+    return sessionIds.sort();
+  }
+
+  private listBackupFiles(): { files: string[]; complete: boolean; reason?: string } {
+    const files: string[] = [];
+    const dirs = [this.storageDir];
+    const maxInspectedEntries = STATUS_ENUMERATION_SESSION_THRESHOLD * 10;
+    let inspectedEntries = 0;
+    let complete = true;
+    let errorCount = 0;
+
+    while (dirs.length > 0) {
+      if (inspectedEntries >= maxInspectedEntries || files.length > STATUS_ENUMERATION_SESSION_THRESHOLD) {
+        complete = false;
+        break;
+      }
+
+      const dirPath = dirs.pop();
+      if (!dirPath || !existsSync(dirPath)) {
+        continue;
+      }
+
+      let dir: Dir;
+      try {
+        dir = opendirSync(dirPath);
+      } catch {
+        complete = false;
+        errorCount += 1;
+        continue;
+      }
+
+      try {
+        for (let entry = dir.readSync(); entry !== null; entry = dir.readSync()) {
+          inspectedEntries += 1;
+          const fullPath = join(dirPath, entry.name);
+          if (entry.isDirectory()) {
+            dirs.push(fullPath);
+          } else if (entry.isFile() && entry.name.includes(".bak.")) {
+            files.push(relative(this.storageDir, fullPath));
+          }
+
+          if (inspectedEntries >= maxInspectedEntries || files.length > STATUS_ENUMERATION_SESSION_THRESHOLD) {
+            complete = false;
+            break;
+          }
+        }
+      } catch {
+        complete = false;
+        errorCount += 1;
+      } finally {
+        dir.closeSync();
+      }
+    }
+
+    const reasons: string[] = [];
+    if (files.length > STATUS_ENUMERATION_SESSION_THRESHOLD || inspectedEntries >= maxInspectedEntries) {
+      reasons.push("Backup file enumeration exceeded status bounds; backupFiles is partial.");
+    }
+    if (errorCount > 0) {
+      reasons.push("Backup file enumeration skipped unreadable directories; backupFiles is partial.");
+    }
+
+    return {
+      files: files.slice(0, STATUS_ENUMERATION_SESSION_THRESHOLD).sort(),
+      complete,
+      reason: reasons.length > 0 ? reasons.join(" ") : undefined,
     };
-    collect(this.storageDir);
-    return files.sort();
   }
 
   private redactEffectiveConfig(config: EffectiveConfigStatus): EffectiveConfigStatus {

--- a/packages/pi-sequential-thinking/extensions/storage.ts
+++ b/packages/pi-sequential-thinking/extensions/storage.ts
@@ -21,6 +21,7 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   DEFAULT_HISTORY_LIMIT,
+  isRecord,
   MAX_HISTORY_LIMIT,
   MAX_IMPORT_BYTES,
   normalizeSessionId,
@@ -132,7 +133,6 @@ export interface ThinkingStatus {
     skippedInvalidNamedSessions?: number;
   };
   schemaVersion: number;
-  storageVersion: number;
 }
 
 interface StoredSession {
@@ -175,7 +175,7 @@ export class ThoughtStorage {
   // =============================================================================
 
   addThought(thought: ThoughtData, sessionId?: string | null): SessionOperationResult {
-    const session = this.resolveSession(sessionId);
+    const session = normalizeSessionId(sessionId);
     const loaded = this.loadSession(session.sessionId);
     const preCount = loaded.thoughts.length;
     const thoughts = [...loaded.thoughts, thought];
@@ -184,16 +184,12 @@ export class ThoughtStorage {
   }
 
   getAllThoughts(sessionId?: string | null): ThoughtData[] {
-    return this.getThoughts(sessionId);
-  }
-
-  getThoughts(sessionId?: string | null): ThoughtData[] {
-    const session = this.resolveSession(sessionId);
+    const session = normalizeSessionId(sessionId);
     return [...this.loadSession(session.sessionId).thoughts];
   }
 
   clearHistory(sessionId?: string | null): SessionOperationResult {
-    const session = this.resolveSession(sessionId);
+    const session = normalizeSessionId(sessionId);
     const loaded = this.loadSession(session.sessionId);
     const preCount = loaded.thoughts.length;
     const savedAt = this.saveSession(session.sessionId, []);
@@ -201,7 +197,7 @@ export class ThoughtStorage {
   }
 
   getHistory(request: HistoryRequest = {}): ThinkingHistory {
-    const session = this.resolveSession(request.sessionId);
+    const session = normalizeSessionId(request.sessionId);
     const limit = request.limit ?? DEFAULT_HISTORY_LIMIT;
     const offset = request.offset ?? 0;
     const includeFullThoughts = request.includeFullThoughts ?? true;
@@ -233,7 +229,7 @@ export class ThoughtStorage {
     if (!filePath?.trim()) {
       throw new Error("file_path is required");
     }
-    const session = this.resolveSession(sessionId);
+    const session = normalizeSessionId(sessionId);
     const thoughts = this.loadSession(session.sessionId).thoughts;
     const targetPath = this.resolveExternalPath(filePath);
     this.ensureExternalWriteTarget(targetPath);
@@ -262,10 +258,10 @@ export class ThoughtStorage {
       explicitImport: true,
     });
 
-    const explicitSession = sessionId === undefined || sessionId === null ? undefined : this.resolveSession(sessionId);
+    const explicitSession = sessionId === undefined || sessionId === null ? undefined : normalizeSessionId(sessionId);
     const embeddedSession =
-      loaded.embeddedSessionId === undefined ? undefined : this.resolveSession(loaded.embeddedSessionId);
-    const targetSession = explicitSession ?? embeddedSession ?? this.resolveSession(undefined);
+      loaded.embeddedSessionId === undefined ? undefined : normalizeSessionId(loaded.embeddedSessionId);
+    const targetSession = explicitSession ?? embeddedSession ?? normalizeSessionId(undefined);
     const warnings = [...loaded.warnings];
     if (explicitSession && embeddedSession && explicitSession.sessionId !== embeddedSession.sessionId) {
       warnings.push(
@@ -348,17 +344,12 @@ export class ThoughtStorage {
         skippedInvalidNamedSessions: skippedInvalidNamedSessions || undefined,
       },
       schemaVersion: SCHEMA_VERSION,
-      storageVersion: SCHEMA_VERSION,
     };
   }
 
   // =============================================================================
   // Session helpers
   // =============================================================================
-
-  private resolveSession(sessionId?: string | null): SessionInfo {
-    return normalizeSessionId(sessionId === null ? undefined : sessionId);
-  }
 
   private resolveSessionFile(sessionId: string | null): string {
     if (sessionId === null) {
@@ -384,7 +375,7 @@ export class ThoughtStorage {
   }
 
   private saveSession(sessionId: string | null, thoughts: ThoughtData[]): string {
-    const session = this.resolveSession(sessionId);
+    const session = normalizeSessionId(sessionId);
     const lastUpdated = new Date().toISOString();
     this.saveToFile(
       this.resolveSessionFile(session.sessionId),
@@ -394,7 +385,7 @@ export class ThoughtStorage {
   }
 
   private getSessionMetadata(sessionId: string | null): SessionStatusMetadata {
-    const session = this.resolveSession(sessionId);
+    const session = normalizeSessionId(sessionId);
     try {
       const loaded = this.loadSessionFile(this.resolveSessionFile(session.sessionId), {
         missingAsEmpty: true,
@@ -470,7 +461,7 @@ export class ThoughtStorage {
       };
     }
 
-    if (!this.isRecord(data)) {
+    if (!isRecord(data)) {
       throw new Error("Session file must be an object or legacy thought array");
     }
 
@@ -494,7 +485,7 @@ export class ThoughtStorage {
     const thoughts: ThoughtData[] = [];
     const warnings: string[] = [];
     records.forEach((record, index) => {
-      if (!this.isRecord(record)) {
+      if (!isRecord(record)) {
         throw new Error(`thoughts[${index}] must be an object`);
       }
       const normalized = normalizeThoughtRecord(record);
@@ -802,7 +793,4 @@ export class ThoughtStorage {
     }
   }
 
-  private isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null && !Array.isArray(value);
-  }
 }

--- a/packages/pi-sequential-thinking/extensions/types.ts
+++ b/packages/pi-sequential-thinking/extensions/types.ts
@@ -445,7 +445,46 @@ export function normalizeThoughtRecord(dict: Record<string, unknown>): ThoughtRe
 }
 
 export function thoughtFromDict(dict: Record<string, unknown>): ThoughtData {
-  return normalizeThoughtRecord(dict).thought;
+  const stageValue = typeof dict.stage === "string" ? parseThoughtStage(dict.stage) : ThoughtStage.ANALYSIS;
+  const thoughtNumber =
+    typeof dict.thoughtNumber === "number"
+      ? dict.thoughtNumber
+      : typeof dict.thought_number === "number"
+        ? dict.thought_number
+        : 1;
+  const totalThoughts =
+    typeof dict.totalThoughts === "number"
+      ? dict.totalThoughts
+      : typeof dict.total_thoughts === "number"
+        ? dict.total_thoughts
+        : 1;
+  const nextThoughtNeeded =
+    typeof dict.nextThoughtNeeded === "boolean"
+      ? dict.nextThoughtNeeded
+      : typeof dict.next_thought_needed === "boolean"
+        ? dict.next_thought_needed
+        : false;
+
+  return {
+    thought: typeof dict.thought === "string" ? dict.thought : "",
+    thought_number: thoughtNumber,
+    total_thoughts: totalThoughts,
+    next_thought_needed: nextThoughtNeeded,
+    stage: stageValue,
+    tags: Array.isArray(dict.tags) ? dict.tags.filter((tag): tag is string => typeof tag === "string") : [],
+    axioms_used: Array.isArray(dict.axiomsUsed)
+      ? dict.axiomsUsed.filter((axiom): axiom is string => typeof axiom === "string")
+      : Array.isArray(dict.axioms_used)
+        ? dict.axioms_used.filter((axiom): axiom is string => typeof axiom === "string")
+        : [],
+    assumptions_challenged: Array.isArray(dict.assumptionsChallenged)
+      ? dict.assumptionsChallenged.filter((assumption): assumption is string => typeof assumption === "string")
+      : Array.isArray(dict.assumptions_challenged)
+        ? dict.assumptions_challenged.filter((assumption): assumption is string => typeof assumption === "string")
+        : [],
+    timestamp: typeof dict.timestamp === "string" ? dict.timestamp : new Date().toISOString(),
+    id: typeof dict.id === "string" && dict.id.trim() ? dict.id : generateUuid(),
+  };
 }
 
 // =============================================================================

--- a/packages/pi-sequential-thinking/extensions/types.ts
+++ b/packages/pi-sequential-thinking/extensions/types.ts
@@ -163,46 +163,47 @@ function normalizeOptionalStringArray(field: string, value: unknown): { value?: 
   return { value };
 }
 
+type FieldResult<T> = { ok: true; value: T } | { ok: false; errors: ValidationError[] };
+
 function readAliasedField<T>(
   args: Record<string, unknown>,
   field: string,
   alias: string,
   normalizer: (field: string, value: unknown) => { value?: T; error?: ValidationError },
   options: { required: true } | { required: false; defaultValue: T },
-): { value?: T; errors: ValidationError[] } {
-  const errors: ValidationError[] = [];
+): FieldResult<T> {
   const hasField = hasOwn(args, field);
   const hasAlias = hasOwn(args, alias);
 
   if (!hasField && !hasAlias) {
     if (options.required) {
-      return { errors: [createError(field, `${field} is required`)] };
+      return { ok: false, errors: [createError(field, `${field} is required`)] };
     }
-    return { value: options.defaultValue, errors };
+    return { ok: true, value: options.defaultValue };
   }
 
   const normalizedField = hasField ? normalizer(field, args[field]) : undefined;
   const normalizedAlias = hasAlias ? normalizer(field, args[alias]) : undefined;
 
-  if (normalizedField?.error) {
-    errors.push(normalizedField.error);
-  }
-  if (normalizedAlias?.error) {
-    errors.push(normalizedAlias.error);
-  }
+  const errors: ValidationError[] = [];
+  if (normalizedField?.error) errors.push(normalizedField.error);
+  if (normalizedAlias?.error) errors.push(normalizedAlias.error);
   if (errors.length > 0) {
-    return { errors };
+    return { ok: false, errors };
   }
 
   if (hasField && hasAlias) {
     if (!valuesEqual(normalizedField?.value, normalizedAlias?.value)) {
-      errors.push(createError(field, `Conflicting aliases for ${field}`));
-      return { errors };
+      return { ok: false, errors: [createError(field, `Conflicting aliases for ${field}`)] };
     }
-    return { value: normalizedField?.value, errors };
+    return { ok: true, value: normalizedField?.value as T };
   }
 
-  return { value: hasField ? normalizedField?.value : normalizedAlias?.value, errors };
+  return { ok: true, value: (hasField ? normalizedField?.value : normalizedAlias?.value) as T };
+}
+
+function pushErrors(target: ValidationError[], result: FieldResult<unknown>): void {
+  if (!result.ok) target.push(...result.errors);
 }
 
 export function normalizeSessionId(value: unknown): SessionInfo {
@@ -278,12 +279,12 @@ export function normalizeThoughtInput(
   const thoughtNumberResult = readAliasedField(args, "thought_number", "thoughtNumber", normalizeRequiredInteger, {
     required: true,
   });
-  errors.push(...thoughtNumberResult.errors);
+  pushErrors(errors, thoughtNumberResult);
 
   const totalThoughtsResult = readAliasedField(args, "total_thoughts", "totalThoughts", normalizeRequiredInteger, {
     required: true,
   });
-  errors.push(...totalThoughtsResult.errors);
+  pushErrors(errors, totalThoughtsResult);
 
   const nextThoughtNeededResult = readAliasedField(
     args,
@@ -292,7 +293,7 @@ export function normalizeThoughtInput(
     normalizeRequiredBoolean,
     { required: true },
   );
-  errors.push(...nextThoughtNeededResult.errors);
+  pushErrors(errors, nextThoughtNeededResult);
 
   let stage: ThoughtStage | undefined;
   if (typeof args.stage !== "string") {
@@ -313,7 +314,7 @@ export function normalizeThoughtInput(
     required: false,
     defaultValue: [],
   });
-  errors.push(...axiomsResult.errors);
+  pushErrors(errors, axiomsResult);
 
   const assumptionsResult = readAliasedField(
     args,
@@ -322,7 +323,7 @@ export function normalizeThoughtInput(
     normalizeOptionalStringArray,
     { required: false, defaultValue: [] },
   );
-  errors.push(...assumptionsResult.errors);
+  pushErrors(errors, assumptionsResult);
 
   const sessionResult = readSession(args);
   errors.push(...sessionResult.errors);
@@ -331,8 +332,22 @@ export function normalizeThoughtInput(
     throw new ThoughtValidationError(errors);
   }
 
-  const thoughtNumber = thoughtNumberResult.value as number;
-  const originalTotalThoughts = totalThoughtsResult.value as number;
+  // Past the error gate, all field results must be ok. Narrow them explicitly
+  // so we do not rely on unchecked `as` casts.
+  if (
+    !thoughtResult.value ||
+    !thoughtNumberResult.ok ||
+    !totalThoughtsResult.ok ||
+    !nextThoughtNeededResult.ok ||
+    !axiomsResult.ok ||
+    !assumptionsResult.ok ||
+    stage === undefined
+  ) {
+    throw new ThoughtValidationError([createError("input", "internal invariant violation after validation gate")]);
+  }
+
+  const thoughtNumber = thoughtNumberResult.value;
+  const originalTotalThoughts = totalThoughtsResult.value;
   const totalThoughts = Math.max(originalTotalThoughts, thoughtNumber);
   const adjustments: ThoughtInputAdjustments = {};
   if (totalThoughts !== originalTotalThoughts) {
@@ -341,14 +356,14 @@ export function normalizeThoughtInput(
 
   return {
     thought: {
-      thought: thoughtResult.value as string,
+      thought: thoughtResult.value,
       thought_number: thoughtNumber,
       total_thoughts: totalThoughts,
-      next_thought_needed: nextThoughtNeededResult.value as boolean,
-      stage: stage as ThoughtStage,
+      next_thought_needed: nextThoughtNeededResult.value,
+      stage,
       tags: tagsResult.value ?? [],
-      axioms_used: axiomsResult.value ?? [],
-      assumptions_challenged: assumptionsResult.value ?? [],
+      axioms_used: axiomsResult.value,
+      assumptions_challenged: assumptionsResult.value,
       timestamp: options.timestamp ?? new Date().toISOString(),
       id: options.id ?? generateUuid(),
     },

--- a/packages/pi-sequential-thinking/extensions/types.ts
+++ b/packages/pi-sequential-thinking/extensions/types.ts
@@ -109,7 +109,7 @@ function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
@@ -442,49 +442,6 @@ export function normalizeThoughtRecord(dict: Record<string, unknown>): ThoughtRe
   });
 
   return { thought: normalized.thought, warnings };
-}
-
-export function thoughtFromDict(dict: Record<string, unknown>): ThoughtData {
-  const stageValue = typeof dict.stage === "string" ? parseThoughtStage(dict.stage) : ThoughtStage.ANALYSIS;
-  const thoughtNumber =
-    typeof dict.thoughtNumber === "number"
-      ? dict.thoughtNumber
-      : typeof dict.thought_number === "number"
-        ? dict.thought_number
-        : 1;
-  const totalThoughts =
-    typeof dict.totalThoughts === "number"
-      ? dict.totalThoughts
-      : typeof dict.total_thoughts === "number"
-        ? dict.total_thoughts
-        : 1;
-  const nextThoughtNeeded =
-    typeof dict.nextThoughtNeeded === "boolean"
-      ? dict.nextThoughtNeeded
-      : typeof dict.next_thought_needed === "boolean"
-        ? dict.next_thought_needed
-        : false;
-
-  return {
-    thought: typeof dict.thought === "string" ? dict.thought : "",
-    thought_number: thoughtNumber,
-    total_thoughts: totalThoughts,
-    next_thought_needed: nextThoughtNeeded,
-    stage: stageValue,
-    tags: Array.isArray(dict.tags) ? dict.tags.filter((tag): tag is string => typeof tag === "string") : [],
-    axioms_used: Array.isArray(dict.axiomsUsed)
-      ? dict.axiomsUsed.filter((axiom): axiom is string => typeof axiom === "string")
-      : Array.isArray(dict.axioms_used)
-        ? dict.axioms_used.filter((axiom): axiom is string => typeof axiom === "string")
-        : [],
-    assumptions_challenged: Array.isArray(dict.assumptionsChallenged)
-      ? dict.assumptionsChallenged.filter((assumption): assumption is string => typeof assumption === "string")
-      : Array.isArray(dict.assumptions_challenged)
-        ? dict.assumptions_challenged.filter((assumption): assumption is string => typeof assumption === "string")
-        : [],
-    timestamp: typeof dict.timestamp === "string" ? dict.timestamp : new Date().toISOString(),
-    id: typeof dict.id === "string" && dict.id.trim() ? dict.id : generateUuid(),
-  };
 }
 
 // =============================================================================

--- a/packages/pi-sequential-thinking/extensions/types.ts
+++ b/packages/pi-sequential-thinking/extensions/types.ts
@@ -13,6 +13,7 @@ export const STATUS_ENUMERATION_SESSION_THRESHOLD = 100;
 export const DEFAULT_HISTORY_LIMIT = 20;
 export const MAX_HISTORY_LIMIT = 100;
 const MAX_SESSION_ID_LENGTH = 80;
+const MAX_THOUGHT_COUNT = 1000;
 
 // =============================================================================
 // ThoughtStage Enum
@@ -135,6 +136,11 @@ function normalizeRequiredString(field: string, value: unknown): { value?: strin
 
 function normalizeRequiredInteger(field: string, value: unknown): { value?: number; error?: ValidationError } {
   if (isPositiveInteger(value)) {
+    if ((field === "thought_number" || field === "total_thoughts") && value > MAX_THOUGHT_COUNT) {
+      return {
+        error: createError(field, `${field} must be ${MAX_THOUGHT_COUNT} or fewer (received ${value})`),
+      };
+    }
     return { value };
   }
   const message =

--- a/packages/pi-sequential-thinking/extensions/types.ts
+++ b/packages/pi-sequential-thinking/extensions/types.ts
@@ -1,6 +1,18 @@
 /**
- * Types for Sequential Thinking extension
+ * Types and normalization helpers for Sequential Thinking extension
  */
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const DEFAULT_SESSION_LABEL = "default";
+export const SCHEMA_VERSION = 1;
+export const MAX_IMPORT_BYTES = 10 * 1024 * 1024;
+export const STATUS_ENUMERATION_SESSION_THRESHOLD = 100;
+export const DEFAULT_HISTORY_LIMIT = 20;
+export const MAX_HISTORY_LIMIT = 100;
+const MAX_SESSION_ID_LENGTH = 80;
 
 // =============================================================================
 // ThoughtStage Enum
@@ -44,6 +56,31 @@ export interface ThoughtData {
   id: string;
 }
 
+export interface SessionInfo {
+  sessionId: string | null;
+  sessionLabel: string;
+}
+
+export interface TotalThoughtsAdjustment {
+  from: number;
+  to: number;
+}
+
+export interface ThoughtInputAdjustments {
+  totalThoughtsAdjusted?: TotalThoughtsAdjustment;
+}
+
+export interface NormalizedThoughtInput {
+  thought: ThoughtData;
+  session: SessionInfo;
+  adjustments: ThoughtInputAdjustments;
+}
+
+export interface NormalizeThoughtOptions {
+  id?: string;
+  timestamp?: string;
+}
+
 // =============================================================================
 // Validation
 // =============================================================================
@@ -53,29 +90,300 @@ export interface ValidationError {
   message: string;
 }
 
+function createError(field: string, message: string): ValidationError {
+  return { field, message };
+}
+
+export class ThoughtValidationError extends Error {
+  readonly errors: ValidationError[];
+
+  constructor(errors: ValidationError[]) {
+    super(errors.map((error) => `${error.field}: ${error.message}`).join("; "));
+    this.name = "ThoughtValidationError";
+    this.errors = errors;
+    Object.setPrototypeOf(this, ThoughtValidationError.prototype);
+  }
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(record, key);
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function normalizeRequiredString(field: string, value: unknown): { value?: string; error?: ValidationError } {
+  if (typeof value !== "string") {
+    return { error: createError(field, `${field} must be a string`) };
+  }
+  if (!value.trim()) {
+    return {
+      error: createError(field, field === "thought" ? "Thought content cannot be empty" : `${field} cannot be empty`),
+    };
+  }
+  return { value };
+}
+
+function normalizeRequiredInteger(field: string, value: unknown): { value?: number; error?: ValidationError } {
+  if (isPositiveInteger(value)) {
+    return { value };
+  }
+  const message =
+    field === "thought_number"
+      ? "Thought number must be a positive integer"
+      : field === "total_thoughts"
+        ? "Total thoughts must be a positive integer"
+        : `${field} must be a positive integer`;
+  return { error: createError(field, message) };
+}
+
+function normalizeRequiredBoolean(field: string, value: unknown): { value?: boolean; error?: ValidationError } {
+  if (typeof value === "boolean") {
+    return { value };
+  }
+  return { error: createError(field, `${field} must be a boolean`) };
+}
+
+function normalizeOptionalStringArray(field: string, value: unknown): { value?: string[]; error?: ValidationError } {
+  if (value === undefined) {
+    return { value: [] };
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return { error: createError(field, `${field} must be an array of strings`) };
+  }
+  return { value };
+}
+
+function readAliasedField<T>(
+  args: Record<string, unknown>,
+  field: string,
+  alias: string,
+  normalizer: (field: string, value: unknown) => { value?: T; error?: ValidationError },
+  options: { required: true } | { required: false; defaultValue: T },
+): { value?: T; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+  const hasField = hasOwn(args, field);
+  const hasAlias = hasOwn(args, alias);
+
+  if (!hasField && !hasAlias) {
+    if (options.required) {
+      return { errors: [createError(field, `${field} is required`)] };
+    }
+    return { value: options.defaultValue, errors };
+  }
+
+  const normalizedField = hasField ? normalizer(field, args[field]) : undefined;
+  const normalizedAlias = hasAlias ? normalizer(field, args[alias]) : undefined;
+
+  if (normalizedField?.error) {
+    errors.push(normalizedField.error);
+  }
+  if (normalizedAlias?.error) {
+    errors.push(normalizedAlias.error);
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+
+  if (hasField && hasAlias) {
+    if (!valuesEqual(normalizedField?.value, normalizedAlias?.value)) {
+      errors.push(createError(field, `Conflicting aliases for ${field}`));
+      return { errors };
+    }
+    return { value: normalizedField?.value, errors };
+  }
+
+  return { value: hasField ? normalizedField?.value : normalizedAlias?.value, errors };
+}
+
+export function normalizeSessionId(value: unknown): SessionInfo {
+  if (value === undefined || value === null) {
+    return { sessionId: null, sessionLabel: DEFAULT_SESSION_LABEL };
+  }
+  if (typeof value !== "string") {
+    throw new ThoughtValidationError([createError("session_id", "session_id must be a string")]);
+  }
+
+  const sessionId = value.trim();
+  const errors: ValidationError[] = [];
+  if (!sessionId) {
+    errors.push(createError("session_id", "session_id cannot be empty"));
+  }
+  if (sessionId.length > MAX_SESSION_ID_LENGTH) {
+    errors.push(createError("session_id", `session_id must be ${MAX_SESSION_ID_LENGTH} characters or fewer`));
+  }
+  if (sessionId.toLowerCase() === DEFAULT_SESSION_LABEL) {
+    errors.push(createError("session_id", "session_id 'default' is reserved"));
+  }
+  if (sessionId === "." || sessionId === ".." || !/^[A-Za-z0-9._-]+$/.test(sessionId)) {
+    errors.push(createError("session_id", "session_id may contain only letters, numbers, dot, underscore, and hyphen"));
+  }
+
+  if (errors.length > 0) {
+    throw new ThoughtValidationError(errors);
+  }
+
+  return { sessionId, sessionLabel: sessionId };
+}
+
+function readSession(args: Record<string, unknown>): { session?: SessionInfo; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+  const hasSnake = hasOwn(args, "session_id");
+  const hasCamel = hasOwn(args, "sessionId");
+
+  if (!hasSnake && !hasCamel) {
+    return { session: normalizeSessionId(undefined), errors };
+  }
+
+  try {
+    const snakeSession = hasSnake ? normalizeSessionId(args.session_id) : undefined;
+    const camelSession = hasCamel ? normalizeSessionId(args.sessionId) : undefined;
+
+    if (snakeSession && camelSession && !valuesEqual(snakeSession, camelSession)) {
+      errors.push(createError("session_id", "Conflicting aliases for session_id"));
+      return { errors };
+    }
+
+    return { session: snakeSession ?? camelSession, errors };
+  } catch (error) {
+    if (error instanceof ThoughtValidationError) {
+      return { errors: error.errors };
+    }
+    throw error;
+  }
+}
+
+export function normalizeThoughtInput(
+  args: Record<string, unknown>,
+  options: NormalizeThoughtOptions = {},
+): NormalizedThoughtInput {
+  if (!isRecord(args)) {
+    throw new ThoughtValidationError([createError("input", "input must be an object")]);
+  }
+
+  const errors: ValidationError[] = [];
+
+  const thoughtResult = normalizeRequiredString("thought", args.thought);
+  if (thoughtResult.error) errors.push(thoughtResult.error);
+
+  const thoughtNumberResult = readAliasedField(args, "thought_number", "thoughtNumber", normalizeRequiredInteger, {
+    required: true,
+  });
+  errors.push(...thoughtNumberResult.errors);
+
+  const totalThoughtsResult = readAliasedField(args, "total_thoughts", "totalThoughts", normalizeRequiredInteger, {
+    required: true,
+  });
+  errors.push(...totalThoughtsResult.errors);
+
+  const nextThoughtNeededResult = readAliasedField(
+    args,
+    "next_thought_needed",
+    "nextThoughtNeeded",
+    normalizeRequiredBoolean,
+    { required: true },
+  );
+  errors.push(...nextThoughtNeededResult.errors);
+
+  let stage: ThoughtStage | undefined;
+  if (typeof args.stage !== "string") {
+    errors.push(createError("stage", "stage must be a string"));
+  } else {
+    try {
+      stage = parseThoughtStage(args.stage);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(createError("stage", message));
+    }
+  }
+
+  const tagsResult = normalizeOptionalStringArray("tags", args.tags);
+  if (tagsResult.error) errors.push(tagsResult.error);
+
+  const axiomsResult = readAliasedField(args, "axioms_used", "axiomsUsed", normalizeOptionalStringArray, {
+    required: false,
+    defaultValue: [],
+  });
+  errors.push(...axiomsResult.errors);
+
+  const assumptionsResult = readAliasedField(
+    args,
+    "assumptions_challenged",
+    "assumptionsChallenged",
+    normalizeOptionalStringArray,
+    { required: false, defaultValue: [] },
+  );
+  errors.push(...assumptionsResult.errors);
+
+  const sessionResult = readSession(args);
+  errors.push(...sessionResult.errors);
+
+  if (errors.length > 0) {
+    throw new ThoughtValidationError(errors);
+  }
+
+  const thoughtNumber = thoughtNumberResult.value as number;
+  const originalTotalThoughts = totalThoughtsResult.value as number;
+  const totalThoughts = Math.max(originalTotalThoughts, thoughtNumber);
+  const adjustments: ThoughtInputAdjustments = {};
+  if (totalThoughts !== originalTotalThoughts) {
+    adjustments.totalThoughtsAdjusted = { from: originalTotalThoughts, to: totalThoughts };
+  }
+
+  return {
+    thought: {
+      thought: thoughtResult.value as string,
+      thought_number: thoughtNumber,
+      total_thoughts: totalThoughts,
+      next_thought_needed: nextThoughtNeededResult.value as boolean,
+      stage: stage as ThoughtStage,
+      tags: tagsResult.value ?? [],
+      axioms_used: axiomsResult.value ?? [],
+      assumptions_challenged: assumptionsResult.value ?? [],
+      timestamp: options.timestamp ?? new Date().toISOString(),
+      id: options.id ?? generateUuid(),
+    },
+    session: sessionResult.session ?? normalizeSessionId(undefined),
+    adjustments,
+  };
+}
+
 export function validateThoughtData(data: Partial<ThoughtData>): ValidationError[] {
   const errors: ValidationError[] = [];
 
-  // thought: non-empty
   if (!data.thought?.trim()) {
     errors.push({ field: "thought", message: "Thought content cannot be empty" });
   }
 
-  // thought_number: positive integer
-  if (data.thought_number === undefined || data.thought_number < 1) {
-    errors.push({
-      field: "thought_number",
-      message: "Thought number must be a positive integer",
-    });
+  if (data.thought_number === undefined || !isPositiveInteger(data.thought_number)) {
+    errors.push({ field: "thought_number", message: "Thought number must be a positive integer" });
   }
 
-  // total_thoughts: >= thought_number
-  if (data.total_thoughts !== undefined && data.thought_number !== undefined) {
-    if (data.total_thoughts < data.thought_number) {
-      errors.push({
-        field: "total_thoughts",
-        message: "Total thoughts must be greater or equal to current thought number",
-      });
+  if (data.total_thoughts === undefined || !isPositiveInteger(data.total_thoughts)) {
+    errors.push({ field: "total_thoughts", message: "Total thoughts must be a positive integer" });
+  }
+
+  if (data.next_thought_needed !== undefined && typeof data.next_thought_needed !== "boolean") {
+    errors.push({ field: "next_thought_needed", message: "next_thought_needed must be a boolean" });
+  }
+
+  if (data.stage !== undefined && !THOUGHT_STAGE_VALUES.includes(data.stage)) {
+    errors.push({ field: "stage", message: "stage must be a valid ThoughtStage" });
+  }
+
+  for (const field of ["tags", "axioms_used", "assumptions_challenged"] as const) {
+    const value = data[field];
+    if (value !== undefined && (!Array.isArray(value) || value.some((item) => typeof item !== "string"))) {
+      errors.push({ field, message: `${field} must be an array of strings` });
     }
   }
 
@@ -114,31 +422,30 @@ export function thoughtToDict(data: ThoughtData, includeId = false): Record<stri
   return result;
 }
 
+export interface ThoughtRecordNormalizationResult {
+  thought: ThoughtData;
+  warnings: string[];
+}
+
+export function normalizeThoughtRecord(dict: Record<string, unknown>): ThoughtRecordNormalizationResult {
+  const warnings: string[] = [];
+  if (typeof dict.id !== "string" || !dict.id.trim()) {
+    warnings.push("Imported thought missing id; generated a new id.");
+  }
+  if (typeof dict.timestamp !== "string" || !dict.timestamp.trim()) {
+    warnings.push("Imported thought missing timestamp; generated an import-time timestamp.");
+  }
+
+  const normalized = normalizeThoughtInput(dict, {
+    id: typeof dict.id === "string" && dict.id.trim() ? dict.id : generateUuid(),
+    timestamp: typeof dict.timestamp === "string" && dict.timestamp.trim() ? dict.timestamp : new Date().toISOString(),
+  });
+
+  return { thought: normalized.thought, warnings };
+}
+
 export function thoughtFromDict(dict: Record<string, unknown>): ThoughtData {
-  const stageValue = typeof dict.stage === "string" ? parseThoughtStage(dict.stage) : ThoughtStage.ANALYSIS;
-
-  const id = typeof dict.id === "string" ? dict.id : generateUuid();
-
-  return {
-    thought: typeof dict.thought === "string" ? dict.thought : "",
-    thought_number: typeof dict.thoughtNumber === "number" ? dict.thoughtNumber : 1,
-    total_thoughts: typeof dict.totalThoughts === "number" ? dict.totalThoughts : 1,
-    next_thought_needed: typeof dict.nextThoughtNeeded === "boolean" ? dict.nextThoughtNeeded : false,
-    stage: stageValue,
-    tags: Array.isArray(dict.tags) ? dict.tags.filter((t): t is string => typeof t === "string") : [],
-    axioms_used: Array.isArray(dict.axiomsUsed)
-      ? dict.axiomsUsed.filter((a): a is string => typeof a === "string")
-      : Array.isArray(dict.axioms_used)
-        ? dict.axioms_used.filter((a): a is string => typeof a === "string")
-        : [],
-    assumptions_challenged: Array.isArray(dict.assumptionsChallenged)
-      ? dict.assumptionsChallenged.filter((a): a is string => typeof a === "string")
-      : Array.isArray(dict.assumptions_challenged)
-        ? dict.assumptions_challenged.filter((a): a is string => typeof a === "string")
-        : [],
-    timestamp: typeof dict.timestamp === "string" ? dict.timestamp : new Date().toISOString(),
-    id,
-  };
+  return normalizeThoughtRecord(dict).thought;
 }
 
 // =============================================================================

--- a/packages/pi-sequential-thinking/package.json
+++ b/packages/pi-sequential-thinking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-sequential-thinking",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Sequential Thinking MCP extension for pi — structured progressive thinking through defined stages",
   "keywords": [
     "pi",

--- a/packages/pi-sequential-thinking/package.json
+++ b/packages/pi-sequential-thinking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-sequential-thinking",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Sequential Thinking MCP extension for pi — structured progressive thinking through defined stages",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

`pi-sequential-thinking` now keeps reasoning state reusable and inspectable across default and named sessions instead of treating all structured thinking as one global history. Agents can record thoughts with snake_case or camelCase inputs, grow the planned depth dynamically, read bounded history, and inspect content-free storage/status diagnostics.

The implementation preserves the default `current_session.json` path and legacy import shapes while adding V1 guardrails for local plaintext state, path-safe session IDs, import size, status enumeration, oversized history reads, and corrupt session files.

## What changed

| Area | End state |
| --- | --- |
| Input boundary | `process_thought` accepts snake_case and camelCase aliases, detects alias conflicts, adjusts `total_thoughts` upward when needed, and keeps `thoughtFromDict` permissive for legacy partial records. |
| Session storage | The default session still uses `current_session.json`; named sessions live under `sessions/<session_id>.json` with path-safe IDs and no migration step for existing default state. |
| History and status | `get_thinking_history` exposes bounded reads with snippets/full text options and a V1 file-size guard; `get_thinking_status` reports content-free diagnostics, bounded partial status, invalid session filenames, corrupt sessions, backup files, and config source labels. |
| Existing tools | `generate_summary`, `clear_history`, `export_session`, `import_session`, and compatibility `sequential_think` now operate on the selected session. |
| Import/export | New exports include schema/session metadata, legacy arrays and `{ thoughts: [...] }` still import, explicit import targets win over embedded metadata, and path/size safeguards reject unsafe inputs. |
| Auditability | Mutating tools return receipts with pre/post counts, session metadata, timestamps, warnings, and non-content state fingerprints. |
| Documentation | The PRD, implementation plan, ideation notes, and README document the state-foundation scope, trust boundary, storage posture, and deferred concurrency assumptions. |

## Design notes

- The extension stays native to pi and does not add MCP transport/server dependencies.
- Status and receipts intentionally avoid thought text, tags, axioms, assumptions, and content-derived hashes. History, summary, import/export, and `sequential_think` remain content-bearing tools.
- V1 targets one active pi process per storage directory. Cross-process locking and true storage-level history paging remain future design work.
- Status is designed to degrade rather than fail closed: very large session/backup sets can return partial metadata, and corrupt named-session files are reported without being moved by a read-only diagnostic.

## Test plan

- `npm run check`
- `npm run test`
- `specdocs_validate`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
