### PR TITLE
feat(pi-code-reasoning): bridgekit 0.13 migration and MCP stdio integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1220,9 +1220,9 @@
       }
     },
     "node_modules/@feniix/bridgekit": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.12.0.tgz",
-      "integrity": "sha512-DCamlrgppIuPCR39YYAMLbhiuk0gYY+wZjy1im/l5zp3T6YH1Hve2wApC83tUDWNfHIEoSSiZdRvGXRFZXuahw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.13.0.tgz",
+      "integrity": "sha512-ejLTDSIKt8szm4cnnbmVVYKILh0QEjrHRZlyfYy3Q00dS6Vj8+0VbgJo/uQbnCvPTQkQAmZMSSW5RHRL8UiLmg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -7908,7 +7908,7 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@feniix/bridgekit": "^0.12.0",
+        "@feniix/bridgekit": "^0.13.0",
         "typebox": "^1.1.31"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1220,9 +1220,9 @@
       }
     },
     "node_modules/@feniix/bridgekit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.5.0.tgz",
-      "integrity": "sha512-rptTXBGLK4S2kBJxkHCDxQUMAsntxcDEqgt+FAAIibFeQ69FG67ErrHWwfJCq2Nkegp5PQNJHoNET7mxsYAKZw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.9.0.tgz",
+      "integrity": "sha512-f/TtipHXzCetOt6AuEt6hJ45pgtGhPMNzL5qn7uxvLWwDTFNFCGpAeba/4YZhM0LZPBYjwEnQR9PXd8taI/1fg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -7908,7 +7908,7 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@feniix/bridgekit": "^0.5.0",
+        "@feniix/bridgekit": "^0.9.0",
         "typebox": "^1.1.31"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1220,9 +1220,9 @@
       }
     },
     "node_modules/@feniix/bridgekit": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.11.0.tgz",
-      "integrity": "sha512-Vs1xadJfgCtr6X0zmG+CgpVkDys//5wTOxy6VF1F7THyf4KCnj91P2I7aQXNXNCWAxZpmYjgZq7cOjyWimKTwg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.12.0.tgz",
+      "integrity": "sha512-DCamlrgppIuPCR39YYAMLbhiuk0gYY+wZjy1im/l5zp3T6YH1Hve2wApC83tUDWNfHIEoSSiZdRvGXRFZXuahw==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -7908,7 +7908,7 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@feniix/bridgekit": "^0.11.0",
+        "@feniix/bridgekit": "^0.12.0",
         "typebox": "^1.1.31"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1220,9 +1220,9 @@
       }
     },
     "node_modules/@feniix/bridgekit": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.9.0.tgz",
-      "integrity": "sha512-f/TtipHXzCetOt6AuEt6hJ45pgtGhPMNzL5qn7uxvLWwDTFNFCGpAeba/4YZhM0LZPBYjwEnQR9PXd8taI/1fg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@feniix/bridgekit/-/bridgekit-0.11.0.tgz",
+      "integrity": "sha512-Vs1xadJfgCtr6X0zmG+CgpVkDys//5wTOxy6VF1F7THyf4KCnj91P2I7aQXNXNCWAxZpmYjgZq7cOjyWimKTwg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -7908,7 +7908,7 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "@feniix/bridgekit": "^0.9.0",
+        "@feniix/bridgekit": "^0.11.0",
         "typebox": "^1.1.31"
       },
       "bin": {

--- a/packages/pi-code-reasoning/__tests__/package.test.ts
+++ b/packages/pi-code-reasoning/__tests__/package.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -18,35 +17,6 @@ const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "
 
 function cleanDist(): void {
   rmSync(join(packageRoot, "dist"), { recursive: true, force: true });
-}
-
-function createWrapperFixture(buildScript: string): string {
-  const fixture = mkdtempSync(join(tmpdir(), "pi-code-reasoning-bin-"));
-  mkdirSync(join(fixture, "bin"), { recursive: true });
-  cpSync(join(packageRoot, "bin", "pi-code-reasoning.js"), join(fixture, "bin", "pi-code-reasoning.js"));
-  writeFileSync(
-    join(fixture, "package.json"),
-    JSON.stringify({ type: "module", scripts: { "build:mcp": buildScript } }),
-    "utf-8",
-  );
-  return fixture;
-}
-
-function writeFixtureServer(fixture: string): void {
-  const serverDir = join(fixture, "dist", "extensions");
-  mkdirSync(serverDir, { recursive: true });
-  writeFileSync(
-    join(serverDir, "mcp-server.js"),
-    'import { writeFileSync } from "node:fs";\nexport async function runServer() { writeFileSync("server-ran", "yes"); }\n',
-    "utf-8",
-  );
-}
-
-function runFixtureWrapper(fixture: string): ReturnType<typeof spawnSync> {
-  return spawnSync(process.execPath, [join(fixture, "bin", "pi-code-reasoning.js")], {
-    cwd: fixture,
-    encoding: "utf-8",
-  });
 }
 
 afterEach(() => {
@@ -108,80 +78,19 @@ describe("pi-code-reasoning package metadata", () => {
     expect(filesByPath.has("dist/extensions/index.js")).toBe(true);
     expect(filesByPath.has("dist/extensions/tools.d.ts")).toBe(true);
 
+    // bin entrypoint delegates to @feniix/bridgekit/bin-wrapper since the
+    // 0.11.0 adoption commit; the four behavioral scenarios (entry present,
+    // entry built on demand, build fails, build exit code preserved) live
+    // in bridgekit's own test suite. Here we only pin that the consumer
+    // invokes the helper with the correct trusted-literal options.
     const binEntrypoint = readFileSync(join(packageRoot, "bin", "pi-code-reasoning.js"), "utf-8");
-    expect(binEntrypoint).toContain("dist");
-    expect(binEntrypoint).toContain("build:mcp");
-    expect(binEntrypoint).toContain("runServer");
+    expect(binEntrypoint).toContain("@feniix/bridgekit/bin-wrapper");
+    expect(binEntrypoint).toContain("runBinWrapper");
+    expect(binEntrypoint).toContain('mcpEntry: "dist/extensions/mcp-server.js"');
+    expect(binEntrypoint).toContain('buildScript: "build:mcp"');
 
     const toolsDeclaration = readFileSync(join(packageRoot, "dist", "extensions", "tools.d.ts"), "utf-8");
     expect(toolsDeclaration).toContain("PortableTool<typeof codeReasoningParams>");
     expect(toolsDeclaration).not.toContain("PortableTool<TObject<{}>");
   }, 30_000);
-
-  it("runs the wrapper against an existing package-local MCP build", () => {
-    const fixture = createWrapperFixture("node missing-build-script.js");
-    try {
-      writeFixtureServer(fixture);
-
-      const run = runFixtureWrapper(fixture);
-
-      expect(run.status, String(run.stderr)).toBe(0);
-      expect(readFileSync(join(fixture, "server-ran"), "utf-8")).toBe("yes");
-    } finally {
-      rmSync(fixture, { recursive: true, force: true });
-    }
-  });
-
-  it("builds missing package-local MCP output before running the wrapper", () => {
-    const fixture = createWrapperFixture("node build.mjs");
-    try {
-      writeFileSync(
-        join(fixture, "build.mjs"),
-        `import { writeFileSync } from "node:fs";\nimport { dirname } from "node:path";\nimport { fileURLToPath } from "node:url";\nimport { mkdirSync } from "node:fs";\nconst root = dirname(fileURLToPath(import.meta.url));\nmkdirSync(new URL("./dist/extensions/", import.meta.url), { recursive: true });\nwriteFileSync(new URL("./dist/extensions/mcp-server.js", import.meta.url), 'import { writeFileSync } from "node:fs";\\nexport async function runServer() { writeFileSync("server-ran", "yes"); }\\n');\nwriteFileSync(new URL("./build-ran", import.meta.url), "yes");\nvoid root;\n`,
-        "utf-8",
-      );
-
-      const run = runFixtureWrapper(fixture);
-
-      expect(run.status, String(run.stderr)).toBe(0);
-      expect(readFileSync(join(fixture, "build-ran"), "utf-8")).toBe("yes");
-      expect(readFileSync(join(fixture, "server-ran"), "utf-8")).toBe("yes");
-    } finally {
-      rmSync(fixture, { recursive: true, force: true });
-    }
-  });
-
-  it("fails the wrapper when the fallback build does not produce an MCP server", () => {
-    const fixture = createWrapperFixture("node build.mjs");
-    try {
-      writeFileSync(
-        join(fixture, "build.mjs"),
-        'import { writeFileSync } from "node:fs";\nwriteFileSync("build-ran", "yes");\n',
-        "utf-8",
-      );
-
-      const run = runFixtureWrapper(fixture);
-
-      expect(run.status).toBe(1);
-      expect(run.stderr).toContain("Failed to build the local MCP server");
-      expect(readFileSync(join(fixture, "build-ran"), "utf-8")).toBe("yes");
-      expect(existsSync(join(fixture, "server-ran"))).toBe(false);
-    } finally {
-      rmSync(fixture, { recursive: true, force: true });
-    }
-  });
-
-  it("preserves the fallback build exit code on wrapper failure", () => {
-    const fixture = createWrapperFixture("node build.mjs");
-    try {
-      writeFileSync(join(fixture, "build.mjs"), "process.exit(7);\n", "utf-8");
-
-      const run = runFixtureWrapper(fixture);
-
-      expect(run.status).toBe(7);
-      expect(run.stderr).toContain("Failed to build the local MCP server");
-    } finally {
-      rmSync(fixture, { recursive: true, force: true });
-    }
-  });
 });

--- a/packages/pi-code-reasoning/bin/pi-code-reasoning.js
+++ b/packages/pi-code-reasoning/bin/pi-code-reasoning.js
@@ -1,27 +1,9 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { spawnSync } from "node:child_process";
+import { runBinWrapper } from "@feniix/bridgekit/bin-wrapper";
 
-const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const serverPath = join(packageRoot, "dist", "extensions", "mcp-server.js");
-
-if (!existsSync(serverPath)) {
-  const build = spawnSync("npm", ["run", "build:mcp", "--silent"], {
-    cwd: packageRoot,
-    stdio: "inherit",
-    shell: process.platform === "win32",
-    timeout: 60_000,
-  });
-
-  if (build.status !== 0 || !existsSync(serverPath)) {
-    console.error(
-      "[pi-code-reasoning] Failed to build the local MCP server. Run `npm run build:mcp --workspace packages/pi-code-reasoning` and try again.",
-    );
-    process.exit(build.status && build.status !== 0 ? build.status : 1);
-  }
-}
-
-const { runServer } = await import(pathToFileURL(serverPath).href);
-await runServer();
+await runBinWrapper({
+  metaUrl: import.meta.url,
+  mcpEntry: "dist/extensions/mcp-server.js",
+  buildScript: "build:mcp",
+  logPrefix: "pi-code-reasoning",
+});

--- a/packages/pi-code-reasoning/bin/pi-code-reasoning.js
+++ b/packages/pi-code-reasoning/bin/pi-code-reasoning.js
@@ -6,4 +6,9 @@ await runBinWrapper({
   mcpEntry: "dist/extensions/mcp-server.js",
   buildScript: "build:mcp",
   logPrefix: "pi-code-reasoning",
+  // Route the build subprocess's stdout to /dev/null so any output (npm
+  // warnings, postinstall scripts, etc.) cannot contaminate the parent
+  // process's MCP JSON-RPC framing on stdout. stderr stays inherited so
+  // build diagnostics remain visible.
+  buildStdio: ["ignore", "inherit", "inherit"],
 });

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -3,11 +3,16 @@
  *
  * Provides tools for reflective problem-solving through sequential thinking.
  * Supports branching (exploring alternatives) and revision (correcting earlier thoughts).
+ *
+ * Pi-side wiring uses bridgekit 0.9.0's registerPiTools adapter directly.
+ * Error semantics default to `errorHandling: "return"`, so portable
+ * `isError: true` results and TypeBox validation failures surface as
+ * `{ content, details, isError: true }` rather than thrown exceptions.
+ * This matches bridgekit's MCP adapter.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { executePortableTool, type PortableTool, type PortableToolResult } from "@feniix/bridgekit";
-import type { TSchema } from "typebox";
+import { type PiToolRegistration, registerPiTools } from "@feniix/bridgekit/pi";
 import { loadConfig, normalizeNumber } from "./config.js";
 import { CODE_REASONING_FLAGS, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./constants.js";
 import { createCodeReasoningTools, type MaxLimits } from "./tools.js";
@@ -60,51 +65,6 @@ function resolveConfigFlag(pi: ExtensionAPI): string | undefined {
   return undefined;
 }
 
-type PiContent = { type: "text"; text: string };
-
-type PiToolResult = {
-  content: PiContent[];
-  details: Record<string, unknown>;
-  isError?: true;
-};
-
-function toPiDetails(result: PortableToolResult): Record<string, unknown> {
-  return result.structuredContent ?? result.details ?? {};
-}
-
-function toPiResult(result: PortableToolResult): PiToolResult {
-  const piResult = {
-    content: [{ type: "text" as const, text: result.text }],
-    details: toPiDetails(result),
-  };
-
-  if (result.isError) {
-    return { ...piResult, isError: true };
-  }
-  return piResult;
-}
-
-function registerCodeReasoningPiTools(pi: ExtensionAPI, tools: readonly PortableTool<TSchema>[]): void {
-  for (const tool of tools) {
-    pi.registerTool({
-      name: tool.name,
-      label: tool.title,
-      description: tool.description,
-      parameters: tool.parameters,
-      async execute(_toolCallId, params, signal, onUpdate, _ctx) {
-        const result = await executePortableTool(tool, params, {
-          host: "pi",
-          signal,
-          progress(update) {
-            onUpdate?.(toPiResult(update));
-          },
-        });
-        return toPiResult(result);
-      },
-    });
-  }
-}
-
 function createPiMaxLimitsResolver(pi: ExtensionAPI): () => MaxLimits {
   let cachedLimits: MaxLimits | undefined;
 
@@ -136,5 +96,11 @@ function createPiMaxLimitsResolver(pi: ExtensionAPI): () => MaxLimits {
 
 export default function codeReasoning(pi: ExtensionAPI) {
   registerFlags(pi);
-  registerCodeReasoningPiTools(pi, createCodeReasoningTools({ getMaxLimits: createPiMaxLimitsResolver(pi) }));
+  const tools = createCodeReasoningTools({ getMaxLimits: createPiMaxLimitsResolver(pi) });
+  // Bridgekit's PiToolRegistration types `promptGuidelines` as
+  // `readonly string[]` while pi-coding-agent's ExtensionAPI accepts mutable
+  // `string[]`. The two are structurally compatible at runtime — bridgekit
+  // never mutates — but TypeScript's contravariance check rejects the
+  // assignment without an explicit cast. Goes away when one side widens.
+  registerPiTools(pi as unknown as PiToolRegistration, tools);
 }

--- a/packages/pi-code-reasoning/extensions/index.ts
+++ b/packages/pi-code-reasoning/extensions/index.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { type PiToolRegistration, registerPiTools } from "@feniix/bridgekit/pi";
+import { registerPiTools } from "@feniix/bridgekit/pi";
 import { loadConfig, normalizeNumber } from "./config.js";
 import { CODE_REASONING_FLAGS, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "./constants.js";
 import { createCodeReasoningTools, type MaxLimits } from "./tools.js";
@@ -97,10 +97,5 @@ function createPiMaxLimitsResolver(pi: ExtensionAPI): () => MaxLimits {
 export default function codeReasoning(pi: ExtensionAPI) {
   registerFlags(pi);
   const tools = createCodeReasoningTools({ getMaxLimits: createPiMaxLimitsResolver(pi) });
-  // Bridgekit's PiToolRegistration types `promptGuidelines` as
-  // `readonly string[]` while pi-coding-agent's ExtensionAPI accepts mutable
-  // `string[]`. The two are structurally compatible at runtime — bridgekit
-  // never mutates — but TypeScript's contravariance check rejects the
-  // assignment without an explicit cast. Goes away when one side widens.
-  registerPiTools(pi as unknown as PiToolRegistration, tools);
+  registerPiTools(pi, tools);
 }

--- a/packages/pi-code-reasoning/extensions/mcp-server.ts
+++ b/packages/pi-code-reasoning/extensions/mcp-server.ts
@@ -1,7 +1,14 @@
-#!/usr/bin/env node
-import { readFileSync, realpathSync } from "node:fs";
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+/**
+ * MCP stdio server module for pi-code-reasoning.
+ *
+ * Strictly import-passive: exports createMcpServerOptions and runServer
+ * for callers. Stdio is started exclusively by bin/pi-code-reasoning.js
+ * (which uses @feniix/bridgekit/bin-wrapper to import this module and
+ * invoke runServer). Tests import the exports directly without side
+ * effects.
+ */
+
+import { readFileSync } from "node:fs";
 import { type CreateMcpServerOptions, runMcpStdioServer as defaultRunMcpStdioServer } from "@feniix/bridgekit/mcp";
 import { isRecord } from "./config.js";
 import { createCodeReasoningTools } from "./tools.js";
@@ -37,20 +44,4 @@ type RunMcpStdioServer = (options: CreateMcpServerOptions) => Promise<void>;
 
 export async function runServer(runMcpStdioServer: RunMcpStdioServer = defaultRunMcpStdioServer): Promise<void> {
   await runMcpStdioServer(createMcpServerOptions());
-}
-
-function realpathIfPossible(path: string): string {
-  try {
-    return realpathSync(path);
-  } catch {
-    return path;
-  }
-}
-
-if (process.argv[1]) {
-  const invokedPath = realpathIfPossible(resolve(process.argv[1]));
-  const modulePath = realpathIfPossible(fileURLToPath(import.meta.url));
-  if (invokedPath === modulePath) {
-    await runServer();
-  }
 }

--- a/packages/pi-code-reasoning/extensions/tools.ts
+++ b/packages/pi-code-reasoning/extensions/tools.ts
@@ -125,9 +125,13 @@ function formatPortableResultWithLimits(
   isError = false,
 ): PortableToolResult {
   const { text, details } = formatToolOutput(toolName, result, limits);
+  const structuredContent = structuredContentFor(result, details);
+  // Add the bridgekit discriminator so consumers can narrow with
+  // isDomainFailure(result). kind comes first so the spread in
+  // structuredContentFor (which may include user data) can't override it.
   return {
     text,
-    structuredContent: structuredContentFor(result, details),
+    structuredContent: isError ? { kind: "domain", ...structuredContent } : structuredContent,
     isError,
   };
 }
@@ -178,11 +182,14 @@ KEY PARAMETERS:
 - Express uncertainty when present
 - End with a validated conclusion`,
       parameters: codeReasoningParams,
-      execute(args, ctx) {
-        ctx.progress?.({
-          text: "Processing thought...",
-          structuredContent: { status: "pending", tool: CODE_REASONING_TOOLS.reasoning },
-        });
+      // pendingMessage now fires pre-validation via bridgekit's pi adapter.
+      // openWorldHint=false: writes to a local in-memory tracker; idempotentHint=false:
+      // each call appends a thought (timestamps and ordering differ between calls).
+      hostExtras: {
+        pi: { pendingMessage: "Processing thought..." },
+        mcp: { annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: false } },
+      },
+      execute(args) {
         return runFormattedTool(
           CODE_REASONING_TOOLS.reasoning,
           args,
@@ -196,11 +203,11 @@ KEY PARAMETERS:
       title: "Code Reasoning Status",
       description: "Get current status of the code reasoning session: branches, thought count.",
       parameters: statusParams,
-      execute(args, ctx) {
-        ctx.progress?.({
-          text: "Getting status...",
-          structuredContent: { status: "pending", tool: CODE_REASONING_TOOLS.status },
-        });
+      hostExtras: {
+        pi: { pendingMessage: "Getting status..." },
+        mcp: { annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false } },
+      },
+      execute(args) {
         return runFormattedTool(
           CODE_REASONING_TOOLS.status,
           args,
@@ -214,6 +221,11 @@ KEY PARAMETERS:
       title: "Reset Code Reasoning",
       description: "Reset the code reasoning session, clearing all thoughts and branches.",
       parameters: resetParams,
+      // destructiveHint=true: clears the tracker. idempotentHint=true: calling
+      // reset on an already-reset session is a no-op (no observable change).
+      hostExtras: {
+        mcp: { annotations: { destructiveHint: true, idempotentHint: true, openWorldHint: false } },
+      },
       execute() {
         tracker.reset();
         return {

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -54,7 +54,7 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@feniix/bridgekit": "^0.9.0",
+    "@feniix/bridgekit": "^0.11.0",
     "typebox": "^1.1.31"
   },
   "peerDependencies": {

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -54,7 +54,7 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@feniix/bridgekit": "^0.12.0",
+    "@feniix/bridgekit": "^0.13.0",
     "typebox": "^1.1.31"
   },
   "peerDependencies": {

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -54,7 +54,7 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@feniix/bridgekit": "^0.11.0",
+    "@feniix/bridgekit": "^0.12.0",
     "typebox": "^1.1.31"
   },
   "peerDependencies": {

--- a/packages/pi-code-reasoning/package.json
+++ b/packages/pi-code-reasoning/package.json
@@ -54,7 +54,7 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@feniix/bridgekit": "^0.5.0",
+    "@feniix/bridgekit": "^0.9.0",
     "typebox": "^1.1.31"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

This PR migrates `pi-code-reasoning` to current BridgeKit patterns: `@feniix/bridgekit@^0.13.0`, adapter simplification via `registerPiTools`, and MCP bin bootstrapping via `runBinWrapper`.

## Scope

- Keep tool definitions host-neutral and aligned with existing schema behavior.
- Remove custom Pi execute/registration wrapper in favor of BridgeKit adapter.
- Update MCP bin wrapper to recommended runtime behavior and build-output handling.
- Preserve existing tool behavior while enabling safer MCP framing and reduced import-time side effects.

## BridgeKit migration details

- Pi entry now uses `registerPiTools(pi, tools)` in `extensions/index.ts`.
- MCP entry path uses `@feniix/bridgekit/bin-wrapper` with safe stdio policy:
  `buildStdio: ["ignore", "inherit", "inherit"]`.
- Host metadata (`pendingMessage`, `mcp.annotations`) is maintained where relevant.
- Branch is up-to-date with post-0.13 best-practice follow-up (`buildStdio`/wrapper alignment).

## Files of interest

- `packages/pi-code-reasoning/extensions/tools.ts`
- `packages/pi-code-reasoning/extensions/index.ts`
- `packages/pi-code-reasoning/extensions/mcp-server.ts`
- `packages/pi-code-reasoning/bin/pi-code-reasoning.js`
- `packages/pi-code-reasoning/__tests__/package.test.ts`
- `packages/pi-code-reasoning/package.json`

## Test plan

- [x] `npm run check` (lint + typecheck)
- [x] `npx vitest run packages/pi-code-reasoning`
- [x] `npm run build:mcp --workspace @feniix/pi-code-reasoning`
- [x] `npm pack --dry-run --workspace @feniix/pi-code-reasoning`
- [ ] Optional live Pi extension verification
- [ ] Optional MCP launch verification

## Commit stack (top to bottom)

- `fda31a5` `refactor(pi-code-reasoning): adopt bridgekit 0.13.0 (drop cast, add buildStdio)`
- `d51f78d` `refactor(pi-code-reasoning): adopt bridgekit/bin-wrapper, drop dead isMainModule + redundant fixture tests`
- `9f8a19c` `chore(pi-code-reasoning): bump @feniix/bridgekit floor to ^0.12.0`
- `17de66a` `chore(pi-code-reasoning): bump @feniix/bridgekit floor to ^0.11.0`
- `143c301` `feat(pi-code-reasoning): adopt bridgekit 0.9.0 hostExtras + domain discriminator`
- `0d4a3b7` `refactor(pi-code-reasoning): drop custom pi adapter, use registerPiTools`

## Notes

Behavioral intent is intentionally additive: MCP support and runtime reliability improvements without changing the public pi tool surface.