### PR TITLE
test(pi-code-reasoning): widen pack-test timeout to 30s for cold CI runners

### DIFF
--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -88,35 +88,39 @@ describe("pi-code-reasoning package metadata", () => {
     expect(packageJson.scripts.prepack).toBe("npm run build:mcp");
   });
 
-  it("packs executable MCP output and concrete portable tool declarations", () => {
-    cleanDist();
-    const pack = spawnSync(
-      "npm",
-      ["pack", "--dry-run", "--json", "--workspace", "packages/pi-code-reasoning", "--silent"],
-      {
-        cwd: repoRoot,
-        encoding: "utf-8",
-      },
-    );
+  it(
+    "packs executable MCP output and concrete portable tool declarations",
+    () => {
+      cleanDist();
+      const pack = spawnSync(
+        "npm",
+        ["pack", "--dry-run", "--json", "--workspace", "packages/pi-code-reasoning", "--silent"],
+        {
+          cwd: repoRoot,
+          encoding: "utf-8",
+        },
+      );
 
-    expect(pack.status, pack.stderr).toBe(0);
-    const [packResult] = JSON.parse(pack.stdout) as [{ files: Array<{ path: string; mode: number }> }];
-    const filesByPath = new Map(packResult.files.map((file) => [file.path, file]));
+      expect(pack.status, pack.stderr).toBe(0);
+      const [packResult] = JSON.parse(pack.stdout) as [{ files: Array<{ path: string; mode: number }> }];
+      const filesByPath = new Map(packResult.files.map((file) => [file.path, file]));
 
-    expect(filesByPath.get("bin/pi-code-reasoning.js")?.mode).toBe(493);
-    expect(filesByPath.get("dist/extensions/mcp-server.js")?.mode).toBe(493);
-    expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
-    expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
+      expect(filesByPath.get("bin/pi-code-reasoning.js")?.mode).toBe(493);
+      expect(filesByPath.get("dist/extensions/mcp-server.js")?.mode).toBe(493);
+      expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
+      expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
 
-    const binEntrypoint = readFileSync(join(packageRoot, "bin", "pi-code-reasoning.js"), "utf-8");
-    expect(binEntrypoint).toContain("dist");
-    expect(binEntrypoint).toContain("build:mcp");
-    expect(binEntrypoint).toContain("runServer");
+      const binEntrypoint = readFileSync(join(packageRoot, "bin", "pi-code-reasoning.js"), "utf-8");
+      expect(binEntrypoint).toContain("dist");
+      expect(binEntrypoint).toContain("build:mcp");
+      expect(binEntrypoint).toContain("runServer");
 
-    const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
-    expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
-    expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
-  });
+      const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
+      expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
+      expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
+    },
+    30_000,
+  );
 
   it("runs the wrapper against an existing package-local MCP build", () => {
     const fixture = createWrapperFixture("node missing-build-script.js");

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -88,39 +88,35 @@ describe("pi-code-reasoning package metadata", () => {
     expect(packageJson.scripts.prepack).toBe("npm run build:mcp");
   });
 
-  it(
-    "packs executable MCP output and concrete portable tool declarations",
-    () => {
-      cleanDist();
-      const pack = spawnSync(
-        "npm",
-        ["pack", "--dry-run", "--json", "--workspace", "packages/pi-code-reasoning", "--silent"],
-        {
-          cwd: repoRoot,
-          encoding: "utf-8",
-        },
-      );
+  it("packs executable MCP output and concrete portable tool declarations", () => {
+    cleanDist();
+    const pack = spawnSync(
+      "npm",
+      ["pack", "--dry-run", "--json", "--workspace", "packages/pi-code-reasoning", "--silent"],
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+      },
+    );
 
-      expect(pack.status, pack.stderr).toBe(0);
-      const [packResult] = JSON.parse(pack.stdout) as [{ files: Array<{ path: string; mode: number }> }];
-      const filesByPath = new Map(packResult.files.map((file) => [file.path, file]));
+    expect(pack.status, pack.stderr).toBe(0);
+    const [packResult] = JSON.parse(pack.stdout) as [{ files: Array<{ path: string; mode: number }> }];
+    const filesByPath = new Map(packResult.files.map((file) => [file.path, file]));
 
-      expect(filesByPath.get("bin/pi-code-reasoning.js")?.mode).toBe(493);
-      expect(filesByPath.get("dist/extensions/mcp-server.js")?.mode).toBe(493);
-      expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
-      expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
+    expect(filesByPath.get("bin/pi-code-reasoning.js")?.mode).toBe(493);
+    expect(filesByPath.get("dist/extensions/mcp-server.js")?.mode).toBe(493);
+    expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
+    expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
 
-      const binEntrypoint = readFileSync(join(packageRoot, "bin", "pi-code-reasoning.js"), "utf-8");
-      expect(binEntrypoint).toContain("dist");
-      expect(binEntrypoint).toContain("build:mcp");
-      expect(binEntrypoint).toContain("runServer");
+    const binEntrypoint = readFileSync(join(packageRoot, "bin", "pi-code-reasoning.js"), "utf-8");
+    expect(binEntrypoint).toContain("dist");
+    expect(binEntrypoint).toContain("build:mcp");
+    expect(binEntrypoint).toContain("runServer");
 
-      const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
-      expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
-      expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
-    },
-    30_000,
-  );
+    const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
+    expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
+    expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
+  }, 30_000);
 
   it("runs the wrapper against an existing package-local MCP build", () => {
     const fixture = createWrapperFixture("node missing-build-script.js");


### PR DESCRIPTION
## Summary

- The `packs executable MCP output and concrete portable tool declarations` test in `packages/pi-code-reasoning/__tests__/package.test.ts` shells out to `npm pack --dry-run`, which triggers the workspace's `prepack` → `tsc --project tsconfig.mcp.json`.
- Locally that completes in ~1.7s; on cold CI runners it can exceed Vitest's default 5s `testTimeout`, surfacing as spurious failures in unrelated PRs (e.g. [run 26368231938](https://github.com/feniix/pi-extensions/actions/runs/26368231938/job/77616011844) on the `pi-sequential-thinking` refactor branch).
- Fix is a per-test timeout bump to 30s. Done at the test granularity rather than globally so genuine hangs in other tests still fail fast.

## Test plan

- [x] `npx vitest run packages/pi-code-reasoning/__tests__/package.test.ts` passes locally (1.87s, 7/7).
- [ ] CI green on this PR.