### PR TITLE
fix(pi-exa): web_research_exa defaults to text-mode synthesis; pin and surface diagnostics (issue #115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
   - `README.md`, `package.json`, and `LICENSE` per package.
 - Root-level configs live in `biome.json`, `tsconfig.json`, and `vitest.config.ts`.
 - `docs/solutions/` contains documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter fields such as `module`, `tags`, and `problem_type`; relevant when implementing or debugging in documented areas.
+- `CONCEPTS.md` defines shared domain vocabulary (entities, named processes, status concepts) with project-specific meaning; relevant when orienting to the codebase or discussing domain concepts.
 
 ## Build, Test, and Development Commands
 Run these from the repo root unless noted:

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,27 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Portable tool
+
+A tool definition that runs in multiple agent host environments (Pi, MCP) via bridgekit's `createExaTools` factory. Each portable tool carries a `description`, a `parameters` schema (TypeBox), and a `perform` function that the host invokes.
+
+*Avoid:* extension, plugin (those mean different things in this project).
+
+The Pi host surfaces `hostExtras.pi.*` fields — `promptSnippet`, `promptGuidelines`, `pendingMessage` — that the MCP host does not consume. Tool behavior is identical across hosts because both run the same `perform` function. Source-of-truth is the `createExaTools` factory in `packages/pi-exa/extensions/tools.ts`; per-host adapters (`extensions/index.ts` for Pi, `extensions/mcp-server.ts` for MCP) just register the returned tools.
+
+## Synthesis
+
+The LLM-generated answer text returned by Exa's deep search types (`deep`, `deep-lite`, `deep-reasoning`) in `output.content`, as distinct from retrieved results (the `results` array). Synthesized answers are always returned alongside per-field `grounding` citations and a list of retrieved source URLs.
+
+*Avoid:* answer (used by Exa's `/answer` endpoint with different semantics — see the `web_answer_exa` tool).
+
+Synthesis requires `outputSchema` to be sent in the request; without it, Exa omits the `output` field entirely and the `web_research_exa` tool returns a diagnostic fallback. This contract is the bug behind issue #115. Default mode is text (`{ type: "text" }`); object mode (`{ type: "object", properties: {...} }`) is an explicit override for structured extraction.
+
+## Research plan
+
+The in-memory state accumulated by `exa_research_step` calls — topic, criteria, sources, gaps, assumptions, branches, and warnings — that `exa_research_summary.mode === "payload"` translates into a suggested `web_research_exa` invocation. The plan is a per-process singleton built by `createResearchPlanner()`; resetting is explicit via `exa_research_reset`.
+
+*Avoid:* research project, research task.
+
+The planner never calls Exa network APIs internally — it only tracks and summarizes planning state, leaving the actual retrieval to an explicit later call (typically `web_research_exa` with the suggested payload, which produces a synthesis).

--- a/docs/solutions/integration-issues/web-research-exa-outputschema-default.md
+++ b/docs/solutions/integration-issues/web-research-exa-outputschema-default.md
@@ -1,0 +1,154 @@
+---
+title: "web_research_exa silently returns the canned no-output fallback when outputSchema is omitted"
+date: 2026-06-15
+category: integration-issues
+module: pi-exa
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "web_research_exa returned the canned no synthesized output was returned message for every call"
+  - "Live Exa /search responses omitted the output field when outputSchema was not sent"
+  - "Text and object synthesis worked only when outputSchema was provided explicitly"
+  - "Package skills (code-search, company-research, exa-research-planner, financial-report-search) only worked because they supplied outputSchema explicitly"
+  - "The fallback hid the requestId and shape needed to identify why synthesis did not run"
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - Exa /search API
+  - exa research planner
+  - portable tool schema
+  - bridgekit tool surface
+tags:
+  - pi-exa
+  - web-research-exa
+  - exa-api
+  - output-schema
+  - synthesized-output
+  - api-contract
+  - diagnostics
+  - research-planner
+---
+
+# web_research_exa silently returns the canned no-output fallback when outputSchema is omitted
+
+## Problem
+
+`@feniix/pi-exa`'s `web_research_exa` tool returned the canned "no synthesized output was returned" message for every call. The implementation passed `undefined` to `exa.search(...)`, but Exa's `/search` endpoint only includes an `output` field in the response when an `outputSchema` is provided. The canned fallback therefore always fired, regardless of query, filters, or tool activation. The bug was masked for users who read the four skills shipped with the package, because each one works around it by passing `outputSchema: { type: "text" }` explicitly.
+
+## Symptoms
+
+- Every `web_research_exa` call returned the canned "no synthesized output was returned" fallback instead of synthesized research content.
+- Direct calls only worked when users manually passed `outputSchema: { type: "text" }` — an undiscoverable workaround that contradicted the README's claim that the default was `"object"`.
+- Live Exa `/search` responses for deep types (`deep`, `deep-lite`, `deep-reasoning`) omitted the `output` field entirely when no `outputSchema` was sent; only the search-results array, `requestId`, `searchTime`, and `costDollars` were returned.
+- The four package skills (`code-search`, `company-research`, `exa-research-planner`, `financial-report-search`) only worked because they each supplied `outputSchema` in their example invocations.
+- The fallback response carried no `requestId` and no shape metadata, so neither the LLM caller nor an operator could tell why synthesis did not run.
+
+## What Didn't Work
+
+- **Manual workaround (undiscoverable):** passing `outputSchema: { type: "text" }` did make Exa return synthesized output, but it contradicted the README's documented default and required callers to know an implicit Exa API requirement. Users should not need insider knowledge to get the default path working.
+- **README documentation lying about the default:** the README claimed `outputSchema` defaulted to `"object"`, but the implementation had no default at all. The lie is worse than the silence because it tells users the wrong thing to expect.
+- **Brittle test assertion (caught in code review):** an early version of the diagnostic test pinned the exact `Object.keys(response)` order for `responseKeys`. That overfit the test to JavaScript key-order details rather than the diagnostic value (set membership). The review pass replaced it with `expect.arrayContaining([...])` plus an assertion that `output` is absent.
+- **Treating it as a backend failure:** the original canned message ("Try a different query or simpler filters") implied a transient failure on the caller's side, not a contract mismatch. The new diagnostic text states the actual sequence — a schema was sent, the response lacked the field.
+
+## Solution
+
+The fix is layered: runtime default, diagnostic surface, discoverability, tests, and release docs.
+
+### 1. Default the runtime request to text synthesis
+
+`parseOutputSchema` in `packages/pi-exa/extensions/web-research.ts` now always returns a schema, using text mode when the caller omits `outputSchema` or passes an object without a `type` field. Explicit object-mode schemas pass through unchanged. The function signature changed from `DeepOutputSchema | undefined` to `DeepOutputSchema`:
+
+```ts
+function parseOutputSchema(outputSchema: Record<string, unknown> | undefined): DeepOutputSchema {
+  // Exa /search only returns an `output` field when an outputSchema
+  // is provided. Without a default, every call without an explicit
+  // schema returns no synthesis and the canned fallback fires.
+  if (!outputSchema || !Object.hasOwn(outputSchema, "type")) {
+    return { type: "text" } as DeepOutputSchema;
+  }
+  const schemaType = outputSchema.type;
+  if (schemaType !== "object" && schemaType !== "text") {
+    throw new Error('outputSchema.type must be either "object" or "text".');
+  }
+  return outputSchema as DeepOutputSchema;
+}
+```
+
+### 2. Surface diagnostic context in the no-output fallback
+
+When `response?.output` is missing, the tool now returns user-facing text that states an `outputSchema` was sent but no `output` field came back, plus a structured `details` payload that operators and downstream LLM agents can act on. A null-guard around `...toMetadata(response)` (added in the code-review pass) prevents the diagnostic from being lost when the response itself is nullish:
+
+```ts
+return {
+  text:
+    `Deep search completed but no synthesized output was returned. ` +
+    `An outputSchema was sent to the Exa API (requestId: ${requestId}, ` +
+    `results returned: ${resultsCount}, outputSchema: ${JSON.stringify(outputSchema)}), ` +
+    `but the response did not include an \`output\` field. ` +
+    `Try a different query, simplify filters, or check Exa's status page.`,
+  details: {
+    tool: "web_research_exa",
+    kind: "domain",
+    error: "no_synthesized_output",
+    requestId,
+    resultsCount,
+    outputSchemaSent: outputSchema,
+    responseKeys,
+    ...(response ? toMetadata(response) : {}),
+  },
+};
+```
+
+### 3. Improve discoverability at call sites
+
+- `packages/pi-exa/extensions/research-planner.ts` `payload(status)` now includes `outputSchema: { type: "text" }` in its suggested `web_research_exa` invocation, so a user (or LLM) copying the suggested JSON verbatim gets synthesis without a hidden requirement.
+- `packages/pi-exa/extensions/schemas.ts` `outputSchemaType` Union now carries a description. The wording is endpoint-neutral (text vs object + the 10-property / depth-2 cap) so the same Union can serve both `webResearchParams` and `webAnswerParams` without leaking tool-specific copy.
+- `packages/pi-exa/extensions/tools.ts` documents the default and the override in the `web_research_exa` tool description, `promptSnippet`, and two `promptGuidelines`. The previous third guideline — "Use web_research_exa when a systemPrompt or outputSchema is needed..." — implied `outputSchema` was exotic; the new wording is explicit about the default.
+- `web_answer_exa` description clarified to state it returns a plain string by default (an `/answer` endpoint default, not a tool behavior change).
+
+### 4. Pin behavior with tests
+
+- `__tests__/portable-tools.test.ts`: 3 new tests + 1 updated assertion pin the default (`outputSchema: { type: "text" }` sent when omitted), the override (explicit object-mode schema passes through unchanged, `parsedOutput` populated), and the diagnostic shape (`kind`, `error`, `requestId`, `resultsCount`, `outputSchemaSent`, `responseKeys` present, `output` absent). The fallback test asserts `responseKeys` semantically, not by insertion order.
+- `__tests__/research-planner.test.ts`: 1 new assertion pins the planner payload's `outputSchema: { type: "text" }`.
+
+### 5. Correct release documentation
+
+- `README.md`: `web_research_exa` section now says default text mode, references issue #115, and links to the [Exa Search API Reference for Coding Agents](https://docs.exa.ai/reference/search-api-guide-for-coding-agents) for the underlying contract.
+- `CHANGELOG.md`: `5.0.1` entry records the runtime fix, the diagnostic surface, the planner change, and the discoverability improvements.
+- `packages/pi-exa/package.json` bumped 5.0.0 → 5.0.1.
+
+## Why This Works
+
+Exa's `/search` contract documents the behavior directly (per the [Search API Reference for Coding Agents](https://docs.exa.ai/reference/search-api-guide-for-coding-agents)):
+
+> `outputSchema` — object — JSON schema for synthesized `output.content`. When provided, the response includes `output`.
+
+The pre-fix code passed `undefined` to `exa.search(...)`, so Exa correctly omitted `output` and the handler always took the canned fallback. The default `{ type: "text" }` makes the synthesis step explicit for the common case, which is what the user's manual workaround was already doing. Object mode is preserved as an explicit override for callers that need structured extraction.
+
+Empirical validation against the live Exa API (with `EXA_API_KEY` and exa-js 2.13.0):
+
+| Scenario | `output` field | Cost |
+| --- | --- | --- |
+| No `outputSchema`, `type: "deep-reasoning"` | absent (canned fallback before fix) | $0.015 |
+| `outputSchema: { type: "text" }` | present, `output.content` is a string | $0.015 |
+| `outputSchema: { type: "object", properties: {...} }` | present, `output.content` is an object with per-field grounding | $0.015 |
+
+Cost is identical across modes, so the default choice is a UX decision, not a cost decision.
+
+## Prevention
+
+- **Keep a regression test** that verifies omitted `outputSchema` is sent as `{ type: "text" }` and that explicit object schemas pass through unchanged. The two assertions in `__tests__/portable-tools.test.ts` (the existing `forwards deep-search options` test updated to include the default assertion, and the new `defaults outputSchema to text-mode synthesis when the caller omits it`) are the test-first pins that would have caught this bug at introduction.
+- **Test fallback diagnostics semantically**, not by brittle key ordering. Assert `details.error`, `outputSchemaSent`, counts, and that `responseKeys` does not include `output` — the diagnostic value is set membership, not insertion order.
+- **Do not document defaults that are not implemented.** Tool descriptions, READMEs, and CHANGELOGs should match runtime behavior. When a default depends on an upstream API contract, link to the contract source so future readers can verify the assumption still holds.
+- **Make planner and skill payloads self-documenting.** The `exa_research_summary` `payload` mode should include every parameter the underlying tool requires to function — including `outputSchema: { type: "text" }` — so a user (or LLM) copying the suggested JSON verbatim does not silently miss a step.
+- **Surface the actual upstream shape in fallbacks**, not a generic "try again" message. When a tool's contract requires a field the caller might omit, the fallback should name the field, the requestId, and what was sent — that turns the next silent regression into a debuggable one. The new `details.outputSchemaSent`, `requestId`, and `responseKeys` fields do this.
+
+## Related Issues
+
+- [GitHub issue #115 in `feniix/pi-extensions`](https://github.com/feniix/pi-extensions/issues/115) — original bug report.
+- [Exa Search API Reference for Coding Agents](https://docs.exa.ai/reference/search-api-guide-for-coding-agents) — documents that responses include `output` only when `outputSchema` is provided.
+- [Exa Deep Revamp changelog](https://exa.ai/docs/changelog/exa-deep-revamp) — defines the `outputSchema` shape for deep search variants (`type`, `description`, `properties`) and the per-field `grounding` response shape.
+- PR #116 in `feniix/pi-extensions` — implements the fix across 4 commits on `fix/pi-exa-115-web-research-outputschema-default` (test pin, runtime fix, version bump, code-review fixes).
+- `packages/pi-exa/docs/exa-api-findings.md` — prior empirical research on the Exa contract. May be worth updating to record the issue #115 lesson (the `/search` endpoint requires `outputSchema` even for prose output).
+- `docs/architecture/plan-pi-exa-api-alignment.md` and `docs/prd/PRD-005-pi-exa-api-alignment.md` — design docs that previously assumed `outputSchema.type` defaulted to `"object"`. Now superseded by this fix; see refresh recommendation in the ce-compound run output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7953,7 +7953,7 @@
     },
     "packages/pi-exa": {
       "name": "@feniix/pi-exa",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@feniix/bridgekit": "^0.13.0",

--- a/packages/pi-exa/CHANGELOG.md
+++ b/packages/pi-exa/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `@feniix/pi-exa` are recorded in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2026-06-15
+
+### Fixed
+
+- **`web_research_exa` returned the canned "no synthesized output was returned" message for every call** (issue #115). The Exa `/search` endpoint only returns an `output` field when an `outputSchema` is provided (per the [Search API Reference for Coding Agents](https://docs.exa.ai/reference/search-api-guide-for-coding-agents): *"When provided, the response includes `output`."*). The previous tool had no default for `outputSchema` and passed `undefined` to `exa.search(...)`, so synthesis was never requested and the canned fallback fired for every deep-type call. The tool now defaults to text-mode synthesis (`{ "type": "text" }`) when the caller omits `outputSchema` or passes a schema without a `type` field. Explicit object-mode `outputSchema` is passed through unchanged and the formatter still surfaces `details.parsedOutput` so callers can consume structured output without re-parsing `result.text`.
+
+### Added
+
+- **Diagnostic context in the `web_research_exa` fallback path.** When the response omits the `output` field, the fallback `details` now include `requestId`, `resultsCount`, `outputSchemaSent`, `responseKeys`, and `kind: "domain"` + `error: "no_synthesized_output"`. The user-facing `text` honestly explains that synthesis was not requested (not that it "failed") and names the two override options. This catches the next silent regression and gives operators a `requestId` to reference in support tickets.
+- **`outputSchema: { "type": "text" }` in `exa_research_summary` mode `payload`.** The planner's auto-suggested `web_research_exa` invocation now spells out the synthesis step explicitly, so a user (or LLM) who copies the suggested JSON verbatim does not silently hit the fallback. Aligns with the workaround already documented in `skills/exa-research-planner/SKILL.md` and the four other skills that pass `outputSchema: { "type": "text" }` explicitly.
+- **Discoverability for object-mode synthesis.** The TypeBox `outputSchema` schema now carries a description that documents the default, the override, and the 10-property / depth-2 constraint. The `web_research_exa` tool description and `promptGuidelines` likewise document the default and how to override it. The misleading third `promptGuidelines` bullet ("...when a systemPrompt or outputSchema is needed...") was replaced with explicit default/override guidance.
+
+### Changed
+
+- **`web_answer_exa` description clarified** to state that it returns a plain string by default (a `/answer` endpoint default, not a tool behavior change) and that passing `outputSchema` switches to structured output. No runtime change.
+- **`web_research_exa` `promptSnippet`** shortened and updated to mention structured output ("Deep research; higher cost/latency. Use `outputSchema: { type: 'object' }` for structured output.") while preserving the cost/latency signal that the cross-tool routing test asserts on.
+
 ## [5.0.0] - 2026-05-25
 
 The 5.0 line ports pi-exa onto bridgekit's portable-tool surface and ships a first-class MCP stdio server. The user-visible tool semantics are unchanged for the Pi host, but the error contract, package layout, and runtime requirements all shift.

--- a/packages/pi-exa/README.md
+++ b/packages/pi-exa/README.md
@@ -189,7 +189,7 @@ Params include:
 - `query` (required)
 - `type`: `deep-reasoning | deep-lite | deep`
 - `systemPrompt`
-- `outputSchema` (`type` may be `"object"` or `"text"`, default `"object"`)
+- `outputSchema` (`type` may be `"object"` or `"text"`, default `"text"`; object mode is capped at 10 properties / depth 2 and gives per-field grounding). The default is required for synthesis to run — Exa's `/search` endpoint only returns an `output` field when an `outputSchema` is provided (see issue #115 and the [Search API Reference for Coding Agents](https://docs.exa.ai/reference/search-api-guide-for-coding-agents)).
 - optional `additionalQueries`, filters, `numResults`, and `textMaxCharacters`
 
 ### web_answer_exa

--- a/packages/pi-exa/__tests__/portable-tools.test.ts
+++ b/packages/pi-exa/__tests__/portable-tools.test.ts
@@ -454,9 +454,130 @@ describe("portable Exa tools", () => {
           numResults: 3,
           includeDomains: ["example.com"],
           startPublishedDate: "2024-01-01",
+          // Issue #115: omitting outputSchema must default to text-mode
+          // synthesis so the backend actually runs synthesis and returns
+          // an `output` field. The Exa API only synthesizes when an
+          // outputSchema is provided; without a default, callers always
+          // hit the canned "no synthesized output" fallback.
+          outputSchema: { type: "text" },
           contents: expect.objectContaining({ text: { maxCharacters: 4000 } }),
         }),
       );
+    });
+
+    it("defaults outputSchema to text-mode synthesis when the caller omits it (issue #115)", async () => {
+      // Regression pin for issue #115: web_research_exa returned the
+      // canned "no synthesized output was returned" message for every
+      // call because the implementation passed `undefined` to
+      // exa.search(...), and the backend only returns an `output` field
+      // when an outputSchema is provided. The fix is to default to
+      // text-mode synthesis when the caller doesn't pass an explicit
+      // outputSchema.
+      mockSearch.mockResolvedValue({
+        requestId: "req-default-text",
+        output: { content: "Synthesized prose answer.", grounding: [] },
+      });
+      const tools = createExaTools({ resolveApiKey: () => "test-key" });
+      const tool = findTool(tools, "web_research_exa");
+
+      await executePortableTool(tool, { query: "default behavior test" }, { host: "test" });
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        "default behavior test",
+        expect.objectContaining({
+          outputSchema: { type: "text" },
+        }),
+      );
+    });
+
+    it("passes explicit object-mode outputSchema through unchanged and renders parsedOutput", async () => {
+      // The default-to-text fix must not override an explicit object
+      // schema the caller passes. Object mode is the LLM's escape hatch
+      // for structured extraction, and the formatter should still set
+      // `details.parsedOutput` so the caller can consume the structured
+      // result without re-parsing `result.text`.
+      mockSearch.mockResolvedValue({
+        requestId: "req-obj",
+        output: {
+          content: { summary: "Structured answer", risks: ["risk-1", "risk-2"] },
+          grounding: [{ field: "summary", citations: [{ url: "https://example.com", title: "src" }], confidence: "high" }],
+        },
+      });
+      const tools = createExaTools({ resolveApiKey: () => "test-key" });
+      const tool = findTool(tools, "web_research_exa");
+
+      const explicitSchema = {
+        type: "object" as const,
+        properties: {
+          summary: { type: "string" },
+          risks: { type: "array", items: { type: "string" } },
+        },
+        required: ["summary"],
+      };
+
+      const result = await executePortableTool(
+        tool,
+        { query: "structured please", outputSchema: explicitSchema },
+        { host: "test" },
+      );
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        "structured please",
+        expect.objectContaining({ outputSchema: explicitSchema }),
+      );
+      expect(result.structuredContent).toMatchObject({
+        tool: "web_research_exa",
+        parsedOutput: { summary: "Structured answer", risks: ["risk-1", "risk-2"] },
+      });
+    });
+
+    it("surfaces diagnostic context when the response omits output (issue #115 fallback)", async () => {
+      // When the backend returns no `output` field, the tool must
+      // surface *why* (synthesis was not requested) and *what shape* it
+      // got, not the generic "try a different query" message. This pins
+      // the diagnostic contract: requestId, resultsCount, what schema
+      // was sent, and the top-level response keys (which lack `output`
+      // is the proof of the contract issue).
+      mockSearch.mockResolvedValue({
+        requestId: "req-no-output",
+        resolvedSearchType: "deep",
+        results: [
+          { title: "Hit 1", url: "https://example.com/1" },
+          { title: "Hit 2", url: "https://example.com/2" },
+        ],
+        searchTime: 1234,
+        costDollars: { total: 0.015 },
+        // No `output` key — matches the bug scenario from issue #115.
+      });
+      const tools = createExaTools({ resolveApiKey: () => "test-key" });
+      const tool = findTool(tools, "web_research_exa");
+
+      const result = await executePortableTool(
+        tool,
+        { query: "synthesis will not run" },
+        { host: "test" },
+      );
+
+      // Not flagged as an error — this is a contract gotcha, not a
+      // transport failure. The model gets a readable text and structured
+      // details to act on.
+      expect(result.isError).toBeFalsy();
+      // User-facing text must be honest: synthesis was not requested.
+      expect(result.text).toMatch(/synthesis was not requested/i);
+      expect(result.text).toMatch(/outputSchema/);
+      // Diagnostic details pin the failure shape.
+      expect(result.structuredContent).toMatchObject({
+        tool: "web_research_exa",
+        kind: "domain",
+        error: "no_synthesized_output",
+        requestId: "req-no-output",
+        resultsCount: 2,
+        outputSchemaSent: { type: "text" },
+        // The proof: the response had no `output` key.
+        responseKeys: ["requestId", "resolvedSearchType", "results", "searchTime", "costDollars"],
+        costDollars: { total: 0.015 },
+        searchTime: 1234,
+      });
     });
 
     it("rejects outputSchema.type other than object|text at the validation layer", async () => {

--- a/packages/pi-exa/__tests__/portable-tools.test.ts
+++ b/packages/pi-exa/__tests__/portable-tools.test.ts
@@ -500,7 +500,9 @@ describe("portable Exa tools", () => {
         requestId: "req-obj",
         output: {
           content: { summary: "Structured answer", risks: ["risk-1", "risk-2"] },
-          grounding: [{ field: "summary", citations: [{ url: "https://example.com", title: "src" }], confidence: "high" }],
+          grounding: [
+            { field: "summary", citations: [{ url: "https://example.com", title: "src" }], confidence: "high" },
+          ],
         },
       });
       const tools = createExaTools({ resolveApiKey: () => "test-key" });
@@ -552,11 +554,7 @@ describe("portable Exa tools", () => {
       const tools = createExaTools({ resolveApiKey: () => "test-key" });
       const tool = findTool(tools, "web_research_exa");
 
-      const result = await executePortableTool(
-        tool,
-        { query: "synthesis will not run" },
-        { host: "test" },
-      );
+      const result = await executePortableTool(tool, { query: "synthesis will not run" }, { host: "test" });
 
       // Not flagged as an error — this is a contract gotcha, not a
       // transport failure. The model gets a readable text and structured

--- a/packages/pi-exa/__tests__/portable-tools.test.ts
+++ b/packages/pi-exa/__tests__/portable-tools.test.ts
@@ -490,6 +490,35 @@ describe("portable Exa tools", () => {
       );
     });
 
+    it("defaults to text-mode when outputSchema is an object without a type field", async () => {
+      // The schema layer accepts { properties: {...} } without a top-level
+      // type (Type.Object + additionalProperties: true). parseOutputSchema
+      // must treat that as "no type provided" and default to text mode,
+      // matching the omitted-outputSchema path.
+      mockSearch.mockResolvedValue({
+        requestId: "req-no-type",
+        output: { content: "Defaulted to text.", grounding: [] },
+      });
+      const tools = createExaTools({ resolveApiKey: () => "test-key" });
+      const tool = findTool(tools, "web_research_exa");
+
+      await executePortableTool(
+        tool,
+        {
+          query: "no-type test",
+          outputSchema: { properties: { summary: { type: "string" } } } as never,
+        },
+        { host: "test" },
+      );
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        "no-type test",
+        expect.objectContaining({
+          outputSchema: { type: "text" },
+        }),
+      );
+    });
+
     it("passes explicit object-mode outputSchema through unchanged and renders parsedOutput", async () => {
       // The default-to-text fix must not override an explicit object
       // schema the caller passes. Object mode is the LLM's escape hatch
@@ -535,11 +564,12 @@ describe("portable Exa tools", () => {
 
     it("surfaces diagnostic context when the response omits output (issue #115 fallback)", async () => {
       // When the backend returns no `output` field, the tool must
-      // surface *why* (synthesis was not requested) and *what shape* it
-      // got, not the generic "try a different query" message. This pins
-      // the diagnostic contract: requestId, resultsCount, what schema
-      // was sent, and the top-level response keys (which lack `output`
-      // is the proof of the contract issue).
+      // surface *why* (synthesis was expected but the response lacked
+      // the field) and *what shape* it got, not the generic "try a
+      // different query" message. This pins the diagnostic contract:
+      // requestId, resultsCount, what schema was sent, and the
+      // top-level response keys (which lack `output` is the proof of
+      // the contract issue).
       mockSearch.mockResolvedValue({
         requestId: "req-no-output",
         resolvedSearchType: "deep",
@@ -560,21 +590,55 @@ describe("portable Exa tools", () => {
       // transport failure. The model gets a readable text and structured
       // details to act on.
       expect(result.isError).toBeFalsy();
-      // User-facing text must be honest: synthesis was not requested.
-      expect(result.text).toMatch(/synthesis was not requested/i);
+      // User-facing text is honest about what happened: a schema was
+      // sent, the response lacked the field.
+      expect(result.text).toMatch(/outputSchema was sent/i);
       expect(result.text).toMatch(/outputSchema/);
       // Diagnostic details pin the failure shape.
-      expect(result.structuredContent).toMatchObject({
+      const details = result.structuredContent as Record<string, unknown>;
+      expect(details).toMatchObject({
         tool: "web_research_exa",
         kind: "domain",
         error: "no_synthesized_output",
         requestId: "req-no-output",
         resultsCount: 2,
         outputSchemaSent: { type: "text" },
-        // The proof: the response had no `output` key.
-        responseKeys: ["requestId", "resolvedSearchType", "results", "searchTime", "costDollars"],
         costDollars: { total: 0.015 },
         searchTime: 1234,
+      });
+      // responseKeys is the diagnostic surface: assert semantically (the
+      // useful keys are present, `output` is absent) rather than pinning
+      // exact insertion order — Object.keys order is stable per the
+      // JS spec, but the value of the diagnostic is the set membership.
+      const responseKeys = details.responseKeys as string[];
+      expect(responseKeys).toEqual(expect.arrayContaining(["requestId", "results", "searchTime", "costDollars"]));
+      expect(responseKeys).not.toContain("output");
+    });
+
+    it("surfaces diagnostic context even when exa.search resolves to null or undefined", async () => {
+      // Defensive coverage: if the SDK ever resolves to a nullish
+      // response (unusual but documented in the exa-js types as
+      // possible during cancellation/timeout edges), the diagnostic
+      // path must not throw. Without the null guard, toMetadata would
+      // dereference response.costDollars on a null value and the
+      // fallback would crash before the model-visible diagnostic is
+      // returned.
+      mockSearch.mockResolvedValueOnce(null);
+      const tools = createExaTools({ resolveApiKey: () => "test-key" });
+      const tool = findTool(tools, "web_research_exa");
+
+      const result = await executePortableTool(tool, { query: "null response test" }, { host: "test" });
+
+      expect(result.isError).toBeFalsy();
+      const details = result.structuredContent as Record<string, unknown>;
+      expect(details).toMatchObject({
+        tool: "web_research_exa",
+        kind: "domain",
+        error: "no_synthesized_output",
+        requestId: "unknown",
+        resultsCount: 0,
+        outputSchemaSent: { type: "text" },
+        responseKeys: [],
       });
     });
 

--- a/packages/pi-exa/__tests__/research-planner.test.ts
+++ b/packages/pi-exa/__tests__/research-planner.test.ts
@@ -608,7 +608,10 @@ describe("research planner state", () => {
     // self-documenting about the synthesis step it is suggesting.
     const jsonBlock = payload.match(/```json\n([\s\S]*?)\n```/);
     expect(jsonBlock, "payload should embed a JSON block").not.toBeNull();
-    const suggested = JSON.parse(jsonBlock![1]) as { outputSchema?: unknown };
+    if (jsonBlock === null) {
+      return; // unreachable: the expect above already failed
+    }
+    const suggested = JSON.parse(jsonBlock[1]) as { outputSchema?: unknown };
     expect(suggested.outputSchema).toEqual({ type: "text" });
   });
 

--- a/packages/pi-exa/__tests__/research-planner.test.ts
+++ b/packages/pi-exa/__tests__/research-planner.test.ts
@@ -600,6 +600,16 @@ describe("research planner state", () => {
     expect(payload).toContain("## Implementation payload");
     expect(payload).toContain('"query"');
     expect(payload).toContain("This payload is a suggestion only; no Exa retrieval call was executed.");
+
+    // Issue #115: the planner's auto-suggested payload must include an
+    // explicit outputSchema so that a user (or LLM) who copies the
+    // suggested JSON straight into web_research_exa does not hit the
+    // canned "no synthesized output" fallback. The planner should be
+    // self-documenting about the synthesis step it is suggesting.
+    const jsonBlock = payload.match(/```json\n([\s\S]*?)\n```/);
+    expect(jsonBlock, "payload should embed a JSON block").not.toBeNull();
+    const suggested = JSON.parse(jsonBlock![1]) as { outputSchema?: unknown };
+    expect(suggested.outputSchema).toEqual({ type: "text" });
   });
 
   it("resets all planner state", () => {

--- a/packages/pi-exa/extensions/constants.ts
+++ b/packages/pi-exa/extensions/constants.ts
@@ -10,3 +10,12 @@ export const DEEP_SEARCH_TYPES = ["deep-reasoning", "deep-lite", "deep"] as cons
 // backwards compatibility. Hard-removing them would be a breaking change.
 export const ADVANCED_SEARCH_TYPES = ["auto", "fast", "instant", "keyword", "neural", "hybrid"] as const;
 export type AdvancedSearchType = (typeof ADVANCED_SEARCH_TYPES)[number];
+
+/**
+ * Default `outputSchema` for deep search. Exa's `/search` endpoint only
+ * returns an `output` field when an `outputSchema` is provided; text mode
+ * is the lowest-friction default (no schema design required). Used by
+ * `web_research_exa` to default omitted/missing-`type` schemas, and by
+ * the research planner to keep copied payloads synthesis-ready.
+ */
+export const DEFAULT_RESEARCH_OUTPUT_SCHEMA = { type: "text" } as const;

--- a/packages/pi-exa/extensions/research-planner.ts
+++ b/packages/pi-exa/extensions/research-planner.ts
@@ -10,6 +10,7 @@
  * via `createResearchPlanner()`.
  */
 
+import { DEFAULT_RESEARCH_OUTPUT_SCHEMA } from "./constants.js";
 import type {
   CriteriaCoverage,
   RecommendedNextAction,
@@ -198,13 +199,9 @@ function payload(status: ResearchStatus): string {
   const suggestedPayload = {
     query: queryParts.join("; ") || "Research the recorded topic.",
     systemPrompt,
-    // Make the synthesis step explicit in the auto-suggested payload
-    // (issue #115). web_research_exa defaults to text-mode synthesis,
-    // but spelling it out here means a reader of the suggested payload
-    // can see that synthesis will happen and how the output will be
-    // shaped. Callers can still override with { type: "object", ... }
-    // for structured extraction.
-    outputSchema: { type: "text" },
+    // Keep copied planner payloads synthesis-ready; Exa requires
+    // outputSchema for output (issue #115).
+    outputSchema: DEFAULT_RESEARCH_OUTPUT_SCHEMA,
     additionalQueries: status.criteria.slice(0, 5).map((criterion) => criterion.label),
     numResults: Math.min(20, Math.max(5, status.criteria.length + status.sources.length)),
   };

--- a/packages/pi-exa/extensions/research-planner.ts
+++ b/packages/pi-exa/extensions/research-planner.ts
@@ -198,6 +198,13 @@ function payload(status: ResearchStatus): string {
   const suggestedPayload = {
     query: queryParts.join("; ") || "Research the recorded topic.",
     systemPrompt,
+    // Make the synthesis step explicit in the auto-suggested payload
+    // (issue #115). web_research_exa defaults to text-mode synthesis,
+    // but spelling it out here means a reader of the suggested payload
+    // can see that synthesis will happen and how the output will be
+    // shaped. Callers can still override with { type: "object", ... }
+    // for structured extraction.
+    outputSchema: { type: "text" },
     additionalQueries: status.criteria.slice(0, 5).map((criterion) => criterion.label),
     numResults: Math.min(20, Math.max(5, status.criteria.length + status.sources.length)),
   };

--- a/packages/pi-exa/extensions/schemas.ts
+++ b/packages/pi-exa/extensions/schemas.ts
@@ -17,7 +17,11 @@ import {
   SUMMARY_MODES,
 } from "./research-planner-types.js";
 
-const outputSchemaType = Type.Union([Type.Literal("object"), Type.Literal("text")]);
+const outputSchemaType = Type.Union([Type.Literal("object"), Type.Literal("text")], {
+  description:
+    'Output mode for deep search synthesis. "text" returns the synthesis as prose (the default for web_research_exa). ' +
+    '"object" returns a JSON object matching `properties` (max 10 properties, max depth 2).',
+});
 
 const outputSchema = Type.Object(
   {

--- a/packages/pi-exa/extensions/schemas.ts
+++ b/packages/pi-exa/extensions/schemas.ts
@@ -19,8 +19,8 @@ import {
 
 const outputSchemaType = Type.Union([Type.Literal("object"), Type.Literal("text")], {
   description:
-    'Output mode for deep search synthesis. "text" returns the synthesis as prose (the default for web_research_exa). ' +
-    '"object" returns a JSON object matching `properties` (max 10 properties, max depth 2).',
+    'Output mode. "text" returns prose; "object" returns a JSON object matching `properties` (max 10 properties, max depth 2). ' +
+    "Tool-specific default behavior is documented in each tool's description.",
 });
 
 const outputSchema = Type.Object(

--- a/packages/pi-exa/extensions/tools.ts
+++ b/packages/pi-exa/extensions/tools.ts
@@ -475,7 +475,9 @@ export function createExaTools(opts: ExaToolsOptions = {}): readonly PortableToo
         {
           name: "web_answer_exa",
           title: "Exa Answer",
-          description: "Get a grounded answer with source citations and optional structured output.",
+          description:
+            "Get a grounded answer with source citations. Returns the answer as a plain string by default; " +
+            "pass `outputSchema` to receive structured output instead.",
           parameters: webAnswerParams,
           pendingMessage: "Fetching answer from Exa...",
           errorPrefix: "Exa answer error",
@@ -549,17 +551,22 @@ export function createExaTools(opts: ExaToolsOptions = {}): readonly PortableToo
         {
           name: "web_research_exa",
           title: "Exa Deep Research",
-          description: "Deep-reasoning Exa search with synthesized, grounded output for complex research topics.",
+          description:
+            "Deep-reasoning Exa search with synthesized, grounded output for complex research topics. " +
+            'Returns the synthesis as plain text by default; pass `outputSchema: { "type": "object", "properties": {...} }` ' +
+            "to receive structured output (max 10 properties, max depth 2).",
           parameters: webResearchParams,
           pendingMessage: "Performing deep research via Exa...",
           errorPrefix: "Exa research error",
           hostExtras: {
             pi: {
-              promptSnippet: "Deep research with grounded synthesis; higher cost and latency.",
+              promptSnippet:
+                "Deep research; higher cost/latency. Use outputSchema: { type: 'object' } for structured output.",
               promptGuidelines: [
                 "Use web_research_exa for conclusions, comparisons, and recommendations; use web_search_exa for simple lookups.",
                 "Use web_research_exa for open-ended synthesis; use web_answer_exa for direct questions needing a concise cited answer.",
-                "Use web_research_exa when a systemPrompt or outputSchema is needed; use web_search_advanced_exa for filtered retrieval only.",
+                "web_research_exa defaults to text-mode synthesis for prose; use web_answer_exa when the question is direct and a short answer suffices.",
+                "web_research_exa accepts `outputSchema: { type: 'object', properties: {...} }` for structured extraction (max 10 properties, max depth 2); use web_search_advanced_exa for filtered retrieval when no synthesis is needed.",
               ],
             },
             mcp: { annotations: { readOnlyHint: true, idempotentHint: false, openWorldHint: true } },

--- a/packages/pi-exa/extensions/web-research.ts
+++ b/packages/pi-exa/extensions/web-research.ts
@@ -82,6 +82,11 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
     // contract issue: top-level keys include requestId/results/etc.
     // but no `output` key. That is the documented behavior of /search
     // when no outputSchema was sent — not a backend failure.
+    //
+    // With the new default-to-text fix, an outputSchema is always
+    // sent, so the previous "synthesis was not requested" wording is
+    // misleading. Say what actually happened: a schema was sent, the
+    // backend returned results, but no `output` field.
     const responseRecord = response as Record<string, unknown> | null | undefined;
     const results = responseRecord?.results;
     const resultsCount = Array.isArray(results) ? (results as unknown[]).length : 0;
@@ -89,10 +94,10 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
     const requestId = typeof responseRecord?.requestId === "string" ? (responseRecord.requestId as string) : "unknown";
     const text =
       `Deep search completed but no synthesized output was returned. ` +
-      `Synthesis was not requested by the Exa API in this call (requestId: ${requestId}, ` +
-      `results returned: ${resultsCount}). Pass outputSchema explicitly to receive synthesis: ` +
-      `\`{ "type": "text" }\` for prose or \`{ "type": "object", "properties": {...} }\` for structured output ` +
-      `(max 10 properties, max depth 2).`;
+      `An outputSchema was sent to the Exa API (requestId: ${requestId}, ` +
+      `results returned: ${resultsCount}, outputSchema: ${JSON.stringify(outputSchema)}), ` +
+      `but the response did not include an \`output\` field. ` +
+      `Try a different query, simplify filters, or check Exa's status page.`;
     return {
       text,
       details: {
@@ -103,7 +108,12 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
         resultsCount,
         outputSchemaSent: outputSchema,
         responseKeys,
-        ...toMetadata(response),
+        // Guard the metadata spread: toMetadata dereferences
+        // response.costDollars and response.searchTime, and a null/
+        // undefined response would throw before the diagnostic can
+        // be returned. (Pre-existing crash; surfaced by the new
+        // diagnostic details block.)
+        ...(response ? toMetadata(response) : {}),
       },
     };
   }

--- a/packages/pi-exa/extensions/web-research.ts
+++ b/packages/pi-exa/extensions/web-research.ts
@@ -3,7 +3,7 @@
  */
 
 import type { DeepOutputSchema, DeepSearchOutput } from "exa-js";
-import { DEEP_SEARCH_TYPES } from "./constants.js";
+import { DEEP_SEARCH_TYPES, DEFAULT_RESEARCH_OUTPUT_SCHEMA } from "./constants.js";
 import { getExaClient } from "./exa-client.js";
 import type { ToolPerformResult } from "./formatters.js";
 import { formatResearchOutput, toMetadata } from "./formatters.js";
@@ -26,21 +26,11 @@ interface ResearchParams {
 }
 
 function parseOutputSchema(outputSchema: Record<string, unknown> | undefined): DeepOutputSchema {
-  // The Exa /search endpoint only returns an `output` field when an
-  // outputSchema is provided (see Exa Search API Reference, the
-  // canonical guide: "When provided, the response includes `output`").
-  // Without a default, every call without an explicit outputSchema
-  // would return no synthesis and the canned "no synthesized output"
-  // fallback would fire — see issue #115.
-  //
-  // Default to text-mode synthesis: it is the lowest-friction mode
-  // (no schema design required), matches every skill example in this
-  // package except `financial-report-search`, and is what the user's
-  // manual workaround in the bug report uses. Callers that want
-  // structured output pass `outputSchema: { type: "object", properties: {...} }`
-  // explicitly; the override is preserved verbatim.
+  // Exa /search only returns an `output` field when an outputSchema is
+  // provided; default to text so omitted schemas still request synthesis
+  // (issue #115). Explicit object-mode schemas pass through unchanged.
   if (!outputSchema || !Object.hasOwn(outputSchema, "type")) {
-    return { type: "text" } as DeepOutputSchema;
+    return DEFAULT_RESEARCH_OUTPUT_SCHEMA as unknown as DeepOutputSchema;
   }
 
   const schemaType = outputSchema.type;
@@ -78,20 +68,12 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
   });
 
   if (!response?.output) {
-    // Synthesize an honest diagnostic. The response shape proves the
-    // contract issue: top-level keys include requestId/results/etc.
-    // but no `output` key. That is the documented behavior of /search
-    // when no outputSchema was sent — not a backend failure.
-    //
-    // With the new default-to-text fix, an outputSchema is always
-    // sent, so the previous "synthesis was not requested" wording is
-    // misleading. Say what actually happened: a schema was sent, the
-    // backend returned results, but no `output` field.
-    const responseRecord = response as Record<string, unknown> | null | undefined;
-    const results = responseRecord?.results;
-    const resultsCount = Array.isArray(results) ? (results as unknown[]).length : 0;
-    const responseKeys = responseRecord ? Object.keys(responseRecord) : [];
-    const requestId = typeof responseRecord?.requestId === "string" ? (responseRecord.requestId as string) : "unknown";
+    // Even with the default outputSchema, surface a non-error diagnostic
+    // when Exa returns results but omits `output` so the operator and
+    // the model-visible text both know what happened.
+    const resultsCount = Array.isArray(response?.results) ? response.results.length : 0;
+    const responseKeys = response ? Object.keys(response) : [];
+    const requestId = typeof response?.requestId === "string" ? response.requestId : "unknown";
     const text =
       `Deep search completed but no synthesized output was returned. ` +
       `An outputSchema was sent to the Exa API (requestId: ${requestId}, ` +
@@ -109,10 +91,8 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
         outputSchemaSent: outputSchema,
         responseKeys,
         // Guard the metadata spread: toMetadata dereferences
-        // response.costDollars and response.searchTime, and a null/
-        // undefined response would throw before the diagnostic can
-        // be returned. (Pre-existing crash; surfaced by the new
-        // diagnostic details block.)
+        // response.costDollars and response.searchTime, and a nullish
+        // response would throw before the diagnostic can be returned.
         ...(response ? toMetadata(response) : {}),
       },
     };

--- a/packages/pi-exa/extensions/web-research.ts
+++ b/packages/pi-exa/extensions/web-research.ts
@@ -25,9 +25,22 @@ interface ResearchParams {
   endPublishedDate?: string;
 }
 
-function parseOutputSchema(outputSchema: Record<string, unknown> | undefined): DeepOutputSchema | undefined {
+function parseOutputSchema(outputSchema: Record<string, unknown> | undefined): DeepOutputSchema {
+  // The Exa /search endpoint only returns an `output` field when an
+  // outputSchema is provided (see Exa Search API Reference, the
+  // canonical guide: "When provided, the response includes `output`").
+  // Without a default, every call without an explicit outputSchema
+  // would return no synthesis and the canned "no synthesized output"
+  // fallback would fire — see issue #115.
+  //
+  // Default to text-mode synthesis: it is the lowest-friction mode
+  // (no schema design required), matches every skill example in this
+  // package except `financial-report-search`, and is what the user's
+  // manual workaround in the bug report uses. Callers that want
+  // structured output pass `outputSchema: { type: "object", properties: {...} }`
+  // explicitly; the override is preserved verbatim.
   if (!outputSchema || !Object.hasOwn(outputSchema, "type")) {
-    return undefined;
+    return { type: "text" } as DeepOutputSchema;
   }
 
   const schemaType = outputSchema.type;
@@ -65,10 +78,31 @@ export async function performResearch(apiKey: string, params: ResearchParams): P
   });
 
   if (!response?.output) {
+    // Synthesize an honest diagnostic. The response shape proves the
+    // contract issue: top-level keys include requestId/results/etc.
+    // but no `output` key. That is the documented behavior of /search
+    // when no outputSchema was sent — not a backend failure.
+    const responseRecord = response as Record<string, unknown> | null | undefined;
+    const results = responseRecord?.results;
+    const resultsCount = Array.isArray(results) ? (results as unknown[]).length : 0;
+    const responseKeys = responseRecord ? Object.keys(responseRecord) : [];
+    const requestId = typeof responseRecord?.requestId === "string" ? (responseRecord.requestId as string) : "unknown";
+    const text =
+      `Deep search completed but no synthesized output was returned. ` +
+      `Synthesis was not requested by the Exa API in this call (requestId: ${requestId}, ` +
+      `results returned: ${resultsCount}). Pass outputSchema explicitly to receive synthesis: ` +
+      `\`{ "type": "text" }\` for prose or \`{ "type": "object", "properties": {...} }\` for structured output ` +
+      `(max 10 properties, max depth 2).`;
     return {
-      text: "Deep search completed, but no synthesized output was returned. Try a different query or simpler filters.",
+      text,
       details: {
         tool: "web_research_exa",
+        kind: "domain",
+        error: "no_synthesized_output",
+        requestId,
+        resultsCount,
+        outputSchemaSent: outputSchema,
+        responseKeys,
         ...toMetadata(response),
       },
     };

--- a/packages/pi-exa/package.json
+++ b/packages/pi-exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feniix/pi-exa",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Exa API extension for pi — web search, content fetching, and advanced search via Exa AI",
   "keywords": [
     "pi",


### PR DESCRIPTION
Fixes #115.

## Problem

`web_research_exa` returned the canned "no synthesized output was returned" message for every call because `parseOutputSchema` passed `undefined` to `exa.search(...)`. Per Exa's [Search API Reference for Coding Agents](https://docs.exa.ai/reference/search-api-guide-for-coding-agents), `/search` only returns an `output` field when an `outputSchema` is provided — so every call without an explicit schema silently hit the canned fallback.

This was a contract bug. The README claimed `outputSchema` defaulted to `"object"`, but the implementation had no default. The project's own skills (`code-search`, `company-research`, `exa-research-planner`, `financial-report-search`) all work around the bug by passing `outputSchema: { type: "text" }` explicitly. The user's manual workaround in the issue report was the same.

## What changes

**Runtime fix (`extensions/web-research.ts`)**

- `parseOutputSchema` now returns `{ type: "text" }` (the shared `DEFAULT_RESEARCH_OUTPUT_SCHEMA` constant in `constants.ts`) when the caller omits `outputSchema` or passes a schema without a `type` field. Return type is `DeepOutputSchema` (non-optional).
- Explicit object-mode `outputSchema` is passed through unchanged; the formatter still sets `details.parsedOutput` for structured extraction.
- The fallback path (response has no `output` field) now surfaces an honest diagnostic shape in `details`: `kind: "domain"`, `error: "no_synthesized_output"`, `requestId`, `resultsCount`, `outputSchemaSent`, `responseKeys`, plus the existing `costDollars` / `searchTime` from `toMetadata`. The user-facing `text` says an `outputSchema` was sent but the response did not include an `output` field, names the requestId and the outputSchema that was sent, and points to the next-step actions (different query / simpler filters / status page).
- A null guard around `...toMetadata(response)` so a nullish response does not throw before the diagnostic is returned.

**Discoverability**

- `extensions/schemas.ts`: `outputSchemaType` Union now carries a description documenting the text vs object modes and the 10-property / depth-2 constraint. The wording is endpoint-neutral so the same Union serves both `webResearchParams` and `webAnswerParams` without leaking tool-specific copy.
- `extensions/tools.ts`: `web_research_exa` description, `promptSnippet`, and two `promptGuidelines` now document the default and the override. The previous third guideline — "Use web_research_exa when a systemPrompt or outputSchema is needed..." — implied `outputSchema` was exotic; the new wording is explicit. `web_answer_exa` description clarified to state it returns a plain string by default (an `/answer` endpoint default, not a tool behavior change).
- `extensions/research-planner.ts`: `exa_research_summary` mode `payload` now includes `outputSchema: { type: "text" }` (the shared `DEFAULT_RESEARCH_OUTPUT_SCHEMA` constant) in the auto-suggested `web_research_exa` invocation, so a user who copies the suggested JSON verbatim does not silently hit the fallback. Aligns with `skills/exa-research-planner/SKILL.md`.

## What does NOT change

- `web_answer_exa` runtime behavior (the `/answer` endpoint works correctly today; only the description was clarified).
- The exa-js dependency version.
- TypeBox schema validation (still `object` and `text` only).
- Cost ceiling (text and object modes are both $0.015 per call; empirically confirmed against the live API).
- The MCP server's `CROSS_TOOL_GUIDELINES` (`extensions/tool-guidance.ts`) — it covers cross-tool routing, not per-tool schema defaults.

## How both hosts benefit

`createExaTools(...)` in `extensions/tools.ts` is the shared host-neutral factory. Both `extensions/index.ts` (the Pi adapter) and `extensions/mcp-server.ts` (the MCP server) call it and register whatever it returns — there is no second copy of any tool definition. So every change in this PR flows to both Pi and MCP by construction. The `promptSnippet` and `promptGuidelines` (Pi-only via `hostExtras.pi.*`) are the only Pi-exclusive surface in the diff; the `description`, `parameters`, and runtime `perform` are shared with MCP.

One-time caveat: the local `dist/` was stale (it was compiled before the source changes). `npm publish` runs `prepack` → `build:mcp` and rebuilds it, so the published tarball will be fresh. `npm run build:mcp` rebuilds it locally for MCP smoke-testing.

## Tests

Test-first workflow (red → green), per `AGENTS.md`:

- 5 new/updated tests, all red on `main`:
  - `__tests__/portable-tools.test.ts`: `forwards deep-search options and returns synthesized text` — added assertion that `mockSearch` was called with `outputSchema: { type: "text" }` when the caller omits it.
  - `__tests__/portable-tools.test.ts` (new): `defaults outputSchema to text-mode synthesis when the caller omits it (issue #115)`.
  - `__tests__/portable-tools.test.ts` (new): `defaults to text-mode when outputSchema is an object without a type field` (added in the ce-code-review pass).
  - `__tests__/portable-tools.test.ts` (new): `passes explicit object-mode outputSchema through unchanged and renders parsedOutput`.
  - `__tests__/portable-tools.test.ts` (new): `surfaces diagnostic context when the response omits output (issue #115 fallback)`.
  - `__tests__/portable-tools.test.ts` (new, from the ce-code-review pass): `surfaces diagnostic context even when exa.search resolves to null or undefined` — pins the null-guard around `toMetadata`.
  - `__tests__/research-planner.test.ts`: added assertion that the suggested payload includes `outputSchema: { type: "text" }`.

Verification:

- 195 tests pass (8 skipped, 0 failed) — 1 file is the live-integration suite gated on `PI_EXA_LIVE=1`
- `npx biome ci packages/pi-exa` clean
- `npx tsc --noEmit --project packages/pi-exa/tsconfig.json` clean

## Subsequent passes (code review, docs, simplify)

After the initial fix, three follow-up passes ran on the branch and are included in this PR.

**`ce-code-review` (9 reviewers, ~70 lines of executable code)**

Cross-validated findings from correctness, testing, reliability, and adversarial. Five low-severity items applied in `12bb123`:

- Guard the `toMetadata(response)` spread with `response ? ... : {}` — pre-existing crash surfaced by the new diagnostic details block.
- Make the `outputSchemaType` Union description endpoint-neutral; tool-specific wording stays in each tool's description.
- Reword the fallback text from "synthesis was not requested" to "an `outputSchema` was sent but the response did not include an `output` field" — the new default always sends a schema.
- Add tests for `outputSchema` object lacking `type` field, and for `exa.search` resolving to null/undefined.
- Loosen the `responseKeys` assertion from exact-order to `arrayContaining` + `not.contain('output')`.

**`ce-compound` (knowledge capture)**

Three discrete commits document the fix and seed the project's vocabulary:

- `docs(solutions): document web_research_exa outputSchema default fix (issue #115)` — bug-track learning at `docs/solutions/integration-issues/web-research-exa-outputschema-default.md` with empirical validation, the Exa contract reference, the four affected skills, and four concrete prevention rules.
- `docs(concepts): seed pi-exa vocabulary` — created `CONCEPTS.md` at repo root with three concepts the fix actually investigated: **Portable tool** (bridgekit abstraction), **Synthesis** (Exa deep search's LLM-generated answer, distinct from retrieved results), **Research plan** (the in-memory state in `exa_research_step`).
- `docs(agents): surface CONCEPTS.md alongside docs/solutions/` — one sibling line in `AGENTS.md`'s structure-overview block pointing at the new `CONCEPTS.md`.

**`ce-simplify-code` (3 reviewers)**

Low-severity findings from reuse, quality, and efficiency passes. All applied in `a2e2e1a`:

- Extract the duplicated `{ type: "text" }` literal to `DEFAULT_RESEARCH_OUTPUT_SCHEMA` in `constants.ts` (reuses the package's existing shared-constant pattern).
- Drop the broad `response as Record<string, unknown> | null | undefined` cast in the no-output fallback; read typed fields directly.
- Trim two long comments to the durable WHY (parseOutputSchema 13 lines → 4; planner payload 7 lines → 1).

Net diff from the simplify pass: +26 / -40 lines.

## Version bump

`@feniix/pi-exa` 5.0.0 → 5.0.1 (patch). `CHANGELOG.md` updated with Fixed / Added / Changed sections. `README.md` corrected from "default object" to "default text" with a reference to issue #115 and the Search API Reference.

## Out-of-scope refresh recommendation

Two design docs that previously assumed `outputSchema.type` defaulted to `"object"` are now superseded by this fix:

- `docs/prd/PRD-005-pi-exa-api-alignment.md`
- `docs/architecture/plan-pi-exa-api-alignment.md`

These live outside `docs/solutions/`, so the `ce-compound-refresh` skill does not cover them. When time allows, a manual edit should update the superseded wording in both and link the new solution doc.

## Commits

```
a2e2e1a refactor(pi-exa): tighten the web_research_exa fallback after simplify-code pass
26db14b docs(agents): surface CONCEPTS.md alongside docs/solutions/ for discoverability
f94aec1 docs(concepts): seed pi-exa vocabulary (portable tool, synthesis, research plan)
6ed39b0 docs(solutions): document web_research_exa outputSchema default fix (issue #115)
12bb123 fix(review): apply 5 review findings to issue #115 fix
11d3a95 chore(release): pi-exa 5.0.1
455d017 fix(pi-exa): default web_research_exa outputSchema to text-mode and surface diagnostics
9f64304 test(pi-exa): pin web_research_exa outputSchema default and diagnostics for issue #115
```

## Files changed

```
AGENTS.md                                                        |   1 +
CONCEPTS.md                                                      |  27 +++
docs/solutions/integration-issues/web-research-exa-outputschema-default.md | 154 +++++++++++++++
package-lock.json                                                |   2 +-
packages/pi-exa/CHANGELOG.md                                     |  17 ++
packages/pi-exa/README.md                                        |   2 +-
packages/pi-exa/__tests__/portable-tools.test.ts                 | 183 +++++++++++++++++++
packages/pi-exa/__tests__/research-planner.test.ts               |  13 ++
packages/pi-exa/extensions/constants.ts                          |   9 +
packages/pi-exa/extensions/research-planner.ts                   |   4 +
packages/pi-exa/extensions/schemas.ts                            |   6 +-
packages/pi-exa/extensions/tools.ts                              |  15 +-
packages/pi-exa/extensions/web-research.ts                       |  34 +++-
packages/pi-exa/package.json                                     |   2 +-
14 files changed, 456 insertions(+), 13 deletions(-)
```
