### PR TITLE
fix(pi-code-reasoning): make npx bin work from workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7905,7 +7905,7 @@
     },
     "packages/pi-code-reasoning": {
       "name": "@feniix/pi-code-reasoning",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@feniix/bridgekit": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7912,7 +7912,7 @@
         "typebox": "^1.1.31"
       },
       "bin": {
-        "pi-code-reasoning": "dist/extensions/mcp-server.js"
+        "pi-code-reasoning": "bin/pi-code-reasoning.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -49,8 +49,9 @@ describe("pi-code-reasoning package metadata", () => {
 
   it("publishes an npx-friendly MCP binary backed by the package-local build", () => {
     expect(packageJson.bin).toEqual({
-      "pi-code-reasoning": "./dist/extensions/mcp-server.js",
+      "pi-code-reasoning": "./bin/pi-code-reasoning.js",
     });
+    expect(packageJson.files).toContain("bin/");
     expect(packageJson.files).toContain("dist/");
     expect(packageJson.scripts["build:mcp"]).toContain("tsconfig.mcp.json");
     expect(packageJson.scripts["build:mcp"]).toContain("chmodSync");
@@ -72,9 +73,15 @@ describe("pi-code-reasoning package metadata", () => {
     const [packResult] = JSON.parse(pack.stdout) as [{ files: Array<{ path: string; mode: number }> }];
     const filesByPath = new Map(packResult.files.map((file) => [file.path, file]));
 
+    expect(filesByPath.get("bin/pi-code-reasoning.js")?.mode).toBe(493);
     expect(filesByPath.get("dist/extensions/mcp-server.js")?.mode).toBe(493);
     expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
     expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
+
+    const binEntrypoint = readFileSync(join(packageRoot, "bin", "pi-code-reasoning.js"), "utf-8");
+    expect(binEntrypoint).toContain("dist");
+    expect(binEntrypoint).toContain("build:mcp");
+    expect(binEntrypoint).toContain("runServer");
 
     const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
     expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -17,6 +18,35 @@ const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "
 
 function cleanDist(): void {
   rmSync(join(packageRoot, "dist"), { recursive: true, force: true });
+}
+
+function createWrapperFixture(buildScript: string): string {
+  const fixture = mkdtempSync(join(tmpdir(), "pi-code-reasoning-bin-"));
+  mkdirSync(join(fixture, "bin"), { recursive: true });
+  cpSync(join(packageRoot, "bin", "pi-code-reasoning.js"), join(fixture, "bin", "pi-code-reasoning.js"));
+  writeFileSync(
+    join(fixture, "package.json"),
+    JSON.stringify({ type: "module", scripts: { "build:mcp": buildScript } }),
+    "utf-8",
+  );
+  return fixture;
+}
+
+function writeFixtureServer(fixture: string): void {
+  const serverDir = join(fixture, "dist", "extensions");
+  mkdirSync(serverDir, { recursive: true });
+  writeFileSync(
+    join(serverDir, "mcp-server.js"),
+    'import { writeFileSync } from "node:fs";\nexport async function runServer() { writeFileSync("server-ran", "yes"); }\n',
+    "utf-8",
+  );
+}
+
+function runFixtureWrapper(fixture: string): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [join(fixture, "bin", "pi-code-reasoning.js")], {
+    cwd: fixture,
+    encoding: "utf-8",
+  });
 }
 
 afterEach(() => {
@@ -86,5 +116,72 @@ describe("pi-code-reasoning package metadata", () => {
     const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
     expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
     expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
+  });
+
+  it("runs the wrapper against an existing package-local MCP build", () => {
+    const fixture = createWrapperFixture("node missing-build-script.js");
+    try {
+      writeFixtureServer(fixture);
+
+      const run = runFixtureWrapper(fixture);
+
+      expect(run.status, String(run.stderr)).toBe(0);
+      expect(readFileSync(join(fixture, "server-ran"), "utf-8")).toBe("yes");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("builds missing package-local MCP output before running the wrapper", () => {
+    const fixture = createWrapperFixture("node build.mjs");
+    try {
+      writeFileSync(
+        join(fixture, "build.mjs"),
+        `import { writeFileSync } from "node:fs";\nimport { dirname } from "node:path";\nimport { fileURLToPath } from "node:url";\nimport { mkdirSync } from "node:fs";\nconst root = dirname(fileURLToPath(import.meta.url));\nmkdirSync(new URL("./dist/extensions/", import.meta.url), { recursive: true });\nwriteFileSync(new URL("./dist/extensions/mcp-server.js", import.meta.url), 'import { writeFileSync } from "node:fs";\\nexport async function runServer() { writeFileSync("server-ran", "yes"); }\\n');\nwriteFileSync(new URL("./build-ran", import.meta.url), "yes");\nvoid root;\n`,
+        "utf-8",
+      );
+
+      const run = runFixtureWrapper(fixture);
+
+      expect(run.status, String(run.stderr)).toBe(0);
+      expect(readFileSync(join(fixture, "build-ran"), "utf-8")).toBe("yes");
+      expect(readFileSync(join(fixture, "server-ran"), "utf-8")).toBe("yes");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the wrapper when the fallback build does not produce an MCP server", () => {
+    const fixture = createWrapperFixture("node build.mjs");
+    try {
+      writeFileSync(
+        join(fixture, "build.mjs"),
+        'import { writeFileSync } from "node:fs";\nwriteFileSync("build-ran", "yes");\n',
+        "utf-8",
+      );
+
+      const run = runFixtureWrapper(fixture);
+
+      expect(run.status).toBe(1);
+      expect(run.stderr).toContain("Failed to build the local MCP server");
+      expect(readFileSync(join(fixture, "build-ran"), "utf-8")).toBe("yes");
+      expect(existsSync(join(fixture, "server-ran"))).toBe(false);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the fallback build exit code on wrapper failure", () => {
+    const fixture = createWrapperFixture("node build.mjs");
+    try {
+      writeFileSync(join(fixture, "build.mjs"), "process.exit(7);\n", "utf-8");
+
+      const run = runFixtureWrapper(fixture);
+
+      expect(run.status).toBe(7);
+      expect(run.stderr).toContain("Failed to build the local MCP server");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/pi-code-reasoning/bin/pi-code-reasoning.js
+++ b/packages/pi-code-reasoning/bin/pi-code-reasoning.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const serverPath = join(packageRoot, "dist", "extensions", "mcp-server.js");
+
+if (!existsSync(serverPath)) {
+  const build = spawnSync("npm", ["run", "build:mcp", "--silent"], {
+    cwd: packageRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (build.status !== 0 || !existsSync(serverPath)) {
+    console.error(
+      "[pi-code-reasoning] Failed to build the local MCP server. Run `npm run build:mcp --workspace packages/pi-code-reasoning` and try again.",
+    );
+    process.exit(build.status ?? 1);
+  }
+}
+
+const { runServer } = await import(pathToFileURL(serverPath).href);
+await runServer();

--- a/packages/pi-code-reasoning/bin/pi-code-reasoning.js
+++ b/packages/pi-code-reasoning/bin/pi-code-reasoning.js
@@ -12,13 +12,14 @@ if (!existsSync(serverPath)) {
     cwd: packageRoot,
     stdio: "inherit",
     shell: process.platform === "win32",
+    timeout: 60_000,
   });
 
   if (build.status !== 0 || !existsSync(serverPath)) {
     console.error(
       "[pi-code-reasoning] Failed to build the local MCP server. Run `npm run build:mcp --workspace packages/pi-code-reasoning` and try again.",
     );
-    process.exit(build.status ?? 1);
+    process.exit(build.status && build.status !== 0 ? build.status : 1);
   }
 }
 

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-code-reasoning",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Code Reasoning tools for pi and MCP — reflective sequential thinking with branching and revision support",
   "keywords": [
     "pi",

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -20,6 +20,7 @@
   ],
   "type": "module",
   "files": [
+    "bin/",
     "extensions/",
     "dist/",
     "README.md",
@@ -83,7 +84,7 @@
     }
   },
   "bin": {
-    "pi-code-reasoning": "./dist/extensions/mcp-server.js"
+    "pi-code-reasoning": "./bin/pi-code-reasoning.js"
   },
   "scripts": {
     "build:mcp": "tsc --project tsconfig.mcp.json && node -e \"require('node:fs').chmodSync('dist/extensions/mcp-server.js', 0o755)\"",


### PR DESCRIPTION
## Summary
- Add a committed `pi-code-reasoning` bin wrapper that can build and run the MCP server from a source workspace checkout.
- Point package metadata and lockfile bin entries at the wrapper instead of generated `dist/` output.
- Cover the npx-friendly packaging behavior in package metadata tests and bump `@feniix/pi-code-reasoning` to 4.0.1.

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- [x] `npx -y @feniix/pi-code-reasoning`
- [x] `npm run test -- packages/pi-code-reasoning/__tests__/package.test.ts`
- [x] `npx tsc --noEmit --project packages/pi-code-reasoning/tsconfig.json`
- [x] `npx biome ci packages/pi-code-reasoning`