### PR TITLE
feat(pi-code-reasoning): expose BridgeKit MCP tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,6 +1219,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@feniix/bridgekit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.4.0.tgz",
+      "integrity": "sha512-T+tj3zyATSPGStgUG3/MKl4oI3H0MkhI/zJpiMx13mHMarSoKy+czpYy0bcu5IW8VshtOqzPfuc0GQw8nfABDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "typebox": "^1.1.31"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@feniix/pi-code-reasoning": {
       "resolved": "packages/pi-code-reasoning",
       "link": true
@@ -7304,10 +7317,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.31.tgz",
-      "integrity": "sha512-bFTa/YRd11e9a+C+hBlUSmD3DnDRnkcHqaUWX4zoq3q4u5WLnuLPc7yLpO5dRO7Z9VPXcm/GzFkvrH5FkDobeg==",
-      "devOptional": true,
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -7895,19 +7907,22 @@
       "name": "@feniix/pi-code-reasoning",
       "version": "3.0.1",
       "license": "MIT",
+      "dependencies": {
+        "@feniix/bridgekit": "^0.4.0",
+        "typebox": "^1.1.31"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "typebox": "*"
+        "@earendil-works/pi-coding-agent": "*"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-ai": {
           "optional": true
         },
         "@earendil-works/pi-coding-agent": {
-          "optional": true
-        },
-        "typebox": {
           "optional": true
         }
       }
@@ -8009,7 +8024,7 @@
     },
     "packages/pi-sequential-thinking": {
       "name": "@feniix/pi-sequential-thinking",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7905,7 +7905,7 @@
     },
     "packages/pi-code-reasoning": {
       "name": "@feniix/pi-code-reasoning",
-      "version": "3.0.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@feniix/bridgekit": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7912,7 +7912,7 @@
         "typebox": "^1.1.31"
       },
       "bin": {
-        "pi-code-reasoning-mcp": "dist/extensions/mcp-server.js"
+        "pi-code-reasoning": "dist/extensions/mcp-server.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7911,6 +7911,9 @@
         "@feniix/bridgekit": "^0.4.0",
         "typebox": "^1.1.31"
       },
+      "bin": {
+        "pi-code-reasoning-mcp": "dist/extensions/mcp-server.js"
+      },
       "engines": {
         "node": ">=22.19.0"
       },

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -29,7 +29,7 @@ pi -e npm:@feniix/pi-code-reasoning
 Run the stdio MCP server with `npx`:
 
 ```bash
-npx -y --package @feniix/pi-code-reasoning pi-code-reasoning-mcp
+npx -y @feniix/pi-code-reasoning
 ```
 
 Example MCP client configuration:
@@ -39,7 +39,7 @@ Example MCP client configuration:
   "mcpServers": {
     "code-reasoning": {
       "command": "npx",
-      "args": ["-y", "--package", "@feniix/pi-code-reasoning", "pi-code-reasoning-mcp"]
+      "args": ["-y", "@feniix/pi-code-reasoning"]
     }
   }
 }

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -63,10 +63,11 @@ The shared portable tool definitions are available from `@feniix/pi-code-reasoni
 
 | Entry point | Purpose |
 |-------------|---------|
-| `@feniix/pi-code-reasoning` | pi extension source entrypoint |
 | `@feniix/pi-code-reasoning/mcp` | compiled MCP server helpers |
 | `@feniix/pi-code-reasoning/tools` | compiled BridgeKit portable tools |
-| `@feniix/pi-code-reasoning/extensions/*` | compatibility deep imports for extension internals |
+| `@feniix/pi-code-reasoning/extensions/*` | compiled compatibility deep imports for extension internals |
+
+The pi extension entrypoint remains source-loaded through the package `pi.extensions` metadata.
 
 ## Tools
 

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -26,7 +26,26 @@ pi -e npm:@feniix/pi-code-reasoning
 
 ## MCP usage
 
-Use the MCP adapter entrypoint when wiring the same tools into an MCP host:
+Run the stdio MCP server with `npx`:
+
+```bash
+npx -y --package @feniix/pi-code-reasoning pi-code-reasoning-mcp
+```
+
+Example MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "code-reasoning": {
+      "command": "npx",
+      "args": ["-y", "--package", "@feniix/pi-code-reasoning", "pi-code-reasoning-mcp"]
+    }
+  }
+}
+```
+
+Use the MCP adapter entrypoint when wiring the same tools into a custom host:
 
 ```ts
 import { createMcpServerOptions, runServer } from "@feniix/pi-code-reasoning/mcp";
@@ -39,6 +58,15 @@ await runServer();
 ```
 
 The shared portable tool definitions are available from `@feniix/pi-code-reasoning/tools` for advanced adapters.
+
+### Package entrypoints
+
+| Entry point | Purpose |
+|-------------|---------|
+| `@feniix/pi-code-reasoning` | pi extension source entrypoint |
+| `@feniix/pi-code-reasoning/mcp` | compiled MCP server helpers |
+| `@feniix/pi-code-reasoning/tools` | compiled BridgeKit portable tools |
+| `@feniix/pi-code-reasoning/extensions/*` | compatibility deep imports for extension internals |
 
 ## Tools
 
@@ -57,10 +85,19 @@ Record and process a thought with metadata.
 | `branch_from_thought` | integer | no | When exploring alternatives (🌿) |
 | `branch_id` | string | no | Identifier for the branch |
 | `needs_more_thoughts` | boolean | no | If more thoughts needed |
+| `piMaxBytes` | integer | no | Per-call output byte limit, clamped by configured max |
+| `piMaxLines` | integer | no | Per-call output line limit, clamped by configured max |
 
 ### `code_reasoning_status`
 
 Get current session status: branches and thought count.
+
+Optional parameters:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `piMaxBytes` | integer | no | Per-call output byte limit, clamped by configured max |
+| `piMaxLines` | integer | no | Per-call output line limit, clamped by configured max |
 
 ### `code_reasoning_reset`
 
@@ -112,6 +149,13 @@ Reset the session, clearing all thoughts and branches.
 3. Scope changed? → Adjust **total_thoughts**
 4. Done? → Set **next_thought_needed = false**
 
+## Limits
+
+- Thought text is limited to 20,000 characters.
+- A session keeps at most 20 thoughts before reset.
+- Output limit values must be positive integers.
+- When output is truncated, the full output is saved to a temp file when possible. If the temp file cannot be written, the tool output includes a warning instead.
+
 ## Configuration
 
 ### CLI Flags
@@ -124,9 +168,12 @@ pi --code-reasoning-max-bytes=102400 --code-reasoning-max-lines=5000
 
 ### Environment Variables
 
+Environment variables apply to both pi and MCP runtimes:
+
 ```bash
 export CODE_REASONING_MAX_BYTES=102400
 export CODE_REASONING_MAX_LINES=5000
+export CODE_REASONING_CONFIG_FILE=/path/to/code-reasoning.json
 ```
 
 ### Settings File
@@ -159,6 +206,20 @@ Under the `pi-code-reasoning` key:
 | `--code-reasoning-config` | `CODE_REASONING_CONFIG` | — | Deprecated alias for the config file path |
 | `--code-reasoning-max-bytes` | `CODE_REASONING_MAX_BYTES` | `51200` | Max output bytes |
 | `--code-reasoning-max-lines` | `CODE_REASONING_MAX_LINES` | `2000` | Max output lines |
+
+## Development
+
+Build the compiled MCP entrypoint locally:
+
+```bash
+npm run build:mcp --workspace packages/pi-code-reasoning
+```
+
+Run the built stdio server directly:
+
+```bash
+node packages/pi-code-reasoning/dist/extensions/mcp-server.js
+```
 
 ## Requirements
 

--- a/packages/pi-code-reasoning/README.md
+++ b/packages/pi-code-reasoning/README.md
@@ -1,8 +1,8 @@
 # @feniix/pi-code-reasoning
 
-[Code Reasoning](https://github.com/mettamatt/code-reasoning) extension for [pi](https://pi.dev/) — reflective problem-solving through sequential thinking with branching and revision support.
+[Code Reasoning](https://github.com/mettamatt/code-reasoning) tools for [pi](https://pi.dev/) and MCP — reflective problem-solving through sequential thinking with branching and revision support.
 
-Based on the MCP server by Matt Westgate, this native TypeScript extension provides structured thinking tools without external dependencies.
+Based on the MCP server by Matt Westgate, this package defines its tools once with [BridgeKit](https://www.npmjs.com/package/@feniix/bridgekit) and exposes the same implementation through both pi and MCP adapters.
 
 ## Features
 
@@ -23,6 +23,22 @@ Ephemeral (one-off) use:
 ```bash
 pi -e npm:@feniix/pi-code-reasoning
 ```
+
+## MCP usage
+
+Use the MCP adapter entrypoint when wiring the same tools into an MCP host:
+
+```ts
+import { createMcpServerOptions, runServer } from "@feniix/pi-code-reasoning/mcp";
+
+// For tests or custom hosts:
+const options = createMcpServerOptions();
+
+// For a stdio MCP server entrypoint:
+await runServer();
+```
+
+The shared portable tool definitions are available from `@feniix/pi-code-reasoning/tools` for advanced adapters.
 
 ## Tools
 
@@ -100,6 +116,8 @@ Reset the session, clearing all thoughts and branches.
 
 ### CLI Flags
 
+CLI flags apply when running as a pi extension:
+
 ```bash
 pi --code-reasoning-max-bytes=102400 --code-reasoning-max-lines=5000
 ```
@@ -144,7 +162,8 @@ Under the `pi-code-reasoning` key:
 
 ## Requirements
 
-- pi v0.51.0 or later
+- Node.js 22.19.0 or later
+- pi v0.51.0 or later when using the pi extension
 
 ## License
 

--- a/packages/pi-code-reasoning/__tests__/config.test.ts
+++ b/packages/pi-code-reasoning/__tests__/config.test.ts
@@ -1,0 +1,204 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../extensions/config.js";
+
+const originalHome = process.env.HOME;
+const originalConfigFile = process.env.CODE_REASONING_CONFIG_FILE;
+const originalLegacyConfig = process.env.CODE_REASONING_CONFIG;
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "pi-code-reasoning-config-"));
+  tempDirs.push(path);
+  return path;
+}
+
+function clearConfigEnv(): void {
+  delete process.env.CODE_REASONING_CONFIG_FILE;
+  delete process.env.CODE_REASONING_CONFIG;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  if (originalConfigFile === undefined) {
+    delete process.env.CODE_REASONING_CONFIG_FILE;
+  } else {
+    process.env.CODE_REASONING_CONFIG_FILE = originalConfigFile;
+  }
+  if (originalLegacyConfig === undefined) {
+    delete process.env.CODE_REASONING_CONFIG;
+  } else {
+    process.env.CODE_REASONING_CONFIG = originalLegacyConfig;
+  }
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("loadConfig", () => {
+  it("returns null for a missing explicit config file", () => {
+    const dir = makeTempDir();
+
+    expect(loadConfig(join(dir, "missing.json"))).toBeNull();
+  });
+
+  it("warns and returns null for malformed explicit config JSON", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dir = makeTempDir();
+    const path = join(dir, "config.json");
+    writeFileSync(path, "{", "utf-8");
+
+    expect(loadConfig(path)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Failed to parse config"));
+  });
+
+  it("warns and returns null for invalid explicit config shape", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dir = makeTempDir();
+    const path = join(dir, "config.json");
+    writeFileSync(path, JSON.stringify("invalid"), "utf-8");
+
+    expect(loadConfig(path)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Invalid Code Reasoning config"));
+  });
+
+  it("loads an explicit config file and normalizes numeric strings", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "config.json");
+    writeFileSync(path, JSON.stringify({ maxBytes: "1024", maxLines: "50" }), "utf-8");
+
+    expect(loadConfig(path)).toEqual({ maxBytes: 1024, maxLines: 50 });
+  });
+
+  it("loads CODE_REASONING_CONFIG_FILE when no explicit path is passed", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "env-config.json");
+    writeFileSync(path, JSON.stringify({ maxBytes: 2048, maxLines: 75 }), "utf-8");
+    process.env.CODE_REASONING_CONFIG_FILE = path;
+    delete process.env.CODE_REASONING_CONFIG;
+
+    expect(loadConfig(undefined)).toEqual({ maxBytes: 2048, maxLines: 75 });
+  });
+
+  it("loads deprecated CODE_REASONING_CONFIG and warns", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const dir = makeTempDir();
+    const path = join(dir, "legacy-env-config.json");
+    writeFileSync(path, JSON.stringify({ maxBytes: 4096 }), "utf-8");
+    delete process.env.CODE_REASONING_CONFIG_FILE;
+    process.env.CODE_REASONING_CONFIG = path;
+
+    expect(loadConfig(undefined)).toEqual({ maxBytes: 4096, maxLines: undefined });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("CODE_REASONING_CONFIG is deprecated"));
+  });
+
+  it("returns null when no config sources exist", () => {
+    const home = makeTempDir();
+    const project = makeTempDir();
+    clearConfigEnv();
+    process.env.HOME = home;
+    vi.spyOn(process, "cwd").mockReturnValue(project);
+
+    expect(loadConfig(undefined)).toBeNull();
+  });
+
+  it("ignores settings files without object config", () => {
+    const home = makeTempDir();
+    const project = makeTempDir();
+    mkdirSync(join(project, ".pi"), { recursive: true });
+    writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({ "pi-code-reasoning": "invalid" }), "utf-8");
+    clearConfigEnv();
+    process.env.HOME = home;
+    vi.spyOn(process, "cwd").mockReturnValue(project);
+
+    expect(loadConfig(undefined)).toBeNull();
+  });
+
+  it("ignores malformed settings JSON", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const home = makeTempDir();
+    const project = makeTempDir();
+    mkdirSync(join(project, ".pi"), { recursive: true });
+    writeFileSync(join(project, ".pi", "settings.json"), "{", "utf-8");
+    clearConfigEnv();
+    process.env.HOME = home;
+    vi.spyOn(process, "cwd").mockReturnValue(project);
+
+    expect(loadConfig(undefined)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Failed to parse settings"));
+  });
+
+  it("warns when ignored legacy config files exist", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const home = makeTempDir();
+    const project = makeTempDir();
+    mkdirSync(join(project, ".pi", "extensions"), { recursive: true });
+    writeFileSync(join(project, ".pi", "extensions", "code-reasoning.json"), "{}", "utf-8");
+    clearConfigEnv();
+    process.env.HOME = home;
+    vi.spyOn(process, "cwd").mockReturnValue(project);
+
+    expect(loadConfig(undefined)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Ignoring legacy config file"));
+  });
+
+  it("merges project settings over global settings", () => {
+    const home = makeTempDir();
+    const project = makeTempDir();
+    const globalSettingsDir = join(home, ".pi", "agent");
+    const projectSettingsDir = join(project, ".pi");
+    mkdirSync(globalSettingsDir, { recursive: true });
+    mkdirSync(projectSettingsDir, { recursive: true });
+    writeFileSync(
+      join(globalSettingsDir, "settings.json"),
+      JSON.stringify({ "pi-code-reasoning": { maxBytes: 1000, maxLines: 100 } }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(projectSettingsDir, "settings.json"),
+      JSON.stringify({ "pi-code-reasoning": { maxLines: 25 } }),
+      "utf-8",
+    );
+
+    clearConfigEnv();
+    process.env.HOME = home;
+    vi.spyOn(process, "cwd").mockReturnValue(project);
+
+    expect(loadConfig(undefined)).toEqual({ maxBytes: 1000, maxLines: 25 });
+  });
+
+  it("falls back to global maxLines when project only sets maxBytes", () => {
+    const home = makeTempDir();
+    const project = makeTempDir();
+    const globalSettingsDir = join(home, ".pi", "agent");
+    const projectSettingsDir = join(project, ".pi");
+    mkdirSync(globalSettingsDir, { recursive: true });
+    mkdirSync(projectSettingsDir, { recursive: true });
+    writeFileSync(
+      join(globalSettingsDir, "settings.json"),
+      JSON.stringify({ "pi-code-reasoning": { maxBytes: 1000, maxLines: 100 } }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(projectSettingsDir, "settings.json"),
+      JSON.stringify({ "pi-code-reasoning": { maxBytes: 2500 } }),
+      "utf-8",
+    );
+
+    clearConfigEnv();
+    process.env.HOME = home;
+    vi.spyOn(process, "cwd").mockReturnValue(project);
+
+    expect(loadConfig(undefined)).toEqual({ maxBytes: 2500, maxLines: 100 });
+  });
+});

--- a/packages/pi-code-reasoning/__tests__/helpers.test.ts
+++ b/packages/pi-code-reasoning/__tests__/helpers.test.ts
@@ -49,6 +49,9 @@ describe("pi-code-reasoning helpers", () => {
   it("normalizes numbers from strings and numbers", () => {
     expect(normalizeNumber(42)).toBe(42);
     expect(normalizeNumber("123")).toBe(123);
+    expect(normalizeNumber(0)).toBeUndefined();
+    expect(normalizeNumber(-1)).toBeUndefined();
+    expect(normalizeNumber("0")).toBeUndefined();
     expect(normalizeNumber("abc")).toBeUndefined();
     expect(normalizeNumber(null)).toBeUndefined();
     expect(normalizeNumber(undefined)).toBeUndefined();
@@ -189,21 +192,40 @@ describe("pi-code-reasoning formatToolOutput", () => {
 
     unlinkSync(result.details.tempFile as string);
   });
+
+  it("keeps truncated output available when the temp file cannot be written", () => {
+    const previousTmpdir = process.env.TMPDIR;
+    process.env.TMPDIR = resolve(process.cwd(), ".missing-tmpdir-for-code-reasoning-tests");
+
+    try {
+      const result = formatToolOutput("test_tool", "x".repeat(200), { maxBytes: 20, maxLines: 2000 });
+
+      expect(result.details.truncated).toBe(true);
+      expect(result.details.tempFile).toBeUndefined();
+      expect(result.text).toContain("Full output could not be saved");
+    } finally {
+      if (previousTmpdir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = previousTmpdir;
+      }
+    }
+  });
 });
 
 describe("pi-code-reasoning writeTempFile", () => {
   const tempFiles: string[] = [];
 
   afterEach(() => {
-    import("node:fs").then(({ unlinkSync }) => {
-      tempFiles.forEach((f) => {
-        try {
-          unlinkSync(f);
-        } catch {
-          // ignore cleanup errors
-        }
-      });
-    });
+    while (tempFiles.length > 0) {
+      const path = tempFiles.pop();
+      if (!path) continue;
+      try {
+        unlinkSync(path);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
   });
 
   it("writes temp file and returns path", () => {

--- a/packages/pi-code-reasoning/__tests__/helpers.test.ts
+++ b/packages/pi-code-reasoning/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -87,6 +87,13 @@ describe("pi-code-reasoning toJsonString", () => {
     expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
   });
 
+  it("falls back to String for values that cannot be JSON-stringified", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(toJsonString(circular)).toBe("[object Object]");
+  });
+
   it("converts primitives", () => {
     expect(toJsonString(42)).toBe("42");
     expect(toJsonString(true)).toBe("true");
@@ -102,8 +109,9 @@ describe("pi-code-reasoning resolveConfigPath", () => {
   });
 
   it("resolves paths starting with ~", () => {
-    const result = resolveConfigPath("~/.pi/config.json");
-    expect(result).toContain(".pi/config.json");
+    const result = resolveConfigPath("~config.json");
+    expect(result).toContain("config.json");
+    expect(result).not.toContain("~");
   });
 
   it("returns absolute paths as-is", () => {
@@ -155,6 +163,31 @@ describe("pi-code-reasoning formatToolOutput", () => {
     const result = formatToolOutput("test_tool", { data: 123 }, {});
     expect(result.text).toContain("data");
     expect(result.text).toContain("123");
+  });
+
+  it("writes a temp file when output is truncated", () => {
+    const result = formatToolOutput(
+      "test_tool",
+      { rows: Array.from({ length: 20 }, (_, index) => index) },
+      { maxLines: 3 },
+    );
+
+    expect(result.details.truncated).toBe(true);
+    expect(result.details.tempFile).toBeDefined();
+    expect(result.text).toContain("Output truncated");
+    expect(existsSync(result.details.tempFile as string)).toBe(true);
+
+    unlinkSync(result.details.tempFile as string);
+  });
+
+  it("marks output when the first line exceeds the byte limit", () => {
+    const result = formatToolOutput("test_tool", "x".repeat(200), { maxBytes: 20, maxLines: 2000 });
+
+    expect(result.details.truncated).toBe(true);
+    expect(result.text).toContain("First line exceeded");
+    expect(result.details.tempFile).toBeDefined();
+
+    unlinkSync(result.details.tempFile as string);
   });
 });
 

--- a/packages/pi-code-reasoning/__tests__/helpers.test.ts
+++ b/packages/pi-code-reasoning/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -240,6 +240,22 @@ describe("pi-code-reasoning writeTempFile", () => {
     const path = writeTempFile("my-tool!@#", "content");
     tempFiles.push(path);
     expect(path).toContain("my-tool__");
+  });
+
+  it("uses collision-resistant names for same-millisecond writes", () => {
+    const originalNow = Date.now;
+    Date.now = () => 12345;
+    try {
+      const first = writeTempFile("same_tool", "first");
+      const second = writeTempFile("same_tool", "second");
+      tempFiles.push(first, second);
+
+      expect(first).not.toBe(second);
+      expect(readFileSync(first, "utf-8")).toBe("first");
+      expect(readFileSync(second, "utf-8")).toBe("second");
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });
 

--- a/packages/pi-code-reasoning/__tests__/index.test.ts
+++ b/packages/pi-code-reasoning/__tests__/index.test.ts
@@ -5,10 +5,25 @@ import codeReasoning from "../extensions/index.js";
 const createMockPi = () =>
   ({
     registerFlag: vi.fn(),
-    getFlag: vi.fn(() => undefined),
+    getFlag: vi.fn((_flagName: string): string | undefined => undefined),
     registerTool: vi.fn(),
     on: vi.fn(),
   }) satisfies Partial<ExtensionAPI>;
+
+const getRegisteredTool = (mockPi: ReturnType<typeof createMockPi>, name: string) => {
+  const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
+  const tool = tools.find((registeredTool) => registeredTool.name === name);
+  expect(tool).toBeDefined();
+  return tool;
+};
+
+const baseThought = (overrides: Record<string, unknown> = {}) => ({
+  thought: "A thought about the problem",
+  thought_number: 1,
+  total_thoughts: 1,
+  next_thought_needed: false,
+  ...overrides,
+});
 
 describe("pi-code-reasoning", () => {
   it("registers tools", () => {
@@ -67,8 +82,7 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
     expect(mainTool?.parameters).toBeDefined();
   });
 
@@ -88,8 +102,7 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
     expect(mainTool?.label).toBe("Code Reasoning");
   });
 
@@ -110,7 +123,6 @@ describe("pi-code-reasoning", () => {
     codeReasoning(mockPi1 as unknown as ExtensionAPI);
     codeReasoning(mockPi2 as unknown as ExtensionAPI);
 
-    // Each should register its own tools
     expect(mockPi1.registerTool).toHaveBeenCalledTimes(3);
     expect(mockPi2.registerTool).toHaveBeenCalledTimes(3);
   });
@@ -119,8 +131,7 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
     const result = await mainTool?.execute(
       "call-123",
@@ -144,8 +155,7 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const statusTool = tools.find((t) => t.name === "code_reasoning_status");
+    const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
 
     const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
 
@@ -157,8 +167,7 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const resetTool = tools.find((t) => t.name === "code_reasoning_reset");
+    const resetTool = getRegisteredTool(mockPi, "code_reasoning_reset");
 
     const result = await resetTool?.execute("call-123", {}, undefined, undefined, undefined);
 
@@ -170,10 +179,8 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    // Missing required parameter should fail
     const result = await mainTool?.execute("call-123", { thought: "" }, undefined, undefined, undefined);
 
     expect(result).toBeDefined();
@@ -181,14 +188,26 @@ describe("pi-code-reasoning", () => {
     expect(result.content[0].text).toContain("Thought cannot be empty");
   });
 
+  it("handles non-Error exceptions from tool setup", async () => {
+    const mockPi = createMockPi();
+    mockPi.getFlag.mockImplementation(() => {
+      throw "flag failed";
+    });
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
+    const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("flag failed");
+  });
+
   it("tracks multiple thoughts", async () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    // Add first thought
     await mainTool?.execute(
       "call-1",
       {
@@ -202,7 +221,6 @@ describe("pi-code-reasoning", () => {
       undefined,
     );
 
-    // Add second thought
     const result2 = await mainTool?.execute(
       "call-2",
       {
@@ -223,17 +241,16 @@ describe("pi-code-reasoning", () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
-    const tools = mockPi.registerTool.mock.calls.map(([tool]) => tool);
-    const mainTool = tools.find((t) => t.name === "code_reasoning");
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
     const result = await mainTool?.execute(
       "call-123",
-      {
+      baseThought({
         thought: "Invalid ordering",
         thought_number: 4,
         total_thoughts: 3,
         next_thought_needed: true,
-      },
+      }),
       undefined,
       undefined,
       undefined,
@@ -241,5 +258,104 @@ describe("pi-code-reasoning", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("thought_number cannot exceed total_thoughts");
+  });
+
+  it("rejects thoughts above the configured thought number limit", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
+
+    const result = await mainTool?.execute(
+      "call-123",
+      baseThought({ thought_number: 21, total_thoughts: 21 }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Max thought_number exceeded");
+  });
+
+  it("rejects invalid branch field combinations", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
+
+    const result = await mainTool?.execute(
+      "call-123",
+      baseThought({ branch_id: "missing-source" }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("branch_id and branch_from_thought required together");
+  });
+
+  it("applies config-file and output-limit flags", async () => {
+    const mockPi = createMockPi();
+    mockPi.getFlag.mockImplementation((flagName) => {
+      const flags: Record<string, string> = {
+        "--code-reasoning-config-file": "/tmp/missing-code-reasoning-config.json",
+        "--code-reasoning-max-bytes": "99999",
+        "--code-reasoning-max-lines": "999",
+      };
+      return flags[String(flagName)];
+    });
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
+    const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
+
+    expect(result.isError).toBe(false);
+    expect(result.details.truncated).toBe(false);
+  });
+
+  it("supports the deprecated config flag with a warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const mockPi = createMockPi();
+    mockPi.getFlag.mockImplementation((flagName) =>
+      flagName === "--code-reasoning-config" ? "/tmp/missing-code-reasoning-legacy-config.json" : undefined,
+    );
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
+    const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
+
+    expect(result.isError).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("--code-reasoning-config is deprecated"));
+  });
+
+  it("caps the in-memory thought history", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
+
+    for (let call = 1; call <= 20; call += 1) {
+      const result = await mainTool?.execute(
+        `call-${call}`,
+        baseThought({ thought: `Thought ${call}` }),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result.isError).toBe(false);
+    }
+
+    const result = await mainTool?.execute(
+      "call-21",
+      baseThought({ thought: "One thought too many" }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Max thought limit reached");
   });
 });

--- a/packages/pi-code-reasoning/__tests__/index.test.ts
+++ b/packages/pi-code-reasoning/__tests__/index.test.ts
@@ -25,6 +25,15 @@ const baseThought = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const expectStructuredError = (
+  result: Awaited<ReturnType<NonNullable<ReturnType<typeof getRegisteredTool>>["execute"]>>,
+  message: string,
+) => {
+  expect(result.isError).toBe(true);
+  expect(result.content[0].text).toContain(message);
+  expect(result.details.error).toContain(message);
+};
+
 describe("pi-code-reasoning", () => {
   it("registers tools", () => {
     const mockPi = createMockPi();
@@ -175,26 +184,51 @@ describe("pi-code-reasoning", () => {
     expect(result.content[0].text).toContain("reset");
   });
 
+  it("returns structured isError results for schema validation failures", async () => {
+    const mockPi = createMockPi();
+    codeReasoning(mockPi as unknown as ExtensionAPI);
+
+    const mainTool = getRegisteredTool(mockPi, "code_reasoning");
+
+    const result = await mainTool?.execute(
+      "call-123",
+      {
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid arguments for code_reasoning");
+    expect(result.details.validationErrors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ message: expect.stringContaining("thought") })]),
+    );
+  });
+
   it("validates thought parameters", async () => {
     const mockPi = createMockPi();
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    await expect(
-      mainTool?.execute(
-        "call-123",
-        {
-          thought: "",
-          thought_number: 1,
-          total_thoughts: 1,
-          next_thought_needed: false,
-        },
-        undefined,
-        undefined,
-        undefined,
-      ),
-    ).rejects.toThrow("Thought cannot be empty");
+    const result = await mainTool?.execute(
+      "call-123",
+      {
+        thought: "",
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expectStructuredError(result, "Thought cannot be empty");
   });
 
   it("handles non-Error exceptions from tool setup", async () => {
@@ -206,7 +240,9 @@ describe("pi-code-reasoning", () => {
 
     const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
 
-    await expect(statusTool?.execute("call-123", {}, undefined, undefined, undefined)).rejects.toThrow("flag failed");
+    const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
+
+    expectStructuredError(result, "flag failed");
   });
 
   it("tracks multiple thoughts", async () => {
@@ -250,20 +286,20 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    await expect(
-      mainTool?.execute(
-        "call-123",
-        baseThought({
-          thought: "Invalid ordering",
-          thought_number: 4,
-          total_thoughts: 3,
-          next_thought_needed: true,
-        }),
-        undefined,
-        undefined,
-        undefined,
-      ),
-    ).rejects.toThrow("thought_number cannot exceed total_thoughts");
+    const result = await mainTool?.execute(
+      "call-123",
+      baseThought({
+        thought: "Invalid ordering",
+        thought_number: 4,
+        total_thoughts: 3,
+        next_thought_needed: true,
+      }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expectStructuredError(result, "thought_number cannot exceed total_thoughts");
   });
 
   it("rejects thoughts above the configured thought number limit", async () => {
@@ -272,15 +308,15 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    await expect(
-      mainTool?.execute(
-        "call-123",
-        baseThought({ thought_number: 21, total_thoughts: 21 }),
-        undefined,
-        undefined,
-        undefined,
-      ),
-    ).rejects.toThrow("Max thought_number exceeded");
+    const result = await mainTool?.execute(
+      "call-123",
+      baseThought({ thought_number: 21, total_thoughts: 21 }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expectStructuredError(result, "Max thought_number exceeded");
   });
 
   it("rejects invalid branch field combinations", async () => {
@@ -289,9 +325,15 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    await expect(
-      mainTool?.execute("call-123", baseThought({ branch_id: "missing-source" }), undefined, undefined, undefined),
-    ).rejects.toThrow("branch_id and branch_from_thought required together");
+    const result = await mainTool?.execute(
+      "call-123",
+      baseThought({ branch_id: "missing-source" }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expectStructuredError(result, "branch_id and branch_from_thought required together");
   });
 
   it("applies config-file and output-limit flags", async () => {
@@ -345,8 +387,14 @@ describe("pi-code-reasoning", () => {
       expect(result.content[0].text).toContain("processed");
     }
 
-    await expect(
-      mainTool?.execute("call-21", baseThought({ thought: "One thought too many" }), undefined, undefined, undefined),
-    ).rejects.toThrow("Max thought limit reached");
+    const result = await mainTool?.execute(
+      "call-21",
+      baseThought({ thought: "One thought too many" }),
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expectStructuredError(result, "Max thought limit reached");
   });
 });

--- a/packages/pi-code-reasoning/__tests__/index.test.ts
+++ b/packages/pi-code-reasoning/__tests__/index.test.ts
@@ -181,11 +181,20 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    const result = await mainTool?.execute("call-123", { thought: "" }, undefined, undefined, undefined);
-
-    expect(result).toBeDefined();
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Thought cannot be empty");
+    await expect(
+      mainTool?.execute(
+        "call-123",
+        {
+          thought: "",
+          thought_number: 1,
+          total_thoughts: 1,
+          next_thought_needed: false,
+        },
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow("Thought cannot be empty");
   });
 
   it("handles non-Error exceptions from tool setup", async () => {
@@ -196,10 +205,8 @@ describe("pi-code-reasoning", () => {
     codeReasoning(mockPi as unknown as ExtensionAPI);
 
     const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
-    const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("flag failed");
+    await expect(statusTool?.execute("call-123", {}, undefined, undefined, undefined)).rejects.toThrow("flag failed");
   });
 
   it("tracks multiple thoughts", async () => {
@@ -243,21 +250,20 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    const result = await mainTool?.execute(
-      "call-123",
-      baseThought({
-        thought: "Invalid ordering",
-        thought_number: 4,
-        total_thoughts: 3,
-        next_thought_needed: true,
-      }),
-      undefined,
-      undefined,
-      undefined,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("thought_number cannot exceed total_thoughts");
+    await expect(
+      mainTool?.execute(
+        "call-123",
+        baseThought({
+          thought: "Invalid ordering",
+          thought_number: 4,
+          total_thoughts: 3,
+          next_thought_needed: true,
+        }),
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow("thought_number cannot exceed total_thoughts");
   });
 
   it("rejects thoughts above the configured thought number limit", async () => {
@@ -266,16 +272,15 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    const result = await mainTool?.execute(
-      "call-123",
-      baseThought({ thought_number: 21, total_thoughts: 21 }),
-      undefined,
-      undefined,
-      undefined,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Max thought_number exceeded");
+    await expect(
+      mainTool?.execute(
+        "call-123",
+        baseThought({ thought_number: 21, total_thoughts: 21 }),
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow("Max thought_number exceeded");
   });
 
   it("rejects invalid branch field combinations", async () => {
@@ -284,16 +289,9 @@ describe("pi-code-reasoning", () => {
 
     const mainTool = getRegisteredTool(mockPi, "code_reasoning");
 
-    const result = await mainTool?.execute(
-      "call-123",
-      baseThought({ branch_id: "missing-source" }),
-      undefined,
-      undefined,
-      undefined,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("branch_id and branch_from_thought required together");
+    await expect(
+      mainTool?.execute("call-123", baseThought({ branch_id: "missing-source" }), undefined, undefined, undefined),
+    ).rejects.toThrow("branch_id and branch_from_thought required together");
   });
 
   it("applies config-file and output-limit flags", async () => {
@@ -311,7 +309,7 @@ describe("pi-code-reasoning", () => {
     const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
     const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
 
-    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain("thought_count");
     expect(result.details.truncated).toBe(false);
   });
 
@@ -326,7 +324,7 @@ describe("pi-code-reasoning", () => {
     const statusTool = getRegisteredTool(mockPi, "code_reasoning_status");
     const result = await statusTool?.execute("call-123", {}, undefined, undefined, undefined);
 
-    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain("thought_count");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("--code-reasoning-config is deprecated"));
   });
 
@@ -344,18 +342,11 @@ describe("pi-code-reasoning", () => {
         undefined,
         undefined,
       );
-      expect(result.isError).toBe(false);
+      expect(result.content[0].text).toContain("processed");
     }
 
-    const result = await mainTool?.execute(
-      "call-21",
-      baseThought({ thought: "One thought too many" }),
-      undefined,
-      undefined,
-      undefined,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Max thought limit reached");
+    await expect(
+      mainTool?.execute("call-21", baseThought({ thought: "One thought too many" }), undefined, undefined, undefined),
+    ).rejects.toThrow("Max thought limit reached");
   });
 });

--- a/packages/pi-code-reasoning/__tests__/mcp-server.test.ts
+++ b/packages/pi-code-reasoning/__tests__/mcp-server.test.ts
@@ -1,6 +1,6 @@
 import { createMcpServer } from "@feniix/bridgekit/mcp";
-import { describe, expect, it } from "vitest";
-import { createMcpServerOptions } from "../extensions/mcp-server.js";
+import { describe, expect, it, vi } from "vitest";
+import { createMcpServerOptions, runServer } from "../extensions/mcp-server.js";
 
 const toolNames = (options: ReturnType<typeof createMcpServerOptions>) => options.tools.map((tool) => tool.name);
 
@@ -18,5 +18,13 @@ describe("code reasoning MCP server", () => {
     const server = createMcpServer(createMcpServerOptions());
 
     expect(server).toBeDefined();
+  });
+
+  it("starts stdio with the MCP options", async () => {
+    const runMcpStdioServer = vi.fn().mockResolvedValue(undefined);
+
+    await runServer(runMcpStdioServer);
+
+    expect(runMcpStdioServer).toHaveBeenCalledWith(expect.objectContaining({ name: "pi-code-reasoning" }));
   });
 });

--- a/packages/pi-code-reasoning/__tests__/mcp-server.test.ts
+++ b/packages/pi-code-reasoning/__tests__/mcp-server.test.ts
@@ -1,15 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createMcpServer } from "@feniix/bridgekit/mcp";
 import { describe, expect, it, vi } from "vitest";
 import { createMcpServerOptions, runServer } from "../extensions/mcp-server.js";
 
 const toolNames = (options: ReturnType<typeof createMcpServerOptions>) => options.tools.map((tool) => tool.name);
+const packageJson = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf-8"),
+) as { version: string };
 
 describe("code reasoning MCP server", () => {
   it("exposes the portable tools through BridgeKit MCP options", () => {
     const options = createMcpServerOptions();
 
     expect(options.name).toBe("pi-code-reasoning");
-    expect(options.version).toBe("3.0.1");
+    expect(options.version).toBe(packageJson.version);
     expect(toolNames(options)).toEqual(["code_reasoning", "code_reasoning_status", "code_reasoning_reset"]);
     expect(options.instructions).toContain("sequential thinking");
   });

--- a/packages/pi-code-reasoning/__tests__/mcp-server.test.ts
+++ b/packages/pi-code-reasoning/__tests__/mcp-server.test.ts
@@ -1,0 +1,22 @@
+import { createMcpServer } from "@feniix/bridgekit/mcp";
+import { describe, expect, it } from "vitest";
+import { createMcpServerOptions } from "../extensions/mcp-server.js";
+
+const toolNames = (options: ReturnType<typeof createMcpServerOptions>) => options.tools.map((tool) => tool.name);
+
+describe("code reasoning MCP server", () => {
+  it("exposes the portable tools through BridgeKit MCP options", () => {
+    const options = createMcpServerOptions();
+
+    expect(options.name).toBe("pi-code-reasoning");
+    expect(options.version).toBe("3.0.1");
+    expect(toolNames(options)).toEqual(["code_reasoning", "code_reasoning_status", "code_reasoning_reset"]);
+    expect(options.instructions).toContain("sequential thinking");
+  });
+
+  it("can create a BridgeKit MCP server", () => {
+    const server = createMcpServer(createMcpServerOptions());
+
+    expect(server).toBeDefined();
+  });
+});

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageJson = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf-8"),
+) as {
+  exports: Record<string, string>;
+};
+
+describe("pi-code-reasoning package metadata", () => {
+  it("keeps extension deep imports available while adding MCP-friendly entrypoints", () => {
+    expect(packageJson.exports).toMatchObject({
+      ".": "./extensions/index.ts",
+      "./mcp": "./extensions/mcp-server.ts",
+      "./tools": "./extensions/tools.ts",
+      "./extensions/*": "./extensions/*",
+    });
+  });
+});

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -1,21 +1,33 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-const packageJson = JSON.parse(
-  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf-8"),
-) as {
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(packageRoot, "..", "..");
+
+const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf-8")) as {
   bin: Record<string, string>;
   exports: Record<string, string | { types: string; import: string }>;
   files: string[];
+  pi: { extensions: string[] };
   scripts: Record<string, string>;
 };
 
+function cleanDist(): void {
+  rmSync(join(packageRoot, "dist"), { recursive: true, force: true });
+}
+
+afterEach(() => {
+  cleanDist();
+});
+
 describe("pi-code-reasoning package metadata", () => {
-  it("keeps the pi source extension available while publishing compiled MCP entrypoints", () => {
+  it("keeps the pi source extension available while publishing compiled Node entrypoints", () => {
+    expect(packageJson.pi.extensions).toEqual(["./extensions/index.ts"]);
+    expect(Object.hasOwn(packageJson.exports, ".")).toBe(false);
     expect(packageJson.exports).toMatchObject({
-      ".": "./extensions/index.ts",
       "./mcp": {
         types: "./dist/extensions/mcp-server.d.ts",
         import: "./dist/extensions/mcp-server.js",
@@ -24,7 +36,14 @@ describe("pi-code-reasoning package metadata", () => {
         types: "./dist/extensions/tools.d.ts",
         import: "./dist/extensions/tools.js",
       },
-      "./extensions/*": "./extensions/*",
+      "./extensions/*.js": {
+        types: "./dist/extensions/*.d.ts",
+        import: "./dist/extensions/*.js",
+      },
+      "./extensions/*": {
+        types: "./dist/extensions/*.d.ts",
+        import: "./dist/extensions/*.js",
+      },
     });
   });
 
@@ -34,6 +53,31 @@ describe("pi-code-reasoning package metadata", () => {
     });
     expect(packageJson.files).toContain("dist/");
     expect(packageJson.scripts["build:mcp"]).toContain("tsconfig.mcp.json");
+    expect(packageJson.scripts["build:mcp"]).toContain("chmodSync");
     expect(packageJson.scripts.prepack).toBe("npm run build:mcp");
+  });
+
+  it("packs executable MCP output and concrete portable tool declarations", () => {
+    cleanDist();
+    const pack = spawnSync(
+      "npm",
+      ["pack", "--dry-run", "--json", "--workspace", "packages/pi-code-reasoning", "--silent"],
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+      },
+    );
+
+    expect(pack.status, pack.stderr).toBe(0);
+    const [packResult] = JSON.parse(pack.stdout) as [{ files: Array<{ path: string; mode: number }> }];
+    const filesByPath = new Map(packResult.files.map((file) => [file.path, file]));
+
+    expect(filesByPath.get("dist/extensions/mcp-server.js")?.mode).toBe(493);
+    expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
+    expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
+
+    const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
+    expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
+    expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
   });
 });

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -30,7 +30,7 @@ describe("pi-code-reasoning package metadata", () => {
 
   it("publishes an npx-friendly MCP binary backed by the package-local build", () => {
     expect(packageJson.bin).toEqual({
-      "pi-code-reasoning-mcp": "./dist/extensions/mcp-server.js",
+      "pi-code-reasoning": "./dist/extensions/mcp-server.js",
     });
     expect(packageJson.files).toContain("dist/");
     expect(packageJson.scripts["build:mcp"]).toContain("tsconfig.mcp.json");

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -6,16 +6,34 @@ import { describe, expect, it } from "vitest";
 const packageJson = JSON.parse(
   readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf-8"),
 ) as {
-  exports: Record<string, string>;
+  bin: Record<string, string>;
+  exports: Record<string, string | { types: string; import: string }>;
+  files: string[];
+  scripts: Record<string, string>;
 };
 
 describe("pi-code-reasoning package metadata", () => {
-  it("keeps extension deep imports available while adding MCP-friendly entrypoints", () => {
+  it("keeps the pi source extension available while publishing compiled MCP entrypoints", () => {
     expect(packageJson.exports).toMatchObject({
       ".": "./extensions/index.ts",
-      "./mcp": "./extensions/mcp-server.ts",
-      "./tools": "./extensions/tools.ts",
+      "./mcp": {
+        types: "./dist/extensions/mcp-server.d.ts",
+        import: "./dist/extensions/mcp-server.js",
+      },
+      "./tools": {
+        types: "./dist/extensions/tools.d.ts",
+        import: "./dist/extensions/tools.js",
+      },
       "./extensions/*": "./extensions/*",
     });
+  });
+
+  it("publishes an npx-friendly MCP binary backed by the package-local build", () => {
+    expect(packageJson.bin).toEqual({
+      "pi-code-reasoning-mcp": "./dist/extensions/mcp-server.js",
+    });
+    expect(packageJson.files).toContain("dist/");
+    expect(packageJson.scripts["build:mcp"]).toContain("tsconfig.mcp.json");
+    expect(packageJson.scripts.prepack).toBe("npm run build:mcp");
   });
 });

--- a/packages/pi-code-reasoning/__tests__/portable-tools.test.ts
+++ b/packages/pi-code-reasoning/__tests__/portable-tools.test.ts
@@ -46,6 +46,47 @@ describe("portable code reasoning tools", () => {
     expect(status.text).toContain('"thought_count": 1');
   });
 
+  it("rejects invalid per-call truncation limits before execution", async () => {
+    const tool = getTool("code_reasoning_status");
+
+    const result = await executePortableTool(tool, { piMaxBytes: 0 }, { host: "test" });
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("Invalid arguments");
+  });
+
+  it("does not mirror oversized truncated output into structuredContent", async () => {
+    const tools = createCodeReasoningTools();
+    const reasoningTool = findTool(tools, "code_reasoning");
+
+    await executePortableTool(
+      reasoningTool,
+      {
+        thought: "First thought",
+        thought_number: 1,
+        total_thoughts: 2,
+        next_thought_needed: true,
+      },
+      { host: "test" },
+    );
+    const result = await executePortableTool(
+      reasoningTool,
+      {
+        thought: "Branch thought",
+        thought_number: 2,
+        total_thoughts: 2,
+        next_thought_needed: false,
+        branch_from_thought: 1,
+        branch_id: "x".repeat(500),
+        piMaxBytes: 200,
+      },
+      { host: "test" },
+    );
+
+    expect(result.structuredContent?.truncated).toBe(true);
+    expect(result.structuredContent).not.toHaveProperty("branches");
+  });
+
   it("reports tool-level validation failures as portable errors", async () => {
     const tool = getTool("code_reasoning");
 

--- a/packages/pi-code-reasoning/__tests__/portable-tools.test.ts
+++ b/packages/pi-code-reasoning/__tests__/portable-tools.test.ts
@@ -1,0 +1,90 @@
+import { executePortableTool } from "@feniix/bridgekit";
+import { describe, expect, it } from "vitest";
+import { createCodeReasoningTools } from "../extensions/tools.js";
+
+type CodeReasoningTool = ReturnType<typeof createCodeReasoningTools>[number];
+
+function findTool(tools: readonly CodeReasoningTool[], name: string): CodeReasoningTool {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Missing portable tool: ${name}`);
+  }
+  return tool;
+}
+
+function getTool(name: string): CodeReasoningTool {
+  return findTool(createCodeReasoningTools(), name);
+}
+
+describe("portable code reasoning tools", () => {
+  it("defines the pi/MCP tool surface once", () => {
+    const tools = createCodeReasoningTools();
+
+    expect(tools.map((tool) => tool.name)).toEqual(["code_reasoning", "code_reasoning_status", "code_reasoning_reset"]);
+    expect(tools.every((tool) => tool.parameters.type === "object")).toBe(true);
+  });
+
+  it("processes thoughts and shares state across portable tools", async () => {
+    const tools = createCodeReasoningTools();
+    const reasoningTool = findTool(tools, "code_reasoning");
+    const statusTool = findTool(tools, "code_reasoning_status");
+
+    const result = await executePortableTool(
+      reasoningTool,
+      {
+        thought: "First portable thought",
+        thought_number: 1,
+        total_thoughts: 2,
+        next_thought_needed: true,
+      },
+      { host: "test" },
+    );
+    const status = await executePortableTool(statusTool, {}, { host: "test" });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.text).toContain("processed");
+    expect(status.text).toContain('"thought_count": 1');
+  });
+
+  it("reports tool-level validation failures as portable errors", async () => {
+    const tool = getTool("code_reasoning");
+
+    const result = await executePortableTool(
+      tool,
+      {
+        thought: "",
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+      },
+      { host: "test" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("Thought cannot be empty");
+    expect(result.structuredContent?.status).toBe("failed");
+  });
+
+  it("resets portable tool state", async () => {
+    const tools = createCodeReasoningTools();
+    const reasoningTool = findTool(tools, "code_reasoning");
+    const resetTool = findTool(tools, "code_reasoning_reset");
+    const statusTool = findTool(tools, "code_reasoning_status");
+
+    await executePortableTool(
+      reasoningTool,
+      {
+        thought: "Before reset",
+        thought_number: 1,
+        total_thoughts: 1,
+        next_thought_needed: false,
+      },
+      { host: "test" },
+    );
+    const reset = await executePortableTool(resetTool, {}, { host: "test" });
+    const status = await executePortableTool(statusTool, {}, { host: "test" });
+
+    expect(reset.text).toContain("reset");
+    expect(status.text).toContain('"thought_count": 0');
+  });
+});

--- a/packages/pi-code-reasoning/__tests__/types.test.ts
+++ b/packages/pi-code-reasoning/__tests__/types.test.ts
@@ -44,7 +44,7 @@ describe("validateThoughtData", () => {
     });
   });
 
-  it("returns error for negative thought_number", () => {
+  it("returns error for zero thought_number", () => {
     const data = {
       thought: "My thought",
       thought_number: 0,

--- a/packages/pi-code-reasoning/__tests__/types.test.ts
+++ b/packages/pi-code-reasoning/__tests__/types.test.ts
@@ -304,6 +304,20 @@ describe("enforceCrossFieldRules", () => {
     expect(errors[0].message).toContain("revises_thought");
   });
 
+  it("rejects revises_thought without revision mode", () => {
+    const data = {
+      thought: "Invalid revision reference",
+      thought_number: 2,
+      total_thoughts: 5,
+      next_thought_needed: true,
+      revises_thought: 1,
+    };
+    const errors = enforceCrossFieldRules(data);
+    expect(errors).toContainEqual({
+      message: "revises_thought only allowed when is_revision=true.",
+    });
+  });
+
   it("accepts valid branch", () => {
     const data = {
       thought: "Exploring alternative",

--- a/packages/pi-code-reasoning/extensions/config.ts
+++ b/packages/pi-code-reasoning/extensions/config.ts
@@ -29,16 +29,17 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function normalizeNumber(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
+  let parsed: number | undefined;
+  if (typeof value === "number") {
+    parsed = value;
+  } else if (typeof value === "string") {
+    parsed = Number(value);
   }
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
+
+  if (parsed === undefined || !Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
   }
-  return undefined;
+  return parsed;
 }
 
 export function splitParams(params: Record<string, unknown>): {
@@ -143,7 +144,12 @@ function loadSettingsConfig(path: string): CodeReasoningConfig | null {
     return null;
   }
 
-  return parseConfig(config, path);
+  try {
+    return parseConfig(config, path);
+  } catch (error) {
+    warnInvalidConfig(error, path, "settings");
+    return null;
+  }
 }
 
 function warnIgnoredLegacyConfigFiles(): void {

--- a/packages/pi-code-reasoning/extensions/config.ts
+++ b/packages/pi-code-reasoning/extensions/config.ts
@@ -1,0 +1,194 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { DEFAULT_CONFIG_FILE, SETTINGS_KEY } from "./constants.js";
+
+export interface CodeReasoningConfig {
+  maxBytes?: number;
+  maxLines?: number;
+}
+
+export interface OutputLimitRequest {
+  maxBytes?: number;
+  maxLines?: number;
+}
+
+interface JsonReadResult {
+  found: boolean;
+  value?: unknown;
+}
+
+export { DEFAULT_CONFIG_FILE };
+
+function getHomeDir(): string {
+  return process.env.HOME || homedir();
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+export function splitParams(params: Record<string, unknown>): {
+  toolArgs: Record<string, unknown>;
+  requestedLimits: OutputLimitRequest;
+} {
+  const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
+    piMaxBytes?: unknown;
+    piMaxLines?: unknown;
+  };
+  return {
+    toolArgs: rest,
+    requestedLimits: {
+      maxBytes: normalizeNumber(piMaxBytes),
+      maxLines: normalizeNumber(piMaxLines),
+    },
+  };
+}
+
+export function resolveEffectiveLimits(
+  requested: OutputLimitRequest,
+  maxAllowed: { maxBytes: number; maxLines: number },
+): { maxBytes: number; maxLines: number } {
+  const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
+  const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
+  return {
+    maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
+    maxLines: Math.min(requestedLines, maxAllowed.maxLines),
+  };
+}
+
+export function resolveConfigPath(configPath: string): string {
+  const trimmed = configPath.trim();
+  if (trimmed.startsWith("~/")) {
+    return join(getHomeDir(), trimmed.slice(2));
+  }
+  if (trimmed.startsWith("~")) {
+    return join(getHomeDir(), trimmed.slice(1));
+  }
+  if (isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return resolve(process.cwd(), trimmed);
+}
+
+export function parseConfig(raw: unknown, pathHint: string): CodeReasoningConfig {
+  if (!isRecord(raw)) {
+    throw new Error(`Invalid Code Reasoning config at ${pathHint}: expected an object.`);
+  }
+  return {
+    maxBytes: normalizeNumber(raw.maxBytes),
+    maxLines: normalizeNumber(raw.maxLines),
+  };
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readJsonFile(path: string, label: "config" | "settings"): JsonReadResult {
+  try {
+    return { found: true, value: JSON.parse(readFileSync(path, "utf-8")) };
+  } catch (error) {
+    if (isFileNotFound(error)) {
+      return { found: false };
+    }
+    console.warn(`[pi-code-reasoning] Failed to parse ${label} ${path}: ${errorMessage(error)}`);
+    return { found: false };
+  }
+}
+
+function warnInvalidConfig(error: unknown, path: string, label: "config" | "settings"): void {
+  console.warn(`[pi-code-reasoning] Failed to parse ${label} ${path}: ${errorMessage(error)}`);
+}
+
+function loadConfigFile(path: string): CodeReasoningConfig | null {
+  const raw = readJsonFile(path, "config");
+  if (!raw.found) {
+    return null;
+  }
+
+  try {
+    return parseConfig(raw.value, path);
+  } catch (error) {
+    warnInvalidConfig(error, path, "config");
+    return null;
+  }
+}
+
+function loadSettingsConfig(path: string): CodeReasoningConfig | null {
+  const raw = readJsonFile(path, "settings");
+  if (!raw.found || !isRecord(raw.value)) {
+    return null;
+  }
+
+  const config = raw.value[SETTINGS_KEY];
+  if (!isRecord(config)) {
+    return null;
+  }
+
+  return parseConfig(config, path);
+}
+
+function warnIgnoredLegacyConfigFiles(): void {
+  const legacyPaths = [
+    join(process.cwd(), ".pi", "extensions", "code-reasoning.json"),
+    join(getHomeDir(), ".pi", "agent", "extensions", "code-reasoning.json"),
+  ];
+
+  for (const legacyPath of legacyPaths) {
+    if (existsSync(legacyPath)) {
+      console.warn(
+        `[pi-code-reasoning] Ignoring legacy config file ${legacyPath}. Migrate non-secret settings to .pi/settings.json or ~/.pi/agent/settings.json under "${SETTINGS_KEY}", or pass --code-reasoning-config-file / CODE_REASONING_CONFIG_FILE explicitly.`,
+      );
+    }
+  }
+}
+
+export function loadConfig(configPath: string | undefined): CodeReasoningConfig | null {
+  const envConfigFile = process.env.CODE_REASONING_CONFIG_FILE;
+  const legacyEnvConfig = process.env.CODE_REASONING_CONFIG;
+  if (configPath) {
+    return loadConfigFile(resolveConfigPath(configPath));
+  }
+  if (envConfigFile) {
+    return loadConfigFile(resolveConfigPath(envConfigFile));
+  }
+  if (legacyEnvConfig) {
+    console.warn("[pi-code-reasoning] CODE_REASONING_CONFIG is deprecated; use CODE_REASONING_CONFIG_FILE.");
+    return loadConfigFile(resolveConfigPath(legacyEnvConfig));
+  }
+
+  warnIgnoredLegacyConfigFiles();
+
+  const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
+  const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
+
+  const globalConfig = loadSettingsConfig(globalSettingsPath);
+  const projectConfig = loadSettingsConfig(projectSettingsPath);
+
+  if (!globalConfig && !projectConfig) {
+    return null;
+  }
+
+  return {
+    maxBytes: projectConfig?.maxBytes ?? globalConfig?.maxBytes,
+    maxLines: projectConfig?.maxLines ?? globalConfig?.maxLines,
+  };
+}

--- a/packages/pi-code-reasoning/extensions/constants.ts
+++ b/packages/pi-code-reasoning/extensions/constants.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
+
+export const SETTINGS_KEY = "pi-code-reasoning";
+
+export const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
+  maxBytes: DEFAULT_MAX_BYTES,
+  maxLines: DEFAULT_MAX_LINES,
+};
+
+export const CODE_REASONING_FLAGS = {
+  configFile: "--code-reasoning-config-file",
+  legacyConfigFile: "--code-reasoning-config",
+  maxBytes: "--code-reasoning-max-bytes",
+  maxLines: "--code-reasoning-max-lines",
+} as const;
+
+export const CODE_REASONING_TOOLS = {
+  reasoning: "code_reasoning",
+  status: "code_reasoning_status",
+  reset: "code_reasoning_reset",
+} as const;

--- a/packages/pi-code-reasoning/extensions/constants.ts
+++ b/packages/pi-code-reasoning/extensions/constants.ts
@@ -1,6 +1,7 @@
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
-
 export const SETTINGS_KEY = "pi-code-reasoning";
+
+export const DEFAULT_MAX_BYTES = 51200;
+export const DEFAULT_MAX_LINES = 2000;
 
 export const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
   maxBytes: DEFAULT_MAX_BYTES,

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -1,23 +1,15 @@
 /**
  * Code Reasoning Extension for pi
  *
- * Provides a tool for reflective problem-solving through sequential thinking.
+ * Provides tools for reflective problem-solving through sequential thinking.
  * Supports branching (exploring alternatives) and revision (correcting earlier thoughts).
  */
 
-import {
-  type AgentToolUpdateCallback,
-  DEFAULT_MAX_BYTES,
-  DEFAULT_MAX_LINES,
-  type ExtensionAPI,
-} from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
-import { loadConfig, normalizeNumber, type OutputLimitRequest, resolveEffectiveLimits, splitParams } from "./config.js";
-import { CODE_REASONING_FLAGS, CODE_REASONING_TOOLS } from "./constants.js";
-import { formatToolOutput } from "./output.js";
-import { processThought } from "./processor.js";
-import { buildError } from "./responses.js";
-import { createThoughtTracker } from "./tracker.js";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerPiTools } from "@feniix/bridgekit/pi";
+import { loadConfig, normalizeNumber } from "./config.js";
+import { CODE_REASONING_FLAGS, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./constants.js";
+import { createCodeReasoningTools, type MaxLimits } from "./tools.js";
 
 export {
   DEFAULT_CONFIG_FILE,
@@ -30,42 +22,8 @@ export {
 } from "./config.js";
 export { formatToolOutput, toJsonString, writeTempFile } from "./output.js";
 export { buildError, buildSuccess, getExampleThought } from "./responses.js";
+export { createCodeReasoningTools } from "./tools.js";
 export { createThoughtTracker } from "./tracker.js";
-
-const codeReasoningParams = Type.Object(
-  {
-    thought: Type.String({ description: "The content of your reasoning/thought." }),
-    thought_number: Type.Integer({
-      minimum: 1,
-      description: "Current number in the thinking sequence.",
-    }),
-    total_thoughts: Type.Integer({
-      minimum: 1,
-      description: "Estimated total number of thoughts.",
-    }),
-    next_thought_needed: Type.Boolean({
-      description: "Set to FALSE only when completely done.",
-    }),
-    is_revision: Type.Optional(Type.Boolean({ description: "When correcting earlier thinking (🔄)." })),
-    revises_thought: Type.Optional(
-      Type.Integer({
-        minimum: 1,
-        description: "Which thought number you're revising.",
-      }),
-    ),
-    branch_from_thought: Type.Optional(
-      Type.Integer({
-        minimum: 1,
-        description: "When exploring alternative approaches (🌿).",
-      }),
-    ),
-    branch_id: Type.Optional(Type.String({ description: "Identifier for this branch." })),
-    needs_more_thoughts: Type.Optional(Type.Boolean({ description: "If more thoughts are needed." })),
-    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
-  },
-  { additionalProperties: true },
-);
 
 function registerFlags(pi: ExtensionAPI): void {
   pi.registerFlag(CODE_REASONING_FLAGS.configFile, {
@@ -101,8 +59,8 @@ function resolveConfigFlag(pi: ExtensionAPI): string | undefined {
   return undefined;
 }
 
-function createMaxLimitsResolver(pi: ExtensionAPI): () => { maxBytes: number; maxLines: number } {
-  let cachedLimits: { maxBytes: number; maxLines: number } | undefined;
+function createPiMaxLimitsResolver(pi: ExtensionAPI): () => MaxLimits {
+  let cachedLimits: MaxLimits | undefined;
 
   return () => {
     if (cachedLimits) {
@@ -130,121 +88,7 @@ function createMaxLimitsResolver(pi: ExtensionAPI): () => { maxBytes: number; ma
   };
 }
 
-function resolveToolLimits(
-  requestedLimits: OutputLimitRequest,
-  getMaxLimits: () => { maxBytes: number; maxLines: number },
-): { maxBytes: number; maxLines: number } {
-  return resolveEffectiveLimits(requestedLimits, getMaxLimits());
-}
-
-function executeTool(
-  toolName: string,
-  pendingMessage: string,
-  executeFn: () => Record<string, unknown>,
-  onUpdate: AgentToolUpdateCallback<unknown> | undefined,
-  requestedLimits: OutputLimitRequest,
-  getMaxLimits: () => { maxBytes: number; maxLines: number },
-) {
-  onUpdate?.({
-    content: [{ type: "text" as const, text: pendingMessage }],
-    details: { status: "pending" },
-  });
-
-  try {
-    const effectiveLimits = resolveToolLimits(requestedLimits, getMaxLimits);
-    const result = executeFn();
-    const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
-    return { content: [{ type: "text" as const, text }], details, isError: false };
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    const result = buildError(err);
-    const { text, details } = formatToolOutput(toolName, result, {});
-    return { content: [{ type: "text" as const, text }], details, isError: true };
-  }
-}
-
 export default function codeReasoning(pi: ExtensionAPI) {
   registerFlags(pi);
-
-  const tracker = createThoughtTracker();
-  const getMaxLimits = createMaxLimitsResolver(pi);
-
-  pi.registerTool({
-    name: CODE_REASONING_TOOLS.reasoning,
-    label: "Code Reasoning",
-    description: `🧠 Reflective problem-solving through sequential thinking with branching and revision support.
-
-KEY PARAMETERS:
-- thought: Your current reasoning step (required)
-- thought_number: Current position in sequence (required)
-- total_thoughts: Estimated total (can adjust as you go) (required)
-- next_thought_needed: Set to FALSE ONLY when done (required)
-- branch_from_thought + branch_id: When exploring alternatives (🌿)
-- is_revision + revises_thought: When correcting earlier thinking (🔄)
-
-✅ CHECKLIST (review every 3 thoughts):
-1. Need to explore alternatives? → Use BRANCH (🌿)
-2. Need to correct earlier thinking? → Use REVISION (🔄)
-3. Scope changed? → Adjust total_thoughts
-4. Done? → Set next_thought_needed = false
-
-💡 TIPS:
-- Don't hesitate to revise when you learn something new
-- Use branching to explore multiple approaches
-- Express uncertainty when present
-- End with a validated conclusion`,
-    parameters: codeReasoningParams,
-    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-      const { toolArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
-      return executeTool(
-        CODE_REASONING_TOOLS.reasoning,
-        "Processing thought...",
-        () => processThought(toolArgs, tracker),
-        onUpdate,
-        requestedLimits,
-        getMaxLimits,
-      );
-    },
-  });
-
-  pi.registerTool({
-    name: CODE_REASONING_TOOLS.status,
-    label: "Code Reasoning Status",
-    description: "Get current status of the code reasoning session: branches, thought count.",
-    parameters: Type.Object({}, { additionalProperties: true }),
-    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-      const { requestedLimits } = splitParams(params as Record<string, unknown>);
-      return executeTool(
-        CODE_REASONING_TOOLS.status,
-        "Getting status...",
-        () => ({
-          branches: tracker.branches(),
-          thought_count: tracker.count(),
-        }),
-        onUpdate,
-        requestedLimits,
-        getMaxLimits,
-      );
-    },
-  });
-
-  pi.registerTool({
-    name: CODE_REASONING_TOOLS.reset,
-    label: "Reset Code Reasoning",
-    description: "Reset the code reasoning session, clearing all thoughts and branches.",
-    parameters: Type.Object({}, { additionalProperties: true }),
-    async execute(_toolCallId, _params, _signal, onUpdate, _ctx) {
-      onUpdate?.({
-        content: [{ type: "text" as const, text: "Resetting..." }],
-        details: { status: "pending" },
-      });
-
-      tracker.reset();
-      return {
-        content: [{ type: "text" as const, text: "Code reasoning session reset." }],
-        isError: false,
-        details: { tool: CODE_REASONING_TOOLS.reset },
-      };
-    },
-  });
+  registerPiTools(pi, createCodeReasoningTools({ getMaxLimits: createPiMaxLimitsResolver(pi) }));
 }

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -3,438 +3,34 @@
  *
  * Provides a tool for reflective problem-solving through sequential thinking.
  * Supports branching (exploring alternatives) and revision (correcting earlier thoughts).
- *
- * Setup:
- * 1. Install: pi install npm:@feniix/pi-code-reasoning
- * 2. Or pass flags:
- *    --code-reasoning-config-file, --code-reasoning-max-bytes, --code-reasoning-max-lines
- *
- * Usage:
- *   "Use code reasoning to think through this architecture decision"
- *   "Process a thought about the database schema design"
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
-import type { AgentToolUpdateCallback, ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
-
 import {
-  enforceCrossFieldRules,
-  MAX_THOUGHT_COUNT,
-  MAX_THOUGHT_LENGTH,
-  type ThoughtData,
-  type ValidatedThoughtData,
-  validateThoughtData,
-} from "./types.js";
+  type AgentToolUpdateCallback,
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { loadConfig, normalizeNumber, type OutputLimitRequest, resolveEffectiveLimits, splitParams } from "./config.js";
+import { CODE_REASONING_FLAGS, CODE_REASONING_TOOLS } from "./constants.js";
+import { formatToolOutput } from "./output.js";
+import { processThought } from "./processor.js";
+import { buildError } from "./responses.js";
+import { createThoughtTracker } from "./tracker.js";
 
-// =============================================================================
-// Constants
-// =============================================================================
-
-const DEFAULT_CONFIG_FILE: Record<string, unknown> = {
-  maxBytes: DEFAULT_MAX_BYTES,
-  maxLines: DEFAULT_MAX_LINES,
-};
-
-// Reserved for future use
-// const DEFAULT_CONFIG_DIR = join(homedir(), ".pi-code-reasoning");
-
-// =============================================================================
-// Types
-// =============================================================================
-
-interface CodeReasoningConfig {
-  maxBytes?: number;
-  maxLines?: number;
-}
-
-interface ThoughtTracker {
-  add: (thought: ValidatedThoughtData) => void;
-  reset: () => void;
-  ensureBranchIsValid: (branchFromThought?: number) => void;
-  ensureRevisionIsValid: (revisesThought?: number) => void;
-  branches: () => string[];
-  count: () => number;
-}
-
-interface McpToolDetails {
-  tool: string;
-  truncated: boolean;
-  truncation?: {
-    truncatedBy: "lines" | "bytes" | null;
-    totalLines: number;
-    totalBytes: number;
-    outputLines: number;
-    outputBytes: number;
-    maxLines: number;
-    maxBytes: number;
-  };
-  tempFile?: string;
-}
-
-// =============================================================================
-// Utility Functions
-// =============================================================================
-
-function getHomeDir(): string {
-  return process.env.HOME || homedir();
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function toJsonString(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
-
-function formatToolOutput(
-  toolName: string,
-  result: unknown,
-  limits: { maxBytes?: number; maxLines?: number },
-): { text: string; details: McpToolDetails } {
-  const rawText = toJsonString(result);
-  const truncation = truncateHead(rawText, {
-    maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
-    maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
-  });
-
-  let text = truncation.content;
-  let tempFile: string | undefined;
-
-  if (truncation.truncated) {
-    tempFile = writeTempFile(toolName, rawText);
-    text +=
-      `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
-      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
-      `Full output saved to: ${tempFile}]`;
-  }
-
-  if (truncation.firstLineExceedsLimit && rawText.length > 0) {
-    text =
-      `[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
-      text;
-  }
-
-  return {
-    text,
-    details: {
-      tool: toolName,
-      truncated: truncation.truncated,
-      truncation: {
-        truncatedBy: truncation.truncatedBy,
-        totalLines: truncation.totalLines,
-        totalBytes: truncation.totalBytes,
-        outputLines: truncation.outputLines,
-        outputBytes: truncation.outputBytes,
-        maxLines: truncation.maxLines,
-        maxBytes: truncation.maxBytes,
-      },
-      tempFile,
-    },
-  };
-}
-
-function writeTempFile(toolName: string, content: string): string {
-  const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
-  const filename = `pi-code-reasoning-${safeName}-${Date.now()}.txt`;
-  const filePath = join(tmpdir(), filename);
-  writeFileSync(filePath, content, "utf-8");
-  return filePath;
-}
-
-function normalizeNumber(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
-  }
-  return undefined;
-}
-
-function splitParams(params: Record<string, unknown>): {
-  toolArgs: Record<string, unknown>;
-  requestedLimits: { maxBytes?: number; maxLines?: number };
-} {
-  const { piMaxBytes, piMaxLines, ...rest } = params as Record<string, unknown> & {
-    piMaxBytes?: unknown;
-    piMaxLines?: unknown;
-  };
-  return {
-    toolArgs: rest,
-    requestedLimits: {
-      maxBytes: normalizeNumber(piMaxBytes),
-      maxLines: normalizeNumber(piMaxLines),
-    },
-  };
-}
-
-function resolveEffectiveLimits(
-  requested: { maxBytes?: number; maxLines?: number },
-  maxAllowed: { maxBytes: number; maxLines: number },
-): { maxBytes: number; maxLines: number } {
-  const requestedBytes = requested.maxBytes ?? maxAllowed.maxBytes;
-  const requestedLines = requested.maxLines ?? maxAllowed.maxLines;
-  return {
-    maxBytes: Math.min(requestedBytes, maxAllowed.maxBytes),
-    maxLines: Math.min(requestedLines, maxAllowed.maxLines),
-  };
-}
-
-function resolveConfigPath(configPath: string): string {
-  const trimmed = configPath.trim();
-  if (trimmed.startsWith("~/")) {
-    return join(getHomeDir(), trimmed.slice(2));
-  }
-  if (trimmed.startsWith("~")) {
-    return join(getHomeDir(), trimmed.slice(1));
-  }
-  if (isAbsolute(trimmed)) {
-    return trimmed;
-  }
-  return resolve(process.cwd(), trimmed);
-}
-
-function parseConfig(raw: unknown, pathHint: string): CodeReasoningConfig {
-  if (!isRecord(raw)) {
-    throw new Error(`Invalid Code Reasoning config at ${pathHint}: expected an object.`);
-  }
-  return {
-    maxBytes: normalizeNumber(raw.maxBytes),
-    maxLines: normalizeNumber(raw.maxLines),
-  };
-}
-
-function loadConfigFile(path: string): CodeReasoningConfig | null {
-  if (!existsSync(path)) {
-    return null;
-  }
-
-  try {
-    const raw = readFileSync(path, "utf-8");
-    const parsed = JSON.parse(raw);
-    return parseConfig(parsed, path);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-code-reasoning] Failed to parse config ${path}: ${message}`);
-    return null;
-  }
-}
-
-function loadSettingsConfig(path: string): CodeReasoningConfig | null {
-  if (!existsSync(path)) {
-    return null;
-  }
-
-  try {
-    const raw = readFileSync(path, "utf-8");
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const config = parsed["pi-code-reasoning"];
-    if (!isRecord(config)) {
-      return null;
-    }
-    return parseConfig(config, path);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-code-reasoning] Failed to parse settings ${path}: ${message}`);
-    return null;
-  }
-}
-
-function warnIgnoredLegacyConfigFiles(): void {
-  const legacyPaths = [
-    join(process.cwd(), ".pi", "extensions", "code-reasoning.json"),
-    join(getHomeDir(), ".pi", "agent", "extensions", "code-reasoning.json"),
-  ];
-
-  for (const legacyPath of legacyPaths) {
-    if (existsSync(legacyPath)) {
-      console.warn(
-        `[pi-code-reasoning] Ignoring legacy config file ${legacyPath}. Migrate non-secret settings to .pi/settings.json or ~/.pi/agent/settings.json under "pi-code-reasoning", or pass --code-reasoning-config-file / CODE_REASONING_CONFIG_FILE explicitly.`,
-      );
-    }
-  }
-}
-
-function loadConfig(configPath: string | undefined): CodeReasoningConfig | null {
-  const envConfigFile = process.env.CODE_REASONING_CONFIG_FILE;
-  const legacyEnvConfig = process.env.CODE_REASONING_CONFIG;
-  if (configPath) {
-    return loadConfigFile(resolveConfigPath(configPath));
-  }
-  if (envConfigFile) {
-    return loadConfigFile(resolveConfigPath(envConfigFile));
-  }
-  if (legacyEnvConfig) {
-    console.warn("[pi-code-reasoning] CODE_REASONING_CONFIG is deprecated; use CODE_REASONING_CONFIG_FILE.");
-    return loadConfigFile(resolveConfigPath(legacyEnvConfig));
-  }
-
-  warnIgnoredLegacyConfigFiles();
-
-  const globalSettingsPath = join(getHomeDir(), ".pi", "agent", "settings.json");
-  const projectSettingsPath = join(process.cwd(), ".pi", "settings.json");
-
-  const globalConfig = loadSettingsConfig(globalSettingsPath);
-  const projectConfig = loadSettingsConfig(projectSettingsPath);
-
-  if (!globalConfig && !projectConfig) {
-    return null;
-  }
-
-  return {
-    maxBytes: projectConfig?.maxBytes ?? globalConfig?.maxBytes,
-    maxLines: projectConfig?.maxLines ?? globalConfig?.maxLines,
-  };
-}
-
-// =============================================================================
-// Thought Tracker
-// =============================================================================
-
-function createThoughtTracker(): ThoughtTracker {
-  const thoughtHistory: ValidatedThoughtData[] = [];
-  const branches = new Map<string, ValidatedThoughtData[]>();
-
-  return {
-    add: (thought) => {
-      thoughtHistory.push(thought);
-      if (thought.branch_id) {
-        const branchThoughts = branches.get(thought.branch_id) ?? [];
-        branchThoughts.push(thought);
-        branches.set(thought.branch_id, branchThoughts);
-      }
-    },
-    ensureBranchIsValid: (branchFromThought) => {
-      if (branchFromThought && branchFromThought > thoughtHistory.length) {
-        throw new Error(`Invalid branch_from_thought ${branchFromThought}.`);
-      }
-    },
-    ensureRevisionIsValid: (revisesThought) => {
-      if (revisesThought && revisesThought > thoughtHistory.length) {
-        throw new Error(`Invalid revises_thought ${revisesThought}.`);
-      }
-    },
-    branches: () => Array.from(branches.keys()),
-    count: () => thoughtHistory.length,
-    reset: () => {
-      thoughtHistory.length = 0;
-      branches.clear();
-    },
-  };
-}
-
-// =============================================================================
-// Formatting Helpers
-// =============================================================================
-
-function _formatThought(t: ValidatedThoughtData): string {
-  const { thought_number, total_thoughts, thought, is_revision, revises_thought, branch_id, branch_from_thought } = t;
-
-  const header = is_revision
-    ? `🔄 Revision ${thought_number}/${total_thoughts} (of ${revises_thought})`
-    : branch_id
-      ? `🌿 Branch ${thought_number}/${total_thoughts} (from ${branch_from_thought}, id:${branch_id})`
-      : `💭 Thought ${thought_number}/${total_thoughts}`;
-
-  const body = thought
-    .split("\n")
-    .map((l) => `  ${l}`)
-    .join("\n");
-
-  return `\n${header}\n---\n${body}\n---`;
-}
-
-function getExampleThought(errorMsg: string): Partial<ThoughtData> {
-  if (errorMsg.includes("branch")) {
-    return {
-      thought: "Exploring alternative: Consider algorithm X.",
-      thought_number: 3,
-      total_thoughts: 7,
-      next_thought_needed: true,
-      branch_from_thought: 2,
-      branch_id: "alternative-algo-x",
-    };
-  }
-  if (errorMsg.includes("revis")) {
-    return {
-      thought: "Revisiting earlier point: Assumption Y was flawed.",
-      thought_number: 4,
-      total_thoughts: 6,
-      next_thought_needed: true,
-      is_revision: true,
-      revises_thought: 2,
-    };
-  }
-  if (errorMsg.includes("length") || errorMsg.includes("empty")) {
-    return {
-      thought: "Breaking down the thought into smaller parts...",
-      thought_number: 2,
-      total_thoughts: 5,
-      next_thought_needed: true,
-    };
-  }
-  return {
-    thought: "Initial exploration of the problem.",
-    thought_number: 1,
-    total_thoughts: 5,
-    next_thought_needed: true,
-  };
-}
-
-function buildSuccess(t: ValidatedThoughtData, tracker: ThoughtTracker): Record<string, unknown> {
-  return {
-    status: "processed",
-    thought_number: t.thought_number,
-    total_thoughts: t.total_thoughts,
-    next_thought_needed: t.next_thought_needed,
-    branches: tracker.branches(),
-    thought_history_length: tracker.count(),
-  };
-}
-
-function buildError(error: Error): Record<string, unknown> {
-  const errorMessage = error.message;
-  let guidance = "Check the tool description and schema for correct usage.";
-  const example = getExampleThought(errorMessage);
-
-  if (errorMessage.includes("branch")) {
-    guidance =
-      "When branching, provide both branch_from_thought (number) and branch_id (string), and do not combine with revision.";
-  } else if (errorMessage.includes("revision")) {
-    guidance =
-      "When revising, set is_revision=true and provide revises_thought (positive number). Do not combine with branching.";
-  } else if (errorMessage.includes("length")) {
-    guidance = `The thought is too long. Keep it under ${MAX_THOUGHT_LENGTH} characters.`;
-  } else if (errorMessage.includes("Max thought")) {
-    guidance = `The maximum thought limit (${MAX_THOUGHT_COUNT}) was reached.`;
-  }
-
-  return {
-    status: "failed",
-    error: errorMessage,
-    guidance,
-    example,
-  };
-}
-
-// =============================================================================
-// Tool Parameters
-// =============================================================================
+export {
+  DEFAULT_CONFIG_FILE,
+  isRecord,
+  normalizeNumber,
+  parseConfig,
+  resolveConfigPath,
+  resolveEffectiveLimits,
+  splitParams,
+} from "./config.js";
+export { formatToolOutput, toJsonString, writeTempFile } from "./output.js";
+export { buildError, buildSuccess, getExampleThought } from "./responses.js";
+export { createThoughtTracker } from "./tracker.js";
 
 const codeReasoningParams = Type.Object(
   {
@@ -471,64 +67,51 @@ const codeReasoningParams = Type.Object(
   { additionalProperties: true },
 );
 
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
-
-export {
-  buildError,
-  buildSuccess,
-  createThoughtTracker,
-  DEFAULT_CONFIG_FILE,
-  formatToolOutput,
-  getExampleThought,
-  isRecord,
-  normalizeNumber,
-  parseConfig,
-  resolveConfigPath,
-  resolveEffectiveLimits,
-  splitParams,
-  toJsonString,
-  writeTempFile,
-};
-
-export default function codeReasoning(pi: ExtensionAPI) {
-  // Register CLI flags
-  pi.registerFlag("--code-reasoning-config-file", {
+function registerFlags(pi: ExtensionAPI): void {
+  pi.registerFlag(CODE_REASONING_FLAGS.configFile, {
     description:
       "Path to JSON config file (overrides .pi/settings.json or ~/.pi/agent/settings.json under pi-code-reasoning).",
     type: "string",
   });
-  pi.registerFlag("--code-reasoning-config", {
+  pi.registerFlag(CODE_REASONING_FLAGS.legacyConfigFile, {
     description: "Deprecated alias for --code-reasoning-config-file.",
     type: "string",
   });
-  pi.registerFlag("--code-reasoning-max-bytes", {
+  pi.registerFlag(CODE_REASONING_FLAGS.maxBytes, {
     description: "Max bytes to keep from tool output (default: 51200).",
     type: "string",
   });
-  pi.registerFlag("--code-reasoning-max-lines", {
+  pi.registerFlag(CODE_REASONING_FLAGS.maxLines, {
     description: "Max lines to keep from tool output (default: 2000).",
     type: "string",
   });
+}
 
-  const tracker = createThoughtTracker();
+function resolveConfigFlag(pi: ExtensionAPI): string | undefined {
+  const configFileFlag = pi.getFlag(CODE_REASONING_FLAGS.configFile);
+  const legacyConfigFlag = pi.getFlag(CODE_REASONING_FLAGS.legacyConfigFile);
 
-  const getMaxLimits = (): { maxBytes: number; maxLines: number } => {
-    const maxBytesFlag = pi.getFlag("--code-reasoning-max-bytes");
-    const maxLinesFlag = pi.getFlag("--code-reasoning-max-lines");
-    const configFileFlag = pi.getFlag("--code-reasoning-config-file");
-    const legacyConfigFlag = pi.getFlag("--code-reasoning-config");
-    const configFlag =
-      typeof configFileFlag === "string"
-        ? configFileFlag
-        : typeof legacyConfigFlag === "string"
-          ? legacyConfigFlag
-          : undefined;
-    if (typeof configFileFlag !== "string" && typeof legacyConfigFlag === "string") {
-      console.warn("[pi-code-reasoning] --code-reasoning-config is deprecated; use --code-reasoning-config-file.");
+  if (typeof configFileFlag === "string") {
+    return configFileFlag;
+  }
+  if (typeof legacyConfigFlag === "string") {
+    console.warn("[pi-code-reasoning] --code-reasoning-config is deprecated; use --code-reasoning-config-file.");
+    return legacyConfigFlag;
+  }
+  return undefined;
+}
+
+function createMaxLimitsResolver(pi: ExtensionAPI): () => { maxBytes: number; maxLines: number } {
+  let cachedLimits: { maxBytes: number; maxLines: number } | undefined;
+
+  return () => {
+    if (cachedLimits) {
+      return cachedLimits;
     }
-    const config = loadConfig(configFlag);
+
+    const maxBytesFlag = pi.getFlag(CODE_REASONING_FLAGS.maxBytes);
+    const maxLinesFlag = pi.getFlag(CODE_REASONING_FLAGS.maxLines);
+    const config = loadConfig(resolveConfigFlag(pi));
 
     const maxBytes =
       typeof maxBytesFlag === "string"
@@ -539,110 +122,55 @@ export default function codeReasoning(pi: ExtensionAPI) {
         ? normalizeNumber(maxLinesFlag)
         : normalizeNumber(process.env.CODE_REASONING_MAX_LINES ?? config?.maxLines);
 
-    return {
+    cachedLimits = {
       maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
       maxLines: maxLines ?? DEFAULT_MAX_LINES,
     };
+    return cachedLimits;
   };
+}
 
-  // Process a single thought
-  const processThought = (args: Record<string, unknown>): Record<string, unknown> => {
-    const thought = args.thought as string;
-    const thought_number = args.thought_number as number;
-    const total_thoughts = args.total_thoughts as number;
-    const next_thought_needed = args.next_thought_needed as boolean;
-    const is_revision = args.is_revision as boolean | undefined;
-    const revises_thought = args.revises_thought as number | undefined;
-    const branch_from_thought = args.branch_from_thought as number | undefined;
-    const branch_id = args.branch_id as string | undefined;
-    const needs_more_thoughts = args.needs_more_thoughts as boolean | undefined;
+function resolveToolLimits(
+  requestedLimits: OutputLimitRequest,
+  getMaxLimits: () => { maxBytes: number; maxLines: number },
+): { maxBytes: number; maxLines: number } {
+  return resolveEffectiveLimits(requestedLimits, getMaxLimits());
+}
 
-    const data: ThoughtData = {
-      thought,
-      thought_number,
-      total_thoughts,
-      next_thought_needed,
-      is_revision,
-      revises_thought,
-      branch_from_thought,
-      branch_id,
-      needs_more_thoughts,
-    };
+function executeTool(
+  toolName: string,
+  pendingMessage: string,
+  executeFn: () => Record<string, unknown>,
+  onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+  requestedLimits: OutputLimitRequest,
+  getMaxLimits: () => { maxBytes: number; maxLines: number },
+) {
+  onUpdate?.({
+    content: [{ type: "text" as const, text: pendingMessage }],
+    details: { status: "pending" },
+  });
 
-    const fieldErrors = validateThoughtData(data);
-    if (fieldErrors.length > 0) {
-      throw new Error(fieldErrors[0].message);
-    }
+  try {
+    const effectiveLimits = resolveToolLimits(requestedLimits, getMaxLimits);
+    const result = executeFn();
+    const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
+    return { content: [{ type: "text" as const, text }], details, isError: false };
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    const result = buildError(err);
+    const { text, details } = formatToolOutput(toolName, result, {});
+    return { content: [{ type: "text" as const, text }], details, isError: true };
+  }
+}
 
-    // Validate thought limits and ordering
-    if (data.thought_number > MAX_THOUGHT_COUNT || data.total_thoughts > MAX_THOUGHT_COUNT) {
-      throw new Error(`Max thought_number exceeded (${MAX_THOUGHT_COUNT}).`);
-    }
-    if (data.thought_number > data.total_thoughts) {
-      throw new Error("thought_number cannot exceed total_thoughts.");
-    }
+export default function codeReasoning(pi: ExtensionAPI) {
+  registerFlags(pi);
 
-    // Cross-field validation
-    const crossErrors = enforceCrossFieldRules(data);
-    if (crossErrors.length > 0) {
-      throw new Error(crossErrors[0].message);
-    }
-
-    // Validate branch/revision references
-    tracker.ensureBranchIsValid(data.branch_from_thought);
-    tracker.ensureRevisionIsValid(data.revises_thought);
-
-    // Add defaults
-    const validated: ValidatedThoughtData = {
-      thought: data.thought,
-      thought_number: data.thought_number,
-      total_thoughts: data.total_thoughts,
-      next_thought_needed: data.next_thought_needed,
-      is_revision: data.is_revision ?? false,
-      branch_from_thought: data.branch_from_thought,
-      branch_id: data.branch_id,
-      needs_more_thoughts: data.needs_more_thoughts ?? data.next_thought_needed,
-    };
-
-    tracker.add(validated);
-
-    return buildSuccess(validated, tracker);
-  };
-
-  // Helper to execute a tool
-  const executeTool = (
-    toolName: string,
-    pendingMessage: string,
-    executeFn: () => Record<string, unknown>,
-    onUpdate: AgentToolUpdateCallback<unknown> | undefined,
-    params: Record<string, unknown>,
-  ) => {
-    onUpdate?.({
-      content: [{ type: "text" as const, text: pendingMessage }],
-      details: { status: "pending" },
-    });
-
-    try {
-      const { requestedLimits } = splitParams(params);
-      const maxLimits = getMaxLimits();
-      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-      const result = executeFn();
-      const { text, details } = formatToolOutput(toolName, result, effectiveLimits);
-      return { content: [{ type: "text" as const, text }], details, isError: false };
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      const result = buildError(err);
-      const { text, details } = formatToolOutput(toolName, result, {});
-      return { content: [{ type: "text" as const, text }], details, isError: true };
-    }
-  };
-
-  // =============================================================================
-  // Register Tool
-  // =============================================================================
+  const tracker = createThoughtTracker();
+  const getMaxLimits = createMaxLimitsResolver(pi);
 
   pi.registerTool({
-    name: "code_reasoning",
+    name: CODE_REASONING_TOOLS.reasoning,
     label: "Code Reasoning",
     description: `🧠 Reflective problem-solving through sequential thinking with branching and revision support.
 
@@ -667,48 +195,41 @@ KEY PARAMETERS:
 - End with a validated conclusion`,
     parameters: codeReasoningParams,
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
-      const { toolArgs } = splitParams(params as Record<string, unknown>);
+      const { toolArgs, requestedLimits } = splitParams(params as Record<string, unknown>);
       return executeTool(
-        "code_reasoning",
+        CODE_REASONING_TOOLS.reasoning,
         "Processing thought...",
-        () => processThought(toolArgs),
+        () => processThought(toolArgs, tracker),
         onUpdate,
-        params as Record<string, unknown>,
+        requestedLimits,
+        getMaxLimits,
       );
     },
   });
 
-  // =============================================================================
-  // Register Helper Tools
-  // =============================================================================
-
   pi.registerTool({
-    name: "code_reasoning_status",
+    name: CODE_REASONING_TOOLS.status,
     label: "Code Reasoning Status",
     description: "Get current status of the code reasoning session: branches, thought count.",
     parameters: Type.Object({}, { additionalProperties: true }),
     async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
       const { requestedLimits } = splitParams(params as Record<string, unknown>);
-      const maxLimits = getMaxLimits();
-      const effectiveLimits = resolveEffectiveLimits(requestedLimits, maxLimits);
-
-      onUpdate?.({
-        content: [{ type: "text" as const, text: "Getting status..." }],
-        details: { status: "pending" },
-      });
-
-      const status = {
-        branches: tracker.branches(),
-        thought_count: tracker.count(),
-      };
-
-      const { text, details } = formatToolOutput("code_reasoning_status", status, effectiveLimits);
-      return { content: [{ type: "text" as const, text }], details, isError: false };
+      return executeTool(
+        CODE_REASONING_TOOLS.status,
+        "Getting status...",
+        () => ({
+          branches: tracker.branches(),
+          thought_count: tracker.count(),
+        }),
+        onUpdate,
+        requestedLimits,
+        getMaxLimits,
+      );
     },
   });
 
   pi.registerTool({
-    name: "code_reasoning_reset",
+    name: CODE_REASONING_TOOLS.reset,
     label: "Reset Code Reasoning",
     description: "Reset the code reasoning session, clearing all thoughts and branches.",
     parameters: Type.Object({}, { additionalProperties: true }),
@@ -722,7 +243,7 @@ KEY PARAMETERS:
       return {
         content: [{ type: "text" as const, text: "Code reasoning session reset." }],
         isError: false,
-        details: { tool: "code_reasoning_reset" },
+        details: { tool: CODE_REASONING_TOOLS.reset },
       };
     },
   });

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -6,7 +6,8 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerPiTools } from "@feniix/bridgekit/pi";
+import { executePortableTool, type PortableTool, type PortableToolResult } from "@feniix/bridgekit";
+import type { TSchema } from "typebox";
 import { loadConfig, normalizeNumber } from "./config.js";
 import { CODE_REASONING_FLAGS, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./constants.js";
 import { createCodeReasoningTools, type MaxLimits } from "./tools.js";
@@ -59,6 +60,51 @@ function resolveConfigFlag(pi: ExtensionAPI): string | undefined {
   return undefined;
 }
 
+type PiContent = { type: "text"; text: string };
+
+type PiToolResult = {
+  content: PiContent[];
+  details: Record<string, unknown>;
+  isError?: true;
+};
+
+function toPiDetails(result: PortableToolResult): Record<string, unknown> {
+  return result.structuredContent ?? result.details ?? {};
+}
+
+function toPiResult(result: PortableToolResult): PiToolResult {
+  const piResult = {
+    content: [{ type: "text" as const, text: result.text }],
+    details: toPiDetails(result),
+  };
+
+  if (result.isError) {
+    return { ...piResult, isError: true };
+  }
+  return piResult;
+}
+
+function registerCodeReasoningPiTools(pi: ExtensionAPI, tools: readonly PortableTool<TSchema>[]): void {
+  for (const tool of tools) {
+    pi.registerTool({
+      name: tool.name,
+      label: tool.title,
+      description: tool.description,
+      parameters: tool.parameters,
+      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+        const result = await executePortableTool(tool, params, {
+          host: "pi",
+          signal,
+          progress(update) {
+            onUpdate?.(toPiResult(update));
+          },
+        });
+        return toPiResult(result);
+      },
+    });
+  }
+}
+
 function createPiMaxLimitsResolver(pi: ExtensionAPI): () => MaxLimits {
   let cachedLimits: MaxLimits | undefined;
 
@@ -90,5 +136,5 @@ function createPiMaxLimitsResolver(pi: ExtensionAPI): () => MaxLimits {
 
 export default function codeReasoning(pi: ExtensionAPI) {
   registerFlags(pi);
-  registerPiTools(pi, createCodeReasoningTools({ getMaxLimits: createPiMaxLimitsResolver(pi) }));
+  registerCodeReasoningPiTools(pi, createCodeReasoningTools({ getMaxLimits: createPiMaxLimitsResolver(pi) }));
 }

--- a/packages/pi-code-reasoning/extensions/mcp-server.ts
+++ b/packages/pi-code-reasoning/extensions/mcp-server.ts
@@ -6,9 +6,21 @@ import { type CreateMcpServerOptions, runMcpStdioServer as defaultRunMcpStdioSer
 import { isRecord } from "./config.js";
 import { createCodeReasoningTools } from "./tools.js";
 
+function readPackageVersion(packageJsonUrl: URL): string | undefined {
+  try {
+    const packageJson: unknown = JSON.parse(readFileSync(packageJsonUrl, "utf-8"));
+    return isRecord(packageJson) && typeof packageJson.version === "string" ? packageJson.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function packageVersion(): string {
-  const packageJson: unknown = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
-  return isRecord(packageJson) && typeof packageJson.version === "string" ? packageJson.version : "0.0.0";
+  return (
+    readPackageVersion(new URL("../package.json", import.meta.url)) ??
+    readPackageVersion(new URL("../../package.json", import.meta.url)) ??
+    "0.0.0"
+  );
 }
 
 export function createMcpServerOptions(): CreateMcpServerOptions {

--- a/packages/pi-code-reasoning/extensions/mcp-server.ts
+++ b/packages/pi-code-reasoning/extensions/mcp-server.ts
@@ -7,7 +7,7 @@ import { isRecord } from "./config.js";
 import { createCodeReasoningTools } from "./tools.js";
 
 function packageVersion(): string {
-  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
+  const packageJson: unknown = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
   return isRecord(packageJson) && typeof packageJson.version === "string" ? packageJson.version : "0.0.0";
 }
 

--- a/packages/pi-code-reasoning/extensions/mcp-server.ts
+++ b/packages/pi-code-reasoning/extensions/mcp-server.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { readFileSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type CreateMcpServerOptions, runMcpStdioServer } from "@feniix/bridgekit/mcp";
+import { isRecord } from "./config.js";
+import { createCodeReasoningTools } from "./tools.js";
+
+function packageVersion(): string {
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
+  return isRecord(packageJson) && typeof packageJson.version === "string" ? packageJson.version : "0.0.0";
+}
+
+export function createMcpServerOptions(): CreateMcpServerOptions {
+  return {
+    name: "pi-code-reasoning",
+    version: packageVersion(),
+    tools: createCodeReasoningTools(),
+    instructions:
+      "Use these tools for reflective sequential thinking with support for branching, revision, status checks, and reset.",
+  };
+}
+
+export async function runServer(): Promise<void> {
+  await runMcpStdioServer(createMcpServerOptions());
+}
+
+function realpathIfPossible(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+if (process.argv[1]) {
+  const invokedPath = realpathIfPossible(resolve(process.argv[1]));
+  const modulePath = realpathIfPossible(fileURLToPath(import.meta.url));
+  if (invokedPath === modulePath) {
+    await runServer();
+  }
+}

--- a/packages/pi-code-reasoning/extensions/mcp-server.ts
+++ b/packages/pi-code-reasoning/extensions/mcp-server.ts
@@ -2,7 +2,7 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { type CreateMcpServerOptions, runMcpStdioServer } from "@feniix/bridgekit/mcp";
+import { type CreateMcpServerOptions, runMcpStdioServer as defaultRunMcpStdioServer } from "@feniix/bridgekit/mcp";
 import { isRecord } from "./config.js";
 import { createCodeReasoningTools } from "./tools.js";
 
@@ -21,7 +21,9 @@ export function createMcpServerOptions(): CreateMcpServerOptions {
   };
 }
 
-export async function runServer(): Promise<void> {
+type RunMcpStdioServer = (options: CreateMcpServerOptions) => Promise<void>;
+
+export async function runServer(runMcpStdioServer: RunMcpStdioServer = defaultRunMcpStdioServer): Promise<void> {
   await runMcpStdioServer(createMcpServerOptions());
 }
 

--- a/packages/pi-code-reasoning/extensions/output.ts
+++ b/packages/pi-code-reasoning/extensions/output.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -105,7 +106,7 @@ function formatSize(bytes: number): string {
 
 export function writeTempFile(toolName: string, content: string): string {
   const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
-  const filename = `pi-code-reasoning-${safeName}-${Date.now()}.txt`;
+  const filename = `pi-code-reasoning-${safeName}-${Date.now()}-${randomUUID()}.txt`;
   const filePath = join(tmpdir(), filename);
   writeFileSync(filePath, content, "utf-8");
   return filePath;

--- a/packages/pi-code-reasoning/extensions/output.ts
+++ b/packages/pi-code-reasoning/extensions/output.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./constants.js";
 
 export interface McpToolDetails {
   tool: string;
@@ -18,6 +18,19 @@ export interface McpToolDetails {
   tempFile?: string;
 }
 
+interface TruncationResult {
+  content: string;
+  truncated: boolean;
+  truncatedBy: "lines" | "bytes" | null;
+  firstLineExceedsLimit: boolean;
+  totalLines: number;
+  totalBytes: number;
+  outputLines: number;
+  outputBytes: number;
+  maxLines: number;
+  maxBytes: number;
+}
+
 export function toJsonString(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -27,6 +40,66 @@ export function toJsonString(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, "utf-8");
+}
+
+function truncateByBytes(value: string, maxBytes: number): string {
+  if (byteLength(value) <= maxBytes) {
+    return value;
+  }
+
+  let output = "";
+  for (const char of value) {
+    const next = output + char;
+    if (byteLength(next) > maxBytes) {
+      break;
+    }
+    output = next;
+  }
+  return output;
+}
+
+function truncateHead(content: string, limits: { maxLines: number; maxBytes: number }): TruncationResult {
+  const totalBytes = byteLength(content);
+  const lines = content.split("\n");
+  const totalLines = lines.length;
+
+  let output = totalLines > limits.maxLines ? lines.slice(0, limits.maxLines).join("\n") : content;
+  let truncatedBy: "lines" | "bytes" | null = output === content ? null : "lines";
+
+  if (byteLength(output) > limits.maxBytes) {
+    output = truncateByBytes(output, limits.maxBytes);
+    truncatedBy = "bytes";
+  }
+
+  const outputLines = output.length === 0 ? 0 : output.split("\n").length;
+  const outputBytes = byteLength(output);
+
+  return {
+    content: output,
+    truncated: output !== content,
+    truncatedBy,
+    firstLineExceedsLimit: lines[0] !== undefined && byteLength(lines[0]) > limits.maxBytes,
+    totalLines,
+    totalBytes,
+    outputLines,
+    outputBytes,
+    maxLines: limits.maxLines,
+    maxBytes: limits.maxBytes,
+  };
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 export function writeTempFile(toolName: string, content: string): string {

--- a/packages/pi-code-reasoning/extensions/output.ts
+++ b/packages/pi-code-reasoning/extensions/output.ts
@@ -1,0 +1,85 @@
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
+
+export interface McpToolDetails {
+  tool: string;
+  truncated: boolean;
+  truncation?: {
+    truncatedBy: "lines" | "bytes" | null;
+    totalLines: number;
+    totalBytes: number;
+    outputLines: number;
+    outputBytes: number;
+    maxLines: number;
+    maxBytes: number;
+  };
+  tempFile?: string;
+}
+
+export function toJsonString(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function writeTempFile(toolName: string, content: string): string {
+  const safeName = toolName.replace(/[^a-z0-9_-]/gi, "_");
+  const filename = `pi-code-reasoning-${safeName}-${Date.now()}.txt`;
+  const filePath = join(tmpdir(), filename);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+export function formatToolOutput(
+  toolName: string,
+  result: unknown,
+  limits: { maxBytes?: number; maxLines?: number },
+): { text: string; details: McpToolDetails } {
+  const rawText = toJsonString(result);
+  const truncation = truncateHead(rawText, {
+    maxLines: limits?.maxLines ?? DEFAULT_MAX_LINES,
+    maxBytes: limits?.maxBytes ?? DEFAULT_MAX_BYTES,
+  });
+
+  let text = truncation.content;
+  let tempFile: string | undefined;
+
+  if (truncation.truncated) {
+    tempFile = writeTempFile(toolName, rawText);
+    text +=
+      `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
+      `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
+      `Full output saved to: ${tempFile}]`;
+  }
+
+  if (truncation.firstLineExceedsLimit && rawText.length > 0) {
+    text =
+      `[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
+      text;
+  }
+
+  return {
+    text,
+    details: {
+      tool: toolName,
+      truncated: truncation.truncated,
+      truncation: {
+        truncatedBy: truncation.truncatedBy,
+        totalLines: truncation.totalLines,
+        totalBytes: truncation.totalBytes,
+        outputLines: truncation.outputLines,
+        outputBytes: truncation.outputBytes,
+        maxLines: truncation.maxLines,
+        maxBytes: truncation.maxBytes,
+      },
+      tempFile,
+    },
+  };
+}

--- a/packages/pi-code-reasoning/extensions/output.ts
+++ b/packages/pi-code-reasoning/extensions/output.ts
@@ -16,6 +16,7 @@ export interface McpToolDetails {
     maxBytes: number;
   };
   tempFile?: string;
+  warning?: string;
 }
 
 interface TruncationResult {
@@ -123,19 +124,27 @@ export function formatToolOutput(
 
   let text = truncation.content;
   let tempFile: string | undefined;
+  let warning: string | undefined;
 
   if (truncation.truncated) {
-    tempFile = writeTempFile(toolName, rawText);
+    try {
+      tempFile = writeTempFile(toolName, rawText);
+    } catch (error) {
+      warning = `Full output could not be saved: ${error instanceof Error ? error.message : String(error)}`;
+    }
+
     text +=
       `\n\n[Output truncated: ${truncation.outputLines} of ${truncation.totalLines} lines ` +
       `(${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). ` +
-      `Full output saved to: ${tempFile}]`;
+      (tempFile ? `Full output saved to: ${tempFile}` : warning) +
+      "]";
   }
 
   if (truncation.firstLineExceedsLimit && rawText.length > 0) {
-    text =
-      `[First line exceeded ${formatSize(truncation.maxBytes)} limit. Full output saved to: ${tempFile ?? "N/A"}]\n` +
-      text;
+    const fullOutputLocation = tempFile
+      ? `Full output saved to: ${tempFile}`
+      : (warning ?? "Full output could not be saved");
+    text = `[First line exceeded ${formatSize(truncation.maxBytes)} limit. ${fullOutputLocation}]\n${text}`;
   }
 
   return {
@@ -153,6 +162,7 @@ export function formatToolOutput(
         maxBytes: truncation.maxBytes,
       },
       tempFile,
+      warning,
     },
   };
 }

--- a/packages/pi-code-reasoning/extensions/processor.ts
+++ b/packages/pi-code-reasoning/extensions/processor.ts
@@ -1,0 +1,68 @@
+import { buildSuccess } from "./responses.js";
+import type { ThoughtTracker } from "./tracker.js";
+import {
+  enforceCrossFieldRules,
+  MAX_THOUGHT_COUNT,
+  type ThoughtData,
+  type ValidatedThoughtData,
+  validateThoughtData,
+} from "./types.js";
+
+export function toThoughtData(args: Record<string, unknown>): ThoughtData {
+  return {
+    thought: args.thought as string,
+    thought_number: args.thought_number as number,
+    total_thoughts: args.total_thoughts as number,
+    next_thought_needed: args.next_thought_needed as boolean,
+    is_revision: args.is_revision as boolean | undefined,
+    revises_thought: args.revises_thought as number | undefined,
+    branch_from_thought: args.branch_from_thought as number | undefined,
+    branch_id: args.branch_id as string | undefined,
+    needs_more_thoughts: args.needs_more_thoughts as boolean | undefined,
+  };
+}
+
+export function applyThoughtDefaults(data: ThoughtData): ValidatedThoughtData {
+  return {
+    thought: data.thought,
+    thought_number: data.thought_number,
+    total_thoughts: data.total_thoughts,
+    next_thought_needed: data.next_thought_needed,
+    is_revision: data.is_revision ?? false,
+    branch_from_thought: data.branch_from_thought,
+    branch_id: data.branch_id,
+    needs_more_thoughts: data.needs_more_thoughts ?? data.next_thought_needed,
+  };
+}
+
+function validateThoughtSequence(data: ThoughtData): void {
+  const fieldErrors = validateThoughtData(data);
+  if (fieldErrors.length > 0) {
+    throw new Error(fieldErrors[0].message);
+  }
+
+  if (data.thought_number > MAX_THOUGHT_COUNT || data.total_thoughts > MAX_THOUGHT_COUNT) {
+    throw new Error(`Max thought_number exceeded (${MAX_THOUGHT_COUNT}).`);
+  }
+  if (data.thought_number > data.total_thoughts) {
+    throw new Error("thought_number cannot exceed total_thoughts.");
+  }
+
+  const crossErrors = enforceCrossFieldRules(data);
+  if (crossErrors.length > 0) {
+    throw new Error(crossErrors[0].message);
+  }
+}
+
+export function processThought(args: Record<string, unknown>, tracker: ThoughtTracker): Record<string, unknown> {
+  const data = toThoughtData(args);
+
+  validateThoughtSequence(data);
+  tracker.ensureBranchIsValid(data.branch_from_thought);
+  tracker.ensureRevisionIsValid(data.revises_thought);
+
+  const validated = applyThoughtDefaults(data);
+  tracker.add(validated);
+
+  return buildSuccess(validated, tracker);
+}

--- a/packages/pi-code-reasoning/extensions/responses.ts
+++ b/packages/pi-code-reasoning/extensions/responses.ts
@@ -1,0 +1,75 @@
+import type { ThoughtTracker } from "./tracker.js";
+import { MAX_THOUGHT_COUNT, MAX_THOUGHT_LENGTH, type ThoughtData, type ValidatedThoughtData } from "./types.js";
+
+export function getExampleThought(errorMsg: string): Partial<ThoughtData> {
+  if (errorMsg.includes("branch")) {
+    return {
+      thought: "Exploring alternative: Consider algorithm X.",
+      thought_number: 3,
+      total_thoughts: 7,
+      next_thought_needed: true,
+      branch_from_thought: 2,
+      branch_id: "alternative-algo-x",
+    };
+  }
+  if (errorMsg.includes("revis")) {
+    return {
+      thought: "Revisiting earlier point: Assumption Y was flawed.",
+      thought_number: 4,
+      total_thoughts: 6,
+      next_thought_needed: true,
+      is_revision: true,
+      revises_thought: 2,
+    };
+  }
+  if (errorMsg.includes("length") || errorMsg.includes("empty")) {
+    return {
+      thought: "Breaking down the thought into smaller parts...",
+      thought_number: 2,
+      total_thoughts: 5,
+      next_thought_needed: true,
+    };
+  }
+  return {
+    thought: "Initial exploration of the problem.",
+    thought_number: 1,
+    total_thoughts: 5,
+    next_thought_needed: true,
+  };
+}
+
+export function buildSuccess(t: ValidatedThoughtData, tracker: ThoughtTracker): Record<string, unknown> {
+  return {
+    status: "processed",
+    thought_number: t.thought_number,
+    total_thoughts: t.total_thoughts,
+    next_thought_needed: t.next_thought_needed,
+    branches: tracker.branches(),
+    thought_history_length: tracker.count(),
+  };
+}
+
+export function buildError(error: Error): Record<string, unknown> {
+  const errorMessage = error.message;
+  let guidance = "Check the tool description and schema for correct usage.";
+  const example = getExampleThought(errorMessage);
+
+  if (errorMessage.includes("branch")) {
+    guidance =
+      "When branching, provide both branch_from_thought (number) and branch_id (string), and do not combine with revision.";
+  } else if (errorMessage.includes("revision")) {
+    guidance =
+      "When revising, set is_revision=true and provide revises_thought (positive number). Do not combine with branching.";
+  } else if (errorMessage.includes("length")) {
+    guidance = `The thought is too long. Keep it under ${MAX_THOUGHT_LENGTH} characters.`;
+  } else if (errorMessage.includes("Max thought")) {
+    guidance = `The maximum thought limit (${MAX_THOUGHT_COUNT}) was reached.`;
+  }
+
+  return {
+    status: "failed",
+    error: errorMessage,
+    guidance,
+    example,
+  };
+}

--- a/packages/pi-code-reasoning/extensions/tools.ts
+++ b/packages/pi-code-reasoning/extensions/tools.ts
@@ -52,13 +52,26 @@ export const codeReasoningParams = Type.Object(
     ),
     branch_id: Type.Optional(Type.String({ description: "Identifier for this branch." })),
     needs_more_thoughts: Type.Optional(Type.Boolean({ description: "If more thoughts are needed." })),
-    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
-    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+    piMaxBytes: Type.Optional(
+      Type.Integer({ minimum: 1, description: "Client-side max bytes override (clamped by config)." }),
+    ),
+    piMaxLines: Type.Optional(
+      Type.Integer({ minimum: 1, description: "Client-side max lines override (clamped by config)." }),
+    ),
   },
   { additionalProperties: true },
 );
 
-const statusParams = Type.Object({}, { additionalProperties: true });
+const outputLimitParams = {
+  piMaxBytes: Type.Optional(
+    Type.Integer({ minimum: 1, description: "Client-side max bytes override (clamped by config)." }),
+  ),
+  piMaxLines: Type.Optional(
+    Type.Integer({ minimum: 1, description: "Client-side max lines override (clamped by config)." }),
+  ),
+};
+
+const statusParams = Type.Object(outputLimitParams, { additionalProperties: true });
 const resetParams = Type.Object({}, { additionalProperties: true });
 
 export function createEnvironmentMaxLimitsResolver(): MaxLimitsResolver {
@@ -84,7 +97,10 @@ function resolveToolLimits(requestedLimits: OutputLimitRequest, getMaxLimits: Ma
 }
 
 function structuredContentFor(result: unknown, details: McpToolDetails): Record<string, unknown> {
-  return isRecord(result) ? { ...details, ...result } : { ...details };
+  if (!isRecord(result) || details.truncated) {
+    return { ...details };
+  }
+  return { ...details, ...result };
 }
 
 function formatPortableResult(

--- a/packages/pi-code-reasoning/extensions/tools.ts
+++ b/packages/pi-code-reasoning/extensions/tools.ts
@@ -1,5 +1,4 @@
-import { definePortableTool, type PortableToolResult } from "@feniix/bridgekit";
-import type { TObject } from "typebox";
+import { definePortableTool, type PortableTool, type PortableToolResult } from "@feniix/bridgekit";
 import { Type } from "typebox";
 import {
   isRecord,
@@ -71,8 +70,14 @@ const outputLimitParams = {
   ),
 };
 
-const statusParams = Type.Object(outputLimitParams, { additionalProperties: true });
-const resetParams = Type.Object({}, { additionalProperties: true });
+export const statusParams = Type.Object(outputLimitParams, { additionalProperties: true });
+export const resetParams = Type.Object({}, { additionalProperties: true });
+
+export type CodeReasoningTools = readonly [
+  PortableTool<typeof codeReasoningParams>,
+  PortableTool<typeof statusParams>,
+  PortableTool<typeof resetParams>,
+];
 
 export function createEnvironmentMaxLimitsResolver(): MaxLimitsResolver {
   let cachedLimits: MaxLimits | undefined;
@@ -143,7 +148,7 @@ function runFormattedTool(
   }
 }
 
-export function createCodeReasoningTools(options: CodeReasoningToolsOptions = {}) {
+export function createCodeReasoningTools(options: CodeReasoningToolsOptions = {}): CodeReasoningTools {
   const tracker = options.tracker ?? createThoughtTracker();
   const getMaxLimits = options.getMaxLimits ?? createEnvironmentMaxLimitsResolver();
 
@@ -217,5 +222,5 @@ KEY PARAMETERS:
         };
       },
     }),
-  ] satisfies readonly ReturnType<typeof definePortableTool<TObject>>[];
+  ];
 }

--- a/packages/pi-code-reasoning/extensions/tools.ts
+++ b/packages/pi-code-reasoning/extensions/tools.ts
@@ -1,0 +1,205 @@
+import { definePortableTool, type PortableToolResult } from "@feniix/bridgekit";
+import type { TObject } from "typebox";
+import { Type } from "typebox";
+import {
+  isRecord,
+  loadConfig,
+  normalizeNumber,
+  type OutputLimitRequest,
+  resolveEffectiveLimits,
+  splitParams,
+} from "./config.js";
+import { CODE_REASONING_TOOLS, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./constants.js";
+import { formatToolOutput, type McpToolDetails } from "./output.js";
+import { processThought } from "./processor.js";
+import { buildError } from "./responses.js";
+import { createThoughtTracker, type ThoughtTracker } from "./tracker.js";
+
+export type MaxLimits = { maxBytes: number; maxLines: number };
+export type MaxLimitsResolver = () => MaxLimits;
+
+export interface CodeReasoningToolsOptions {
+  tracker?: ThoughtTracker;
+  getMaxLimits?: MaxLimitsResolver;
+}
+
+export const codeReasoningParams = Type.Object(
+  {
+    thought: Type.String({ description: "The content of your reasoning/thought." }),
+    thought_number: Type.Integer({
+      minimum: 1,
+      description: "Current number in the thinking sequence.",
+    }),
+    total_thoughts: Type.Integer({
+      minimum: 1,
+      description: "Estimated total number of thoughts.",
+    }),
+    next_thought_needed: Type.Boolean({
+      description: "Set to FALSE only when completely done.",
+    }),
+    is_revision: Type.Optional(Type.Boolean({ description: "When correcting earlier thinking (🔄)." })),
+    revises_thought: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "Which thought number you're revising.",
+      }),
+    ),
+    branch_from_thought: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "When exploring alternative approaches (🌿).",
+      }),
+    ),
+    branch_id: Type.Optional(Type.String({ description: "Identifier for this branch." })),
+    needs_more_thoughts: Type.Optional(Type.Boolean({ description: "If more thoughts are needed." })),
+    piMaxBytes: Type.Optional(Type.Integer({ description: "Client-side max bytes override (clamped by config)." })),
+    piMaxLines: Type.Optional(Type.Integer({ description: "Client-side max lines override (clamped by config)." })),
+  },
+  { additionalProperties: true },
+);
+
+const statusParams = Type.Object({}, { additionalProperties: true });
+const resetParams = Type.Object({}, { additionalProperties: true });
+
+export function createEnvironmentMaxLimitsResolver(): MaxLimitsResolver {
+  let cachedLimits: MaxLimits | undefined;
+
+  return () => {
+    if (cachedLimits) return cachedLimits;
+
+    const config = loadConfig(undefined);
+    const maxBytes = normalizeNumber(process.env.CODE_REASONING_MAX_BYTES ?? config?.maxBytes);
+    const maxLines = normalizeNumber(process.env.CODE_REASONING_MAX_LINES ?? config?.maxLines);
+
+    cachedLimits = {
+      maxBytes: maxBytes ?? DEFAULT_MAX_BYTES,
+      maxLines: maxLines ?? DEFAULT_MAX_LINES,
+    };
+    return cachedLimits;
+  };
+}
+
+function resolveToolLimits(requestedLimits: OutputLimitRequest, getMaxLimits: MaxLimitsResolver): MaxLimits {
+  return resolveEffectiveLimits(requestedLimits, getMaxLimits());
+}
+
+function structuredContentFor(result: unknown, details: McpToolDetails): Record<string, unknown> {
+  return isRecord(result) ? { ...details, ...result } : { ...details };
+}
+
+function formatPortableResult(
+  toolName: string,
+  result: unknown,
+  requestedLimits: OutputLimitRequest,
+  getMaxLimits: MaxLimitsResolver,
+): PortableToolResult {
+  const effectiveLimits = resolveToolLimits(requestedLimits, getMaxLimits);
+  return formatPortableResultWithLimits(toolName, result, effectiveLimits);
+}
+
+function formatPortableResultWithLimits(
+  toolName: string,
+  result: unknown,
+  limits: { maxBytes?: number; maxLines?: number },
+  isError = false,
+): PortableToolResult {
+  const { text, details } = formatToolOutput(toolName, result, limits);
+  return {
+    text,
+    structuredContent: structuredContentFor(result, details),
+    isError,
+  };
+}
+
+function runFormattedTool(
+  toolName: string,
+  args: object,
+  executeFn: (toolArgs: Record<string, unknown>) => Record<string, unknown>,
+  getMaxLimits: MaxLimitsResolver,
+): PortableToolResult {
+  const { toolArgs, requestedLimits } = splitParams(args as Record<string, unknown>);
+
+  try {
+    return formatPortableResult(toolName, executeFn(toolArgs), requestedLimits, getMaxLimits);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    return formatPortableResultWithLimits(toolName, buildError(err), {}, true);
+  }
+}
+
+export function createCodeReasoningTools(options: CodeReasoningToolsOptions = {}) {
+  const tracker = options.tracker ?? createThoughtTracker();
+  const getMaxLimits = options.getMaxLimits ?? createEnvironmentMaxLimitsResolver();
+
+  return [
+    definePortableTool({
+      name: CODE_REASONING_TOOLS.reasoning,
+      title: "Code Reasoning",
+      description: `🧠 Reflective problem-solving through sequential thinking with branching and revision support.
+
+KEY PARAMETERS:
+- thought: Your current reasoning step (required)
+- thought_number: Current position in sequence (required)
+- total_thoughts: Estimated total (can adjust as you go) (required)
+- next_thought_needed: Set to FALSE ONLY when done (required)
+- branch_from_thought + branch_id: When exploring alternatives (🌿)
+- is_revision + revises_thought: When correcting earlier thinking (🔄)
+
+✅ CHECKLIST (review every 3 thoughts):
+1. Need to explore alternatives? → Use BRANCH (🌿)
+2. Need to correct earlier thinking? → Use REVISION (🔄)
+3. Scope changed? → Adjust total_thoughts
+4. Done? → Set next_thought_needed = false
+
+💡 TIPS:
+- Don't hesitate to revise when you learn something new
+- Use branching to explore multiple approaches
+- Express uncertainty when present
+- End with a validated conclusion`,
+      parameters: codeReasoningParams,
+      execute(args, ctx) {
+        ctx.progress?.({
+          text: "Processing thought...",
+          structuredContent: { status: "pending", tool: CODE_REASONING_TOOLS.reasoning },
+        });
+        return runFormattedTool(
+          CODE_REASONING_TOOLS.reasoning,
+          args,
+          (toolArgs) => processThought(toolArgs, tracker),
+          getMaxLimits,
+        );
+      },
+    }),
+    definePortableTool({
+      name: CODE_REASONING_TOOLS.status,
+      title: "Code Reasoning Status",
+      description: "Get current status of the code reasoning session: branches, thought count.",
+      parameters: statusParams,
+      execute(args, ctx) {
+        ctx.progress?.({
+          text: "Getting status...",
+          structuredContent: { status: "pending", tool: CODE_REASONING_TOOLS.status },
+        });
+        return runFormattedTool(
+          CODE_REASONING_TOOLS.status,
+          args,
+          () => ({ branches: tracker.branches(), thought_count: tracker.count() }),
+          getMaxLimits,
+        );
+      },
+    }),
+    definePortableTool({
+      name: CODE_REASONING_TOOLS.reset,
+      title: "Reset Code Reasoning",
+      description: "Reset the code reasoning session, clearing all thoughts and branches.",
+      parameters: resetParams,
+      execute() {
+        tracker.reset();
+        return {
+          text: "Code reasoning session reset.",
+          structuredContent: { tool: CODE_REASONING_TOOLS.reset },
+        };
+      },
+    }),
+  ] satisfies readonly ReturnType<typeof definePortableTool<TObject>>[];
+}

--- a/packages/pi-code-reasoning/extensions/tracker.ts
+++ b/packages/pi-code-reasoning/extensions/tracker.ts
@@ -21,7 +21,7 @@ function ensureReferenceExists(
 
 export function createThoughtTracker(): ThoughtTracker {
   const thoughtHistory: ValidatedThoughtData[] = [];
-  const branches = new Map<string, ValidatedThoughtData[]>();
+  const branches = new Set<string>();
 
   return {
     add: (thought) => {
@@ -31,9 +31,7 @@ export function createThoughtTracker(): ThoughtTracker {
 
       thoughtHistory.push(thought);
       if (thought.branch_id) {
-        const branchThoughts = branches.get(thought.branch_id) ?? [];
-        branchThoughts.push(thought);
-        branches.set(thought.branch_id, branchThoughts);
+        branches.add(thought.branch_id);
       }
     },
     ensureBranchIsValid: (branchFromThought) => {
@@ -42,7 +40,7 @@ export function createThoughtTracker(): ThoughtTracker {
     ensureRevisionIsValid: (revisesThought) => {
       ensureReferenceExists("revises_thought", revisesThought, thoughtHistory.length);
     },
-    branches: () => Array.from(branches.keys()),
+    branches: () => Array.from(branches),
     count: () => thoughtHistory.length,
     reset: () => {
       thoughtHistory.length = 0;

--- a/packages/pi-code-reasoning/extensions/tracker.ts
+++ b/packages/pi-code-reasoning/extensions/tracker.ts
@@ -1,0 +1,52 @@
+import { MAX_THOUGHT_COUNT, type ValidatedThoughtData } from "./types.js";
+
+export interface ThoughtTracker {
+  add: (thought: ValidatedThoughtData) => void;
+  reset: () => void;
+  ensureBranchIsValid: (branchFromThought?: number) => void;
+  ensureRevisionIsValid: (revisesThought?: number) => void;
+  branches: () => string[];
+  count: () => number;
+}
+
+function ensureReferenceExists(
+  field: "branch_from_thought" | "revises_thought",
+  value: number | undefined,
+  count: number,
+): void {
+  if (value && value > count) {
+    throw new Error(`Invalid ${field} ${value}.`);
+  }
+}
+
+export function createThoughtTracker(): ThoughtTracker {
+  const thoughtHistory: ValidatedThoughtData[] = [];
+  const branches = new Map<string, ValidatedThoughtData[]>();
+
+  return {
+    add: (thought) => {
+      if (thoughtHistory.length >= MAX_THOUGHT_COUNT) {
+        throw new Error(`Max thought limit reached (${MAX_THOUGHT_COUNT}).`);
+      }
+
+      thoughtHistory.push(thought);
+      if (thought.branch_id) {
+        const branchThoughts = branches.get(thought.branch_id) ?? [];
+        branchThoughts.push(thought);
+        branches.set(thought.branch_id, branchThoughts);
+      }
+    },
+    ensureBranchIsValid: (branchFromThought) => {
+      ensureReferenceExists("branch_from_thought", branchFromThought, thoughtHistory.length);
+    },
+    ensureRevisionIsValid: (revisesThought) => {
+      ensureReferenceExists("revises_thought", revisesThought, thoughtHistory.length);
+    },
+    branches: () => Array.from(branches.keys()),
+    count: () => thoughtHistory.length,
+    reset: () => {
+      thoughtHistory.length = 0;
+      branches.clear();
+    },
+  };
+}

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -77,7 +77,7 @@
     }
   },
   "bin": {
-    "pi-code-reasoning-mcp": "./dist/extensions/mcp-server.js"
+    "pi-code-reasoning": "./dist/extensions/mcp-server.js"
   },
   "scripts": {
     "build:mcp": "tsc --project tsconfig.mcp.json && chmod +x dist/extensions/mcp-server.js",

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -21,6 +21,7 @@
   "type": "module",
   "files": [
     "extensions/",
+    "dist/",
     "README.md",
     "LICENSE"
   ],
@@ -31,8 +32,14 @@
   },
   "exports": {
     ".": "./extensions/index.ts",
-    "./mcp": "./extensions/mcp-server.ts",
-    "./tools": "./extensions/tools.ts",
+    "./mcp": {
+      "types": "./dist/extensions/mcp-server.d.ts",
+      "import": "./dist/extensions/mcp-server.js"
+    },
+    "./tools": {
+      "types": "./dist/extensions/tools.d.ts",
+      "import": "./dist/extensions/tools.js"
+    },
     "./package.json": "./package.json",
     "./extensions/*": "./extensions/*"
   },
@@ -68,5 +75,12 @@
     "@earendil-works/pi-coding-agent": {
       "optional": true
     }
+  },
+  "bin": {
+    "pi-code-reasoning-mcp": "./dist/extensions/mcp-server.js"
+  },
+  "scripts": {
+    "build:mcp": "tsc --project tsconfig.mcp.json && chmod +x dist/extensions/mcp-server.js",
+    "prepack": "npm run build:mcp"
   }
 }

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -31,7 +31,6 @@
     ]
   },
   "exports": {
-    ".": "./extensions/index.ts",
     "./mcp": {
       "types": "./dist/extensions/mcp-server.d.ts",
       "import": "./dist/extensions/mcp-server.js"
@@ -41,7 +40,14 @@
       "import": "./dist/extensions/tools.js"
     },
     "./package.json": "./package.json",
-    "./extensions/*": "./extensions/*"
+    "./extensions/*.js": {
+      "types": "./dist/extensions/*.d.ts",
+      "import": "./dist/extensions/*.js"
+    },
+    "./extensions/*": {
+      "types": "./dist/extensions/*.d.ts",
+      "import": "./dist/extensions/*.js"
+    }
   },
   "engines": {
     "node": ">=22.19.0"
@@ -80,7 +86,7 @@
     "pi-code-reasoning": "./dist/extensions/mcp-server.js"
   },
   "scripts": {
-    "build:mcp": "tsc --project tsconfig.mcp.json && chmod +x dist/extensions/mcp-server.js",
+    "build:mcp": "tsc --project tsconfig.mcp.json && node -e \"require('node:fs').chmodSync('dist/extensions/mcp-server.js', 0o755)\"",
     "prepack": "npm run build:mcp"
   }
 }

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -33,7 +33,8 @@
     ".": "./extensions/index.ts",
     "./mcp": "./extensions/mcp-server.ts",
     "./tools": "./extensions/tools.ts",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./extensions/*": "./extensions/*"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@feniix/pi-code-reasoning",
   "version": "3.0.1",
-  "description": "Code Reasoning extension for pi — reflective problem-solving through sequential thinking with branching and revision support",
+  "description": "Code Reasoning tools for pi and MCP — reflective sequential thinking with branching and revision support",
   "keywords": [
     "pi",
     "pi-package",
@@ -12,7 +12,11 @@
     "sequential-thinking",
     "branching",
     "revision",
-    "problem-solving"
+    "problem-solving",
+    "mcp",
+    "model-context-protocol",
+    "bridgekit",
+    "portable-tools"
   ],
   "type": "module",
   "files": [
@@ -25,10 +29,22 @@
       "./extensions/index.ts"
     ]
   },
+  "exports": {
+    ".": "./extensions/index.ts",
+    "./mcp": "./extensions/mcp-server.ts",
+    "./tools": "./extensions/tools.ts",
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "dependencies": {
+    "@feniix/bridgekit": "^0.4.0",
+    "typebox": "^1.1.31"
+  },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "typebox": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "repository": {
     "type": "git",
@@ -49,9 +65,6 @@
       "optional": true
     },
     "@earendil-works/pi-coding-agent": {
-      "optional": true
-    },
-    "typebox": {
       "optional": true
     }
   }

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-code-reasoning",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Code Reasoning tools for pi and MCP — reflective sequential thinking with branching and revision support",
   "keywords": [
     "pi",

--- a/packages/pi-code-reasoning/tsconfig.mcp.json
+++ b/packages/pi-code-reasoning/tsconfig.mcp.json
@@ -9,6 +9,7 @@
     "rootDir": "."
   },
   "include": [
+    "extensions/index.ts",
     "extensions/mcp-server.ts",
     "extensions/tools.ts",
     "extensions/config.ts",

--- a/packages/pi-code-reasoning/tsconfig.mcp.json
+++ b/packages/pi-code-reasoning/tsconfig.mcp.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "extensions/mcp-server.ts",
+    "extensions/tools.ts",
+    "extensions/config.ts",
+    "extensions/constants.ts",
+    "extensions/output.ts",
+    "extensions/processor.ts",
+    "extensions/responses.ts",
+    "extensions/tracker.ts",
+    "extensions/types.ts"
+  ],
+  "exclude": ["__tests__", "dist"]
+}


### PR DESCRIPTION
## Summary

`pi-code-reasoning` can now run from pi, MCP hosts, and direct `npx -y @feniix/pi-code-reasoning` stdio clients through the same BridgeKit-backed tool definitions, so future host adapters do not need divergent tool implementations. The existing pi extension surface remains available through `pi.extensions`, while package consumers get compiled MCP helpers, compiled portable tools, compiled compatibility deep imports, and a default npm binary for MCP client configuration. The refactor also tightens output-limit handling, validation paths, and temp-output persistence so adapter errors remain structured instead of leaking brittle runtime behavior.

## Design notes

- Portable tools are the source of truth. Pi registration and MCP server options both consume the same definitions, preserving tool names and schemas across hosts.
- The package keeps the source-loaded pi extension entrypoint for pi, then builds the Node-facing MCP/tools/deep-import surfaces into `dist/` for npm-launched MCP usage.
- The package binary is named `pi-code-reasoning`, matching the unscoped package name so `npx -y @feniix/pi-code-reasoning` runs the MCP stdio server directly.
- Published exports avoid TypeScript source paths for Node consumers; compatibility deep imports now resolve to compiled `dist/extensions/*` files.
- Output limits are validated as positive integers, and truncated output reports when temp-file persistence fails so callers still receive usable output. Saved temp output names include a UUID to avoid same-millisecond collisions.
- Thought tracking keeps bounded history and stores branch IDs directly instead of carrying unused branch-history state.

## Test plan

- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/pi-code-reasoning/__tests__/package.test.ts`
- `npx vitest run packages/pi-code-reasoning/__tests__`
- `npm run build:mcp --workspace packages/pi-code-reasoning`
- `npm pack --dry-run --json --workspace packages/pi-code-reasoning`
- packed install/import smoke for `@feniix/pi-code-reasoning/mcp`, `@feniix/pi-code-reasoning/tools`, and compiled deep imports
- packed `npx --package <tarball> pi-code-reasoning` smoke test
- `npm run test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5_%28272K,_xhigh%29](https://img.shields.io/badge/GPT_5.5_%28272K,_xhigh%29-000000)
